### PR TITLE
fix(skills): quote Rust style description

### DIFF
--- a/.agents/skills/rust-modern-style/SKILL.md
+++ b/.agents/skills/rust-modern-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-modern-style
-description: Apply rag-rat's Rust style when writing or reviewing Rust: current stable idioms, module-qualified free functions and constants, explicit persistence contracts, and narrow APIs.
+description: "Apply rag-rat's Rust style when writing or reviewing Rust: current stable idioms, module-qualified free functions and constants, explicit persistence contracts, and narrow APIs."
 metadata:
   type: code-style
   language: rust


### PR DESCRIPTION
## Summary

- quote the `rust-modern-style` frontmatter description so its colon is valid YAML

## Verification

- parsed the frontmatter with Ruby Psych (`YAML.safe_load`)
- `git diff --check`