### PR TITLE
chore: release v0.22.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.1 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.22.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "rag-rat",
       "source": "plugin",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "homepage": "https://github.com/cq27-dev/rag-rat",
       "repository": "https://github.com/cq27-dev/rag-rat",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02
+
+### Added
+
+- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
+- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
+- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
+- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
+- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
+- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
+- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
+- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))
+
+### Fixed
+
+- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
+- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
+- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
+- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
+- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
+- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
+- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
+- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
+- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))
+
+### Other
+
+- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
+- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
+- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
+
 ## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,7 +4929,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-base"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "dunce",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-clones"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-db"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-dream"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-llm"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oplog"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oracle"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "protobuf",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-papertrail"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-query"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-sync"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.21.1"
+version = "0.22.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -38,18 +38,18 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-base = { version = "0.21.1", path = "crates/rag-rat-base", default-features = false }
-rag-rat-clones = { version = "0.21.1", path = "crates/rag-rat-clones", default-features = false }
-rag-rat-db = { version = "0.21.1", path = "crates/rag-rat-db", default-features = false }
-rag-rat-dream = { version = "0.21.1", path = "crates/rag-rat-dream", default-features = false }
-rag-rat-llm = { version = "0.21.1", path = "crates/rag-rat-llm", default-features = false }
-rag-rat-oracle = { version = "0.21.1", path = "crates/rag-rat-oracle", default-features = false }
-rag-rat-oplog = { version = "0.21.1", path = "crates/rag-rat-oplog", default-features = false }
-rag-rat-papertrail = { version = "0.21.1", path = "crates/rag-rat-papertrail", default-features = false }
-rag-rat-query = { version = "0.21.1", path = "crates/rag-rat-query", default-features = false }
-rag-rat-core = { version = "0.21.1", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.21.1", path = "crates/rag-rat-mcp", default-features = false }
-rag-rat-sync = { version = "0.21.1", path = "crates/rag-rat-sync", default-features = false }
+rag-rat-base = { version = "0.22.0", path = "crates/rag-rat-base", default-features = false }
+rag-rat-clones = { version = "0.22.0", path = "crates/rag-rat-clones", default-features = false }
+rag-rat-db = { version = "0.22.0", path = "crates/rag-rat-db", default-features = false }
+rag-rat-dream = { version = "0.22.0", path = "crates/rag-rat-dream", default-features = false }
+rag-rat-llm = { version = "0.22.0", path = "crates/rag-rat-llm", default-features = false }
+rag-rat-oracle = { version = "0.22.0", path = "crates/rag-rat-oracle", default-features = false }
+rag-rat-oplog = { version = "0.22.0", path = "crates/rag-rat-oplog", default-features = false }
+rag-rat-papertrail = { version = "0.22.0", path = "crates/rag-rat-papertrail", default-features = false }
+rag-rat-query = { version = "0.22.0", path = "crates/rag-rat-query", default-features = false }
+rag-rat-core = { version = "0.22.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.22.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-sync = { version = "0.22.0", path = "crates/rag-rat-sync", default-features = false }
 anyhow = "1.0"
 axum = "0.8"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.21.1", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.22.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.21.1", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.22.0", "mcp"]
     }
   }
 }

--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/plugin-opencode",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
   "license": "MIT",
   "type": "module",

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -3,7 +3,7 @@
 // opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
 // additionalContext channel on tool.execute.before), so this module is a thin shim over the same
 // shared pieces the other harnesses use:
-//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.21.1<version> mcp` (pinned; kept
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.22.0<version> mcp` (pinned; kept
 //     in lockstep with the release by tools/sync-plugin-version.mjs).
 //   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
 //     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
@@ -35,7 +35,7 @@ const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
 
 // Single source of truth for the version: the pinned npm package (kept in lockstep with the
 // release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
-const MCP_PACKAGE = "@rag-rat/bin@0.21.1";
+const MCP_PACKAGE = "@rag-rat/bin@0.22.0";
 const VERSION = MCP_PACKAGE.split("@").pop()!;
 
 const TOOL_TIMEOUT_MS = 10_000;

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.1 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.22.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cq27-dev/rag-rat",
   "title": "rag-rat",
   "description": "Repository intelligence, code graph, history, papertrail, and cross-agent memory for coding agents.",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "websiteUrl": "https://rag-rat.cq27.dev/",
   "repository": {
     "url": "https://github.com/cq27-dev/rag-rat",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@rag-rat/bin",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-base`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-db`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-clones`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-llm`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-papertrail`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-query`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-dream`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-oplog`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-oracle`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-core`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-sync`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat`: 0.21.1 -> 0.22.0

### ⚠ `rag-rat-base` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OracleConfig.live in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/config/types.rs:212
  field Config.sync in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/config/types.rs:27

--- failure enum_repr_variant_discriminant_changed: variant of an enum with explicit repr changed discriminant ---

Description:
An enum variant has changed its discriminant value. The enum has a defined primitive representation, so this breaks downstream code that used the discriminant value via an unsafe pointer cast.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_repr_variant_discriminant_changed.ron

Failed in:
  variant Language::Markdown 7 -> 8 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/language.rs:19

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Language:Go in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/language.rs:18
  variant ConfigError:TargetOutsideRoot in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/config/mod.rs:146
  variant ConfigError:OracleLiveRequestBudgetZero in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/config/mod.rs:187
  variant ConfigError:OracleLiveCheckoutCapZero in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/config/mod.rs:192

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Language::supports_embeddings, previously in file /tmp/.tmpPAdD0k/rag-rat-base/src/language.rs:166

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  Language::Markdown moved from position 8 to 9, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-base/src/language.rs:19
```

### ⚠ `rag-rat-db` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function rag_rat_db::schema::apply_files_generation, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:2367
  function rag_rat_db::schema::apply_account_candidate_dag, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4514
  function rag_rat_db::schema::apply_papertrail_distill_substrate, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5460
  function rag_rat_db::schema::apply_oplog_storage, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4364
  function rag_rat_db::schema::apply_repo_id_periphery_scoping, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:3867
  function rag_rat_db::schema::apply_github_repo_id_scoping, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:2583
  function rag_rat_db::schema::apply_content_digest_state, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5952
  function rag_rat_db::schema::apply_content_projected_tables, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4649
  function rag_rat_db::schema::apply_clone_fingerprint_tables, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:1775
  function rag_rat_db::schema::apply_papertrail_mirror_resume_state, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:3443
  function rag_rat_db::schema::apply_distill_safe_input_snapshot, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5752
  function rag_rat_db::schema::apply_oplog_device_x25519, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4498
  function rag_rat_db::schema::apply_papertrail_provider_neutral_schema, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:3361
  function rag_rat_db::schema::apply_clone_df_epoch, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4308
  function rag_rat_db::schema::apply_dream_findings, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5252
  function rag_rat_db::schema::apply_edge_string_interning, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:1123
  function rag_rat_db::schema::apply_github_child_key_widening, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:2947
  function rag_rat_db::schema::apply_account_authority_boundaries, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4997
  function rag_rat_db::schema::apply_repos_registry, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:1935
  function rag_rat_db::schema::apply_chunk_symbol_id, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4807
  function rag_rat_db::schema::apply_sync_origin_and_edge_tombstone, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5908
  function rag_rat_db::schema::apply_edge_target_qname_index, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:780
  function rag_rat_db::schema::apply_oplog_local_account, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4626
  function rag_rat_db::schema::apply_distill_anchor_selection, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5694
  function rag_rat_db::schema::apply_scip_moniker_anchors, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:659
  function rag_rat_db::schema::apply_oplog_device_identity, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4473
  function rag_rat_db::schema::apply_memory_model_failures_table, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:3078
  function rag_rat_db::schema::apply_clone_delta_maintenance, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4270
  function rag_rat_db::schema::apply_account_authority_projection, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4923
  function rag_rat_db::schema::apply_clone_postings_row_count, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:6098
  function rag_rat_db::schema::apply_content_refold_queue_and_stats, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4712
  function rag_rat_db::schema::apply_clone_graph_tables, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:1852
  function rag_rat_db::schema::apply_distill_evidence_source_part, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5880
  function rag_rat_db::schema::apply_content_candidate_dag, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4565
  function rag_rat_db::schema::apply_distill_record_store, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5538
  function rag_rat_db::schema::apply_oracle_tables, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:557
  function rag_rat_db::schema::apply_repo_id_core_scoping, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:2207
  function rag_rat_db::schema::apply_oplog_stream_scoping, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4411
  function rag_rat_db::schema::apply_memory_verification_tables, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:3010
  function rag_rat_db::schema::apply_move_per_repo_meta, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:2019
  function rag_rat_db::schema::apply_git_change_couplings, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5063
  function rag_rat_db::schema::apply_table_sync_tables, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:6036
  function rag_rat_db::schema::apply_files_has_test_code, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:818
  function rag_rat_db::schema::apply_content_streams_pending_refold, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:4682
  function rag_rat_db::schema::apply_papertrail_binding_health, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:3482
  function rag_rat_db::schema::apply_distill_enriched_context, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:5823
  function rag_rat_db::schema::apply_external_symbols, previously in file /tmp/.tmpPAdD0k/rag-rat-db/src/schema/migrations.rs:730
```

### ⚠ `rag-rat-oplog` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RosterContentAuthority.role in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oplog/src/account/fold.rs:283

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant DeviceRole::Member 0 -> 1 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oplog/src/account/ops.rs:57
  variant DeviceRole::Owner 1 -> 2 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oplog/src/account/ops.rs:58

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant DeviceRole:ReadOnly in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oplog/src/account/ops.rs:56

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx now takes 3 parameters instead of 2, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oplog/src/account/content/storage.rs:1586
  rag_rat_oplog::settle_pending_content_refolds now takes 3 parameters instead of 2, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oplog/src/account/content/storage.rs:1459
```

### ⚠ `rag-rat-oracle` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Harness is no longer Send, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oracle/src/test_support.rs:39

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant OracleTool:RaLsp in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oracle/src/lib.rs:734
  variant OracleTool:TsLsp in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oracle/src/lib.rs:740
  variant OracleTool:ClangdLsp in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-oracle/src/lib.rs:746

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ToolManifest::scip_command, previously in file /tmp/.tmpPAdD0k/rag-rat-oracle/src/manifest.rs:213

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field skipped_local of struct OracleReport, previously in file /tmp/.tmpPAdD0k/rag-rat-oracle/src/lib.rs:821

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait rag_rat_oracle::Oracle, previously in file /tmp/.tmpPAdD0k/rag-rat-oracle/src/lib.rs:841
```

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field WorktreeOverlayReport.source_root in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs:69
  field WorktreeOverlayReport.changed_paths in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs:87
  field WorktreeOverlayReport.coverage in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs:89

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ParserKind::Markdown 8 -> 9 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-core/src/index/parser.rs:216

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ParserKind:Go in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-core/src/index/parser.rs:215
  variant OverlayScope:Paths in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-core/src/watch/overlay.rs:44
```

### ⚠ `rag-rat-sync` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Frame::Hello 1 -> 2 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:71
  variant Frame::Entries 2 -> 3 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:73
  variant Frame::Done 3 -> 4 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:76
  variant Frame::Hello 1 -> 2 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:71
  variant Frame::Entries 2 -> 3 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:73
  variant Frame::Done 3 -> 4 in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:76

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant SyncFailure:Enrollment in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:854
  variant SyncFailure:TableSession in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:858
  variant SyncFailure:Enrollment in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:854
  variant SyncFailure:TableSession in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:858
  variant EndpointError:PeerId in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:60
  variant EndpointError:PeerId in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:60
  variant Frame:AuthGrant in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:68
  variant Frame:Ack in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:80
  variant Frame:AuthGrant in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:68
  variant Frame:Ack in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/wire.rs:80
  variant SessionError:UnauthorizedPush in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/session.rs:100
  variant SessionError:UnauthorizedPush in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/session.rs:100

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_sync::session::run_session now takes 5 parameters instead of 3, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/session.rs:127
  rag_rat_sync::run_session now takes 5 parameters instead of 3, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/session.rs:127
  rag_rat_sync::endpoint::connect_and_sync now takes 6 parameters instead of 5, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:425
  rag_rat_sync::connect_and_sync now takes 6 parameters instead of 5, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/endpoint.rs:425
  rag_rat_sync::session::run_session_with_idle_timeout now takes 6 parameters instead of 4, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/session.rs:144
  rag_rat_sync::run_session_with_idle_timeout now takes 6 parameters instead of 4, in /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/session.rs:144

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method rag_rat_sync::auth::NodeAuth::local_auth in file /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/auth.rs:155
  trait method rag_rat_sync::NodeAuth::local_auth in file /tmp/.tmp3B4XcF/rag-rat/crates/rag-rat-sync/src/auth.rs:155

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method local_binding of trait NodeAuth, previously in file /tmp/.tmpPAdD0k/rag-rat-sync/src/auth.rs:91
  method local_binding of trait NodeAuth, previously in file /tmp/.tmpPAdD0k/rag-rat-sync/src/auth.rs:91
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-base`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-db`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-clones`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-llm`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-papertrail`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-query`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-dream`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-oplog`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-oracle`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-core`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-sync`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02

### Added

- *(sync)* account-keyed peer discovery ([#1078](https://github.com/cq27-dev/rag-rat/pull/1078))
- *(oracle)* give each checkout its own live oracle sessions and worklist ([#1054](https://github.com/cq27-dev/rag-rat/pull/1054))
- *(languages)* add Go language support ([#994](https://github.com/cq27-dev/rag-rat/pull/994))
- *(lens)* add authenticated VS Code repository lens ([#985](https://github.com/cq27-dev/rag-rat/pull/985))
- *(oracle)* add a live TypeScript LSP backend ([#536](https://github.com/cq27-dev/rag-rat/pull/536)) ([#992](https://github.com/cq27-dev/rag-rat/pull/992))
- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(index)* treat a literal backslash in a Unix filename as part of the name ([#1052](https://github.com/cq27-dev/rag-rat/pull/1052))
- *(paths)* resolve filesystem paths off the Windows verbatim spelling ([#1055](https://github.com/cq27-dev/rag-rat/pull/1055))
- *(index)* canonicalize fixture config roots so the suite matches Config::load ([#1047](https://github.com/cq27-dev/rag-rat/pull/1047))
- *(oracle)* separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011) ([#1031](https://github.com/cq27-dev/rag-rat/pull/1031))
- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- derive schema recognizers from the ladder and reuse shared helpers ([#1098](https://github.com/cq27-dev/rag-rat/pull/1098))
- document Go language support ([#1061](https://github.com/cq27-dev/rag-rat/pull/1061))
- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).