### PR TITLE
feat(skills): add repository Rust style guidance

### DIFF
--- a/.agents/skills/rust-modern-style/SKILL.md
+++ b/.agents/skills/rust-modern-style/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: rust-modern-style
+description: Apply rag-rat's Rust style when writing or reviewing Rust: current stable idioms, module-qualified free functions and constants, explicit persistence contracts, and narrow APIs.
+metadata:
+  type: code-style
+  language: rust
+  triggers: Rust, imports, modules, SQL, persisted enums, code style, code review
+---
+
+# Rust Modern Style
+
+Use this skill when writing or reviewing Rust in the rag-rat repository. It complements async-specific
+guidance; this skill owns the workspace's general Rust, module, persistence, and API conventions.
+
+## Baseline
+
+- Target the Rust 2024 edition and the current workspace `rust-version`; do not add compatibility
+  shims for older compilers that the workspace does not support.
+- Prefer current stable idioms when they make control flow clearer: `let-else`, inline format args,
+  `matches!`, `is_some_and`, and `is_none_or`.
+- Modern does not mean clever. Prefer explicit `match`, `if let`, and early returns over iterator or
+  combinator chains that hide domain states or side effects.
+- Prefer `std::sync::OnceLock` or `LazyLock` over new `lazy_static!` usage.
+- Use `&str` and slices at borrowed boundaries instead of `&String` and `&Vec<T>`.
+
+## Imports
+
+Types, traits, enums, and structs may be imported directly. In a mixed or large import group, bring
+the module in with `{self, ..}` and qualify free functions, constants, and macros at the call site.
+This preserves origin information where the code is read.
+
+```rust
+// Avoid: callables and constants lose their module identity.
+use crate::index::graph_index::{
+    KeyVersionStamp, LOGICAL_KEY_VERSION, rebuild_logical_symbols,
+};
+
+// Prefer: types are direct; operations and constants retain their origin.
+use crate::index::graph_index::{self, KeyVersionStamp};
+
+graph_index::rebuild_logical_symbols(...);
+let version = graph_index::LOGICAL_KEY_VERSION;
+```
+
+A small, single-purpose import of one function is fine. Apply this rule when an import list mixes
+roles or makes bare call sites ambiguous, not mechanically to every `use`.
+
+## Modules And Visibility
+
+- Treat `mod.rs` as a curated index: module declarations and intentional `pub`/`pub(crate)`
+  re-exports. Put implementation in cohesive sibling files.
+- Split by domain job, not arbitrary line count. Keep helpers private and adjacent to the flow they
+  support.
+- Sibling modules should import through `super::`, not back through their parent's public re-export.
+- Start private and widen only for a real production caller: private, then `pub(super)`, then
+  `pub(crate)`, and `pub` only for a genuine public boundary.
+- Never widen production visibility solely for a test; colocate the test or use a test-only seam.
+
+## Errors And State
+
+- Convert errors where subsystem ownership changes. Do not leak low-level DB or transport errors
+  through layers whose callers cannot act on them.
+- Capability loss must be explicit (`Blocked`, a typed reason, or an error), never an empty result or
+  success-with-zero-work.
+- Avoid catch-all classifications for errors that affect persistence, retry, or user-visible state.
+  Use a testable classification function with deliberate cases.
+
+## Persisted Enums
+
+Persisted classifications are schema. Keep them closed and low-cardinality. Prefer deriving
+`strum::EnumString` and `strum::IntoStaticStr` with an explicit `#[strum(serialize_all = "...")]`
+token policy; keep `as_db_str()` and `from_db_str()` as thin, named DB-boundary wrappers and add an
+exact-token round-trip test. Use a manual match only when parsing intentionally has custom semantics
+such as a compatibility alias, fallback, or richer error classification.
+
+Never persist `Display`, `Debug`, or user-facing prose as a machine classification. Changing a stored
+token requires the same migration discipline as changing a column.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+enum RunState {
+    Completed,
+    Blocked,
+}
+
+impl RunState {
+    fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown run state `{value}`"))
+    }
+}
+```
+
+When the same enum also crosses serde/config boundaries, set the corresponding explicit serde rename
+policy and test that it agrees with the strum tokens. Do not assume one derive configures the other.
+
+## Database Code
+
+- Make read/write direction obvious in names. Reads use verbs such as `get_`, `list_`, `find_`,
+  `load_`, and `exists_`; writes use `insert_`, `upsert_`, `record_`, `clear_`, `delete_`, `mark_`,
+  and `apply_`.
+- Keep non-trivial SQL in a helper named for the domain question, not the table or orchestration step.
+- Document scope, visibility, generation, suppression, and ordering invariants beside the SQL.
+- Tests assert the domain predicate and migration behavior, not the query text.
+- One durable transition has one canonical writer that owns timestamping, versioning, cleanup, and
+  related side effects.
+
+## Time And Boundaries
+
+- Use the subsystem's injected or centralized clock (`now_ms()` or a passed timestamp). Domain logic
+  must not read wall-clock time independently.
+- Read time once per logical operation and pass it into helpers so persisted rows agree.
+- Use owned, simple DTOs across FFI, worker, thread, and persistence boundaries.
+- Introduce newtypes for IDs or timestamps when same-typed values can be transposed.
+- Never hold a database guard or borrowed row across `.await`; complete the DB phase, return owned
+  data, then await, then enter the next DB phase.
+
+## Function Shape
+
+- Prefer parameter structs once a function has more than roughly four meaningful parameters,
+  repeated same-typed IDs, or values that always travel together. Construct them with named fields,
+  not another positional constructor.
+- Separate stable context/dependencies from each call's command or query payload.
+- Replace positional booleans with enums that name the behavior. Named boolean fields in a DTO are
+  fine when the field name makes intent clear.
+- Keep scopes small. Use inner blocks to end borrows, locks, and transactions at phase boundaries.
+- A long function is acceptable when it reads as one linear protocol. Extract stable, named phases,
+  not arbitrary chunks such as `process_part_2`.
+- Keep match arms as dispatch. Extract multi-step side effects into a named operation.
+- Peel off terminal states with early returns so the success path stays flat.
+
+## Naming
+
+- Types are nouns, operations are verb phrases, and boolean predicates read as questions.
+- Name locals for their state-machine role (`pending_paths`, `active_generation`), not their container
+  type (`items`, `data`, `result`).
+- Side-effecting functions say so: `record_`, `persist_`, `emit_`, `apply_`, `mark_`, or `clear_`.
+  Functions named `build_`, `resolve_`, `classify_`, or `derive_` should remain pure.
+- Avoid vague `Manager`, `Handler`, `Processor`, and `Helper` types when a capability-specific name
+  is available.
+
+## Orchestration
+
+Background reconciliation follows: scan for real work, decide capability/blocking state, act within
+an explicit budget, then report what happened. Scan before checking optional capabilities so existing
+work cannot be mislabeled as `NoWork`.
+
+Orchestration owns sequencing, not mechanics. SQL, protocol encoding, retry bookkeeping, and durable
+state transitions belong to their named subsystem helpers.
+
+## Comments And Verification
+
+- Comments explain invariants, rationale, ordering, or threat models, not the next obvious line.
+- Durable comments describe the scenario, not a review round, agent workflow, or temporary task ID.
+- Keep migration tests with migration SQL and add negative tests for scope/isolation boundaries.
+- Format with `cargo +nightly fmt`; CI uses nightly rustfmt.
+- Run the narrowest relevant tests first, then the affected crate or workspace checks required by the
+  change.

--- a/.claude/skills/rust-modern-style
+++ b/.claude/skills/rust-modern-style
@@ -1,0 +1,1 @@
+../../.agents/skills/rust-modern-style

--- a/.codex/skills/rust-modern-style
+++ b/.codex/skills/rust-modern-style
@@ -1,0 +1,1 @@
+../../.agents/skills/rust-modern-style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,29 +101,43 @@ layer and may record provenance freely.)
 
 ## Repo orientation
 
-- Rust workspace, nine crates in a layered DAG (Rust 2024 edition):
+- Rust workspace, 13 crates in a layered DAG (Rust 2024 edition):
   - `rag-rat-base` — foundation: config, repo identity/discovery, language + embedding-model
     registries, path classification, canonical JSON, locks, logging.
   - `rag-rat-db` — the SQLite substrate: schema/migrations (+ the `MigrationHooks` seam),
     storage, meta, chunk-text store/compression.
-  - satellites on db+base: `rag-rat-llm` (embedder providers, cookbook provisioning),
-    `rag-rat-papertrail` (tracker mirrors: GitHub/GitLab), `rag-rat-clones` (fingerprints,
-    postings, refine/antiunify), `rag-rat-oracle` (SCIP/LSP evidence, verdict store),
-    `rag-rat-query` (the read layer: graph/impact/symbol/tree queries, repo-memory reads +
-    evidence engine, pagerank), `rag-rat-dream` (memory-maintenance findings + verify/compact
-    model passes, on query+llm).
+  - domain layers on base+db: `rag-rat-llm` (embedder providers, cookbook provisioning),
+    `rag-rat-papertrail` (provider-neutral GitHub/GitLab tracker mirrors), `rag-rat-clones`
+    (fingerprints, postings, refine/antiunify), and `rag-rat-oracle` (SCIP/LSP evidence,
+    manifests, verdict store).
+  - `rag-rat-query` — the read layer: graph/impact/symbol/tree queries, repo-memory reads +
+    evidence resolution, pagerank, orientation primitives.
+  - `rag-rat-dream` — deterministic memory-maintenance findings plus model-driven verify/compact
+    passes, built on query+llm.
+  - `rag-rat-oplog` — signed, hash-chained memory op-log: operation model, projection fold,
+    account/authority substrate, content-candidate DAG, durable store.
   - `rag-rat-core` — the engine that remains: indexing + tree-sitter graph, the
-    `IndexDatabase` query surface, memory writes + op-log/account sync, watcher, eval.
-  - `rag-rat-mcp` (the STDIO MCP server), `rag-rat-cli` (the `rag-rat` binary).
+    `IndexDatabase` query surface, memory-write orchestration, watcher, eval.
+  - `rag-rat-sync` — iroh QUIC peer transport for exchanging signed op-log entries.
+  - entrypoints: `rag-rat-mcp` (the STDIO MCP server) and `rag-rat-cli` (package name `rag-rat`,
+    the CLI binary).
   All crates version in lockstep; see docs/releasing.md.
 - `rag-rat.toml` (repo root) configures what gets indexed and the SQLite database path.
 
+## Worktree correctness
+
+All changes that affect indexing or worktree-overlay behavior MUST support both the main checkout and
+linked worktrees sharing the same database. Every such change MUST include regression tests that
+exercise worktree behavior, including active-checkout scope and sibling-checkout preservation or
+isolation as applicable. Single-checkout coverage alone is not sufficient for index/overlay changes.
+
 ## Style
 
-Follow the `rust-modern-style` conventions: closed/persisted enums with `as_db_str`/`from_db_str`,
-`{self, ..}` imports for mixed lists, read/write-obvious DB method names, injected time (`now_ms()`),
-parameter structs over long arg trains, `mod.rs` as a curated index. Keep SQL in helpers named for
-the domain question, with invariant comments and tests (migrations included).
+Follow the `rust-modern-style` conventions: closed/persisted enums use strum-backed stable tokens
+behind `as_db_str`/`from_db_str`, `{self, ..}` imports for mixed lists, read/write-obvious DB method
+names, injected time (`now_ms()`), parameter structs over long arg trains, `mod.rs` as a curated
+index. Keep SQL in helpers named for the domain question, with invariant comments and tests
+(migrations included).
 
 ## Build / test
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,7 +10,7 @@ not need to `cargo install` / `brew install` / put `rag-rat` on `PATH` first.
 ```
 plugin/                          plugin root (CLAUDE_PLUGIN_ROOT / CODEX_PLUGIN_ROOT)
   scripts/launch.js                the all-OS hook launcher (resolves the binary; never installs)
-  skills/                          shared skills: using-rag-rat, dream-review
+  skills/                          curated public skills (four rag-rat workflows)
   hooks/hooks.json                 Claude hooks (auto-discovered)
   .mcp.json                        Codex MCP config (root) → npx @rag-rat/bin mcp
   .claude-plugin/plugin.json       Claude: mcpServers → npx @rag-rat/bin mcp
@@ -51,9 +51,10 @@ Version comes from `plugin.json`. Intel Mac has no prebuilt → the launcher pri
 
 ## Skills
 
-`using-rag-rat` and `dream-review`, copied from the repo's `.agents/skills/` source of truth. One
-`skills/` dir serves every harness (a package step should regenerate it from `.agents/skills/` so the
-copies never drift).
+`using-rag-rat`, `dream-review`, `init-rag-rat`, and `configure-rag-rat-dream`, copied from the
+repo's `.agents/skills/` source of truth. One `skills/` dir serves every harness and is also the
+public source used by `@rag-rat/skills`. Regeneration must copy this explicit allowlist, never mirror
+all of `.agents/skills`: contributor-only guidance such as `rust-modern-style` stays repository-local.
 
 ## Hooks
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -48,7 +48,7 @@ npx @rag-rat/skills -y                   # non-interactive
 ## How it works
 
 This package is a **thin wrapper** over the [`skills`](https://github.com/vercel-labs/skills) CLI,
-pinned to rag-rat's canonical skill directory (`.agents/skills` in the rag-rat repo). It doesn't
+pinned to rag-rat's curated public skill bundle (`plugin/skills` in the rag-rat repo). It doesn't
 reinvent the multi-agent installer — `skills` already knows how to place a `SKILL.md` into every
 supported agent, symlink-or-copy, project-or-global. `npx @rag-rat/skills` is just the branded,
 single-command entry point; it forwards your flags verbatim.
@@ -56,8 +56,9 @@ single-command entry point; it forwards your flags verbatim.
 Equivalent to running:
 
 ```bash
-npx skills add https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills
+npx skills add https://github.com/cq27-dev/rag-rat/tree/main/plugin/skills
 ```
 
-The skills themselves live in [`.agents/skills/`](https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills)
-in the rag-rat repo — that's the single source of truth; this package installs from it.
+The public skills are copied from the repository's `.agents/skills` source of truth into
+[`plugin/skills/`](https://github.com/cq27-dev/rag-rat/tree/main/plugin/skills). Repository-only
+contributor skills remain under `.agents/skills` and are deliberately absent from this installer.

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -8,15 +8,14 @@
  *   npx @rag-rat/skills remove          # remove them
  *
  * It is a THIN wrapper over the vercel-labs `skills` CLI (https://github.com/vercel-labs/skills),
- * pinned to rag-rat's canonical skills directory. Rather than reinvent a multi-agent installer, the
- * default command delegates to `skills add <rag-rat's .agents/skills>`, which knows how to place a
+ * pinned to rag-rat's public plugin skill bundle. Rather than reinvent a multi-agent installer, the
+ * default command delegates to `skills add <rag-rat's plugin/skills>`, which knows how to place a
  * SKILL.md into 70+ agents (Claude Code → .claude/skills, Codex → .codex/skills, Cursor, opencode,
  * …), symlink or copy, project or --global. Every flag you pass is forwarded verbatim.
  *
- * SOURCE is pinned to the `.agents/skills` PATH (not the bare repo) on purpose: rag-rat mirrors its
- * skills into .claude/ and .codex/ via symlinks for its own agents, and pointing `skills` at the
- * whole repo would rediscover those mirror copies. Pinning the one canonical directory installs each
- * skill exactly once.
+ * SOURCE is pinned to the curated `plugin/skills` PATH (not `.agents/skills`) on purpose:
+ * `.agents/skills` also contains contributor-only repo guidance that must not ship through this
+ * public installer. The plugin bundle is the public projection and installs each public skill once.
  */
 
 // cross-spawn, not node:child_process — on Windows `npx` is a `.cmd` shim that Node can only run
@@ -25,8 +24,8 @@
 // args itself, so we never enable `shell` and untrusted args pass through verbatim.
 import spawn from "cross-spawn";
 
-/** rag-rat's canonical skill directory on GitHub (walked one level deep: <name>/SKILL.md). */
-const SOURCE = "https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills";
+/** rag-rat's public skill bundle on GitHub (walked one level deep: <name>/SKILL.md). */
+const SOURCE = "https://github.com/cq27-dev/rag-rat/tree/main/plugin/skills";
 
 /** rag-rat's own skills — used to scope destructive/refresh subcommands to ONLY these. */
 const RAG_RAT_SKILLS = ["using-rag-rat", "dream-review", "init-rag-rat", "configure-rag-rat-dream"];
@@ -53,7 +52,7 @@ const SAFE_MAINT_FLAGS = new Set(["-g", "--global", "-p", "--project", "-y", "--
 
 function usage() {
   process.stdout.write(
-    `@rag-rat/skills — install rag-rat's agent skills (using-rag-rat, dream-review)\n\n` +
+    `@rag-rat/skills — install rag-rat's public agent skills\n\n` +
       `Usage:\n` +
       `  npx @rag-rat/skills [add|install]   install into your agent(s) (default)\n` +
       `  npx @rag-rat/skills update          refresh rag-rat's installed skills\n` +

--- a/skills/package-lock.json
+++ b/skills/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/skills",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/skills",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/skills/package.json
+++ b/skills/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rag-rat/skills",
-  "version": "0.1.1",
-  "description": "One-command installer for rag-rat's agent skills (using-rag-rat, dream-review, init-rag-rat, configure-rag-rat-dream). A thin wrapper over the vercel-labs `skills` CLI, pinned to rag-rat's canonical skills directory, so `npx @rag-rat/skills` places them into Claude Code, Codex, Cursor, and 70+ other agents.",
+  "version": "0.1.2",
+  "description": "One-command installer for rag-rat's public agent skills (using-rag-rat, dream-review, init-rag-rat, configure-rag-rat-dream). A thin wrapper over the vercel-labs `skills` CLI, pinned to rag-rat's curated plugin skill bundle.",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- add a repository-only `rust-modern-style` skill with Claude and Codex mirrors
- update `AGENTS.md` for the current 13-crate workspace, strum-backed persisted enums, and mandatory linked-worktree regression coverage for index/overlay changes
- keep `@rag-rat/skills` limited to the curated four-skill `plugin/skills` bundle and bump it to 0.1.2

## Verification

- `npm install --package-lock-only --ignore-scripts`
- `node --check skills/cli.mjs`
- `npm pack --dry-run --json`
- verified the local skill set contains `rust-modern-style` while `plugin/skills` remains the four-skill public allowlist
- verified both repository skill mirrors resolve to the canonical skill
- `git diff --check`