### PR TITLE
fix(tests): isolate fixture git invocations from the ambient environment

### DIFF
--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -53,7 +53,7 @@ fn config_load_resolves_main_and_linked_worktrees_to_one_database() {
     // The actual guarantee (review item 1): Config::load from the main worktree and from a
     // linked worktree of the same repo produce the *same* database path — not two DBs.
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("cfgload");
     let main = tmp.join("main");
@@ -330,8 +330,7 @@ fn repo_id_override_is_parsed_and_does_not_change_the_database_path() {
 /// identity).
 fn git_commit_all(dir: &Path) {
     let git = |args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     git(&["init", "-q"]);
     git(&["config", "user.email", "t@e"]);
@@ -373,8 +372,7 @@ fn config_load_without_a_database_key_resolves_to_the_global_database() {
 #[test]
 fn config_load_in_a_linked_worktree_is_governed_wholesale_by_the_main_config() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("wholecfg");
     let main = tmp.join("main");
@@ -420,8 +418,7 @@ fn config_load_in_a_linked_worktree_is_governed_wholesale_by_the_main_config() {
 #[test]
 fn config_load_falls_back_to_the_local_config_when_main_has_none() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("nomaincfg");
     let main = tmp.join("main");
@@ -460,8 +457,7 @@ fn config_load_falls_back_to_the_local_config_when_main_has_none() {
 #[test]
 fn discover_config_path_resolves_the_governing_checkout() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("discover");
     let main = tmp.join("main");
@@ -533,8 +529,7 @@ fn discover_config_path_walks_up_to_a_parent_repo_config() {
 #[test]
 fn discover_config_path_does_not_cross_a_nested_repo_boundary() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("nested");
     let parent = tmp.join("parent");
@@ -564,8 +559,7 @@ fn discover_config_path_does_not_cross_a_nested_repo_boundary() {
 #[test]
 fn discover_config_path_finds_a_branch_local_config_from_a_linked_worktree_subdir() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("wtsub");
     let main = tmp.join("main");
@@ -606,8 +600,7 @@ fn discover_config_path_finds_a_branch_local_config_from_a_linked_worktree_subdi
 #[test]
 fn linked_worktree_main_root_derives_linkedness_from_topology() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("linkpred");
     let main = tmp.join("main");
@@ -647,8 +640,7 @@ fn linked_worktree_main_root_derives_linkedness_from_topology() {
 #[test]
 fn config_load_ignores_an_invalid_branch_config_when_main_governs() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("brokecfg");
     let main = tmp.join("main");
@@ -700,8 +692,7 @@ fn config_load_ignores_an_invalid_branch_config_when_main_governs() {
 #[test]
 fn config_load_governs_from_main_even_when_a_branch_only_root_defeats_anchoring() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("branchroot");
     let main = tmp.join("main");
@@ -800,8 +791,7 @@ fn config_load_refuses_an_identity_less_pin_at_the_global_store() {
 #[test]
 fn config_load_anchors_the_database_key_to_the_main_worktree() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("dbanchor");
     let main = tmp.join("main");
@@ -949,9 +939,7 @@ fn config_load_without_a_database_key_stays_per_root_for_identity_less_roots() {
     // existing single-repo adoption flow), instead of stranding in the global store.
     let unborn = keyless_config("unborn");
     let git = |args: &[&str]| {
-        let out =
-            std::process::Command::new("git").arg("-C").arg(&*unborn).args(args).output().unwrap();
-        assert!(out.status.success());
+        crate::test_git::run(&unborn, args);
     };
     git(&["init", "-q"]);
     let config = Config::load(unborn.join("rag-rat.toml")).unwrap();
@@ -1001,7 +989,7 @@ fn config_load_in_a_linked_worktree_uses_main_base_targets_not_the_branch() {
     // any main file outside it. The branch's extra target is served via the overlay, not the
     // base config.
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("cfgbranch");
     let main = tmp.join("main");
@@ -1066,7 +1054,7 @@ fn config_load_in_a_linked_worktree_keeps_main_targets_when_the_branch_narrows_t
     // base scope — hiding committed files from main queries. The stored base targets
     // must be MAIN's.
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("cfgnarrow");
     let main = tmp.join("main");
@@ -1115,7 +1103,7 @@ fn config_load_anchors_repo_id_override_to_main_when_the_branch_diverges() {
     // a DIFFERENT id must still resolve MAIN's — otherwise identity splits by which checkout
     // launched. This mirrors the root/database/targets anchoring above.
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("repoid-anchor");
     let main = tmp.join("main");
@@ -1167,7 +1155,7 @@ fn config_load_anchors_repo_id_override_to_main_when_main_omits_it() {
     // NOT honored for the shared identity (honoring it would make identity depend on
     // which worktree launched).
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("repoid-mainomit");
     let main = tmp.join("main");
@@ -1212,8 +1200,7 @@ fn config_load_anchors_repo_id_override_to_main_when_main_omits_it() {
 #[test]
 fn load_records_the_pre_anchor_root_for_a_linked_worktree() {
     let git = |dir: &Path, args: &[&str]| {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("reanchor");
     let main = tmp.join("main");
@@ -1290,7 +1277,7 @@ fn cpp_target_renders_h_in_its_default_globs_but_c_keeps_h_too() {
 #[test]
 fn anchor_root_preserves_subdir_and_redirects_linked_to_main() {
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("cfg");
     let main = tmp.join("main");
@@ -2832,7 +2819,7 @@ fn log_dir_defaults_to_db_sibling_and_custom_is_config_relative() {
 #[test]
 fn for_linked_worktree_overlay_falls_back_when_branch_config_is_missing_or_invalid() {
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("overlay-fallback");
     let main = tmp.join("main");
@@ -2875,7 +2862,7 @@ fn for_linked_worktree_overlay_falls_back_when_branch_config_is_missing_or_inval
 #[test]
 fn config_load_propagates_main_parse_error_from_linked_worktree() {
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("main-broken");
     let main = tmp.join("main");
@@ -2906,7 +2893,7 @@ fn config_load_propagates_main_parse_error_from_linked_worktree() {
 #[test]
 fn config_load_rejects_reserved_papertrail_table_from_governing_main() {
     let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        crate::test_git::run(dir, args);
     };
     let tmp = scratch("main-papertrail");
     let main = tmp.join("main");

--- a/crates/rag-rat-base/src/lib.rs
+++ b/crates/rag-rat-base/src/lib.rs
@@ -19,6 +19,7 @@ pub mod repo_identity;
 pub mod serde_big_id;
 pub mod single_flight;
 pub mod stack;
+pub mod test_git;
 pub mod test_scratch;
 pub mod time;
 pub mod version;

--- a/crates/rag-rat-base/src/repo_identity.rs
+++ b/crates/rag-rat-base/src/repo_identity.rs
@@ -360,7 +360,6 @@ fn empty_repo_error(root: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
-    use std::process::Command;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
@@ -376,14 +375,11 @@ mod tests {
     }
 
     fn git(root: &Path, args: &[&str]) {
-        let out = Command::new("git").args(args).current_dir(root).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        crate::test_git::run(root, args);
     }
 
     fn git_out(root: &Path, args: &[&str]) -> String {
-        let out = Command::new("git").args(args).current_dir(root).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
-        String::from_utf8(out.stdout).unwrap().trim().to_string()
+        crate::test_git::output(root, args)
     }
 
     fn init_repo(root: &Path) {

--- a/crates/rag-rat-base/src/test_git.rs
+++ b/crates/rag-rat-base/src/test_git.rs
@@ -1,0 +1,116 @@
+//! Shared, environment-isolated `git` invocation for the workspace's test fixtures (#970).
+//!
+//! Test fixtures shell out to `git` to build throwaway repos. A helper that runs with the AMBIENT
+//! environment inherits whatever git configuration the developer or CI runner happens to have —
+//! `core.hooksPath` (a hostile global hook fails every fixture commit), `commit.gpgsign`,
+//! `init.defaultBranch` (fixture branch names drift between machines), `core.autocrlf` (GitHub's
+//! windows-latest runner rewrites LF fixtures as CRLF, changing content sha256), `user.*`, and
+//! templates. Tests then pass or fail depending on the machine rather than the code (#581).
+//!
+//! [`command`] pins the entire class at one seam, so a new fixture cannot reintroduce it:
+//!   * `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` are `/dev/null` — no user/system gitconfig leaks
+//!     in at all (hooks, signing, aliases, templates);
+//!   * `HOME` is pinned to the fixture directory, so nothing (credential helpers, global ignore)
+//!     resolves to the developer's real home;
+//!   * the author/committer identity is pinned (fixtures must not depend on `git config user.*`
+//!     calls, and commit identity stays deterministic across machines);
+//!   * command-scope config (`GIT_CONFIG_COUNT`) pins `init.defaultBranch = main` and
+//!     `core.autocrlf = false`, so a plain `git init` and every checkout are byte-identical
+//!     everywhere. Command scope deliberately outranks repo-local config.
+//!
+//! Not `#[cfg(test)]`: that gate does not propagate across crates, and fixtures in sibling crates
+//! (`rag-rat-core`, `rag-rat-cli`, …) consume this helper. It is not part of the semver-stable
+//! API surface. Matches the [`crate::test_scratch`] convention. Production code that must honor
+//! the ambient environment (config discovery, eval replay) does NOT belong here.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// A `git` invocation in `dir` with the full fixture isolation applied (see module docs). Callers
+/// needing non-standard output handling or extra environment (e.g. pinned commit dates) chain
+/// onto the returned [`Command`].
+pub fn command(dir: &Path, args: &[&str]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "rag-rat-test")
+        .env("GIT_AUTHOR_EMAIL", "rag-rat-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "rag-rat-test")
+        .env("GIT_COMMITTER_EMAIL", "rag-rat-test@example.invalid")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("HOME", dir)
+        .env("GIT_CONFIG_COUNT", "2")
+        .env("GIT_CONFIG_KEY_0", "init.defaultBranch")
+        .env("GIT_CONFIG_VALUE_0", "main")
+        .env("GIT_CONFIG_KEY_1", "core.autocrlf")
+        .env("GIT_CONFIG_VALUE_1", "false");
+    cmd
+}
+
+/// Run `git` to completion, panicking with the captured stderr on failure.
+pub fn run(dir: &Path, args: &[&str]) -> Output {
+    let out = command(dir, args).output().unwrap();
+    assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+    out
+}
+
+/// Run `git` to completion, returning its trimmed stdout (panicking with stderr on failure).
+pub fn output(dir: &Path, args: &[&str]) -> String {
+    let out = run(dir, args);
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pinned environment: a fixture's branch name and config view never drift with the
+    /// developer's/CI's ambient git config (#970).
+    #[test]
+    fn fixtures_get_the_pinned_environment() {
+        let root = crate::test_scratch::ScratchDir::new("git-isolation");
+        run(&root, &["init", "-q"]);
+        // `init.defaultBranch` is pinned, so a plain `git init` lands on `main` everywhere.
+        assert_eq!(output(&root, &["branch", "--show-current"]), "main");
+        std::fs::write(root.join("f.txt"), "x\n").unwrap();
+        run(&root, &["add", "."]);
+        run(&root, &["commit", "-q", "-m", "seed"]);
+        // No hooks configuration is visible to fixture git, so a hostile global `core.hooksPath`
+        // cannot fire inside a fixture.
+        let hooks = command(&root, &["config", "core.hooksPath"]).output().unwrap();
+        assert!(!hooks.status.success(), "no core.hooksPath is visible to fixture git");
+    }
+
+    /// Guard the guard: the ambient failure this isolates against (#581's repro) really happens
+    /// WITHOUT the helper, so the isolation can never silently degrade to a no-op.
+    #[test]
+    fn the_ambient_failure_mode_is_real() {
+        let root = crate::test_scratch::ScratchDir::new("git-isolation-repro");
+        let hooks = root.join("hooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+        let pre_commit = hooks.join("pre-commit");
+        std::fs::write(&pre_commit, "#!/bin/sh\nexit 1\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&pre_commit, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        std::fs::write(
+            root.join("gitconfig"),
+            format!("[core]\nhooksPath = {}\n", hooks.display()),
+        )
+        .unwrap();
+        run(&root, &["init", "-q"]);
+        std::fs::write(root.join("f.txt"), "x\n").unwrap();
+        run(&root, &["add", "."]);
+        let out = Command::new("git")
+            .current_dir(root.path())
+            .args(["commit", "-q", "-m", "seed"])
+            .env("GIT_CONFIG_GLOBAL", root.join("gitconfig"))
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "the hostile global hook must fire without isolation");
+    }
+}

--- a/crates/rag-rat-base/src/test_git.rs
+++ b/crates/rag-rat-base/src/test_git.rs
@@ -47,6 +47,14 @@ pub fn command(dir: &Path, args: &[&str]) -> Command {
         .env_remove("GIT_NAMESPACE")
         .env_remove("GIT_CONFIG")
         .env_remove("GIT_CONFIG_PARAMETERS")
+        .env_remove("GIT_CONFIG_COUNT")
+        // `GIT_TEMPLATE_DIR` would copy template hooks into every fixture `git init` (local hooks
+        // bypass config isolation entirely), and inherited `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`
+        // leak into fixture commits (an invalid value fails the commit outright) — callers like
+        // the CLI's `git_commit` pin their own dates afterwards.
+        .env_remove("GIT_TEMPLATE_DIR")
+        .env_remove("GIT_AUTHOR_DATE")
+        .env_remove("GIT_COMMITTER_DATE")
         .env("GIT_AUTHOR_NAME", "rag-rat-test")
         .env("GIT_AUTHOR_EMAIL", "rag-rat-test@example.invalid")
         .env("GIT_COMMITTER_NAME", "rag-rat-test")
@@ -97,14 +105,19 @@ mod tests {
     }
 
     /// Guard the guard: the ambient failure this isolates against (#581's repro) really happens
-    /// WITHOUT the helper, so the isolation can never silently degrade to a no-op.
+    /// WITHOUT the helper, so the isolation can never silently degrade to a no-op. The hook
+    /// writes a marker file, so the assertion proves the hook RAN (a bare `exit 1` could be
+    /// masked by an earlier failure such as a missing identity), and an identity is pinned so the
+    /// commit can only fail because of the hook.
     #[test]
     fn the_ambient_failure_mode_is_real() {
         let root = crate::test_scratch::ScratchDir::new("git-isolation-repro");
         let hooks = root.join("hooks");
         std::fs::create_dir_all(&hooks).unwrap();
+        let marker = root.join("hook-ran.marker");
         let pre_commit = hooks.join("pre-commit");
-        std::fs::write(&pre_commit, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::write(&pre_commit, format!("#!/bin/sh\ntouch '{}'\nexit 1\n", marker.display()))
+            .unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -121,6 +134,11 @@ mod tests {
         let out = Command::new("git")
             .current_dir(root.path())
             .args(["commit", "-q", "-m", "seed"])
+            // The identity is pinned, so the commit cannot fail early for a missing `user.*`.
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@e")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@e")
             .env("GIT_CONFIG_GLOBAL", root.join("gitconfig"))
             .env("GIT_CONFIG_NOSYSTEM", "1")
             // The repro pins the hostile GLOBAL file, but ambient command-scope config
@@ -136,6 +154,16 @@ mod tests {
             .env_remove("GIT_COMMON_DIR")
             .output()
             .unwrap();
-        assert!(!out.status.success(), "the hostile global hook must fire without isolation");
+        assert!(!out.status.success(), "the hostile global hook must fail the commit");
+        assert!(
+            marker.exists(),
+            "the pinned hook really RAN — without the marker a non-success could be masked by an \
+             unrelated failure",
+        );
+
+        // The same fixture repo, through the isolated helper: the hook never fires.
+        std::fs::remove_file(&marker).unwrap();
+        run(&root, &["commit", "-q", "-m", "second"]);
+        assert!(!marker.exists(), "the isolated helper let the hostile hook fire");
     }
 }

--- a/crates/rag-rat-base/src/test_git.rs
+++ b/crates/rag-rat-base/src/test_git.rs
@@ -123,6 +123,17 @@ mod tests {
             .args(["commit", "-q", "-m", "seed"])
             .env("GIT_CONFIG_GLOBAL", root.join("gitconfig"))
             .env("GIT_CONFIG_NOSYSTEM", "1")
+            // The repro pins the hostile GLOBAL file, but ambient command-scope config
+            // (`GIT_CONFIG_COUNT`/`GIT_CONFIG_PARAMETERS`/`GIT_CONFIG`) outranks it and could
+            // silence — or mis-trigger — the hook; routing vars get the same scrub so the repro
+            // always measures exactly the pinned file.
+            .env_remove("GIT_CONFIG")
+            .env_remove("GIT_CONFIG_PARAMETERS")
+            .env_remove("GIT_CONFIG_COUNT")
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
             .output()
             .unwrap();
         assert!(!out.status.success(), "the hostile global hook must fire without isolation");

--- a/crates/rag-rat-base/src/test_git.rs
+++ b/crates/rag-rat-base/src/test_git.rs
@@ -33,6 +33,20 @@ pub fn command(dir: &Path, args: &[&str]) -> Command {
     let mut cmd = Command::new("git");
     cmd.current_dir(dir)
         .args(args)
+        // Repository-routing variables are removed outright: an exported `GIT_DIR` /
+        // `GIT_WORK_TREE` / `GIT_INDEX_FILE` (a worktree shell, an IDE, a hook context) beats
+        // `current_dir` and would operate the fixture on an UNRELATED repository (#219's exact
+        // hijack shape), and `GIT_CONFIG` / `GIT_CONFIG_PARAMETERS` are inline-config vectors
+        // that could smuggle a hostile `hooksPath` past the `/dev/null` files below.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_NAMESPACE")
+        .env_remove("GIT_CONFIG")
+        .env_remove("GIT_CONFIG_PARAMETERS")
         .env("GIT_AUTHOR_NAME", "rag-rat-test")
         .env("GIT_AUTHOR_EMAIL", "rag-rat-test@example.invalid")
         .env("GIT_COMMITTER_NAME", "rag-rat-test")

--- a/crates/rag-rat-base/src/test_git.rs
+++ b/crates/rag-rat-base/src/test_git.rs
@@ -152,6 +152,11 @@ mod tests {
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
             .env_remove("GIT_COMMON_DIR")
+            // An inherited invalid `GIT_*_DATE` would fail the commit BEFORE the hook runs, and a
+            // template could plant a second hook — the repro must measure only the pinned file.
+            .env_remove("GIT_TEMPLATE_DIR")
+            .env_remove("GIT_AUTHOR_DATE")
+            .env_remove("GIT_COMMITTER_DATE")
             .output()
             .unwrap();
         assert!(!out.status.success(), "the hostile global hook must fail the commit");

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -835,7 +835,7 @@ mod tests {
         // worktree's branch overlay. Without it, a commit/checkout/merge in a linked worktree
         // indexes the base `config.root` but leaves the worktree overlay stale.
         let git = |dir: &std::path::Path, args: &[&str]| {
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+            rag_rat_base::test_git::run(dir, args);
         };
         let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-overlay");
         let main = root.join("main");
@@ -913,7 +913,7 @@ mod tests {
         // embedder needed — with zero embeddings every chunk is `missing`, so `missing`
         // tracks the scoped chunk count.)
         let git = |dir: &std::path::Path, args: &[&str]| {
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+            rag_rat_base::test_git::run(dir, args);
         };
         let root = rag_rat_base::test_scratch::ScratchDir::new("cli-scope360");
         let main = root.join("main");
@@ -989,7 +989,7 @@ mod tests {
     #[test]
     fn maintenance_pass_owns_the_wal_checkpoint() {
         let git = |dir: &std::path::Path, args: &[&str]| {
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+            rag_rat_base::test_git::run(dir, args);
         };
         let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-wal");
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -1056,7 +1056,7 @@ mod tests {
         // and the approximate ones (skipped, the retryable/waiting split) + expensive per-chunk
         // breakdowns are ABSENT — those need `reconcile --plan`.
         let git = |dir: &std::path::Path, args: &[&str]| {
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+            rag_rat_base::test_git::run(dir, args);
         };
         let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-backlog");
         std::fs::create_dir_all(root.join("src")).unwrap();

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -397,15 +397,7 @@ mod tests {
     use super::*;
 
     fn git(root: &Path, args: &[&str]) {
-        let status = std::process::Command::new("git")
-            .arg("-C")
-            .arg(root)
-            .args(args)
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .status()
-            .unwrap();
-        assert!(status.success(), "git {args:?} failed");
+        rag_rat_base::test_git::run(root, args);
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -404,13 +404,7 @@ mod tests {
             &["add", "-A"],
             &["commit", "-qm", "seed"],
         ] {
-            let out = std::process::Command::new("git")
-                .arg("-C")
-                .arg(&*root)
-                .args(args)
-                .output()
-                .unwrap();
-            assert!(out.status.success());
+            rag_rat_base::test_git::run(&root, args);
         }
         let plan = InitPlan {
             root_value: ".".to_string(),

--- a/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
@@ -1249,58 +1249,51 @@ fn integration_combines_version_check_and_hooks() {
     assert!(!state.draft.hooks.git);
 }
 
-/// Scrub the repository-routing git env for the duration of `f` (serialized): `git_paths` is
-/// env-aware BY DESIGN (#213 — bare-dir + hook contexts), so an ambient `GIT_DIR`/`GIT_WORK_TREE`
-/// would resolve the fixture to an unrelated repo and fail the test depending on the machine
-/// (#970). Process-global mutation is serialized by the lock; restoring is manual (a panicking
-/// body keeps the scrub, which only hides the ambient vars from later tests in the same process).
-fn without_routing_env<T>(f: impl FnOnce() -> T) -> T {
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    const KEYS: [&str; 2] = ["GIT_DIR", "GIT_WORK_TREE"];
-    let _guard = LOCK.lock().unwrap();
-    let saved = KEYS.map(std::env::var_os);
-    // SAFETY: process-global env mutation, serialized by LOCK (nextest also isolates each test in
-    // its own process).
-    unsafe {
-        for key in KEYS {
-            std::env::remove_var(key);
-        }
-    }
-    let out = f();
-    // SAFETY: same as above.
-    unsafe {
-        for (key, value) in KEYS.into_iter().zip(saved) {
-            match value {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
-            }
-        }
-    }
-    out
-}
-
 #[test]
 fn integration_blocks_unresolved_foreign_hook_conflicts() {
+    // `validate_hooks` resolves the repo through the env-aware `git_paths` (#213), so an ambient
+    // `GIT_DIR`/`GIT_WORK_TREE` (or a global `core.hooksPath`) would make this test
+    // machine-dependent (#970) — and seeding through the same env-aware path would write the
+    // fixture hook into an UNRELATED repo. Re-exec this test with a scrubbed environment instead
+    // of mutating the process-wide one.
+    if std::env::var_os("RAG_RAT_TEST_GIT_ENV_SCRUBBED").is_none() {
+        let home = rag_rat_base::test_scratch::ScratchDir::new("wizard-hooks-home");
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "init::wizard::steps::tests::integration_blocks_unresolved_foreign_hook_conflicts",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("RAG_RAT_TEST_GIT_ENV_SCRUBBED", "1")
+            .env("HOME", home.path())
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_CONFIG_GLOBAL")
+            .env_remove("GIT_CONFIG_SYSTEM")
+            .status()
+            .unwrap();
+        assert!(status.success(), "scrubbed re-exec failed");
+        return;
+    }
     let dir = tempfile::tempdir().unwrap();
     rag_rat_base::test_git::run(dir.path(), &["init", "-q"]);
-    without_routing_env(|| {
-        let gp = git_paths(dir.path()).unwrap();
-        std::fs::create_dir_all(&gp.hooks_dir).unwrap();
-        let hook = MANAGED_HOOKS[0];
-        std::fs::write(gp.hooks_dir.join(hook), "#!/bin/sh\necho custom\n").unwrap();
-        let scan = scan_repo(dir.path()).unwrap();
-        let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
-        draft.hooks.git = true;
-        let mut state = WizardState::new(draft, scan);
+    let gp = git_paths(dir.path()).unwrap();
+    std::fs::create_dir_all(&gp.hooks_dir).unwrap();
+    let hook = MANAGED_HOOKS[0];
+    std::fs::write(gp.hooks_dir.join(hook), "#!/bin/sh\necho custom\n").unwrap();
+    let scan = scan_repo(dir.path()).unwrap();
+    let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+    draft.hooks.git = true;
+    let mut state = WizardState::new(draft, scan);
 
-        let unresolved = validate_hooks(&state);
-        state.hook_conflicts.insert(hook, hooks::HookConflict::Skip);
-        let resolved = validate_hooks(&state);
+    let unresolved = validate_hooks(&state);
+    state.hook_conflicts.insert(hook, hooks::HookConflict::Skip);
+    let resolved = validate_hooks(&state);
 
-        assert_eq!(unresolved.severity, Sev::Block);
-        assert!(unresolved.message.unwrap().contains(hook));
-        assert_eq!(resolved.severity, Sev::Ok);
-    });
+    assert_eq!(unresolved.severity, Sev::Block);
+    assert!(unresolved.message.unwrap().contains(hook));
+    assert_eq!(resolved.severity, Sev::Ok);
 }
 
 #[test]

--- a/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
@@ -1249,26 +1249,58 @@ fn integration_combines_version_check_and_hooks() {
     assert!(!state.draft.hooks.git);
 }
 
+/// Scrub the repository-routing git env for the duration of `f` (serialized): `git_paths` is
+/// env-aware BY DESIGN (#213 — bare-dir + hook contexts), so an ambient `GIT_DIR`/`GIT_WORK_TREE`
+/// would resolve the fixture to an unrelated repo and fail the test depending on the machine
+/// (#970). Process-global mutation is serialized by the lock; restoring is manual (a panicking
+/// body keeps the scrub, which only hides the ambient vars from later tests in the same process).
+fn without_routing_env<T>(f: impl FnOnce() -> T) -> T {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    const KEYS: [&str; 2] = ["GIT_DIR", "GIT_WORK_TREE"];
+    let _guard = LOCK.lock().unwrap();
+    let saved = KEYS.map(std::env::var_os);
+    // SAFETY: process-global env mutation, serialized by LOCK (nextest also isolates each test in
+    // its own process).
+    unsafe {
+        for key in KEYS {
+            std::env::remove_var(key);
+        }
+    }
+    let out = f();
+    // SAFETY: same as above.
+    unsafe {
+        for (key, value) in KEYS.into_iter().zip(saved) {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+    out
+}
+
 #[test]
 fn integration_blocks_unresolved_foreign_hook_conflicts() {
     let dir = tempfile::tempdir().unwrap();
     rag_rat_base::test_git::run(dir.path(), &["init", "-q"]);
-    let gp = git_paths(dir.path()).unwrap();
-    std::fs::create_dir_all(&gp.hooks_dir).unwrap();
-    let hook = MANAGED_HOOKS[0];
-    std::fs::write(gp.hooks_dir.join(hook), "#!/bin/sh\necho custom\n").unwrap();
-    let scan = scan_repo(dir.path()).unwrap();
-    let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
-    draft.hooks.git = true;
-    let mut state = WizardState::new(draft, scan);
+    without_routing_env(|| {
+        let gp = git_paths(dir.path()).unwrap();
+        std::fs::create_dir_all(&gp.hooks_dir).unwrap();
+        let hook = MANAGED_HOOKS[0];
+        std::fs::write(gp.hooks_dir.join(hook), "#!/bin/sh\necho custom\n").unwrap();
+        let scan = scan_repo(dir.path()).unwrap();
+        let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+        draft.hooks.git = true;
+        let mut state = WizardState::new(draft, scan);
 
-    let unresolved = validate_hooks(&state);
-    state.hook_conflicts.insert(hook, hooks::HookConflict::Skip);
-    let resolved = validate_hooks(&state);
+        let unresolved = validate_hooks(&state);
+        state.hook_conflicts.insert(hook, hooks::HookConflict::Skip);
+        let resolved = validate_hooks(&state);
 
-    assert_eq!(unresolved.severity, Sev::Block);
-    assert!(unresolved.message.unwrap().contains(hook));
-    assert_eq!(resolved.severity, Sev::Ok);
+        assert_eq!(unresolved.severity, Sev::Block);
+        assert!(unresolved.message.unwrap().contains(hook));
+        assert_eq!(resolved.severity, Sev::Ok);
+    });
 }
 
 #[test]

--- a/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
@@ -1252,12 +1252,7 @@ fn integration_combines_version_check_and_hooks() {
 #[test]
 fn integration_blocks_unresolved_foreign_hook_conflicts() {
     let dir = tempfile::tempdir().unwrap();
-    let status = std::process::Command::new("git")
-        .arg("init")
-        .arg(dir.path())
-        .status()
-        .expect("git init should run");
-    assert!(status.success());
+    rag_rat_base::test_git::run(dir.path(), &["init", "-q"]);
     let gp = git_paths(dir.path()).unwrap();
     std::fs::create_dir_all(&gp.hooks_dir).unwrap();
     let hook = MANAGED_HOOKS[0];

--- a/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
@@ -1266,11 +1266,18 @@ fn integration_blocks_unresolved_foreign_hook_conflicts() {
             ])
             .env("RAG_RAT_TEST_GIT_ENV_SCRUBBED", "1")
             .env("HOME", home.path())
+            // `/dev/null` config files (not merely removing the overrides, which would restore
+            // the machine's real system/global config), and no inline-config vectors: any of
+            // `GIT_CONFIG`/`GIT_CONFIG_PARAMETERS`/`GIT_CONFIG_COUNT` could still smuggle a
+            // `core.hooksPath` into the child's `git_paths` resolution.
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
             .env_remove("GIT_DIR")
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
-            .env_remove("GIT_CONFIG_GLOBAL")
-            .env_remove("GIT_CONFIG_SYSTEM")
+            .env_remove("GIT_CONFIG")
+            .env_remove("GIT_CONFIG_PARAMETERS")
+            .env_remove("GIT_CONFIG_COUNT")
             .status()
             .unwrap();
         assert!(status.success(), "scrubbed re-exec failed");

--- a/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
@@ -1275,6 +1275,7 @@ fn integration_blocks_unresolved_foreign_hook_conflicts() {
             .env_remove("GIT_DIR")
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
             .env_remove("GIT_CONFIG")
             .env_remove("GIT_CONFIG_PARAMETERS")
             .env_remove("GIT_CONFIG_COUNT")

--- a/crates/rag-rat-cli/tests/common/mod.rs
+++ b/crates/rag-rat-cli/tests/common/mod.rs
@@ -15,7 +15,6 @@
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// 2021-01-01T00:00:00Z — a fixed, wall-clock-independent anchor for fixture commit dates.
@@ -88,8 +87,7 @@ pub fn toml_path(path: &Path) -> String {
 /// deterministic, unique date (a plain `git(dir, &["commit", ...])` would commit on the wall clock
 /// and could collide on `repo_id`).
 pub fn git(dir: &Path, args: &[&str]) {
-    let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-    assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+    rag_rat_base::test_git::run(dir, args);
 }
 
 /// `git commit` with `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` pinned to a fixed base epoch plus a
@@ -98,10 +96,7 @@ pub fn git(dir: &Path, args: &[&str]) {
 /// are the commit flags/message, e.g. `&["-q", "-m", "seed"]`.
 pub fn git_commit(dir: &Path, args: &[&str]) {
     let date = format!("@{} +0000", FIXTURE_EPOCH_BASE + next_seq());
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .arg("commit")
+    let out = rag_rat_base::test_git::command(dir, &["commit"])
         .args(args)
         .env("GIT_AUTHOR_DATE", &date)
         .env("GIT_COMMITTER_DATE", &date)

--- a/crates/rag-rat-cli/tests/index_guards.rs
+++ b/crates/rag-rat-cli/tests/index_guards.rs
@@ -80,11 +80,7 @@ fn index_warns_when_a_clone_joins_an_indexed_repo() {
 
     // Clone B (same root commit → same portable identity) pointed at the SAME database.
     let b = tmp.join("B");
-    let cloned = Command::new("git")
-        .args(["clone", "-q", a.to_str().unwrap(), b.to_str().unwrap()])
-        .status()
-        .unwrap();
-    assert!(cloned.success(), "git clone A B failed");
+    rag_rat_base::test_git::run(&a, &["clone", "-q", a.to_str().unwrap(), b.to_str().unwrap()]);
     std::fs::write(b.join("rag-rat.toml"), shared_config(&shared)).unwrap();
 
     let out = run_index(&b.join("rag-rat.toml"), &b);
@@ -116,18 +112,15 @@ fn index_warns_when_root_names_a_linked_worktree() {
 
     // A linked worktree with a local config whose root="." resolves to the worktree.
     let wt = tmp.join("wt");
-    let added = Command::new("git")
-        .args([
-            "-C",
-            main.to_str().unwrap(),
-            "worktree",
-            "add",
-            "--detach",
-            "-q",
-            wt.to_str().unwrap(),
-        ])
-        .status()
-        .unwrap();
+    let added = rag_rat_base::test_git::command(&main, &[
+        "worktree",
+        "add",
+        "--detach",
+        "-q",
+        wt.to_str().unwrap(),
+    ])
+    .status()
+    .unwrap();
     assert!(added.success(), "git worktree add failed");
     std::fs::create_dir_all(wt.join("src")).unwrap();
     std::fs::write(wt.join("rag-rat.toml"), shared_config(&shared)).unwrap();
@@ -202,7 +195,7 @@ fn full_rebuild_prunes_an_existing_placeholder_index_instead_of_refusing() {
 
     // Give the root a git identity the DB has NOT adopted, then delete all target files.
     let git = |args: &[&str]| {
-        Command::new("git").arg("-C").arg(repo).args(args).output().unwrap();
+        rag_rat_base::test_git::run(repo, args);
     };
     git(&["init", "-q"]);
     git(&["config", "user.email", "t@example.com"]);
@@ -256,7 +249,7 @@ fn index_discover_refuses_a_first_time_empty_repo_against_an_existing_db() {
     std::fs::create_dir_all(b.join("src")).unwrap();
     std::fs::write(b.join("src/b.rs"), "fn b() {}\n").unwrap();
     let git_b = |args: &[&str]| {
-        Command::new("git").arg("-C").arg(&b).args(args).output().unwrap();
+        rag_rat_base::test_git::run(&b, args);
     };
     git_b(&["init", "-q"]);
     git_b(&["config", "user.email", "t@example.com"]);
@@ -418,7 +411,7 @@ fn git_available() -> bool {
 
 fn git_init_commit(dir: &Path) {
     let git = |args: &[&str]| {
-        Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+        rag_rat_base::test_git::run(dir, args);
     };
     git(&["init", "-q"]);
     git(&["config", "user.email", "t@example.com"]);

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -70,6 +70,11 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
         // (#970): a hostile ambient `core.hooksPath` must not reach the fixture's hook install.
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        // Routing vars are scrubbed too: production discovery honors GIT_DIR/GIT_WORK_TREE
+        // (#213 bare-dir/hook contexts), which would re-point the fixture at an unrelated repo.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
         .output()
         .expect("run rag-rat init --yes");
 
@@ -153,6 +158,9 @@ fn init_in_a_new_repo_leaves_an_existing_repos_heal_owed_meta() {
             .env("XDG_CACHE_HOME", &cache)
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap()
     };

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -75,6 +75,10 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_CONFIG")
+        .env_remove("GIT_CONFIG_PARAMETERS")
+        .env_remove("GIT_CONFIG_COUNT")
         .output()
         .expect("run rag-rat init --yes");
 
@@ -161,6 +165,10 @@ fn init_in_a_new_repo_leaves_an_existing_repos_heal_owed_meta() {
             .env_remove("GIT_DIR")
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_COMMON_DIR")
+            .env_remove("GIT_CONFIG")
+            .env_remove("GIT_CONFIG_PARAMETERS")
+            .env_remove("GIT_CONFIG_COUNT")
             .output()
             .unwrap()
     };

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -65,6 +65,11 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
         .env("RAG_RAT_DATA_DIR", &data_dir)
         .env("HOME", &*root)
         .env("XDG_CACHE_HOME", &cache)
+        // The production subprocess honors the ambient git config (it must — hook install is a
+        // real user-facing path), so the harness isolates it to keep the test machine-independent
+        // (#970): a hostile ambient `core.hooksPath` must not reach the fixture's hook install.
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .output()
         .expect("run rag-rat init --yes");
 
@@ -146,6 +151,8 @@ fn init_in_a_new_repo_leaves_an_existing_repos_heal_owed_meta() {
             .env("RAG_RAT_DATA_DIR", &data_dir)
             .env("HOME", &*base)
             .env("XDG_CACHE_HOME", &cache)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
             .output()
             .unwrap()
     };
@@ -243,14 +250,13 @@ fn init_refuses_to_run_in_a_linked_worktree() {
     git_init(&root);
 
     let linked = common::unique_dir("init-yes-linked");
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(&*root)
-        .args(["worktree", "add", "--detach", "-q"])
-        .arg(&*linked)
-        .output()
-        .unwrap();
-    assert!(out.status.success(), "worktree add: {}", String::from_utf8_lossy(&out.stderr));
+    rag_rat_base::test_git::run(&root, &[
+        "worktree",
+        "add",
+        "--detach",
+        "-q",
+        linked.to_str().unwrap(),
+    ]);
 
     let output = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
         .args(["init", "-y"])

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -367,13 +367,7 @@ fn identical_content_fixtures_get_distinct_repo_ids() {
     let repo_b = keyless_repo("c0-b", &files);
 
     let root_commit = |root: &Path| -> String {
-        let out = Command::new("git")
-            .arg("-C")
-            .arg(root)
-            .args(["rev-list", "--max-parents=0", "HEAD"])
-            .output()
-            .unwrap();
-        String::from_utf8(out.stdout).unwrap().trim().to_string()
+        rag_rat_base::test_git::output(root, &["rev-list", "--max-parents=0", "HEAD"])
     };
     assert_ne!(
         root_commit(&repo_a),

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -2261,9 +2261,7 @@ mod tests {
         let root = rag_rat_base::test_scratch::ScratchDir::new("distill-merge");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let git = |args: &[&str]| {
-            let status =
-                std::process::Command::new("git").current_dir(&root).args(args).status().unwrap();
-            assert!(status.success(), "git {args:?} failed");
+            rag_rat_base::test_git::run(&root, args);
         };
         git(&["init", "-q"]);
         git(&["config", "user.name", "Rag Rat"]);
@@ -2278,12 +2276,7 @@ mod tests {
         git(&["checkout", "-q", "-"]);
         // `--no-ff` forces a real merge commit (a fast-forward would carry no merge node).
         git(&["merge", "--no-ff", "-q", "-m", "Merge feature", "feature"]);
-        let out = std::process::Command::new("git")
-            .current_dir(&root)
-            .args(["rev-parse", "HEAD"])
-            .output()
-            .unwrap();
-        let merge_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+        let merge_sha = rag_rat_base::test_git::output(&root, &["rev-parse", "HEAD"]);
         (root, merge_sha, "src/widget.rs".to_string())
     }
 
@@ -2484,18 +2477,14 @@ mod tests {
         let (root, merge_sha, path) = build_merge_repo();
         // `git clone` into the guard's fresh, empty directory.
         let shallow = rag_rat_base::test_scratch::ScratchDir::new("distill-shallow");
-        let status = std::process::Command::new("git")
-            .args([
-                "clone",
-                "-q",
-                "--depth",
-                "1",
-                &format!("file://{}", root.display()),
-                shallow.to_str().unwrap(),
-            ])
-            .status()
-            .unwrap();
-        assert!(status.success(), "shallow clone failed");
+        rag_rat_base::test_git::run(&root, &[
+            "clone",
+            "-q",
+            "--depth",
+            "1",
+            &format!("file://{}", root.display()),
+            shallow.to_str().unwrap(),
+        ]);
 
         let conn = scoped_conn("repoA");
         seed_item(
@@ -2526,9 +2515,7 @@ mod tests {
         let root = rag_rat_base::test_scratch::ScratchDir::new("distill-big");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let git = |args: &[&str]| {
-            let status =
-                std::process::Command::new("git").current_dir(&root).args(args).status().unwrap();
-            assert!(status.success(), "git {args:?} failed");
+            rag_rat_base::test_git::run(&root, args);
         };
         git(&["init", "-q"]);
         git(&["config", "user.name", "Rag Rat"]);
@@ -2540,12 +2527,7 @@ mod tests {
         std::fs::write(root.join("src/big.rs"), "x".repeat(1_200_000)).unwrap();
         git(&["add", "."]);
         git(&["commit", "-q", "-m", "fix: widget and a giant file"]);
-        let out = std::process::Command::new("git")
-            .current_dir(&root)
-            .args(["rev-parse", "HEAD"])
-            .output()
-            .unwrap();
-        let fix_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+        let fix_sha = rag_rat_base::test_git::output(&root, &["rev-parse", "HEAD"]);
         (root, fix_sha)
     }
 
@@ -2759,9 +2741,7 @@ mod tests {
         let root = rag_rat_base::test_scratch::ScratchDir::new("distill-del");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let git = |args: &[&str]| {
-            let status =
-                std::process::Command::new("git").current_dir(&root).args(args).status().unwrap();
-            assert!(status.success(), "git {args:?} failed");
+            rag_rat_base::test_git::run(&root, args);
         };
         git(&["init", "-q"]);
         git(&["config", "user.name", "Rag Rat"]);
@@ -2772,12 +2752,7 @@ mod tests {
         std::fs::remove_file(root.join("src/gone.rs")).unwrap();
         git(&["add", "-A"]);
         git(&["commit", "-q", "-m", "fix: remove gone"]);
-        let out = std::process::Command::new("git")
-            .current_dir(&root)
-            .args(["rev-parse", "HEAD"])
-            .output()
-            .unwrap();
-        let fix_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+        let fix_sha = rag_rat_base::test_git::output(&root, &["rev-parse", "HEAD"]);
         (root, fix_sha, "src/gone.rs".to_string())
     }
 

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -246,24 +246,10 @@ mod tests {
     // Run a git command in `root`, panicking on failure — models
     // `query_api::oracle_surfacing_tests::git`, private to that module and not reachable here.
     fn git(root: &std::path::Path, args: &[&str]) {
-        let status = std::process::Command::new("git")
-            .args(args)
-            .current_dir(root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@t")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@t")
-            // Isolate from the ambient environment (#581): no user/system gitconfig leaks in
-            // (a hostile global `core.hooksPath` fails every commit here), and HOME is pinned
-            // to the temp root so nothing resolves to the developer's/CI runner's real home.
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .env("HOME", root)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .unwrap();
-        assert!(status.success(), "git {args:?} failed");
+        // The shared seam keeps the #581 isolation (no ambient gitconfig, pinned HOME and
+        // identity) and adds repository-routing isolation (an exported `GIT_DIR`/`GIT_WORK_TREE`
+        // can never re-point a fixture at an external repo).
+        rag_rat_base::test_git::run(root, args);
     }
 
     /// A clone sharing a checkout's portable (root-commit-derived) identity, pointed at the SAME

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -257,21 +257,11 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
 
 #[cfg(test)]
 mod worktree_scope_tests {
-    use std::process::Command;
 
     use super::*;
 
     fn git(dir: &Path, args: &[&str]) {
-        let out = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@e")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@e")
-            .output()
-            .unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        rag_rat_base::test_git::run(dir, args);
     }
 
     /// An owned scratch dir (removed on drop) plus its canonical path, which is what the git

--- a/crates/rag-rat-core/src/index/git_history/tests.rs
+++ b/crates/rag-rat-core/src/index/git_history/tests.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::process::Command;
 
 use super::apply::current_history_cursors_at_or_after_prepared;
 use super::read::read_history_excluding;
@@ -10,14 +9,11 @@ fn temp_root(label: &str) -> rag_rat_base::test_scratch::ScratchDir {
 }
 
 fn run_git(root: &Path, args: &[&str]) {
-    let status = Command::new("git").current_dir(root).args(args).status().unwrap();
-    assert!(status.success(), "git {args:?} failed");
+    rag_rat_base::test_git::run(root, args);
 }
 
 fn git_output(root: &Path, args: &[&str]) -> String {
-    let output = Command::new("git").current_dir(root).args(args).output().unwrap();
-    assert!(output.status.success(), "git {args:?} failed");
-    String::from_utf8(output.stdout).unwrap().trim().to_string()
+    rag_rat_base::test_git::output(root, args)
 }
 
 fn insert_commit_row(conn: &Connection, repo_id: &str, hash: &str) {

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -431,13 +431,7 @@ mod tests {
     /// Initialize a real (empty) Git repo at `dir` so worktree-root resolution returns `dir`. Used
     /// by the ancestor-chain test; the others don't need git (base falls back to `root`).
     fn git_init(dir: &Path) {
-        let ok = std::process::Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(dir)
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        assert!(ok, "git init failed (git must be on PATH for this test)");
+        rag_rat_base::test_git::run(dir, &["init", "-q"]);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail_autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail_autosync.rs
@@ -650,13 +650,7 @@ mod tests {
     fn temp_git_repo(tag: &str) -> rag_rat_base::test_scratch::ScratchDir {
         let root = rag_rat_base::test_scratch::ScratchDir::new(tag);
         let git = |args: &[&str]| {
-            let out = std::process::Command::new("git")
-                .arg("-C")
-                .arg(&*root)
-                .args(args)
-                .output()
-                .unwrap();
-            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+            rag_rat_base::test_git::run(&root, args);
         };
         git(&["init", "-q"]);
         git(&[

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -826,18 +826,7 @@ fn oracle_run_without_tool_is_blocked_not_error() {
 /// so `resolve_git_context` returns a non-empty `commit_sha` AND `worktree_id` (the active
 /// context every other e2e test misses by running in a non-git temp dir).
 fn git(root: &std::path::Path, args: &[&str]) {
-    let status = std::process::Command::new("git")
-        .args(args)
-        .current_dir(root)
-        .env("GIT_AUTHOR_NAME", "t")
-        .env("GIT_AUTHOR_EMAIL", "t@t")
-        .env("GIT_COMMITTER_NAME", "t")
-        .env("GIT_COMMITTER_EMAIL", "t@t")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .unwrap();
-    assert!(status.success(), "git {args:?} failed");
+    rag_rat_base::test_git::run(root, args);
 }
 
 /// Global (un-seeded) ranking — the common assertion shape: no explicit seed, no auto-diff.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
@@ -278,13 +278,7 @@ fn commit_fts_heals_even_while_chunk_staging_exists() {
     fs::write(root.join("src/lib.rs"), "pub fn staged_commit_witness() {}\n").unwrap();
     // commit_fts indexes git history — the corruption probe needs a non-empty mirror.
     let git = |args: &[&str]| {
-        let out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(root.as_os_str())
-            .args(args)
-            .output()
-            .unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        rag_rat_base::test_git::run(&root, args);
     };
     git(&["init", "-q"]);
     git(&["add", "-A"]);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -583,24 +583,11 @@ fn first_chunk_id(db: &IndexDatabase) -> i64 {
 /// defeats the HEAD-move carry (#502) sha match and corrupts the committed index db. `GIT_CONFIG_*`
 /// overrides global config without touching the user's config.
 fn git_command(root: &Path, args: &[&str]) -> Command {
-    let mut cmd = Command::new("git");
-    cmd.args(args)
-        .current_dir(root)
-        .env("GIT_CONFIG_COUNT", "1")
-        .env("GIT_CONFIG_KEY_0", "core.autocrlf")
-        .env("GIT_CONFIG_VALUE_0", "false");
-    cmd
+    rag_rat_base::test_git::command(root, args)
 }
 
 fn run_git(root: &Path, args: &[&str]) {
-    let output = git_command(root, args).output().unwrap();
-    assert!(
-        output.status.success(),
-        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
-        args,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    rag_rat_base::test_git::run(root, args);
 }
 
 fn run_git_with_env(root: &Path, args: &[&str], env: &[(&str, &str)]) {
@@ -609,9 +596,7 @@ fn run_git_with_env(root: &Path, args: &[&str], env: &[(&str, &str)]) {
 }
 
 fn git_output(root: &Path, args: &[&str]) -> String {
-    let output = git_command(root, args).output().unwrap();
-    assert!(output.status.success(), "git {:?} failed", args);
-    String::from_utf8(output.stdout).unwrap().trim().to_string()
+    rag_rat_base::test_git::output(root, args)
 }
 
 struct MockGitHubClient;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -1770,13 +1770,7 @@ fn real_git_repo(tag: &str) -> ScratchRoot {
 
 /// The full HEAD commit hash — a commit reachable from HEAD, used as a recorded shallow boundary.
 fn head_commit_hash(root: &Path) -> String {
-    let out = std::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(root)
-        .output()
-        .unwrap();
-    assert!(out.status.success(), "git rev-parse HEAD failed");
-    String::from_utf8(out.stdout).unwrap().trim().to_string()
+    rag_rat_base::test_git::output(root, &["rev-parse", "HEAD"])
 }
 
 /// PROOF gates the RE-POINT, not the registration (A7): a DB first indexed from a cut shallow clone

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -848,9 +848,7 @@ fn overlay_only_pass_skips_base_tail_but_still_validates_memories() {
     let _ = std::fs::remove_dir_all(&linked);
     std::fs::create_dir_all(main.join("src")).unwrap();
     let git = |dir: &Path, args: &[&str]| {
-        let status =
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).status().unwrap();
-        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+        rag_rat_base::test_git::run(dir, args);
     };
     git(&main, &["init", "-q"]);
     git(&main, &["config", "user.email", "t@e"]);
@@ -1302,9 +1300,7 @@ fn initial_watch_state_places_worktree_registry() {
     let _ = std::fs::remove_dir_all(&linked);
     std::fs::create_dir_all(main.join("src")).unwrap();
     let git = |dir: &Path, args: &[&str]| {
-        let status =
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).status().unwrap();
-        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+        rag_rat_base::test_git::run(dir, args);
     };
     git(&main, &["init", "-q"]);
     git(&main, &["config", "user.email", "t@e"]);
@@ -1903,7 +1899,6 @@ fn linked_worktree_target_ancestor_gitignore_is_compiled() {
 
 #[test]
 fn linked_subdir_root_watch_placement_keeps_checkout_root_when_config_root_missing() {
-    use std::process::Command;
     use std::sync::atomic::{AtomicU64, Ordering};
     static N: AtomicU64 = AtomicU64::new(0);
     let id = N.fetch_add(1, Ordering::Relaxed);
@@ -1921,8 +1916,7 @@ fn linked_subdir_root_watch_placement_keeps_checkout_root_when_config_root_missi
         vec!["add", "."],
         vec!["commit", "-q", "-m", "base"],
     ] {
-        let output = Command::new("git").args(&args).current_dir(&repo).output().unwrap();
-        assert!(output.status.success(), "git {args:?} failed: {output:?}");
+        rag_rat_base::test_git::run(&repo, &args);
     }
     std::fs::create_dir_all(checkout.join("packages")).unwrap();
     let checkout = checkout.canonicalize().unwrap();
@@ -2215,7 +2209,6 @@ fn event_touches_worktree_rebases_subdir_rooted_config() {
     // edit arrives as `<checkout>/crate/src/a.rs`. Stripping only the checkout root leaves
     // `crate/src/a.rs`, which `target_for_path` (config-root-relative, expecting `src/a.rs`)
     // rejects — so the subdir prefix must be stripped too.
-    use std::process::Command;
     use std::sync::atomic::{AtomicU64, Ordering};
     static N: AtomicU64 = AtomicU64::new(0);
     let id = N.fetch_add(1, Ordering::Relaxed);
@@ -2230,7 +2223,7 @@ fn event_touches_worktree_rebases_subdir_rooted_config() {
         vec!["add", "."],
         vec!["commit", "-q", "-m", "base"],
     ] {
-        Command::new("git").args(&args).current_dir(&repo).output().unwrap();
+        rag_rat_base::test_git::run(&repo, &args);
     }
     // `config.root` is the `crate` SUBDIR of the repo.
     let config_root = repo.join("crate").canonicalize().unwrap();
@@ -2418,13 +2411,7 @@ fn worktree_root_gitignore_edit_recompiles_for_subdir_config_root() {
     let wt = scratch_root(format!("ragrat-wtgi-{}-{id}", std::process::id()));
     std::fs::create_dir_all(wt.join("crates")).unwrap();
     let wt = wt.canonicalize().unwrap();
-    let ok = std::process::Command::new("git")
-        .args(["init", "-q"])
-        .current_dir(&wt)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    assert!(ok, "git init failed (git must be on PATH)");
+    rag_rat_base::test_git::run(&wt, &["init", "-q"]);
     std::fs::write(wt.join(".gitignore"), "").unwrap();
 
     let sub = wt.join("crates"); // config.root is the subdirectory.
@@ -3027,9 +3014,8 @@ fn worktree_watch_targets_excludes_the_main_checkout_for_a_subdir_config_root() 
     let id = N.fetch_add(1, Ordering::Relaxed);
     let main = scratch_root(format!("ragrat-wwt-{}-{id}", std::process::id()));
     std::fs::create_dir_all(main.join("crate/src")).unwrap();
-    let git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git").arg("-C").arg(dir).args(args).status().unwrap()
-    };
+    let git =
+        |dir: &Path, args: &[&str]| rag_rat_base::test_git::command(dir, args).status().unwrap();
     git(&main, &["init", "-q"]);
     git(&main, &["config", "user.email", "t@e"]);
     git(&main, &["config", "user.name", "t"]);
@@ -3086,13 +3072,7 @@ fn gitignore_watch_dirs_includes_worktree_root_for_subdir_config_root() {
     let wt = scratch_root(format!("ragrat-wdirs-{}-{id}", std::process::id()));
     std::fs::create_dir_all(wt.join("crates/app")).unwrap();
     let wt = wt.canonicalize().unwrap();
-    let ok = std::process::Command::new("git")
-        .args(["init", "-q"])
-        .current_dir(&wt)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    assert!(ok, "git init failed (git must be on PATH)");
+    rag_rat_base::test_git::run(&wt, &["init", "-q"]);
 
     let sub = wt.join("crates/app");
     let dirs = gitignore_watch_dirs(&sub);
@@ -3140,13 +3120,7 @@ fn root_gitignore_edit_is_delivered_to_a_real_watcher() {
     let wt = scratch_root(format!("ragrat-deliv-{}-{id}", std::process::id()));
     std::fs::create_dir_all(wt.join("crates")).unwrap();
     let wt = wt.canonicalize().unwrap();
-    let ok = std::process::Command::new("git")
-        .args(["init", "-q"])
-        .current_dir(&wt)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    assert!(ok, "git init failed (git must be on PATH)");
+    rag_rat_base::test_git::run(&wt, &["init", "-q"]);
     std::fs::write(wt.join(".gitignore"), "").unwrap();
 
     let sub = wt.join("crates"); // config.root is the subdirectory.
@@ -3199,9 +3173,7 @@ fn watcher_main_routes_gitignore_mutations_through_central_helpers() {
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(root.join("src")).unwrap();
     let git = |dir: &Path, args: &[&str]| {
-        let status =
-            std::process::Command::new("git").arg("-C").arg(dir).args(args).status().unwrap();
-        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+        rag_rat_base::test_git::run(dir, args);
     };
     git(&root, &["init", "-q"]);
     git(&root, &["config", "user.email", "t@e"]);

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1142,16 +1142,7 @@ fn unique_temp_root() -> rag_rat_base::test_scratch::ScratchDir {
 }
 
 fn git(root: &Path, args: &[&str]) {
-    let out = std::process::Command::new("git")
-        .args(args)
-        .current_dir(root)
-        .env("GIT_AUTHOR_NAME", "t")
-        .env("GIT_AUTHOR_EMAIL", "t@e")
-        .env("GIT_COMMITTER_NAME", "t")
-        .env("GIT_COMMITTER_EMAIL", "t@e")
-        .output()
-        .unwrap();
-    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    rag_rat_base::test_git::run(root, args);
 }
 
 fn candidate_count(value: &Value) -> usize {

--- a/crates/rag-rat-papertrail/src/trackers.rs
+++ b/crates/rag-rat-papertrail/src/trackers.rs
@@ -408,8 +408,7 @@ mod tests {
     }
 
     fn git(dir: &Path, args: &[&str]) {
-        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        rag_rat_base::test_git::run(dir, args);
     }
 
     fn temp_git_repo() -> rag_rat_base::test_scratch::ScratchDir {


### PR DESCRIPTION
## Summary
- new `rag_rat_base::test_git` seam (`command` / `run` / `output`) that pins the whole class at one place: `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`, `HOME` pinned to the fixture dir, pinned author/committer identity, and command-scope `init.defaultBranch=main` + `core.autocrlf=false`
- every test-code `git` invocation delegates to it — the six files listed in #970 (`cli/tests/common`, `oracle_surfacing_tests`, `git_context`, `repo_identity`, `papertrail/trackers`, `mcp/tools/tests`) plus the same-class helpers the file audit surfaced: `schema_bootstrap_tests` (previously pinned only `core.autocrlf`), `config/tests`, `distill/extract`, `papertrail_autosync`, `git_history/tests`, `watch/tests`, `ignore_rules`, `cli` unit tests (`index_ops`, `init/mod`, wizard steps), `index_guards`, `init_yes`, `multi_repo_e2e`
- the `init --yes` integration tests isolate the production subprocess from the ambient config: hook install is a real user-facing path that honors the environment by design, so the harness pins `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to keep the test machine-independent
- `test_git`’s own tests include a guard-the-guard: a hostile global `core.hooksPath` with a failing pre-commit hook really aborts a commit without the helper, so the isolation can never silently degrade

Benches and production paths (`build.rs`, eval replay) intentionally keep the ambient environment; `--version` probes stay ambient by design.

## Verification
- `cargo check --workspace --tests --benches`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo nextest run --workspace` (3912 passed) under an isolated `TMPDIR` with `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pointed at a config that sets a failing `core.hooksPath`, `core.autocrlf=true`, `init.defaultBranch=dev`, and a foreign `user.*` — the #581/#970 repro; the scratch namespace contained no fixture directories after the run
- `git diff --check`

Closes #970.