### PR TITLE
fix(oracle): gate and bound live LSP requests

### DIFF
--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -30,6 +30,7 @@ use crate::index::{IndexDatabase, papertrail_autosync as autosync};
 pub(crate) const FLEET_DEBOUNCE: Duration = Duration::from_millis(500);
 pub(crate) const FLEET_MAX_LATENCY: Duration = Duration::from_millis(2000);
 pub(crate) const IDLE_WAIT: Duration = Duration::from_millis(500);
+pub(crate) const LIVE_ORACLE_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 
 /// A running watcher. Dropping it signals the thread to stop and joins it.
 #[derive(Debug)]
@@ -223,6 +224,7 @@ fn watcher_main(
                     Some(&mut live_oracle),
                 ),
             };
+            live_oracle.retry_needed()
         }
     }) else {
         return;
@@ -252,6 +254,7 @@ fn watcher_main(
         scheduler: &mut scheduler,
         papertrail_tx: papertrail_tx.as_ref(),
         papertrail_interval,
+        live_oracle_retry_interval: LIVE_ORACLE_RETRY_INTERVAL,
         stop,
         fleet_trigger: &mut fire_fleet_trigger,
     }
@@ -348,6 +351,8 @@ pub(crate) struct EventLoop<'a, W: notify::Watcher> {
     /// `None` disables the papertrail trigger (no tracker bindings, or no worker thread).
     pub(crate) papertrail_tx: Option<&'a Sender<AutosyncRequest>>,
     pub(crate) papertrail_interval: Option<Duration>,
+    /// Delay before retrying a live-oracle backlog without waiting for another filesystem event.
+    pub(crate) live_oracle_retry_interval: Duration,
     pub(crate) stop: &'a AtomicBool,
     /// Injected so tests can observe the fleet firing; production wires [`fleet::trigger`].
     pub(crate) fleet_trigger: &'a mut (dyn FnMut(&Path) + Send),
@@ -382,6 +387,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
         let mut papertrail_clock =
             PapertrailClock::new(self.papertrail_tx.and(self.papertrail_interval), Instant::now());
         let mut papertrail_scheduler = PapertrailScheduler::new();
+        let mut live_oracle_retry_at: Option<Instant> = None;
         // The overlay scope accumulated while the debounce is armed (#577): every firing event
         // merges its contribution, and the union rides the next dispatched pass. Cleared ONLY on
         // dispatch, like the debounce itself — mid-pass events keep accumulating for the
@@ -422,6 +428,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     fleet_debounce.due_in(now),
                     sweep.due_in(now),
                     papertrail_clock.due_in(now),
+                    live_oracle_retry_at.map(|at| at.saturating_duration_since(now)),
                 ]
                 .into_iter()
                 .flatten()
@@ -490,9 +497,11 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     }
                 },
                 Ok(LoopMsg::Fs(Err(_))) => {},
-                Ok(LoopMsg::PassDone) => {
+                Ok(LoopMsg::PassDone { live_oracle_retry }) => {
                     self.scheduler.on_done();
                     let done_at = Instant::now();
+                    live_oracle_retry_at =
+                        live_oracle_retry.then(|| done_at + self.live_oracle_retry_interval);
                     sweep.on_pass_done(done_at);
                     // The cooldown counts from pass COMPLETION (#823) — the armed debounce below
                     // is typically long-elapsed by now, and without this the next iteration
@@ -541,10 +550,14 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                 }
             }
             let periodic_due = sweep.due(now);
+            let live_oracle_retry_due = live_oracle_retry_at.is_some_and(|at| now >= at);
             // The cooldown (#823) holds back only the DEBOUNCE-driven dispatch; a due periodic
             // sweep dispatches regardless — the missed-event backstop is never starved by the
             // cooldown.
-            if periodic_due || (debounce.should_fire(now) && cooldown.ready(now)) {
+            if periodic_due
+                || live_oracle_retry_due
+                || (debounce.should_fire(now) && cooldown.ready(now))
+            {
                 // The periodic sweep is the missed-event backstop, so it refreshes every overlay;
                 // an event-driven pass carries the roots accumulated above (#577). When both are
                 // due at once, `All` is the superset — and because the sweep clock counts from
@@ -564,6 +577,9 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                         sweep.on_dispatch(matches!(overlay_scope, OverlayScope::All));
                     }
                     let _ = self.pass_tx.send(request);
+                    // Every pass retries the resident backlog. Its completion re-arms this only
+                    // when unfinished work remains.
+                    live_oracle_retry_at = None;
                     // Reset ONLY on dispatch: while a pass is in flight the armed debounce (and
                     // the scope accumulated with it) is the record that a follow-up is owed, and
                     // it fires as soon as `PassDone` lands.

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -8,10 +8,10 @@
 //! (a heal/bootstrap leaves `clone_delta_hint = None`) contributes no paths: live's scope is
 //! exactly "files the pass reindexed", and a whole-checkout sweep is the BATCH pass's job.
 //!
-//! Everything here is best-effort: a missing `rust-analyzer`, a failed spawn, or a dead server
-//! mid-pass never fails the maintenance pass — the worklist rides to the next pass via the
-//! backlog, and the session is dropped so a later pass respawns (crash tolerance/warm-up
-//! hardening is slice 3, #535).
+//! Everything here is best-effort: a missing `rust-analyzer`, a failed spawn, a warming server,
+//! or a dead server mid-pass never fails the maintenance pass — the worklist rides to the next
+//! pass via the backlog, and an aborted session is dropped so a later pass respawns. Bounded
+//! respawn backoff and idle scheduling independent of maintenance passes remain in #535.
 
 use std::collections::{BTreeSet, HashSet};
 

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -90,14 +90,15 @@ impl LiveOracleTail {
                 // session so the next pass respawns a clean one instead of reusing a broken
                 // transport (the aborted files are already requeued in `unfinished_paths`).
                 if report.status.starts_with("Aborted:")
-                    && let Some(session) = self.session.take()
+                    && let Some(_aborted_session) = self.session.take()
                 {
+                    // Let the binding hard-kill on Drop; graceful shutdown would attempt another
+                    // bounded request against the same wedged transport.
                     tracing::warn!(
                         target: "rag_rat_core::watch",
                         status = %report.status,
                         "live oracle: server aborted; session dropped, respawn on next pass"
                     );
-                    session.shutdown();
                 }
                 if report.rows_written > 0 || !report.unfinished_paths.is_empty() {
                     tracing::info!(

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -11,7 +11,7 @@
 //! Everything here is best-effort: a missing `rust-analyzer`, a failed spawn, a warming server,
 //! or a dead server mid-pass never fails the maintenance pass — the worklist rides to the next
 //! pass via the backlog, and an aborted session is dropped so a later pass respawns. Bounded
-//! respawn backoff and idle scheduling independent of maintenance passes remain in #535.
+//! respawn backoff remains in #535.
 
 use std::collections::{BTreeSet, HashSet};
 
@@ -34,6 +34,11 @@ pub(crate) struct LiveOracleTail {
 impl LiveOracleTail {
     pub(crate) fn new() -> Self {
         Self { session: None, backlog: Vec::new() }
+    }
+
+    /// Whether the watcher must schedule another pass even if no filesystem event arrives.
+    pub(crate) fn retry_needed(&self) -> bool {
+        !self.backlog.is_empty()
     }
 
     /// One pass's live stage: the idle-shutdown sweep, then (when enabled and there is work)

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -190,7 +190,7 @@ pub(crate) enum PassRequest {
 #[derive(Debug)]
 pub(crate) enum LoopMsg {
     Fs(notify::Result<Event>),
-    PassDone,
+    PassDone { live_oracle_retry: bool },
     PapertrailDone,
     Wake,
 }
@@ -246,19 +246,20 @@ impl PassScheduler {
 /// each pass still takes the write lock itself, so concurrent writers (git-hook `maintenance`,
 /// other servers' elected watchers, the CLI) serialize exactly as before; the single worker
 /// thread is what keeps THIS watcher to one pass at a time. Each request is answered with
-/// [`LoopMsg::PassDone`] so the loop can refresh worktree watch state and dispatch a coalesced
-/// follow-up; the worker exits when the request channel closes.
+/// [`LoopMsg::PassDone`] so the loop can refresh worktree watch state, schedule any live-oracle
+/// backlog retry, and dispatch a coalesced follow-up; the worker exits when the request channel
+/// closes.
 pub(crate) fn spawn_pass_worker(
     pass_rx: Receiver<PassRequest>,
     done_tx: Sender<LoopMsg>,
-    mut run_pass_request: impl FnMut(&PassRequest) + Send + 'static,
+    mut run_pass_request: impl FnMut(&PassRequest) -> bool + Send + 'static,
 ) -> Option<JoinHandle<()>> {
     std::thread::Builder::new()
         .name("rag-rat-watch-pass".to_string())
         .spawn(move || {
             while let Ok(request) = pass_rx.recv() {
-                run_pass_request(&request);
-                if done_tx.send(LoopMsg::PassDone).is_err() {
+                let live_oracle_retry = run_pass_request(&request);
+                if done_tx.send(LoopMsg::PassDone { live_oracle_retry }).is_err() {
                     return;
                 }
             }

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -523,6 +523,7 @@ fn the_event_loop_drain_persists_a_placement_failure_while_running() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2683,7 +2684,10 @@ fn pass_worker_runs_requests_in_order_and_reports_completion() {
     let ran = Arc::new(std::sync::Mutex::new(Vec::new()));
     let worker = spawn_pass_worker(pass_rx, done_tx, {
         let ran = Arc::clone(&ran);
-        move |request: &PassRequest| ran.lock().unwrap().push(request.clone())
+        move |request: &PassRequest| {
+            ran.lock().unwrap().push(request.clone());
+            false
+        }
     })
     .expect("worker thread spawns");
     pass_tx.send(PassRequest::StartupCatchup).unwrap();
@@ -2692,7 +2696,7 @@ fn pass_worker_runs_requests_in_order_and_reports_completion() {
         .unwrap();
     for _ in 0..2 {
         match done_rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(LoopMsg::PassDone) => {},
+            Ok(LoopMsg::PassDone { live_oracle_retry: false }) => {},
             other => panic!("expected PassDone, got {other:?}"),
         }
     }
@@ -2753,6 +2757,7 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2788,7 +2793,7 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         );
 
         // Completing the pass dispatches the coalesced follow-up.
-        tx.send(LoopMsg::PassDone).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_retry: false }).unwrap();
         assert_eq!(
             pass_rx.recv_timeout(Duration::from_secs(5)),
             Ok(PassRequest::Maintenance {
@@ -2849,6 +2854,7 @@ fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2872,7 +2878,7 @@ fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
         // debounce is already past due and the loop's own PassDone iteration is where the
         // back-to-back redispatch used to happen.
         std::thread::sleep(Duration::from_millis(100));
-        tx.send(LoopMsg::PassDone).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_retry: false }).unwrap();
 
         // The pre-#823 behavior was an immediate redispatch here. The follow-up must instead
         // wait out the cooldown (2 s; the 700 ms probe leaves ample CI-jitter margin)...
@@ -2944,6 +2950,7 @@ fn a_due_periodic_sweep_overrides_the_pass_cooldown() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2955,7 +2962,7 @@ fn a_due_periodic_sweep_overrides_the_pass_cooldown() {
             pass_rx.recv_timeout(Duration::from_secs(5)),
             Ok(PassRequest::Maintenance { run_gc: false, overlay_scope: OverlayScope::All }),
         );
-        tx.send(LoopMsg::PassDone).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_retry: false }).unwrap();
 
         // The next sweep falls due one second later — deep inside the cooldown — and must
         // dispatch anyway: the backstop bypasses the cooldown.
@@ -3757,6 +3764,7 @@ fn event_loop_ignores_fs_errors_and_exits_on_disconnect() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -3810,6 +3818,7 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -3829,6 +3838,68 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
         drop(tx);
         drop(pass_tx);
         let _ = handle.join();
+    });
+}
+
+#[test]
+fn live_oracle_backlog_retries_without_events_or_periodic_sweeps() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    config.watch.periodic_sweep_secs = 0;
+    config.watch.pass_cooldown_secs = 3_600;
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+    let mut notify_watcher =
+        <RecordingWatcher as notify::Watcher>::new(|_| {}, notify::Config::default()).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (pass_tx, pass_rx) = std::sync::mpsc::channel();
+    let pass_tx_for_loop = pass_tx.clone();
+    let mut scheduler = PassScheduler::new();
+    let _startup = scheduler.dispatch_startup();
+    let stop = AtomicBool::new(false);
+    let mut fleet_trigger = |_: &Path| {};
+
+    let counters = placement_counters();
+    let event_loop = EventLoop {
+        config: &config,
+        target_dirs: &target_dirs,
+        fleet_bin: None,
+        notify_watcher: &mut notify_watcher,
+        counters: &counters,
+        ignore: &mut ignore,
+        linked_worktrees: &mut linked_worktrees,
+        worktree_registry: None,
+        rx,
+        pass_tx: &pass_tx_for_loop,
+        scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
+        live_oracle_retry_interval: Duration::from_millis(25),
+        stop: &stop,
+        fleet_trigger: &mut fleet_trigger,
+    };
+
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(move || event_loop.run());
+        tx.send(LoopMsg::PassDone { live_oracle_retry: true }).unwrap();
+        assert_eq!(
+            pass_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(PassRequest::Maintenance {
+                run_gc: false,
+                overlay_scope: OverlayScope::Linked(BTreeSet::new())
+            }),
+            "the resident backlog must provide its own retry source",
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        let _ = tx.send(LoopMsg::Wake);
+        drop(tx);
+        drop(pass_tx);
+        assert!(!handle.join().unwrap());
     });
 }
 
@@ -3964,6 +4035,7 @@ fn idle_watcher_enqueues_papertrail_evaluation_without_filesystem_activity() {
         scheduler: &mut scheduler,
         papertrail_tx: Some(&papertrail_tx),
         papertrail_interval: Some(Duration::from_millis(50)),
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -4021,6 +4093,7 @@ fn papertrail_deadline_fires_during_an_in_flight_pass_and_ticks_coalesce() {
         scheduler: &mut scheduler,
         papertrail_tx: Some(&papertrail_tx),
         papertrail_interval: Some(Duration::from_millis(100)),
+        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -183,7 +183,7 @@ pub struct LivePassReport {
     /// in an unindexed file, or mapping to no indexed symbol. Live writes no `resolved-external`
     /// rows (see the module docs).
     pub skipped_external: u64,
-    /// Callees the server left unresolved (a `null` definition — e.g. still indexing).
+    /// Callees the quiescent server left unresolved (a `null` definition).
     pub unresolved: u64,
     /// Whether the scip-mode refine cache was invalidated (a row's `scip_symbol` changed under
     /// unchanged bytes, or newly inserted non-local evidence became visible).
@@ -290,6 +290,7 @@ pub fn live_oracle_pass(
         }
     }
     let mut aborted: Option<String> = None;
+    let mut warming = false;
     // Per-pass caches: definition-file disk bytes / indexed sha / symbol spans, keyed by
     // repo-relative path (the LSP returns a bounded set of def paths, so these stay small — the
     // whole-checkout sha map is deliberately NOT loaded).
@@ -307,13 +308,25 @@ pub fn live_oracle_pass(
         // Budget gate: nothing left → every candidate-bearing path from here rides the backlog.
         let remaining = input.max_requests.saturating_sub(report.requests_used) as usize;
         if remaining == 0 {
-            report.unfinished_paths.extend(
-                input.worklist[position..]
-                    .iter()
-                    .filter(|p| by_path.contains_key(p.as_str()))
-                    .cloned(),
-            );
+            defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
             break 'files;
+        }
+
+        // Readiness is dynamic: Cargo metadata or workspace changes can put rust-analyzer back
+        // into loading after the pass-entry gate. Never begin another definition batch while it is
+        // non-quiescent, or temporary nulls would become permanently completed unresolved work.
+        match session.is_ready() {
+            Ok(true) => {},
+            Ok(false) => {
+                warming = true;
+                defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
+                break 'files;
+            },
+            Err(err) => {
+                aborted = Some(err.to_string());
+                defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
+                break 'files;
+            },
         }
 
         // Callsite drift gate: the server resolves the DIRTY disk bytes, so those bytes must
@@ -384,18 +397,27 @@ pub fn live_oracle_pass(
             Err(err) => {
                 // A dead/wedged server: keep what earlier files produced, REQUEUE this file and
                 // every candidate-bearing path after it (the watcher rides them into the next
-                // pass and replaces the session), and never fail the maintenance pass over it
-                // (#535 hardens this further).
+                // pass and replaces the session), and never fail the maintenance pass over it.
                 aborted = Some(err.to_string());
-                report.unfinished_paths.extend(
-                    input.worklist[position..]
-                        .iter()
-                        .filter(|p| by_path.contains_key(p.as_str()))
-                        .cloned(),
-                );
+                defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
                 break 'files;
             },
         };
+        // A reload may begin while the synchronous batch is in flight. Discard the whole batch
+        // before interpreting any null definitions, and retry this file once the server is ready.
+        match session.is_ready() {
+            Ok(true) => {},
+            Ok(false) => {
+                warming = true;
+                defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
+                break 'files;
+            },
+            Err(err) => {
+                aborted = Some(err.to_string());
+                defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
+                break 'files;
+            },
+        }
         // The caller may change while synchronous requests are in flight. Re-read AFTER the batch:
         // the server resolved the didOpen snapshot, and writing it against an already-changed disk
         // file would look current until the queued reindex catches up (or forever if its event was
@@ -584,6 +606,7 @@ pub fn live_oracle_pass(
         report.run_recorded = true;
         report.status = match &aborted {
             Some(err) => format!("Aborted: {err}"),
+            None if warming => "Warming".to_string(),
             None if report.rows_written == 0 => "VersionMigrated".to_string(),
             None if report.unfinished_paths.is_empty() => "Completed".to_string(),
             None => "BudgetExhausted".to_string(),
@@ -607,6 +630,7 @@ pub fn live_oracle_pass(
     } else {
         report.status = match &aborted {
             Some(err) => format!("Aborted: {err}"),
+            None if warming => "Warming".to_string(),
             None if report.unfinished_paths.is_empty() => "NoVerdicts".to_string(),
             None => "BudgetExhausted".to_string(),
         };
@@ -616,6 +640,17 @@ pub fn live_oracle_pass(
     // not read as idle on the next pass (that would force a needless respawn + warm-up).
     session.touch(rag_rat_base::time::now_ms());
     Ok(report)
+}
+
+fn defer_candidate_paths_from(
+    report: &mut LivePassReport,
+    worklist: &[String],
+    position: usize,
+    by_path: &HashMap<&str, Vec<&store::EdgeJoinCandidate>>,
+) {
+    report.unfinished_paths.extend(
+        worklist[position..].iter().filter(|path| by_path.contains_key(path.as_str())).cloned(),
+    );
 }
 
 /// The content-stable SCIP-local sentinel a live verdict carries when the resolved symbol has no

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -1,6 +1,6 @@
-//! The live oracle pass (#74 slice 2 / #534): wire the resident LSP client (slice 1's `lsp`
-//! substrate) to the watcher's maintenance pass and WRITE its per-callee verdicts into the
-//! `edge_oracle` seam, under the distinct [`OracleTool::RaLsp`] tool id.
+//! The live oracle pass: wire the resident LSP client to the watcher's maintenance pass and WRITE
+//! its per-callee verdicts into the `edge_oracle` seam under the distinct
+//! [`OracleTool::RaLsp`] tool id.
 //!
 //! Invariants this module upholds (settled on #74):
 //!
@@ -34,9 +34,9 @@
 //!   — the live analog of the batch join's index-vs-disk content gate. Anything else is skipped,
 //!   never mis-joined.
 //!
-//! Out of scope (later slices): crash/version/warm-up hardening and server→client request
-//! handlers (#535), non-Rust backends (#536), `resolved-external` verdicts (a live def outside
-//! the checkout has no batch-interchangeable SCIP symbol string, so it is skipped, not written).
+//! Out of scope: watcher-level respawn backoff and independent idle scheduling (#535), non-Rust
+//! backends (#536), and `resolved-external` verdicts (a live definition outside the checkout has
+//! no batch-interchangeable SCIP symbol string, so it is skipped, not written).
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -86,6 +86,22 @@ impl LiveOracleSession {
     #[cfg(test)]
     pub(crate) fn from_client(mut client: LspClient, tool_version: &str, root_uri: &str) -> Self {
         client.initialize(root_uri).expect("test server completes the handshake");
+        client.assume_ready();
+        Self::from_initialized_client(client, tool_version, root_uri)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_warming_client(
+        mut client: LspClient,
+        tool_version: &str,
+        root_uri: &str,
+    ) -> Self {
+        client.initialize(root_uri).expect("test server completes the handshake");
+        Self::from_initialized_client(client, tool_version, root_uri)
+    }
+
+    #[cfg(test)]
+    fn from_initialized_client(client: LspClient, tool_version: &str, root_uri: &str) -> Self {
         Self {
             client,
             tool_version: tool_version.to_string(),
@@ -117,6 +133,10 @@ impl LiveOracleSession {
 
     fn touch(&mut self, now_ms: i64) {
         self.last_used_ms = now_ms;
+    }
+
+    fn is_ready(&mut self) -> std::io::Result<bool> {
+        self.client.is_server_ready()
     }
 }
 
@@ -190,6 +210,21 @@ pub fn live_oracle_pass(
     input: &LivePassInput<'_>,
 ) -> anyhow::Result<LivePassReport> {
     let mut report = LivePassReport::default();
+    match session.is_ready() {
+        Ok(true) => {},
+        Ok(false) => {
+            report.unfinished_paths = input.worklist.to_vec();
+            report.status = "Warming".to_string();
+            session.touch(rag_rat_base::time::now_ms());
+            return Ok(report);
+        },
+        Err(err) => {
+            report.unfinished_paths = input.worklist.to_vec();
+            report.status = format!("Aborted: {err}");
+            session.touch(rag_rat_base::time::now_ms());
+            return Ok(report);
+        },
+    }
     let tool = OracleTool::RaLsp;
     // The batch tool whose monikers live copies (rust-analyzer for ra-lsp) — always `Some` for a
     // live tool; the join is vacuous without it.

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -135,8 +135,8 @@ impl LiveOracleSession {
         self.last_used_ms = now_ms;
     }
 
-    fn is_ready(&mut self) -> std::io::Result<bool> {
-        self.client.is_server_ready()
+    fn readiness_checkpoint(&mut self) -> std::io::Result<Option<u64>> {
+        self.client.readiness_checkpoint()
     }
 }
 
@@ -210,9 +210,9 @@ pub fn live_oracle_pass(
     input: &LivePassInput<'_>,
 ) -> anyhow::Result<LivePassReport> {
     let mut report = LivePassReport::default();
-    match session.is_ready() {
-        Ok(true) => {},
-        Ok(false) => {
+    match session.readiness_checkpoint() {
+        Ok(Some(_)) => {},
+        Ok(None) => {
             report.unfinished_paths = input.worklist.to_vec();
             report.status = "Warming".to_string();
             session.touch(rag_rat_base::time::now_ms());
@@ -315,9 +315,9 @@ pub fn live_oracle_pass(
         // Readiness is dynamic: Cargo metadata or workspace changes can put rust-analyzer back
         // into loading after the pass-entry gate. Never begin another definition batch while it is
         // non-quiescent, or temporary nulls would become permanently completed unresolved work.
-        match session.is_ready() {
-            Ok(true) => {},
-            Ok(false) => {
+        let readiness_checkpoint = match session.readiness_checkpoint() {
+            Ok(Some(checkpoint)) => checkpoint,
+            Ok(None) => {
                 warming = true;
                 defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
                 break 'files;
@@ -327,7 +327,7 @@ pub fn live_oracle_pass(
                 defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
                 break 'files;
             },
-        }
+        };
 
         // Callsite drift gate: the server resolves the DIRTY disk bytes, so those bytes must
         // still hash to the indexed `file_sha` the candidates were built from — a mid-pass edit
@@ -405,9 +405,9 @@ pub fn live_oracle_pass(
         };
         // A reload may begin while the synchronous batch is in flight. Discard the whole batch
         // before interpreting any null definitions, and retry this file once the server is ready.
-        match session.is_ready() {
-            Ok(true) => {},
-            Ok(false) => {
+        match session.readiness_checkpoint() {
+            Ok(Some(checkpoint)) if checkpoint == readiness_checkpoint => {},
+            Ok(_) => {
                 warming = true;
                 defer_candidate_paths_from(&mut report, input.worklist, position, &by_path);
                 break 'files;

--- a/crates/rag-rat-oracle/src/lsp/client.rs
+++ b/crates/rag-rat-oracle/src/lsp/client.rs
@@ -14,7 +14,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -38,6 +38,10 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// the client's heap without limit.
 const INCOMING_QUEUE_CAPACITY: usize = 64;
 
+/// The low bit of `readiness_state` is current readiness; the remaining bits count non-ready
+/// transitions. Keeping both in one atomic makes a checkpoint an indivisible snapshot.
+const SERVER_READY_BIT: u64 = 1;
+
 type IncomingMessage = io::Result<Option<Value>>;
 
 struct OutgoingMessage {
@@ -60,7 +64,7 @@ pub(crate) struct LspClient {
     next_id: i64,
     encoding: LspEncoding,
     request_timeout: Duration,
-    server_ready: Arc<AtomicBool>,
+    readiness_state: Arc<AtomicU64>,
     /// The child process for a spawned server; `None` for an injected (test) transport. Present so
     /// [`Drop`] can hard-kill it.
     child: Option<Child>,
@@ -83,17 +87,17 @@ impl LspClient {
             child.stdin.take().ok_or_else(|| io::Error::other("child stdin unavailable"))?;
         let stdout =
             child.stdout.take().ok_or_else(|| io::Error::other("child stdout unavailable"))?;
-        let server_ready = Arc::new(AtomicBool::new(false));
+        let readiness_state = Arc::new(AtomicU64::new(0));
         Ok(Self {
             outgoing: spawn_writer_pump(Box::new(stdin)),
             incoming: spawn_reader_pump(
                 Box::new(BufReader::new(stdout)),
-                Arc::clone(&server_ready),
+                Arc::clone(&readiness_state),
             ),
             next_id: 1,
             encoding: LspEncoding::Utf16,
             request_timeout: REQUEST_TIMEOUT,
-            server_ready,
+            readiness_state,
             child: Some(child),
         })
     }
@@ -108,14 +112,14 @@ impl LspClient {
         writer: Box<dyn Write + Send>,
         request_timeout: Duration,
     ) -> Self {
-        let server_ready = Arc::new(AtomicBool::new(false));
+        let readiness_state = Arc::new(AtomicU64::new(0));
         Self {
             outgoing: spawn_writer_pump(writer),
-            incoming: spawn_reader_pump(reader, Arc::clone(&server_ready)),
+            incoming: spawn_reader_pump(reader, Arc::clone(&readiness_state)),
             next_id: 1,
             encoding: LspEncoding::Utf16,
             request_timeout,
-            server_ready,
+            readiness_state,
             child: None,
         }
     }
@@ -126,11 +130,12 @@ impl LspClient {
         self.encoding
     }
 
-    /// Drain status notifications already emitted by the server. `true` means rust-analyzer has
-    /// completed background loading (`quiescent`) and is not in an error state. Unknown status is
-    /// deliberately not ready: sending definitions before the first status can turn warm-up
-    /// `null`s into permanently missing evidence.
-    pub(crate) fn is_server_ready(&mut self) -> io::Result<bool> {
+    /// Drain pending server messages and return a checkpoint only when rust-analyzer is ready.
+    /// Comparing checkpoints around a definition batch detects even a non-ready→ready cycle that
+    /// the latest boolean state alone would hide. Unknown status is deliberately not ready:
+    /// sending definitions before the first status can turn warm-up `null`s into permanently
+    /// missing evidence.
+    pub(crate) fn readiness_checkpoint(&mut self) -> io::Result<Option<u64>> {
         let deadline = Instant::now() + self.request_timeout;
         loop {
             if Instant::now() >= deadline {
@@ -142,7 +147,8 @@ impl LspClient {
                     self.handle_server_message(&message, deadline)?;
                 },
                 Err(TryRecvError::Empty) => {
-                    return Ok(self.server_ready.load(Ordering::Relaxed));
+                    let state = self.readiness_state.load(Ordering::SeqCst);
+                    return Ok((state & SERVER_READY_BIT != 0).then_some(state >> 1));
                 },
                 Err(TryRecvError::Disconnected) => return Err(server_closed_error()),
             }
@@ -151,7 +157,7 @@ impl LspClient {
 
     #[cfg(test)]
     pub(crate) fn assume_ready(&mut self) {
-        self.server_ready.store(true, Ordering::Relaxed);
+        self.readiness_state.fetch_or(SERVER_READY_BIT, Ordering::SeqCst);
     }
 
     /// Send a request and return its `result`, mapping a JSON-RPC `error` response to an `Err`.
@@ -344,7 +350,7 @@ fn spawn_writer_pump(mut writer: Box<dyn Write + Send>) -> SyncSender<OutgoingMe
 
 fn spawn_reader_pump(
     mut reader: Box<dyn BufRead + Send>,
-    server_ready: Arc<AtomicBool>,
+    readiness_state: Arc<AtomicU64>,
 ) -> Receiver<IncomingMessage> {
     let (sender, receiver) = mpsc::sync_channel(INCOMING_QUEUE_CAPACITY);
     thread::spawn(move || {
@@ -352,7 +358,16 @@ fn spawn_reader_pump(
             let message = protocol::read_message(&mut reader);
             match message {
                 Ok(Some(message)) if is_server_status(&message) => {
-                    server_ready.store(status_is_ready(&message), Ordering::Relaxed);
+                    let ready = status_is_ready(&message);
+                    if ready {
+                        readiness_state.fetch_or(SERVER_READY_BIT, Ordering::SeqCst);
+                    } else {
+                        let _ = readiness_state.fetch_update(
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                            |state| Some(state.wrapping_add(2) & !SERVER_READY_BIT),
+                        );
+                    }
                 },
                 Ok(Some(message)) if should_queue_incoming(&message) => {
                     if sender.send(Ok(Some(message))).is_err() {
@@ -613,7 +628,7 @@ mod tests {
             }
         });
         client.initialize("file:///repo").unwrap();
-        assert!(client.is_server_ready().unwrap());
+        assert!(client.readiness_checkpoint().unwrap().is_some());
     }
 
     #[test]
@@ -662,9 +677,11 @@ mod tests {
         )
         .unwrap();
 
-        let ready = Arc::new(AtomicBool::new(false));
-        let incoming =
-            spawn_reader_pump(Box::new(BufReader::new(std::io::Cursor::new(framed))), ready);
+        let readiness_state = Arc::new(AtomicU64::new(0));
+        let incoming = spawn_reader_pump(
+            Box::new(BufReader::new(std::io::Cursor::new(framed))),
+            readiness_state,
+        );
         assert_eq!(
             incoming.recv_timeout(Duration::from_secs(1)).unwrap().unwrap(),
             Some(json!({"jsonrpc": "2.0", "id": 7, "result": {"ok": true}})),

--- a/crates/rag-rat-oracle/src/lsp/client.rs
+++ b/crates/rag-rat-oracle/src/lsp/client.rs
@@ -291,11 +291,23 @@ impl LspClient {
         };
         let reply = match method {
             "workspace/configuration" => {
-                json!({"jsonrpc": "2.0", "id": peer_id.clone(), "result": []})
+                let item_count = message["params"]["items"].as_array().map_or(0, Vec::len);
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": peer_id.clone(),
+                    "result": vec![Value::Null; item_count],
+                })
             },
-            "client/registerCapability" | "window/workDoneProgress/create" => {
+            "window/workDoneProgress/create" => {
                 json!({"jsonrpc": "2.0", "id": peer_id.clone(), "result": null})
             },
+            "client/registerCapability" => json!({
+                "jsonrpc": "2.0", "id": peer_id.clone(),
+                "error": {
+                    "code": METHOD_NOT_FOUND,
+                    "message": "dynamic capability registration is not supported"
+                }
+            }),
             _ => json!({
                 "jsonrpc": "2.0", "id": peer_id.clone(),
                 "error": {"code": METHOD_NOT_FOUND,
@@ -593,7 +605,8 @@ mod tests {
                     pending_id = msg.get("id").cloned();
                     Some(vec![json!({
                         "jsonrpc": "2.0", "id": 4242,
-                        "method": "workspace/configuration", "params": {"items": []}
+                        "method": "workspace/configuration",
+                        "params": {"items": [{"section": "rust-analyzer"}, {"section": "rust"}]}
                     })])
                 },
                 // Our reply to the server's request (id 4242, no method) → now answer the original.
@@ -608,7 +621,42 @@ mod tests {
         });
         let result = client.request("custom/thing", json!({})).unwrap();
         assert_eq!(result, json!({"ok": true}), "the original request completed after we replied");
-        assert_eq!(server_reply.lock().unwrap().as_ref().unwrap()["result"], json!([]));
+        assert_eq!(
+            server_reply.lock().unwrap().as_ref().unwrap()["result"],
+            json!([null, null]),
+            "workspace/configuration returns one value per requested item",
+        );
+    }
+
+    #[test]
+    fn request_rejects_unsupported_dynamic_capability_registration() {
+        let mut pending_id: Option<Value> = None;
+        let server_reply = Arc::new(Mutex::new(None));
+        let captured_reply = Arc::clone(&server_reply);
+        let mut client = client_with_server(move |msg: &Value| {
+            match msg.get("method").and_then(Value::as_str) {
+                Some("custom/thing") => {
+                    pending_id = msg.get("id").cloned();
+                    Some(vec![json!({
+                        "jsonrpc": "2.0", "id": 4243,
+                        "method": "client/registerCapability",
+                        "params": {"registrations": [{
+                            "id": "definition", "method": "textDocument/definition"
+                        }]}
+                    })])
+                },
+                None if msg.get("id") == Some(&json!(4243)) => {
+                    *captured_reply.lock().unwrap() = Some(msg.clone());
+                    Some(vec![json!({"jsonrpc": "2.0", "id": pending_id.take(), "result": null})])
+                },
+                _ => Some(vec![]),
+            }
+        });
+
+        client.request("custom/thing", json!({})).unwrap();
+        let reply = server_reply.lock().unwrap();
+        assert_eq!(reply.as_ref().unwrap()["error"]["code"], METHOD_NOT_FOUND);
+        assert!(reply.as_ref().unwrap().get("result").is_none());
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/lsp/client.rs
+++ b/crates/rag-rat-oracle/src/lsp/client.rs
@@ -1,9 +1,10 @@
 //! The resident LSP client: process lifecycle (spawn, `initialize` handshake with position-encoding
 //! negotiation, graceful `shutdown`, kill-on-drop) and synchronous JSON-RPC request/response over
-//! the [`super::protocol`] framing. A reader-pump thread feeds a bounded-wait channel so a wedged
-//! server cannot hold the repository write lock forever. Requests remain single-flight: the client
-//! reads until it sees the response for the id it just sent, tracking status notifications and
-//! replying to server→client requests so a server awaiting that reply cannot deadlock the loop.
+//! the [`super::protocol`] framing. Dedicated transport workers keep blocking pipe I/O off the
+//! maintenance thread, while bounded waits prevent a wedged server from holding the repository
+//! write lock forever. Requests remain single-flight: the client reads until it sees the response
+//! for the id it just sent and replies to server→client requests so a server awaiting that reply
+//! cannot deadlock the loop.
 //!
 //! The transport is injectable (`Box<dyn Write/BufRead>`): [`LspClient::spawn`] wires a child
 //! process, while tests wire an in-process fake server over `std::io::pipe`. That is what makes the
@@ -12,7 +13,9 @@
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -30,7 +33,17 @@ const METHOD_NOT_FOUND: i64 = -32601;
 /// request so a live but non-responsive language server cannot block all writers indefinitely.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Only responses and server requests enter this queue; ordinary notifications are discarded and
+/// readiness is coalesced separately. Bounding the remainder prevents an idle server from growing
+/// the client's heap without limit.
+const INCOMING_QUEUE_CAPACITY: usize = 64;
+
 type IncomingMessage = io::Result<Option<Value>>;
+
+struct OutgoingMessage {
+    message: Value,
+    completed: SyncSender<io::Result<()>>,
+}
 
 /// A JSON-RPC error object from a response (`code` + `message`), so callers can distinguish a
 /// `MethodNotFound` (optional-capability) from a real failure.
@@ -42,12 +55,12 @@ struct LspRpcError {
 /// A live language-server session. Owns the transport and (for a spawned server) the child process,
 /// which it kills on drop so a crashed or abandoned pass never leaks a resident `rust-analyzer`.
 pub(crate) struct LspClient {
-    writer: Box<dyn Write + Send>,
+    outgoing: SyncSender<OutgoingMessage>,
     incoming: Receiver<IncomingMessage>,
     next_id: i64,
     encoding: LspEncoding,
     request_timeout: Duration,
-    server_ready: bool,
+    server_ready: Arc<AtomicBool>,
     /// The child process for a spawned server; `None` for an injected (test) transport. Present so
     /// [`Drop`] can hard-kill it.
     child: Option<Child>,
@@ -70,13 +83,17 @@ impl LspClient {
             child.stdin.take().ok_or_else(|| io::Error::other("child stdin unavailable"))?;
         let stdout =
             child.stdout.take().ok_or_else(|| io::Error::other("child stdout unavailable"))?;
+        let server_ready = Arc::new(AtomicBool::new(false));
         Ok(Self {
-            writer: Box::new(stdin),
-            incoming: spawn_reader_pump(Box::new(BufReader::new(stdout))),
+            outgoing: spawn_writer_pump(Box::new(stdin)),
+            incoming: spawn_reader_pump(
+                Box::new(BufReader::new(stdout)),
+                Arc::clone(&server_ready),
+            ),
             next_id: 1,
             encoding: LspEncoding::Utf16,
             request_timeout: REQUEST_TIMEOUT,
-            server_ready: false,
+            server_ready,
             child: Some(child),
         })
     }
@@ -91,13 +108,14 @@ impl LspClient {
         writer: Box<dyn Write + Send>,
         request_timeout: Duration,
     ) -> Self {
+        let server_ready = Arc::new(AtomicBool::new(false));
         Self {
-            writer,
-            incoming: spawn_reader_pump(reader),
+            outgoing: spawn_writer_pump(writer),
+            incoming: spawn_reader_pump(reader, Arc::clone(&server_ready)),
             next_id: 1,
             encoding: LspEncoding::Utf16,
             request_timeout,
-            server_ready: false,
+            server_ready,
             child: None,
         }
     }
@@ -113,13 +131,19 @@ impl LspClient {
     /// deliberately not ready: sending definitions before the first status can turn warm-up
     /// `null`s into permanently missing evidence.
     pub(crate) fn is_server_ready(&mut self) -> io::Result<bool> {
+        let deadline = Instant::now() + self.request_timeout;
         loop {
+            if Instant::now() >= deadline {
+                return Err(request_timeout_error("server readiness", self.request_timeout));
+            }
             match self.incoming.try_recv() {
                 Ok(message) => {
                     let message = message?.ok_or_else(server_closed_error)?;
-                    self.handle_server_message(&message)?;
+                    self.handle_server_message(&message, deadline)?;
                 },
-                Err(TryRecvError::Empty) => return Ok(self.server_ready),
+                Err(TryRecvError::Empty) => {
+                    return Ok(self.server_ready.load(Ordering::Relaxed));
+                },
                 Err(TryRecvError::Disconnected) => return Err(server_closed_error()),
             }
         }
@@ -127,7 +151,7 @@ impl LspClient {
 
     #[cfg(test)]
     pub(crate) fn assume_ready(&mut self) {
-        self.server_ready = true;
+        self.server_ready.store(true, Ordering::Relaxed);
     }
 
     /// Send a request and return its `result`, mapping a JSON-RPC `error` response to an `Err`.
@@ -167,8 +191,8 @@ impl LspClient {
         let id = self.next_id;
         self.next_id += 1;
         let request = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
-        protocol::write_message(&mut self.writer, &request)?;
         let deadline = Instant::now() + self.request_timeout;
+        self.send_message_until(request, deadline, method)?;
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
@@ -184,7 +208,7 @@ impl LspClient {
             // A `method`-bearing message is server→client: a notification (no id) is ignored; a
             // request (id present) MUST be answered so the server doesn't block waiting on us.
             if msg.get("method").is_some() {
-                self.handle_server_message(&msg)?;
+                self.handle_server_message(&msg, deadline)?;
                 continue;
             }
             // A response with no `method`: ours iff the id matches (single-flight; a stray id is
@@ -209,7 +233,7 @@ impl LspClient {
     /// Send a notification (no id, no response expected).
     pub(crate) fn notify(&mut self, method: &str, params: Value) -> io::Result<()> {
         let notification = json!({"jsonrpc": "2.0", "method": method, "params": params});
-        protocol::write_message(&mut self.writer, &notification)
+        self.send_message_until(notification, Instant::now() + self.request_timeout, method)
     }
 
     /// The `initialize`/`initialized` handshake: advertise the byte-space-friendly encodings we
@@ -252,15 +276,10 @@ impl LspClient {
         self.notify("exit", Value::Null)
     }
 
-    fn handle_server_message(&mut self, message: &Value) -> io::Result<()> {
+    fn handle_server_message(&mut self, message: &Value, deadline: Instant) -> io::Result<()> {
         let Some(method) = message.get("method").and_then(Value::as_str) else {
             return Ok(());
         };
-        if method == "experimental/serverStatus" {
-            let params = &message["params"];
-            self.server_ready = params.get("quiescent").and_then(Value::as_bool) == Some(true)
-                && params.get("health").and_then(Value::as_str) != Some("error");
-        }
         let Some(peer_id) = message.get("id") else {
             return Ok(());
         };
@@ -277,26 +296,103 @@ impl LspClient {
                           "message": "not handled by the rag-rat live oracle"}
             }),
         };
-        protocol::write_message(&mut self.writer, &reply)
+        self.send_message_until(reply, deadline, method)
+    }
+
+    fn send_message_until(
+        &self,
+        message: Value,
+        deadline: Instant,
+        operation: &str,
+    ) -> io::Result<()> {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(request_timeout_error(operation, self.request_timeout));
+        }
+        let (completed, completion) = mpsc::sync_channel(1);
+        self.outgoing.try_send(OutgoingMessage { message, completed }).map_err(
+            |err| match err {
+                TrySendError::Full(_) => io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "server stdin worker is still blocked on an earlier message",
+                ),
+                TrySendError::Disconnected(_) => server_stdin_closed_error(),
+            },
+        )?;
+        match completion.recv_timeout(remaining) {
+            Ok(result) => result,
+            Err(RecvTimeoutError::Timeout) =>
+                Err(request_timeout_error(operation, self.request_timeout)),
+            Err(RecvTimeoutError::Disconnected) => Err(server_stdin_closed_error()),
+        }
     }
 }
 
-fn spawn_reader_pump(mut reader: Box<dyn BufRead + Send>) -> Receiver<IncomingMessage> {
-    let (sender, receiver) = mpsc::channel();
+fn spawn_writer_pump(mut writer: Box<dyn Write + Send>) -> SyncSender<OutgoingMessage> {
+    let (sender, receiver) = mpsc::sync_channel::<OutgoingMessage>(1);
+    thread::spawn(move || {
+        while let Ok(outgoing) = receiver.recv() {
+            let result = protocol::write_message(&mut writer, &outgoing.message);
+            let terminal = result.is_err();
+            if outgoing.completed.send(result).is_err() || terminal {
+                return;
+            }
+        }
+    });
+    sender
+}
+
+fn spawn_reader_pump(
+    mut reader: Box<dyn BufRead + Send>,
+    server_ready: Arc<AtomicBool>,
+) -> Receiver<IncomingMessage> {
+    let (sender, receiver) = mpsc::sync_channel(INCOMING_QUEUE_CAPACITY);
     thread::spawn(move || {
         loop {
             let message = protocol::read_message(&mut reader);
-            let terminal = !matches!(&message, Ok(Some(_)));
-            if sender.send(message).is_err() || terminal {
-                return;
+            match message {
+                Ok(Some(message)) if is_server_status(&message) => {
+                    server_ready.store(status_is_ready(&message), Ordering::Relaxed);
+                },
+                Ok(Some(message)) if should_queue_incoming(&message) => {
+                    if sender.send(Ok(Some(message))).is_err() {
+                        return;
+                    }
+                },
+                // Diagnostics, logs, and progress are irrelevant to this client.
+                Ok(Some(_)) => {},
+                terminal => {
+                    let _ = sender.send(terminal);
+                    return;
+                },
             }
         }
     });
     receiver
 }
 
+fn is_server_status(message: &Value) -> bool {
+    message.get("method").and_then(Value::as_str) == Some("experimental/serverStatus")
+}
+
+fn should_queue_incoming(message: &Value) -> bool {
+    // Responses and server requests have ids. Ordinary notifications do not and would otherwise
+    // accumulate while the watcher is idle.
+    message.get("id").is_some()
+}
+
+fn status_is_ready(message: &Value) -> bool {
+    let params = &message["params"];
+    params.get("quiescent").and_then(Value::as_bool) == Some(true)
+        && params.get("health").and_then(Value::as_str) != Some("error")
+}
+
 fn server_closed_error() -> io::Error {
     io::Error::new(io::ErrorKind::UnexpectedEof, "server closed before responding")
+}
+
+fn server_stdin_closed_error() -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, "server stdin closed before accepting the message")
 }
 
 fn request_timeout_error(method: &str, timeout: Duration) -> io::Error {
@@ -529,6 +625,55 @@ mod tests {
         let err = client.request("custom/thing", json!({})).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         assert!(err.to_string().contains("custom/thing"));
+    }
+
+    #[test]
+    fn notification_times_out_when_the_server_stops_consuming_stdin() {
+        let (blocked_read, blocked_write) = std::io::pipe().unwrap();
+        let mut client = LspClient::from_transport_with_timeout(
+            Box::new(BufReader::new(io::empty())),
+            Box::new(blocked_write),
+            Duration::from_millis(20),
+        );
+        let err = client
+            .notify("textDocument/didOpen", json!({"text": "x".repeat(8 * 1024 * 1024)}))
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(err.to_string().contains("textDocument/didOpen"));
+        drop(blocked_read); // Release the writer worker after proving the caller is bounded.
+    }
+
+    #[test]
+    fn reader_pump_discards_an_idle_notification_flood() {
+        let mut framed = Vec::new();
+        for sequence in 0..INCOMING_QUEUE_CAPACITY * 2 {
+            protocol::write_message(
+                &mut framed,
+                &json!({
+                    "jsonrpc": "2.0", "method": "window/logMessage",
+                    "params": {"sequence": sequence}
+                }),
+            )
+            .unwrap();
+        }
+        protocol::write_message(
+            &mut framed,
+            &json!({"jsonrpc": "2.0", "id": 7, "result": {"ok": true}}),
+        )
+        .unwrap();
+
+        let ready = Arc::new(AtomicBool::new(false));
+        let incoming =
+            spawn_reader_pump(Box::new(BufReader::new(std::io::Cursor::new(framed))), ready);
+        assert_eq!(
+            incoming.recv_timeout(Duration::from_secs(1)).unwrap().unwrap(),
+            Some(json!({"jsonrpc": "2.0", "id": 7, "result": {"ok": true}})),
+            "ordinary notifications must not occupy the bounded response queue"
+        );
+        assert!(
+            incoming.recv_timeout(Duration::from_secs(1)).unwrap().unwrap().is_none(),
+            "EOF follows the preserved response"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/lsp/client.rs
+++ b/crates/rag-rat-oracle/src/lsp/client.rs
@@ -1,9 +1,9 @@
 //! The resident LSP client: process lifecycle (spawn, `initialize` handshake with position-encoding
 //! negotiation, graceful `shutdown`, kill-on-drop) and synchronous JSON-RPC request/response over
-//! the [`super::protocol`] framing. Single-flight by design — slice 1 issues one request at a time
-//! from the maintenance-pass worker thread — so `request` reads until it sees the response for the
-//! id it just sent, skipping interleaved notifications and replying `MethodNotFound` to any
-//! server→client request so a server awaiting that reply can't deadlock the loop.
+//! the [`super::protocol`] framing. A reader-pump thread feeds a bounded-wait channel so a wedged
+//! server cannot hold the repository write lock forever. Requests remain single-flight: the client
+//! reads until it sees the response for the id it just sent, tracking status notifications and
+//! replying to server→client requests so a server awaiting that reply cannot deadlock the loop.
 //!
 //! The transport is injectable (`Box<dyn Write/BufRead>`): [`LspClient::spawn`] wires a child
 //! process, while tests wire an in-process fake server over `std::io::pipe`. That is what makes the
@@ -12,6 +12,9 @@
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
@@ -22,6 +25,12 @@ use super::protocol;
 /// optional request like `textDocument/moniker`), and the code we reply with to a server→client
 /// request we don't handle.
 const METHOD_NOT_FOUND: i64 = -32601;
+
+/// Definition requests run while the maintenance pass owns the repository write lock. Bound every
+/// request so a live but non-responsive language server cannot block all writers indefinitely.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+type IncomingMessage = io::Result<Option<Value>>;
 
 /// A JSON-RPC error object from a response (`code` + `message`), so callers can distinguish a
 /// `MethodNotFound` (optional-capability) from a real failure.
@@ -34,9 +43,11 @@ struct LspRpcError {
 /// which it kills on drop so a crashed or abandoned pass never leaks a resident `rust-analyzer`.
 pub(crate) struct LspClient {
     writer: Box<dyn Write + Send>,
-    reader: Box<dyn BufRead + Send>,
+    incoming: Receiver<IncomingMessage>,
     next_id: i64,
     encoding: LspEncoding,
+    request_timeout: Duration,
+    server_ready: bool,
     /// The child process for a spawned server; `None` for an injected (test) transport. Present so
     /// [`Drop`] can hard-kill it.
     child: Option<Child>,
@@ -61,22 +72,62 @@ impl LspClient {
             child.stdout.take().ok_or_else(|| io::Error::other("child stdout unavailable"))?;
         Ok(Self {
             writer: Box::new(stdin),
-            reader: Box::new(BufReader::new(stdout)),
+            incoming: spawn_reader_pump(Box::new(BufReader::new(stdout))),
             next_id: 1,
             encoding: LspEncoding::Utf16,
+            request_timeout: REQUEST_TIMEOUT,
+            server_ready: false,
             child: Some(child),
         })
     }
 
     /// Build a client over an injected transport (no child process). The fake-server test seam.
     fn from_transport(reader: Box<dyn BufRead + Send>, writer: Box<dyn Write + Send>) -> Self {
-        Self { writer, reader, next_id: 1, encoding: LspEncoding::Utf16, child: None }
+        Self::from_transport_with_timeout(reader, writer, REQUEST_TIMEOUT)
+    }
+
+    fn from_transport_with_timeout(
+        reader: Box<dyn BufRead + Send>,
+        writer: Box<dyn Write + Send>,
+        request_timeout: Duration,
+    ) -> Self {
+        Self {
+            writer,
+            incoming: spawn_reader_pump(reader),
+            next_id: 1,
+            encoding: LspEncoding::Utf16,
+            request_timeout,
+            server_ready: false,
+            child: None,
+        }
     }
 
     /// The position encoding negotiated during [`initialize`](Self::initialize) (UTF-16 until
     /// then).
     pub(crate) fn encoding(&self) -> LspEncoding {
         self.encoding
+    }
+
+    /// Drain status notifications already emitted by the server. `true` means rust-analyzer has
+    /// completed background loading (`quiescent`) and is not in an error state. Unknown status is
+    /// deliberately not ready: sending definitions before the first status can turn warm-up
+    /// `null`s into permanently missing evidence.
+    pub(crate) fn is_server_ready(&mut self) -> io::Result<bool> {
+        loop {
+            match self.incoming.try_recv() {
+                Ok(message) => {
+                    let message = message?.ok_or_else(server_closed_error)?;
+                    self.handle_server_message(&message)?;
+                },
+                Err(TryRecvError::Empty) => return Ok(self.server_ready),
+                Err(TryRecvError::Disconnected) => return Err(server_closed_error()),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn assume_ready(&mut self) {
+        self.server_ready = true;
     }
 
     /// Send a request and return its `result`, mapping a JSON-RPC `error` response to an `Err`.
@@ -105,10 +156,9 @@ impl LspClient {
 
     /// Send a request and block until its response arrives, returning the `result` (`Ok(Ok)`) or
     /// the JSON-RPC error object (`Ok(Err)`); the outer `io::Result` is the transport. While
-    /// waiting it skips notifications AND — crucially — REPLIES to any server→client request
-    /// with a `MethodNotFound` error, because a server that awaits that reply before answering
-    /// us would otherwise deadlock this single-flight loop (slice 3 can add real handlers for
-    /// `workspace/configuration` etc.).
+    /// waiting it tracks notifications and replies to server→client requests. The whole operation
+    /// shares one deadline, including any interleaved messages, so notification traffic cannot
+    /// postpone timeout indefinitely.
     fn request_raw(
         &mut self,
         method: &str,
@@ -118,21 +168,23 @@ impl LspClient {
         self.next_id += 1;
         let request = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
         protocol::write_message(&mut self.writer, &request)?;
+        let deadline = Instant::now() + self.request_timeout;
         loop {
-            let msg = protocol::read_message(&mut self.reader)?.ok_or_else(|| {
-                io::Error::new(io::ErrorKind::UnexpectedEof, "server closed before responding")
-            })?;
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(request_timeout_error(method, self.request_timeout));
+            }
+            let msg = match self.incoming.recv_timeout(remaining) {
+                Ok(message) => message?.ok_or_else(server_closed_error)?,
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(request_timeout_error(method, self.request_timeout));
+                },
+                Err(RecvTimeoutError::Disconnected) => return Err(server_closed_error()),
+            };
             // A `method`-bearing message is server→client: a notification (no id) is ignored; a
             // request (id present) MUST be answered so the server doesn't block waiting on us.
             if msg.get("method").is_some() {
-                if let Some(peer_id) = msg.get("id") {
-                    let reply = json!({
-                        "jsonrpc": "2.0", "id": peer_id.clone(),
-                        "error": {"code": METHOD_NOT_FOUND,
-                                  "message": "not handled by the rag-rat live oracle"}
-                    });
-                    protocol::write_message(&mut self.writer, &reply)?;
-                }
+                self.handle_server_message(&msg)?;
                 continue;
             }
             // A response with no `method`: ours iff the id matches (single-flight; a stray id is
@@ -178,6 +230,7 @@ impl LspClient {
                 "textDocument": {
                     "definition": { "dynamicRegistration": false, "linkSupport": true },
                 },
+                "experimental": { "serverStatusNotification": true },
             },
         });
         let result = self.request("initialize", params)?;
@@ -198,6 +251,59 @@ impl LspClient {
         self.request("shutdown", Value::Null)?;
         self.notify("exit", Value::Null)
     }
+
+    fn handle_server_message(&mut self, message: &Value) -> io::Result<()> {
+        let Some(method) = message.get("method").and_then(Value::as_str) else {
+            return Ok(());
+        };
+        if method == "experimental/serverStatus" {
+            let params = &message["params"];
+            self.server_ready = params.get("quiescent").and_then(Value::as_bool) == Some(true)
+                && params.get("health").and_then(Value::as_str) != Some("error");
+        }
+        let Some(peer_id) = message.get("id") else {
+            return Ok(());
+        };
+        let reply = match method {
+            "workspace/configuration" => {
+                json!({"jsonrpc": "2.0", "id": peer_id.clone(), "result": []})
+            },
+            "client/registerCapability" | "window/workDoneProgress/create" => {
+                json!({"jsonrpc": "2.0", "id": peer_id.clone(), "result": null})
+            },
+            _ => json!({
+                "jsonrpc": "2.0", "id": peer_id.clone(),
+                "error": {"code": METHOD_NOT_FOUND,
+                          "message": "not handled by the rag-rat live oracle"}
+            }),
+        };
+        protocol::write_message(&mut self.writer, &reply)
+    }
+}
+
+fn spawn_reader_pump(mut reader: Box<dyn BufRead + Send>) -> Receiver<IncomingMessage> {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        loop {
+            let message = protocol::read_message(&mut reader);
+            let terminal = !matches!(&message, Ok(Some(_)));
+            if sender.send(message).is_err() || terminal {
+                return;
+            }
+        }
+    });
+    receiver
+}
+
+fn server_closed_error() -> io::Error {
+    io::Error::new(io::ErrorKind::UnexpectedEof, "server closed before responding")
+}
+
+fn request_timeout_error(method: &str, timeout: Duration) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("LSP request {method} timed out after {}s", timeout.as_secs_f64()),
+    )
 }
 
 impl Drop for LspClient {
@@ -216,6 +322,7 @@ impl Drop for LspClient {
 pub(crate) mod test_support {
     use std::io::BufReader;
     use std::thread;
+    use std::time::Duration;
 
     use serde_json::Value;
 
@@ -228,6 +335,13 @@ pub(crate) mod test_support {
     /// real EOF rather than blocking. The server thread also exits when the client drops (its
     /// write end closes → the server reads EOF).
     pub(crate) fn client_with_server<H>(handler: H) -> LspClient
+    where
+        H: FnMut(&Value) -> Option<Vec<Value>> + Send + 'static,
+    {
+        client_with_server_timeout(handler, super::REQUEST_TIMEOUT)
+    }
+
+    pub(crate) fn client_with_server_timeout<H>(handler: H, timeout: Duration) -> LspClient
     where
         H: FnMut(&Value) -> Option<Vec<Value>> + Send + 'static,
     {
@@ -248,9 +362,10 @@ pub(crate) mod test_support {
                 }
             }
         });
-        LspClient::from_transport(
+        LspClient::from_transport_with_timeout(
             Box::new(BufReader::new(from_server_read)),
             Box::new(to_server_write),
+            timeout,
         )
     }
 }
@@ -284,6 +399,10 @@ mod tests {
             .expect("an initialize request was sent");
         assert_eq!(
             init["params"]["capabilities"]["textDocument"]["definition"]["linkSupport"].as_bool(),
+            Some(true),
+        );
+        assert_eq!(
+            init["params"]["capabilities"]["experimental"]["serverStatusNotification"].as_bool(),
             Some(true),
         );
     }
@@ -355,6 +474,8 @@ mod tests {
         // dropped the server request, the server would block forever (the run's terminate-after
         // would kill it). A returned result proves the client replied.
         let mut pending_id: Option<Value> = None;
+        let server_reply = Arc::new(Mutex::new(None));
+        let captured_reply = Arc::clone(&server_reply);
         let mut client = client_with_server(move |msg: &Value| {
             match msg.get("method").and_then(Value::as_str) {
                 Some("custom/thing") => {
@@ -365,14 +486,49 @@ mod tests {
                     })])
                 },
                 // Our reply to the server's request (id 4242, no method) → now answer the original.
-                None if msg.get("id") == Some(&json!(4242)) => Some(vec![
-                    json!({"jsonrpc": "2.0", "id": pending_id.take(), "result": {"ok": true}}),
-                ]),
+                None if msg.get("id") == Some(&json!(4242)) => {
+                    *captured_reply.lock().unwrap() = Some(msg.clone());
+                    Some(vec![
+                        json!({"jsonrpc": "2.0", "id": pending_id.take(), "result": {"ok": true}}),
+                    ])
+                },
                 _ => Some(vec![]),
             }
         });
         let result = client.request("custom/thing", json!({})).unwrap();
         assert_eq!(result, json!({"ok": true}), "the original request completed after we replied");
+        assert_eq!(server_reply.lock().unwrap().as_ref().unwrap()["result"], json!([]));
+    }
+
+    #[test]
+    fn server_status_tracks_quiescent_non_error_readiness() {
+        let mut client = client_with_server(|msg: &Value| {
+            let id = msg.get("id").cloned();
+            match msg.get("method").and_then(Value::as_str) {
+                Some("initialize") => Some(vec![
+                    json!({
+                        "jsonrpc": "2.0", "method": "experimental/serverStatus",
+                        "params": {"health": "ok", "quiescent": true}
+                    }),
+                    json!({"jsonrpc": "2.0", "id": id, "result": {"capabilities": {}}}),
+                ]),
+                _ if id.is_none() => Some(vec![]),
+                _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+            }
+        });
+        client.initialize("file:///repo").unwrap();
+        assert!(client.is_server_ready().unwrap());
+    }
+
+    #[test]
+    fn request_times_out_when_the_server_stays_open_without_replying() {
+        let mut client = test_support::client_with_server_timeout(
+            |_msg| Some(vec![]),
+            Duration::from_millis(20),
+        );
+        let err = client.request("custom/thing", json!({})).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(err.to_string().contains("custom/thing"));
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -180,6 +180,10 @@ fn live_pass_discards_a_definition_batch_when_readiness_regresses() {
                     "params": {"health": "ok", "quiescent": false}
                 }),
                 json!({
+                    "jsonrpc": "2.0", "method": "experimental/serverStatus",
+                    "params": {"health": "ok", "quiescent": true}
+                }),
+                json!({
                     "jsonrpc": "2.0", "id": id,
                     "result": {
                         "uri": definition_uri,

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -162,6 +162,53 @@ fn live_pass_defers_the_whole_worklist_while_the_server_is_warming() {
 }
 
 #[test]
+fn live_pass_discards_a_definition_batch_when_readiness_regresses() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let definition_uri = def_uri(&h, "defs.rs");
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            Some("textDocument/definition") => Some(vec![
+                json!({
+                    "jsonrpc": "2.0", "method": "experimental/serverStatus",
+                    "params": {"health": "ok", "quiescent": false}
+                }),
+                json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {
+                        "uri": definition_uri,
+                        "range": {
+                            "start": {"line": 0, "character": 3},
+                            "end": {"line": 0, "character": 9}
+                        }
+                    }
+                }),
+            ]),
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let mut session = LiveOracleSession::from_client(client, LIVE_VERSION, &uri);
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.status, "Warming");
+    assert_eq!(report.requests_used, 1);
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.unresolved, 0);
+    assert_eq!(report.unfinished_paths, worklist);
+    assert!(h.verdict(edge).is_none(), "the in-flight batch must be discarded");
+    assert_eq!(live_run_count(&h.conn), 0);
+}
+
+#[test]
 fn live_verdict_copies_the_batch_moniker_verbatim() {
     let h = Harness::new();
     let (_src, target, edge) = seed_corpus(&h);

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -3,6 +3,8 @@
 //! definitions to symbols + batch monikers and persists `ra-lsp` verdicts + a backing run row.
 //! No real rust-analyzer, no network.
 
+use std::sync::{Arc, Mutex};
+
 use serde_json::{Value, json};
 
 use super::*;
@@ -114,6 +116,49 @@ fn live_pass_upgrades_a_name_only_edge_and_records_the_run() {
         "no batch baseline ⇒ the content-stable sentinel: {symbol}"
     );
     assert_eq!(live_run_count(&h.conn), 1, "one backing run row for the writing pass");
+}
+
+#[test]
+fn live_pass_defers_the_whole_worklist_while_the_server_is_warming() {
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let requested_methods = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&requested_methods);
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        if let Some(method) = msg.get("method").and_then(Value::as_str) {
+            captured.lock().unwrap().push(method.to_string());
+        }
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![
+                json!({
+                    "jsonrpc": "2.0", "method": "experimental/serverStatus",
+                    "params": {"health": "ok", "quiescent": false}
+                }),
+                json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {"capabilities": {"positionEncoding": "utf-16"}}
+                }),
+            ]),
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let mut session = LiveOracleSession::from_warming_client(client, LIVE_VERSION, &uri);
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.status, "Warming");
+    assert_eq!(report.requests_used, 0);
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.unfinished_paths, worklist);
+    assert_eq!(live_run_count(&h.conn), 0);
+    assert!(
+        !requested_methods.lock().unwrap().iter().any(|method| method == "textDocument/definition"),
+        "warm-up must not turn temporary null definitions into completed work"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- gate live definition resolution on rust-analyzer `serverStatus` quiescence so temporary warm-up nulls do not become completed unresolved evidence
- bound synchronous LSP requests with a 30-second deadline and preserve unfinished work when the server closes or wedges
- handle rust-analyzer server requests for configuration, capability registration, and work-done progress

This addresses the readiness, server-request, and write-lock timeout portions of #535. Respawn backoff and idle scheduling independent of maintenance passes remain follow-up work in that issue.

## Verification

- `cargo nextest run -p rag-rat-oracle`
- `cargo nextest run -p rag-rat-core live_oracle`
- `cargo clippy -p rag-rat-oracle --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`