### PR TITLE
fix(release): persist MCP manifest version sync

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,12 +48,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      # release-plz bumps Cargo.toml but not the plugin JSON manifests, and it has no non-Cargo-file
-      # support. The launcher fetches releases/download/v<plugin-version>, so the manifests must match
-      # the crate version — sync them into the SAME Release PR release-plz just opened/updated. This
-      # runs after release-plz every time, so its force-push of the PR branch can never leave the
-      # manifests stale. Pushes to the release-plz-* branch (never main), so it triggers nothing.
-      - name: Sync plugin manifest versions into the release PR
+      # release-plz bumps Cargo.toml but has no non-Cargo-file support. Plugin launchers and MCP
+      # Registry metadata must match the crate version, so sync them into the SAME Release PR
+      # release-plz just opened/updated. This runs after release-plz every time, so its force-push of
+      # the PR branch can never leave the manifests stale. Pushes to the release-plz-* branch (never
+      # main), so it triggers nothing.
+      - name: Sync non-Cargo manifest versions into the release PR
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
@@ -65,10 +65,10 @@ jobs:
           git fetch origin "$branch"
           git checkout -B "$branch" "origin/$branch"
           node tools/sync-plugin-version.mjs
-          if git diff --quiet; then echo "manifests already in sync"; exit 0; fi
+          if git diff --quiet; then echo "non-Cargo manifests already in sync"; exit 0; fi
           git -c user.name="github-actions[bot]" \
               -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-              commit -am "chore: sync plugin manifest versions to the workspace version"
+              commit -am "chore: sync non-Cargo manifest versions to the workspace version"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$branch"
 
   # When the release PR merges (the version commit lands on main), tag, publish each crate to

--- a/tools/sync-plugin-version.mjs
+++ b/tools/sync-plugin-version.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-// Sync the plugin manifests' version to the workspace crate version.
+// Sync non-Cargo manifests' versions to the workspace crate version.
 //
 // release-plz bumps only Cargo.toml ([workspace.package].version) — it has no support for non-Cargo
-// files. The plugin launcher fetches releases/download/v<plugin-version>, so the manifests MUST match
-// the released crate version or it downloads the wrong release. `.github/workflows/release-plz.yml`
-// runs this on the Release PR branch so the manifest bump rides in the same PR that cuts the tag.
+// files. The plugin launcher and MCP Registry metadata MUST match the released crate version or they
+// point at the wrong release. `.github/workflows/release-plz.yml` runs this on the Release PR branch
+// so the manifest bumps ride in the same PR that cuts the tag.
 //
 // Idempotent; run from the repo root. Exits non-zero only on a structural mismatch (so a cargo-dist /
 // release-plz change that moves the version can't silently ship a stale manifest).
@@ -32,18 +32,22 @@ function fail(msg) {
 const VERSION = workspaceVersion();
 let changed = 0;
 
-// 1) The manifests' `"version"` field — each has exactly one; rewrite it surgically to preserve
-// formatting.
+// 1) Manifest `"version"` fields. Most have one; server.json has both server and package versions.
+// Require the exact count so a schema change cannot silently leave one stale.
 const VERSION_FILES = [
-  ".claude-plugin/marketplace.json",
-  "plugin/.claude-plugin/plugin.json",
-  "plugin/.codex-plugin/plugin.json",
-  "plugin/opencode/package.json",
+  [".claude-plugin/marketplace.json", 1],
+  ["plugin/.claude-plugin/plugin.json", 1],
+  ["plugin/.codex-plugin/plugin.json", 1],
+  ["plugin/opencode/package.json", 1],
+  ["server.json", 2],
 ];
-const versionRe = /("version"\s*:\s*)"[^"]*"/;
-for (const file of VERSION_FILES) {
+const versionRe = /("version"\s*:\s*)"[^"]*"/g;
+for (const [file, expectedFields] of VERSION_FILES) {
   const src = readFileSync(file, "utf8");
-  if (!versionRe.test(src)) fail(`no "version" field in ${file}`);
+  const fields = src.match(versionRe)?.length ?? 0;
+  if (fields !== expectedFields) {
+    fail(`expected ${expectedFields} "version" field(s) in ${file}, found ${fields}`);
+  }
   const out = src.replace(versionRe, `$1"${VERSION}"`);
   if (out !== src) {
     writeFileSync(file, out);


### PR DESCRIPTION
## Summary

- include the canonical MCP `server.json` in release-plz's post-generation manifest synchronization
- update both the server and npm package versions together
- require exact version-field counts so manifest schema changes fail loudly instead of leaving stale metadata
- describe the workflow step as synchronizing all non-Cargo manifests

This keeps the MCP manifest correction durable when release-plz regenerates or force-pushes its release branch.

## Verification

- `node --check tools/sync-plugin-version.mjs`
- `node tools/sync-plugin-version.mjs` (idempotent at the current workspace version)
- `git diff --check`