### PR TITLE
fix(sync): acknowledge transfers before closing

### DIFF
--- a/crates/rag-rat-sync/src/codec.rs
+++ b/crates/rag-rat-sync/src/codec.rs
@@ -103,6 +103,7 @@ mod tests {
             Frame::Hello { account_id: [3; 32], have: vec![[1; 32]] },
             Frame::Entries { entries: vec![vec![9, 9, 9]], more: false },
             Frame::Done,
+            Frame::Ack,
         ];
         let to_send = sent.clone();
         let writer = tokio::spawn(async move {

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -312,12 +312,11 @@ pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     })
     .await
     .map_err(SyncFailure::Auth)?;
-    let report = run_session(store, send, recv).await.map_err(SyncFailure::Session)?;
-    // The DIALER drives the close: our `run_session` returned only after reading the acceptor's
-    // finished streams, so closing now can't truncate our own read. The acceptor waits for this
-    // close (bounded) before closing its side, so any entries it streamed reach us first. The
-    // reverse (entries WE pushed that the acceptor is still reading) can still truncate on this
-    // close — bounded and self-healing (next cadence re-sends the diff); see issue #926.
+    let report =
+        run_session(store, send, recv, AuthRole::Dialer).await.map_err(SyncFailure::Session)?;
+    // The role-ordered completion acknowledgement proves the acceptor consumed everything we
+    // pushed before replying, and we consumed its whole stream before sending our acknowledgement.
+    // The dialer therefore closes only after both directions are delivered.
     conn.close(0u32.into(), b"done");
     Ok(report)
 }
@@ -380,9 +379,10 @@ pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
     })
     .await
     .map_err(SyncFailure::Auth)?;
-    let report = run_session(store, send, recv).await.map_err(SyncFailure::Session)?;
-    // As the ACCEPTOR we may have STREAMED entries the dialer is still reading; wait for the dialer
-    // to close first so those frames are delivered, then close (see `GRACEFUL_CLOSE_TIMEOUT`).
+    let report =
+        run_session(store, send, recv, AuthRole::Acceptor).await.map_err(SyncFailure::Session)?;
+    // The acceptor sends the final completion acknowledgement. Keep the connection alive until the
+    // dialer reads it and closes, bounded so a vanished dialer cannot wedge the server.
     let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
     conn.close(0u32.into(), b"done");
     Ok(report)
@@ -486,13 +486,12 @@ where
     // Route the session to the store the negotiated ALPN names (validated to be one of the two
     // routed ALPNs above, so the `else` is the content stream, not an unknown-ALPN fallthrough).
     let report = if alpn.as_slice() == SYNC_ALPN {
-        run_session(account_store, send, recv).await
+        run_session(account_store, send, recv, AuthRole::Acceptor).await
     } else {
-        run_session(content_store, send, recv).await
+        run_session(content_store, send, recv, AuthRole::Acceptor).await
     }
     .map_err(SyncFailure::Session)?;
-    // As the ACCEPTOR we may have STREAMED entries the dialer is still reading; wait for the dialer
-    // to close first so those frames are delivered, then close (see `GRACEFUL_CLOSE_TIMEOUT`).
+    // Keep the acceptor alive until the dialer reads its final acknowledgement and closes.
     let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
     conn.close(0u32.into(), b"done");
     Ok((alpn, report))
@@ -641,6 +640,39 @@ mod tests {
             .port();
         EndpointAddr::new(endpoint.id())
             .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+    }
+
+    #[tokio::test]
+    async fn dialer_push_is_acknowledged_before_the_connection_closes() {
+        let source = database();
+        let account = rag_rat_oplog::local_account(&source, NOW).unwrap();
+        let expected = rag_rat_oplog::account_entries_for_sync(&source, account).unwrap();
+        let destination = database();
+        let (listener, dialer) = loopback_endpoints().await;
+        let mut source_store = crate::store::OplogSyncStore::new(&source, account, || NOW);
+        let mut destination_store =
+            crate::store::OplogSyncStore::new(&destination, account, || NOW);
+        let policy = AuthPolicy::Open;
+
+        // This is the direction #926 exposed: the dialer has the data and may close as soon as its
+        // own session returns, while the acceptor is still ingesting the pushed stream.
+        let server = accept_and_sync(&listener, &mut destination_store, policy, || NOW);
+        let client = connect_and_sync(
+            &dialer,
+            direct_addr(&listener),
+            SYNC_ALPN,
+            &mut source_store,
+            policy,
+            NOW,
+        );
+        let (server_result, client_result) = tokio::join!(server, client);
+        let server_report = server_result.unwrap();
+        let client_report = client_result.unwrap();
+
+        assert_eq!(client_report.entries_sent, expected.len());
+        assert_eq!(server_report.entries_newly_stored, expected.len());
+        let received = rag_rat_oplog::account_entries_for_sync(&destination, account).unwrap();
+        assert_eq!(received.len(), expected.len(), "the acceptor ingested the full dialer push");
     }
 
     #[tokio::test]

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -7,7 +7,7 @@
 //! local write does. The transport adds movement, never trust.
 //!
 //! Layers, bottom up:
-//! - [`wire`] — the frozen CBOR frame protocol (hello / entries / done).
+//! - [`wire`] — the frozen CBOR frame protocol (hello / entries / done / ack).
 //! - [`codec`] — length-prefixed framing over any async byte stream (iroh in production, an
 //!   in-memory duplex in tests).
 //! - [`session`] — the symmetric state machine and the [`session::SyncStore`] seam.

--- a/crates/rag-rat-sync/src/session.rs
+++ b/crates/rag-rat-sync/src/session.rs
@@ -4,7 +4,9 @@
 //! every account-log entry hash it holds, then streams the entries the other lacks and ends with
 //! [`Frame::Done`]. The two directions run concurrently over one bidirectional stream, so a large
 //! transfer in one direction never blocks the other (the deadlock a send-then-receive ordering
-//! would cause on a bounded stream).
+//! would cause on a bounded stream). After both data directions finish, a role-ordered
+//! [`Frame::Ack`] exchange proves both receivers consumed the complete peer stream before the
+//! dialer closes.
 //!
 //! The session is transport-agnostic — generic over any [`AsyncRead`]/[`AsyncWrite`] pair — and
 //! trusts nothing it receives: every entry is handed to [`SyncStore::ingest`], which re-verifies it
@@ -16,6 +18,7 @@ use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
+use crate::auth::AuthRole;
 use crate::codec::{self, CodecError};
 use crate::wire::{Frame, MAX_ENTRIES_PER_PAGE, MAX_HELLO_HASHES};
 
@@ -117,13 +120,14 @@ pub async fn run_session<S, R, W>(
     store: &mut S,
     send: W,
     recv: R,
+    role: AuthRole,
 ) -> Result<SessionReport, SessionError>
 where
     S: SyncStore,
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    run_session_with_idle_timeout(store, send, recv, DEFAULT_IDLE_TIMEOUT).await
+    run_session_with_idle_timeout(store, send, recv, role, DEFAULT_IDLE_TIMEOUT).await
 }
 
 /// [`run_session`] with an explicit idle timeout — the receiver aborts if the peer sends no frame
@@ -132,6 +136,7 @@ pub async fn run_session_with_idle_timeout<S, R, W>(
     store: &mut S,
     mut send: W,
     mut recv: R,
+    role: AuthRole,
     idle_timeout: Duration,
 ) -> Result<SessionReport, SessionError>
 where
@@ -153,7 +158,7 @@ where
             .map_err(SessionError::Codec)?;
         // If the receiver aborted before delivering the peer hello, there is nothing to stream.
         let Ok(peer_have) = peer_have_rx.await else {
-            return Ok(0usize);
+            return Ok((send, 0usize));
         };
         let mut to_send: Vec<Vec<u8>> = snapshot
             .into_iter()
@@ -172,11 +177,9 @@ where
                 .map_err(SessionError::Codec)?;
         }
         codec::write_frame(&mut send, &Frame::Done).await.map_err(SessionError::Codec)?;
-        // Cleanly finish the send half. On an iroh stream `shutdown` maps to quinn `finish` (a FIN
-        // the peer sees after the last frame); dropping without it would RESET and could truncate
-        // the final page. On a duplex it just closes the write half → clean EOF for the peer.
-        send.shutdown().await.map_err(|e| SessionError::Codec(CodecError::Io(e)))?;
-        Ok::<usize, SessionError>(total)
+        // Keep the send half open for the completion acknowledgement. Returning ownership lets the
+        // role-ordered phase below send it only after this side has consumed the peer's `Done`.
+        Ok::<(W, usize), SessionError>((send, total))
     };
 
     let receiver = async {
@@ -244,6 +247,11 @@ where
                     }
                     break;
                 },
+                Ok(Frame::Ack) => {
+                    return Err(SessionError::Protocol(
+                        "peer acknowledged before sending Done".into(),
+                    ));
+                },
                 Ok(Frame::Hello { .. }) => {
                     return Err(SessionError::Protocol("a second hello mid-session".into()));
                 },
@@ -257,15 +265,61 @@ where
                 Err(e) => return Err(e),
             }
         }
-        Ok::<(usize, usize), SessionError>((received, newly_stored))
+        Ok::<(R, usize, usize), SessionError>((recv, received, newly_stored))
     };
 
     // `try_join!`, not `join!`: if either half errors, the other is cancelled immediately. Without
     // it, a peer that sends a bad frame and stops reading would leave the sender blocked on QUIC
     // flow control mid-stream, and the session would hang instead of failing.
-    let (entries_sent, (entries_received, entries_newly_stored)) =
+    let ((mut send, entries_sent), (mut recv, entries_received, entries_newly_stored)) =
         tokio::try_join!(sender, receiver)?;
+    complete_session(&mut send, &mut recv, role, idle_timeout).await?;
     Ok(SessionReport { entries_sent, entries_received, entries_newly_stored })
+}
+
+/// Prove both data streams were consumed before the dialer may close the connection. The ordering
+/// is deliberate: the dialer acknowledges first, the acceptor reads that proof before replying,
+/// and the dialer waits for the reply. The acceptor endpoint then keeps the connection alive until
+/// the dialer closes, so its final acknowledgement cannot be truncated in flight.
+async fn complete_session<R, W>(
+    send: &mut W,
+    recv: &mut R,
+    role: AuthRole,
+    idle_timeout: Duration,
+) -> Result<(), SessionError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    match role {
+        AuthRole::Dialer => {
+            send_ack_and_finish(send).await?;
+            read_ack_before(recv, idle_timeout).await
+        },
+        AuthRole::Acceptor => {
+            read_ack_before(recv, idle_timeout).await?;
+            send_ack_and_finish(send).await
+        },
+    }
+}
+
+async fn send_ack_and_finish<W: AsyncWrite + Unpin>(send: &mut W) -> Result<(), SessionError> {
+    codec::write_frame(send, &Frame::Ack).await.map_err(SessionError::Codec)?;
+    // On iroh this maps to QUIC FIN. The acceptor remains alive until the dialer closes, while the
+    // dialer does not close until it has read the acceptor's acknowledgement.
+    send.shutdown().await.map_err(|e| SessionError::Codec(CodecError::Io(e)))
+}
+
+async fn read_ack_before<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    idle_timeout: Duration,
+) -> Result<(), SessionError> {
+    match read_frame_before(recv, idle_timeout).await? {
+        Frame::Ack => Ok(()),
+        _ => Err(SessionError::Protocol(
+            "peer sent another data-phase frame instead of the completion acknowledgement".into(),
+        )),
+    }
 }
 
 /// Read the next frame, failing if the peer sends nothing within `idle_timeout`. Folds a clean EOF
@@ -278,7 +332,7 @@ async fn read_frame_before<R: AsyncRead + Unpin>(
     match tokio::time::timeout(idle_timeout, codec::read_frame(recv)).await {
         Ok(Ok(frame)) => Ok(frame),
         Ok(Err(CodecError::Eof)) => Err(SessionError::Protocol(
-            "peer closed the stream before sending Done — transfer truncated".into(),
+            "peer closed the stream before session completion — transfer truncated".into(),
         )),
         Ok(Err(e)) => Err(SessionError::Codec(e)),
         Err(_elapsed) => Err(SessionError::Protocol(format!(
@@ -338,8 +392,10 @@ mod tests {
     async fn sync_pair(a: &mut MemStore, b: &mut MemStore) -> (SessionReport, SessionReport) {
         let (a_send, b_recv) = tokio::io::duplex(1 << 20);
         let (b_send, a_recv) = tokio::io::duplex(1 << 20);
-        let (ra, rb) =
-            tokio::join!(run_session(a, a_send, a_recv), run_session(b, b_send, b_recv),);
+        let (ra, rb) = tokio::join!(
+            run_session(a, a_send, a_recv, AuthRole::Dialer),
+            run_session(b, b_send, b_recv, AuthRole::Acceptor),
+        );
         (ra.unwrap(), rb.unwrap())
     }
 
@@ -384,6 +440,82 @@ mod tests {
         assert_eq!(rb.entries_newly_stored, 0);
     }
 
+    #[tokio::test]
+    async fn completion_ack_is_required_after_done() {
+        let mut receiver = MemStore::new([3; 32], &[]);
+        let (mut peer_send, recv) = tokio::io::duplex(1 << 16);
+        let (send, _peer_recv) = tokio::io::duplex(1 << 16);
+        let feeder = tokio::spawn(async move {
+            codec::write_frame(&mut peer_send, &Frame::Hello { account_id: [3; 32], have: vec![] })
+                .await
+                .unwrap();
+            codec::write_frame(&mut peer_send, &Frame::Done).await.unwrap();
+            // Drop without Ack: Done terminates the data phase, not the delivery handshake.
+        });
+
+        let result = run_session(&mut receiver, send, recv, AuthRole::Dialer).await;
+        feeder.await.unwrap();
+        assert!(
+            matches!(result, Err(SessionError::Protocol(ref message)) if message.contains("completion")),
+            "Done without Ack must not report a delivered session: {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn ack_before_done_is_rejected() {
+        let mut receiver = MemStore::new([4; 32], &[]);
+        let (mut peer_send, recv) = tokio::io::duplex(1 << 16);
+        let (send, _peer_recv) = tokio::io::duplex(1 << 16);
+        let feeder = tokio::spawn(async move {
+            codec::write_frame(&mut peer_send, &Frame::Hello { account_id: [4; 32], have: vec![] })
+                .await
+                .unwrap();
+            codec::write_frame(&mut peer_send, &Frame::Ack).await.unwrap();
+        });
+
+        let result = run_session(&mut receiver, send, recv, AuthRole::Dialer).await;
+        feeder.await.unwrap();
+        assert!(
+            matches!(result, Err(SessionError::Protocol(ref message)) if message.contains("before sending Done")),
+            "an early Ack cannot skip the data phase: {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptor_replies_only_after_the_dialer_ack() {
+        let mut acceptor = MemStore::new([5; 32], &[]);
+        let (acceptor_send, mut dialer_recv) = tokio::io::duplex(1 << 16);
+        let (mut dialer_send, acceptor_recv) = tokio::io::duplex(1 << 16);
+
+        let dialer = async move {
+            codec::write_frame(&mut dialer_send, &Frame::Hello {
+                account_id: [5; 32],
+                have: vec![],
+            })
+            .await
+            .unwrap();
+            codec::write_frame(&mut dialer_send, &Frame::Done).await.unwrap();
+
+            assert!(matches!(codec::read_frame(&mut dialer_recv).await, Ok(Frame::Hello { .. })));
+            assert_eq!(codec::read_frame(&mut dialer_recv).await.unwrap(), Frame::Done);
+            assert!(
+                tokio::time::timeout(
+                    Duration::from_millis(20),
+                    codec::read_frame(&mut dialer_recv),
+                )
+                .await
+                .is_err(),
+                "the acceptor must wait for the dialer acknowledgement before replying",
+            );
+
+            codec::write_frame(&mut dialer_send, &Frame::Ack).await.unwrap();
+            assert_eq!(codec::read_frame(&mut dialer_recv).await.unwrap(), Frame::Ack);
+        };
+        let session = run_session(&mut acceptor, acceptor_send, acceptor_recv, AuthRole::Acceptor);
+        let ((), report) = tokio::join!(dialer, session);
+        report.unwrap();
+    }
+
     /// A stream that ends after a `more: true` page — a truncated transfer — must FAIL, not report
     /// success, or the caller would treat a partial account as complete.
     #[tokio::test]
@@ -405,7 +537,7 @@ mod tests {
             .unwrap();
             // … then drop without Done: a truncated stream.
         });
-        let result = run_session(&mut receiver, send, recv).await;
+        let result = run_session(&mut receiver, send, recv, AuthRole::Dialer).await;
         feeder.await.unwrap();
         assert!(
             matches!(result, Err(SessionError::Protocol(_))),
@@ -430,7 +562,7 @@ mod tests {
                 .unwrap();
             write_frame(&mut peer_send, &Frame::Done).await.unwrap();
         });
-        let result = run_session(&mut receiver, send, recv).await;
+        let result = run_session(&mut receiver, send, recv, AuthRole::Dialer).await;
         feeder.await.unwrap();
         assert!(
             matches!(result, Err(SessionError::Protocol(_))),
@@ -458,6 +590,7 @@ mod tests {
             &mut receiver,
             send,
             recv,
+            AuthRole::Dialer,
             std::time::Duration::from_millis(50),
         )
         .await;
@@ -487,7 +620,7 @@ mod tests {
                 .await
                 .unwrap();
         });
-        let result = run_session(&mut receiver, send, recv).await;
+        let result = run_session(&mut receiver, send, recv, AuthRole::Dialer).await;
         feeder.await.unwrap();
         match result {
             Err(SessionError::Protocol(m)) => assert!(m.contains("after the final page"), "{m}"),
@@ -509,7 +642,7 @@ mod tests {
                 .await
                 .unwrap();
         });
-        let result = run_session(&mut receiver, send, recv).await;
+        let result = run_session(&mut receiver, send, recv, AuthRole::Dialer).await;
         feeder.await.unwrap();
         // Assert the SPECIFIC guard fired — a dropped feeder also trips the EOF-before-Done guard,
         // so a bare `Protocol` match would not distinguish the empty-page rejection from it.
@@ -540,8 +673,10 @@ mod tests {
         let mut b = MemStore::new([2; 32], &[entry(2)]);
         let (a_send, b_recv) = tokio::io::duplex(1 << 16);
         let (b_send, a_recv) = tokio::io::duplex(1 << 16);
-        let (ra, rb) =
-            tokio::join!(run_session(&mut a, a_send, a_recv), run_session(&mut b, b_send, b_recv),);
+        let (ra, rb) = tokio::join!(
+            run_session(&mut a, a_send, a_recv, AuthRole::Dialer),
+            run_session(&mut b, b_send, b_recv, AuthRole::Acceptor),
+        );
         assert!(matches!(ra, Err(SessionError::Protocol(_))));
         assert!(matches!(rb, Err(SessionError::Protocol(_))));
     }

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -2,10 +2,11 @@
 //!
 //! One symmetric protocol for device↔device and device↔server: both peers send [`Frame::Hello`]
 //! naming the account and every account-log entry hash they already hold, then each streams the
-//! entries the other lacks as [`Frame::Entries`] pages, ending with [`Frame::Done`]. The receiver
-//! feeds every entry through the op-log ingest seam, which re-verifies signature, canonicity, and
-//! chain continuity from scratch — the sender is never trusted, so a malformed or forged frame is
-//! rejected exactly as a malformed local write would be.
+//! entries the other lacks as [`Frame::Entries`] pages, ending with [`Frame::Done`]. A role-ordered
+//! [`Frame::Ack`] exchange then proves both receivers consumed their peer's complete stream before
+//! the dialer closes the connection. The receiver feeds every entry through the op-log ingest seam,
+//! which re-verifies signature, canonicity, and chain continuity from scratch — the sender is never
+//! trusted, so a malformed or forged frame is rejected exactly as a malformed local write would be.
 //!
 //! Frames are canonical CBOR arrays tagged by a leading discriminant, encoded by hand with
 //! `minicbor::Encoder` to match the op-log's envelope style (no derive). The byte layout is a
@@ -14,10 +15,10 @@
 use minicbor::{Decoder, Encoder};
 
 /// The ALPN for the ACCOUNT-LOG stream. Versioned: a breaking wire change bumps the suffix so an
-/// old peer declines the handshake instead of misreading frames. Bumped to `/2` for the #881 auth
-/// phase (the `Auth` frame exchanged before any inventory) — a `/1` peer, which would stream its
-/// inventory without authenticating, must not interoperate.
-pub const SYNC_ALPN: &[u8] = b"rag-rat/sync/2";
+/// old peer declines the handshake instead of misreading frames. Bumped to `/3` for the #926
+/// role-ordered completion acknowledgement; a `/2` peer would stop after `Done` and deadlock or
+/// truncate a `/3` peer waiting for proof that its stream was consumed.
+pub const SYNC_ALPN: &[u8] = b"rag-rat/sync/3";
 
 /// The ALPN for the `/3` CONTENT stream — the memories themselves (#907). Same frame protocol and
 /// same account-level auth phase as [`SYNC_ALPN`]; only the STORE differs (`OplogContentSyncStore`
@@ -25,7 +26,8 @@ pub const SYNC_ALPN: &[u8] = b"rag-rat/sync/2";
 /// acceptor picks the store from `conn.alpn()` and the account-log wire stays byte-identical. A
 /// peer that does not speak this ALPN simply never exchanges content — account-log sync is
 /// unaffected.
-pub const CONTENT_SYNC_ALPN: &[u8] = b"rag-rat/content/1";
+/// Bumped to `/2` alongside [`SYNC_ALPN`] because content uses the same completion state machine.
+pub const CONTENT_SYNC_ALPN: &[u8] = b"rag-rat/content/2";
 
 /// Domain tag committed into every frame's leading array element, so a frame from another protocol
 /// (or a truncated one) cannot be mistaken for a valid frame.
@@ -66,8 +68,12 @@ pub enum Frame {
     /// A page of `signed_bytes` the peer lacked. `more` is true when further pages follow.
     Entries { entries: Vec<Vec<u8>>, more: bool },
     /// The sender has streamed every entry the peer lacked. A session ends when both directions are
-    /// `Done`.
+    /// `Done`, followed by the role-ordered acknowledgement exchange.
     Done,
+    /// Confirms that the sender consumed the peer's complete stream through [`Frame::Done`]. The
+    /// dialer sends first; the acceptor replies only after reading it, so the dialer can close
+    /// after the reply without truncating either direction.
+    Ack,
 }
 
 mod tag {
@@ -75,6 +81,7 @@ mod tag {
     pub const ENTRIES: u8 = 1;
     pub const DONE: u8 = 2;
     pub const AUTH: u8 = 3;
+    pub const ACK: u8 = 4;
 }
 
 /// A frame that failed to decode. Kept distinct from an I/O error so the session can treat a
@@ -140,6 +147,11 @@ impl Frame {
                 enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
                 enc.u8(tag::DONE).expect(INFALLIBLE);
             },
+            Frame::Ack => {
+                enc.array(2).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::ACK).expect(INFALLIBLE);
+            },
         }
         buf
     }
@@ -161,6 +173,7 @@ impl Frame {
             tag::ENTRIES => 4,
             tag::DONE => 2,
             tag::AUTH => 4,
+            tag::ACK => 2,
             other => return Err(WireError::Malformed(format!("unknown frame tag {other}"))),
         };
         if outer != expected_outer {
@@ -221,6 +234,7 @@ impl Frame {
                 Ok(Frame::Entries { entries, more })
             },
             tag::DONE => Ok(Frame::Done),
+            tag::ACK => Ok(Frame::Ack),
             other => Err(WireError::Malformed(format!("unknown frame tag {other}"))),
         }
     }
@@ -255,8 +269,8 @@ mod tests {
     /// acceptor can route account-log vs content by ALPN.
     #[test]
     fn alpn_identifiers_are_frozen() {
-        assert_eq!(SYNC_ALPN, b"rag-rat/sync/2");
-        assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/1");
+        assert_eq!(SYNC_ALPN, b"rag-rat/sync/3");
+        assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/2");
         assert_eq!(crate::enrollment::ENROLL_ALPN, b"rag-rat/enroll/1");
         assert_ne!(SYNC_ALPN, CONTENT_SYNC_ALPN);
         assert_ne!(SYNC_ALPN, crate::enrollment::ENROLL_ALPN);
@@ -272,6 +286,7 @@ mod tests {
         roundtrip(&Frame::Entries { entries: vec![vec![1, 2, 3], vec![]], more: true });
         roundtrip(&Frame::Entries { entries: vec![], more: false });
         roundtrip(&Frame::Done);
+        roundtrip(&Frame::Ack);
     }
 
     #[test]
@@ -347,6 +362,19 @@ mod tests {
             [
                 0x82, 0x74, b'r', b'a', b'g', b'-', b'r', b'a', b't', b'/', b's', b'y', b'n', b'c',
                 b'-', b'f', b'r', b'a', b'm', b'e', b'/', b'1', 0x02,
+            ],
+        );
+    }
+
+    #[test]
+    fn ack_frame_bytes_are_frozen() {
+        let bytes = Frame::Ack.encode();
+        assert_eq!(
+            bytes,
+            // array(2), text "rag-rat/sync-frame/1", u8 4
+            [
+                0x82, 0x74, b'r', b'a', b'g', b'-', b'r', b'a', b't', b'/', b's', b'y', b'n', b'c',
+                b'-', b'f', b'r', b'a', b'm', b'e', b'/', b'1', 0x04,
             ],
         );
     }

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -6,7 +6,7 @@
 //! receiver re-verifies via `account_ingest`.
 
 use rag_rat_oplog::{AccountId, account_entries_for_sync, local_account};
-use rag_rat_sync::{OplogSyncStore, run_session};
+use rag_rat_sync::{AuthRole, OplogSyncStore, run_session};
 use rusqlite::Connection;
 
 const NOW: i64 = 1_700_000_000_000;
@@ -39,8 +39,8 @@ async fn a_fresh_peer_restores_an_account_over_the_session() {
     let (a_send, b_recv) = tokio::io::duplex(1 << 20);
     let (b_send, a_recv) = tokio::io::duplex(1 << 20);
     let (source_report, dest_report) = tokio::join!(
-        run_session(&mut source_store, a_send, a_recv),
-        run_session(&mut dest_store, b_send, b_recv),
+        run_session(&mut source_store, a_send, a_recv, AuthRole::Acceptor),
+        run_session(&mut dest_store, b_send, b_recv, AuthRole::Dialer),
     );
     let source_report = source_report.unwrap();
     let dest_report = dest_report.unwrap();
@@ -83,8 +83,8 @@ async fn two_peers_in_sync_transfer_nothing() {
     let (a_send, b_recv) = tokio::io::duplex(1 << 16);
     let (b_send, a_recv) = tokio::io::duplex(1 << 16);
     let (ra, rb) = tokio::join!(
-        run_session(&mut a_store, a_send, a_recv),
-        run_session(&mut b_store, b_send, b_recv),
+        run_session(&mut a_store, a_send, a_recv, AuthRole::Acceptor),
+        run_session(&mut b_store, b_send, b_recv, AuthRole::Dialer),
     );
     let (ra, rb) = (ra.unwrap(), rb.unwrap());
     assert_eq!(ra.entries_newly_stored, 0);
@@ -150,8 +150,8 @@ async fn a_fresh_peer_restores_the_accounts_content_after_the_account_log() {
         let (a_send, b_recv) = tokio::io::duplex(1 << 20);
         let (b_send, a_recv) = tokio::io::duplex(1 << 20);
         let (ra, rb) = tokio::join!(
-            run_session(&mut src, a_send, a_recv),
-            run_session(&mut dst, b_send, b_recv),
+            run_session(&mut src, a_send, a_recv, AuthRole::Acceptor),
+            run_session(&mut dst, b_send, b_recv, AuthRole::Dialer),
         );
         ra.unwrap();
         rb.unwrap();
@@ -164,8 +164,8 @@ async fn a_fresh_peer_restores_the_accounts_content_after_the_account_log() {
         let (a_send, b_recv) = tokio::io::duplex(1 << 20);
         let (b_send, a_recv) = tokio::io::duplex(1 << 20);
         let (ra, rb) = tokio::join!(
-            run_session(&mut src, a_send, a_recv),
-            run_session(&mut dst, b_send, b_recv),
+            run_session(&mut src, a_send, a_recv, AuthRole::Acceptor),
+            run_session(&mut dst, b_send, b_recv, AuthRole::Dialer),
         );
         ra.unwrap();
         rb.unwrap()


### PR DESCRIPTION
## Summary

- add a role-ordered completion acknowledgement after the terminal `Done` frame
- keep the acceptor alive until the dialer acknowledges receipt, preventing the final response from being truncated during QUIC close
- bump account and content sync ALPN versions to fence the wire-protocol change while leaving enrollment unchanged
- cover malformed ordering, missing acknowledgements, acceptor close behavior, and a real loopback push

## Verification

- `cargo nextest run -p rag-rat-sync` (91 passed, 2 skipped)
- `cargo nextest run --workspace` (4,029 passed, 4 skipped)
- `cargo build`
- workspace clippy with no-default-features and all-features
- `cargo +nightly fmt --check`
- `git diff --check`

Closes #926