### PR TITLE
feat(lens): add authenticated VS Code repository lens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,22 @@ jobs:
           # Tokenless upload works for public repos; CODECOV_TOKEN is used if the secret is set.
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  lens-extension:
+    name: vscode lens extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+      # Strict typecheck, dual Node/web production bundles, transport tests, and a clean
+      # dependency audit — the whole TS tree is otherwise invisible to CI (#216).
+      - run: npm ci && npm run package && npm test && npm audit --audit-level=moderate
+        working-directory: editors/vscode
+      # Packaging smoke: the published VSIX must build from a clean checkout with no runtime
+      # dependencies (both Node and web bundles are pre-built by `vscode:prepublish`).
+      - run: npx --yes @vscode/vsce package --no-dependencies --out /tmp/rag-rat-lens.vsix
+        working-directory: editors/vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3750,6 +3808,12 @@ checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
@@ -4891,6 +4955,7 @@ dependencies = [
  "toon-format",
  "tracing",
  "tui-tree-widget",
+ "url",
  "zeroize",
 ]
 
@@ -4992,6 +5057,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "unicase",
  "unicode-normalization",
  "ureq 3.3.0",
  "x25519-dalek",
@@ -5058,6 +5124,10 @@ name = "rag-rat-mcp"
 version = "0.21.1"
 dependencies = [
  "anyhow",
+ "axum",
+ "futures-util",
+ "getrandom 0.4.3",
+ "gix",
  "libc",
  "rag-rat-base",
  "rag-rat-core",
@@ -5072,7 +5142,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tracing",
+ "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5877,6 +5950,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6658,6 +6742,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ rag-rat-core = { version = "0.21.1", path = "crates/rag-rat-core", default-featu
 rag-rat-mcp = { version = "0.21.1", path = "crates/rag-rat-mcp", default-features = false }
 rag-rat-sync = { version = "0.21.1", path = "crates/rag-rat-sync", default-features = false }
 anyhow = "1.0"
+axum = "0.8"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`
 # CSPRNG-keygen feature stays OFF — device keys derive deterministically from a seed via
@@ -88,6 +89,16 @@ getrandom = "0.4"
 gix = { version = "0.86.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
 httpdate = "1.0"
 libc = "0.2"
+# Win32 bindings for the Lens discovery credential's owner-only DACL. Unix keeps the token private
+# with mode bits; Windows has no equivalent, so the ACL has to be written through advapi32. Already
+# in the tree transitively (tokio, gix); this only adds the security feature modules.
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+] }
 # Separator-aware path→forward-slash conversion. Unlike a raw `\`→`/` replace, it only rewrites the
 # actual path SEPARATOR — so a literal backslash in a Unix filename is preserved. Used where a path
 # becomes a string for a non-filesystem consumer (a `node`/`npx` command arg, a TOML value).

--- a/README.md
+++ b/README.md
@@ -384,6 +384,26 @@ Optional git hooks (`rag-rat hooks install`) keep the index current on checkout/
 One watcher per worktree and one writer at a time are enforced with file locks (unreliable on
 NFS / WSL2 `/mnt` mounts).
 
+## Editor Lens HTTP API
+
+An active `rag-rat mcp` process also elects one authenticated Lens HTTP server per worktree. It
+publishes the loopback URL and bearer token to `.rag-rat/sockets/lens.json`; the credential file is
+owner-readable only on Unix. Set `RAG_RAT_NO_LENS=1` to disable this embedded server, or set
+`RAG_RAT_LENS_ORIGINS` to a comma-separated exact browser-origin allowlist.
+
+Run `rag-rat serve` when the HTTP API needs its own lifecycle. Loopback serving generates a token;
+clients read it from the discovery file. A non-loopback bind requires both an explicit token
+environment variable and at least one trusted browser origin:
+
+```bash
+LENS_TOKEN="$(openssl rand -hex 32)" rag-rat serve \
+  --bind 0.0.0.0 --token-env LENS_TOKEN --allow-origin https://lens.example.com
+```
+
+Every non-preflight request uses `Authorization: Bearer <token>`. Allowed origins are matched
+exactly; wildcard CORS is never emitted. The built-in listener is plain HTTP, so terminate TLS in a
+trusted reverse proxy or tunnel before exposing a non-loopback server across an untrusted network.
+
 By default every repo's index and memories live in **one consolidated database per machine**
 (`$XDG_DATA_HOME/rag-rat/rag-rat.sqlite`; override with `RAG_RAT_DATA_DIR`), so a deleted checkout or
 `git clean -fdx` no longer loses your authored memories. Set an explicit `[index] database` to keep a
@@ -507,6 +527,7 @@ rag-rat consolidate                # import a legacy per-repo index into the glo
 rag-rat hooks install              # git maintenance hooks
 rag-rat gc                         # prune rows for dead git contexts
 rag-rat eval [--json|--update-baseline]   # CI search-quality gate; requires a `--features eval` build (absent from the released binary)
+rag-rat serve                      # authenticated editor Lens HTTP API
 rag-rat mcp                        # start the STDIO server
 ```
 

--- a/crates/rag-rat-base/src/locks.rs
+++ b/crates/rag-rat-base/src/locks.rs
@@ -588,6 +588,15 @@ pub fn socket_lock_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
     base_dir.join("locks").join(format!("{}.socket.lock", worktree_hash(worktree_root)))
 }
 
+/// Election lock for the editor lens HTTP server. It lives beside the database, not under the
+/// disposable workspace discovery directory, so deleting `.rag-rat/` cannot unlink a held lock
+/// and elect a second server for the same worktree.
+pub fn lens_server_lock_path_for(config: &Config, worktree_root: &Path) -> PathBuf {
+    let base =
+        config.database.parent().map(Path::to_path_buf).unwrap_or_else(|| config.root.clone());
+    base.join("locks").join(format!("{}.lens.lock", worktree_hash(worktree_root)))
+}
+
 /// Where the elected listener binds. Prefers a `sockets/` sibling of `locks/` under the shared
 /// DB dir; diverts to `$XDG_RUNTIME_DIR/rag-rat/` then the OS temp dir when the result would
 /// exceed the `sun_path` budget. Hook clients compute the same path independently, so this must

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -36,9 +36,10 @@ rag-rat-query.workspace = true
 rag-rat-mcp = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["net", "signal"] }
 tracing.workspace = true
 rusqlite.workspace = true
+url.workspace = true
 # Minting the persisted sync node key (OS CSPRNG) and scrubbing the in-memory copy.
 getrandom.workspace = true
 zeroize.workspace = true

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -3,6 +3,7 @@
 //! the typed result. The global `--config` defaults to governing-path discovery and may appear
 //! before or after the subcommand.
 
+use std::net::IpAddr;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -80,6 +81,9 @@ pub(crate) enum Command {
 
     /// Run the stdio MCP server.
     Mcp,
+
+    /// Serve the authenticated editor Lens HTTP API.
+    Serve(ServeArgs),
 
     /// Inspect and re-anchor source-anchored repo memories.
     Memory(MemoryArgs),
@@ -184,6 +188,48 @@ pub(crate) enum AgentHookHarnessArg {
     Auto,
     Cursor,
     Vscode,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ServeArgs {
+    /// Address to bind. Non-loopback interfaces require --token-env and --allow-origin.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub bind: IpAddr,
+    /// TCP port to bind. Use 0 to let the operating system choose an available port.
+    #[arg(long, default_value_t = 18120)]
+    pub port: u16,
+    /// Environment variable containing the bearer token. Loopback serving generates a token when
+    /// omitted; non-loopback serving requires an explicit token variable.
+    #[arg(long, value_name = "ENV_VAR")]
+    pub token_env: Option<String>,
+    /// Exact browser Origin allowed to call the API (`scheme://host[:port]`, no path). Repeat
+    /// for multiple trusted origins.
+    #[arg(long, value_name = "ORIGIN", value_parser = parse_lens_origin)]
+    pub allow_origin: Vec<String>,
+}
+
+/// clap `value_parser` for `--allow-origin`: an Origin header is `scheme://host[:port]` with no
+/// path, query, or fragment. A trailing slash is normalized away; anything else that would
+/// silently never match the header is rejected at parse time.
+fn parse_lens_origin(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    let parsed = url::Url::parse(trimmed)
+        .map_err(|_| format!("origin `{raw}` must look like scheme://host[:port]"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(format!("origin scheme must be http or https: `{raw}`"));
+    }
+    if parsed.host().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.path() != "/"
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err(format!(
+            "origin must not contain credentials, a path, query, or fragment: `{raw}`"
+        ));
+    }
+    Ok(parsed.origin().ascii_serialization())
 }
 
 #[derive(Debug, Args)]
@@ -1015,6 +1061,55 @@ mod tests {
             Command::AgentHook(args) => assert_eq!(args.harness, AgentHookHarnessArg::Auto),
             other => panic!("expected agent-hook, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn serve_defaults_to_loopback_and_accepts_port_zero() {
+        let defaults = Cli::try_parse_from(["rag-rat", "serve"]).expect("parse");
+        match defaults.command {
+            Command::Serve(args) => {
+                assert!(args.bind.is_loopback());
+                assert_eq!(args.port, 18120);
+                assert!(args.token_env.is_none());
+                assert!(args.allow_origin.is_empty());
+            },
+            other => panic!("expected serve, got {other:?}"),
+        }
+
+        let ephemeral = Cli::try_parse_from(["rag-rat", "serve", "--port", "0"]).expect("parse");
+        match ephemeral.command {
+            Command::Serve(args) => assert_eq!(args.port, 0),
+            other => panic!("expected serve, got {other:?}"),
+        }
+
+        let hosted = Cli::try_parse_from([
+            "rag-rat",
+            "serve",
+            "--bind",
+            "0.0.0.0",
+            "--token-env",
+            "LENS_TOKEN",
+            "--allow-origin",
+            "HTTPS://Lens.Example:443/",
+        ])
+        .expect("parse");
+        match hosted.command {
+            Command::Serve(args) => {
+                assert_eq!(args.token_env.as_deref(), Some("LENS_TOKEN"));
+                assert_eq!(args.allow_origin, ["https://lens.example"]);
+            },
+            other => panic!("expected serve, got {other:?}"),
+        }
+
+        assert!(
+            Cli::try_parse_from([
+                "rag-rat",
+                "serve",
+                "--allow-origin",
+                "https://lens.example/path",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -20,7 +20,7 @@ use rag_rat_core::index::IndexProgress;
 use rag_rat_core::search::lexical::SearchHit;
 pub(crate) use render::*;
 
-use crate::cli::{Cli, Command as Cmd, DoctorArgs};
+use crate::cli::{Cli, Command as Cmd, DoctorArgs, ServeArgs};
 
 mod agent_hook;
 mod init;
@@ -131,6 +131,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::ImportantSymbols(args) => important_symbols(&config, &args)?,
         Cmd::Clones(args) => clones(&config, &args)?,
         Cmd::ClonesFor(args) => clones_for(&config, &args)?,
+        Cmd::Serve(args) => serve_http(config, &args)?,
         Cmd::Memory(args) => memory(&config, &args)?,
         Cmd::Sync(args) => sync(&config, &args)?,
         Cmd::Dream(args) => dream(&config, &args)?,
@@ -457,6 +458,63 @@ fn run_mcp(explicit: Option<&str>, json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn serve_http(config: Config, args: &ServeArgs) -> anyhow::Result<()> {
+    if !args.bind.is_loopback() && (args.token_env.is_none() || args.allow_origin.is_empty()) {
+        anyhow::bail!(
+            "non-loopback `rag-rat serve` requires --token-env and at least one --allow-origin"
+        );
+    }
+    let token = match args.token_env.as_deref() {
+        Some(name) => std::env::var(name)
+            .map_err(|_| anyhow::anyhow!("--token-env variable `{name}` is missing"))?
+            .trim()
+            .to_string(),
+        None => rag_rat_mcp::lens_server::ownership_token()?,
+    };
+    anyhow::ensure!(!token.is_empty(), "lens bearer token must not be empty");
+    // Election BEFORE side effects: a second `rag-rat serve` on the same worktree must fail
+    // fast without healing the index or spawning a watcher it never uses.
+    let workspace_root = rag_rat_mcp::lens_server::workspace_root(&config);
+    let election_lock = rag_rat_base::locks::FileLock::try_acquire(
+        &rag_rat_base::locks::lens_server_lock_path_for(&config, &workspace_root),
+    )?
+    .ok_or_else(|| anyhow::anyhow!("a lens server already owns this worktree"))?;
+    drop(IndexDatabase::open_config(&config)?);
+    let _watcher = rag_rat_core::watch::Watcher::spawn(config.clone());
+    let address = std::net::SocketAddr::new(args.bind, args.port);
+    let allowed_origins = args.allow_origin.clone();
+    let runtime =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
+    runtime.block_on(async move {
+        rag_rat_mcp::lens_server::serve_standalone(
+            config,
+            workspace_root,
+            address,
+            token,
+            allowed_origins,
+            election_lock,
+            shutdown_signal(),
+        )
+        .await
+    })
+}
+
+async fn shutdown_signal() -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut terminate = signal(SignalKind::terminate())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result,
+            _ = terminate.recv() => Ok(()),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await
+    }
+}
+
 /// Run `doctor`, tolerating the ABSENCE of a config: with no `rag-rat.toml` at or above the cwd,
 /// report the machine-global store (`$XDG_DATA_HOME/rag-rat/rag-rat.sqlite`) instead of erroring —
 /// "no local config" is not "no data". `--vacuum` rewrites a specific repo's index, so it still
@@ -568,6 +626,7 @@ fn log_role(cmd: &Cmd) -> rag_rat_base::logging::Role {
     use rag_rat_base::logging::Role;
     match cmd {
         Cmd::Mcp => Role::Mcp,
+        Cmd::Serve(_) => Role::Cli("serve".to_string()),
         Cmd::Maintenance(args) if is_git_hook_trigger(args.trigger.as_deref()) => Role::Hook,
         Cmd::Maintenance(_) => Role::Cli("maintenance".to_string()),
         Cmd::Reconcile(_) => Role::Cli("reconcile".to_string()),

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -219,6 +219,10 @@ fn mcp_stdio_serves_dormant_without_a_config() {
     // The server is still alive after those calls — a further request is answered.
     send(&mut stdin, json!({"jsonrpc": "2.0", "id": 5, "method": "tools/list"}));
     assert_eq!(recv(&mut reader)["id"], 5, "the dormant server stays alive across calls");
+    assert!(
+        !root.join(".rag-rat/sockets/lens.json").exists(),
+        "a dormant MCP lifecycle must not publish lens discovery"
+    );
 
     stop(child);
 }

--- a/crates/rag-rat-clones/src/refine/split.rs
+++ b/crates/rag-rat-clones/src/refine/split.rs
@@ -29,6 +29,9 @@
 //! real small cliques, while a genuinely dense ≥200-member clique (every pair ≥ θ) still collapses
 //! to one class. NO member is lost — every θ-edge endpoint lands in at least its own seed clique.
 
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
+
 /// Budget on the number of GROWN maximal cliques before the cover stops growing and falls back to
 /// emitting the remaining θ-edges as ungrown 2-member cliques (#256). It bounds the superlinear
 /// maximal-subset-removal pass (O(grown² × n)) — to a sub-second budget (256² × n) on a
@@ -119,6 +122,21 @@ pub fn coherence_split(
     edges: &[(i64, i64)],
     similarity: impl Fn(i64, i64) -> f64,
 ) -> Vec<Vec<i64>> {
+    coherence_split_cancellable(component, edges, similarity, || false)
+        .expect("a permanently-false cancellation predicate cannot cancel")
+}
+
+/// Cancellation-aware form used by latency-bounded editor reads. Returns `None` without exposing
+/// a partial clique cover when the caller's request has expired.
+pub fn coherence_split_cancellable(
+    component: &[i64],
+    edges: &[(i64, i64)],
+    similarity: impl Fn(i64, i64) -> f64,
+    cancelled: impl Fn() -> bool,
+) -> Option<Vec<Vec<i64>>> {
+    if cancelled() {
+        return None;
+    }
     // 1. Sort ascending (determinism).
     let mut members: Vec<i64> = component.to_vec();
     members.sort_unstable();
@@ -134,17 +152,16 @@ pub fn coherence_split(
     // ≥ θ edges (verified by `candidate_pairs_from_bags` at the call site), so there is no
     // all-pairs similarity scan here — that scan was the reason for the removed `SPLIT_MAX`
     // member cap.
-    let mut coherent_edges: Vec<(i64, i64)> = edges
-        .iter()
-        .filter_map(|&(a, b)| {
-            if a == b || !member_set.contains(&a) || !member_set.contains(&b) {
-                return None;
-            }
-            Some((a.min(b), a.max(b)))
-        })
-        .collect();
-    coherent_edges.sort_unstable();
-    coherent_edges.dedup();
+    let mut coherent_edges = Vec::with_capacity(edges.len());
+    for (index, &(a, b)) in edges.iter().enumerate() {
+        if index.is_multiple_of(1024) && cancelled() {
+            return None;
+        }
+        if a != b && member_set.contains(&a) && member_set.contains(&b) {
+            coherent_edges.push((a.min(b), a.max(b)));
+        }
+    }
+    let coherent_edges = sort_dedup_edges_cancellable(coherent_edges, &cancelled)?;
 
     // 2a. Adjacency set over the canonical θ-edges, for the O(1) GROW coherence check (#258).
     //
@@ -178,7 +195,13 @@ pub fn coherence_split(
     //   two grows are byte-identical — the production invariant the issue assumed, and what the
     //   `coherence_split_edge_adjacency_equals_similarity_recompute_when_edges_are_theta_set` test
     //   pins on `edges == exactly the ≥ θ set`.
-    let adjacency: std::collections::HashSet<(i64, i64)> = coherent_edges.iter().copied().collect();
+    let mut adjacency = std::collections::HashSet::with_capacity(coherent_edges.len());
+    for (index, &edge) in coherent_edges.iter().enumerate() {
+        if index.is_multiple_of(1024) && cancelled() {
+            return None;
+        }
+        adjacency.insert(edge);
+    }
 
     // 2b. Seed high-similarity edges FIRST so tight real cliques grow WITHIN the MAX_SPLIT_GROUPS
     // budget instead of falling into the bare-pair tail (#256 R-A). On the dogfood a true 7-member
@@ -190,12 +213,17 @@ pub fn coherence_split(
     // since they are the over-merge noise, not real clones. Similarity is computed ONCE per
     // edge here (O(edges)), NOT in the comparator. The descending-sim + `(a, b)` tie-break
     // keeps the seed order deterministic.
-    let mut seeds: Vec<(f64, i64, i64)> =
-        coherent_edges.iter().map(|&(a, b)| (similarity(a, b), a, b)).collect();
+    let mut seeds = Vec::with_capacity(coherent_edges.len());
+    for (index, &(a, b)) in coherent_edges.iter().enumerate() {
+        if index.is_multiple_of(1024) && cancelled() {
+            return None;
+        }
+        seeds.push((similarity(a, b), a, b));
+    }
     // `total_cmp` (not `partial_cmp(...).unwrap_or(Equal)`): a guaranteed TOTAL order so the sort
     // can never panic on a non-total comparator. similarity() cannot produce NaN today (both call
     // sites guard `max_len == 0 → 1.0`), but total_cmp removes that footgun for any future caller.
-    seeds.sort_by(|x, y| y.0.total_cmp(&x.0).then_with(|| (x.1, x.2).cmp(&(y.1, y.2))));
+    let seeds = sort_seeds_cancellable(seeds, &cancelled)?;
 
     // 3. Greedy maximal clique cover: for each coherent edge not already fully inside some emitted
     // group, grow a maximal coherent group from {a, b} by adding any remaining member (in id order)
@@ -232,7 +260,10 @@ pub fn coherence_split(
     let mut covered: std::collections::HashSet<i64> = std::collections::HashSet::new();
     let mut budget_tripped = false;
 
-    for &(_sim, a, b) in &seeds {
+    for (seed_index, &(_sim, a, b)) in seeds.iter().enumerate() {
+        if seed_index.is_multiple_of(256) && cancelled() {
+            return None;
+        }
         if budget_tripped {
             // Over budget: emit this θ-edge as a 2-member clique ONLY if it covers a
             // still-uncovered member (#282). Emitting EVERY remaining edge (the old
@@ -266,7 +297,10 @@ pub fn coherence_split(
         // dense clique, #256).
         let mut group: Vec<i64> = vec![a, b];
         let mut group_set: std::collections::HashSet<i64> = group.iter().copied().collect();
-        for &m in &members {
+        for (member_index, &m) in members.iter().enumerate() {
+            if member_index.is_multiple_of(256) && cancelled() {
+                return None;
+            }
             if group_set.contains(&m) {
                 continue;
             }
@@ -277,7 +311,17 @@ pub fn coherence_split(
             // `similarity(m, g) >= theta` (see the `adjacency` construction above). This removes
             // the O(token_len) factor from the grow, making a dense (near-)clique
             // component O(n²) lookups instead of O(n² · token_len) overlap recomputes.
-            if group.iter().all(|&g| adjacency.contains(&(m.min(g), m.max(g)))) {
+            let mut coherent = true;
+            for (group_index, &g) in group.iter().enumerate() {
+                if group_index.is_multiple_of(1024) && cancelled() {
+                    return None;
+                }
+                if !adjacency.contains(&(m.min(g), m.max(g))) {
+                    coherent = false;
+                    break;
+                }
+            }
+            if coherent {
                 group.push(m);
                 group_set.insert(m);
             }
@@ -309,10 +353,33 @@ pub fn coherence_split(
         groups
     } else {
         let mut kept: Vec<Vec<i64>> = Vec::new();
-        for g in &groups {
-            let is_subset = groups
-                .iter()
-                .any(|other| other.len() > g.len() && g.iter().all(|x| other.contains(x)));
+        for (group_index, g) in groups.iter().enumerate() {
+            if group_index.is_multiple_of(32) && cancelled() {
+                return None;
+            }
+            let mut is_subset = false;
+            for other in &groups {
+                if cancelled() {
+                    return None;
+                }
+                if other.len() <= g.len() {
+                    continue;
+                }
+                let mut contained = true;
+                for (member_index, member) in g.iter().enumerate() {
+                    if member_index.is_multiple_of(256) && cancelled() {
+                        return None;
+                    }
+                    if !other.contains(member) {
+                        contained = false;
+                        break;
+                    }
+                }
+                if contained {
+                    is_subset = true;
+                    break;
+                }
+            }
             if !is_subset {
                 kept.push(g.clone());
             }
@@ -330,12 +397,160 @@ pub fn coherence_split(
     // 8. Sort by lowest member id (determinism).
     maximal.sort_by_key(|g| g[0]);
 
-    maximal
+    Some(maximal)
+}
+
+fn sort_dedup_edges_cancellable(
+    mut edges: Vec<(i64, i64)>,
+    cancelled: &impl Fn() -> bool,
+) -> Option<Vec<(i64, i64)>> {
+    const SORT_CHUNK: usize = 65_536;
+    for chunk in edges.chunks_mut(SORT_CHUNK) {
+        if cancelled() {
+            return None;
+        }
+        chunk.sort_unstable();
+    }
+    let mut heap = BinaryHeap::new();
+    for chunk in 0..edges.len().div_ceil(SORT_CHUNK) {
+        let index = chunk * SORT_CHUNK;
+        heap.push(Reverse((edges[index], chunk, index)));
+    }
+    let mut sorted = Vec::with_capacity(edges.len());
+    let mut visits = 0usize;
+    while let Some(Reverse((edge, chunk, index))) = heap.pop() {
+        if visits.is_multiple_of(1024) && cancelled() {
+            return None;
+        }
+        visits += 1;
+        if sorted.last() != Some(&edge) {
+            sorted.push(edge);
+        }
+        let next = index + 1;
+        let chunk_end = ((chunk + 1) * SORT_CHUNK).min(edges.len());
+        if next < chunk_end {
+            heap.push(Reverse((edges[next], chunk, next)));
+        }
+    }
+    Some(sorted)
+}
+
+type Seed = (f64, i64, i64);
+
+fn seed_order(a: &Seed, b: &Seed) -> Ordering {
+    b.0.total_cmp(&a.0).then_with(|| (a.1, a.2).cmp(&(b.1, b.2)))
+}
+
+/// One chunk's current head during the merge below. `Seed` holds an `f64` and the merge is ordered
+/// by `seed_order`, so the heap needs an explicit `Ord`: inverted, because `BinaryHeap` pops the
+/// greatest element and the merge wants the seed that sorts first.
+#[derive(Debug)]
+struct SeedHead {
+    seed: Seed,
+    chunk: usize,
+    index: usize,
+}
+
+impl Ord for SeedHead {
+    fn cmp(&self, other: &Self) -> Ordering {
+        seed_order(&other.seed, &self.seed)
+    }
+}
+
+impl PartialOrd for SeedHead {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for SeedHead {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for SeedHead {}
+
+fn sort_seeds_cancellable(
+    mut seeds: Vec<Seed>,
+    cancelled: &impl Fn() -> bool,
+) -> Option<Vec<Seed>> {
+    const SORT_CHUNK: usize = 65_536;
+    for chunk in seeds.chunks_mut(SORT_CHUNK) {
+        if cancelled() {
+            return None;
+        }
+        chunk.sort_by(seed_order);
+    }
+    // Merge the sorted chunks through a heap, like the edge sorter above: a component with millions
+    // of verified edges spans many chunks, and rescanning every chunk head per emitted seed would
+    // cost O(seeds × chunks) comparisons instead of O(seeds × log chunks).
+    let chunk_count = seeds.len().div_ceil(SORT_CHUNK);
+    let mut heap = BinaryHeap::with_capacity(chunk_count);
+    for chunk in 0..chunk_count {
+        let index = chunk * SORT_CHUNK;
+        heap.push(SeedHead { seed: seeds[index], chunk, index });
+    }
+    let mut sorted = Vec::with_capacity(seeds.len());
+    while let Some(SeedHead { seed, chunk, index }) = heap.pop() {
+        if sorted.len().is_multiple_of(1024) && cancelled() {
+            return None;
+        }
+        sorted.push(seed);
+        let next = index + 1;
+        let chunk_end = ((chunk + 1) * SORT_CHUNK).min(seeds.len());
+        if next < chunk_end {
+            heap.push(SeedHead { seed: seeds[next], chunk, index: next });
+        }
+    }
+    Some(sorted)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+
+    #[test]
+    fn coherence_split_cancellation_discards_partial_work() {
+        let members: Vec<i64> = (0..100).collect();
+        let edges: Vec<(i64, i64)> = members
+            .iter()
+            .enumerate()
+            .flat_map(|(index, &a)| members[index + 1..].iter().map(move |&b| (a, b)))
+            .collect();
+        let checks = AtomicUsize::new(0);
+
+        let result = coherence_split_cancellable(
+            &members,
+            &edges,
+            |_, _| 1.0,
+            || checks.fetch_add(1, Ordering::Relaxed) >= 3,
+        );
+
+        assert!(result.is_none());
+    }
+
+    /// Seeds beyond one sort chunk are merged through a heap; the result must stay exactly what a
+    /// single global sort produces, including across the partial final chunk.
+    #[test]
+    fn seed_sort_merges_chunks_in_seed_order() {
+        let count = 2 * 65_536 + 1_234;
+        let seeds: Vec<Seed> = (0..count)
+            .map(|index| {
+                // Deterministic scatter so chunk-local order differs from the global order.
+                let scattered = (index as u64).wrapping_mul(2_654_435_761) % 10_007;
+                (scattered as f64 / 10_007.0, index as i64, index as i64 + 1)
+            })
+            .collect();
+
+        let merged = sort_seeds_cancellable(seeds.clone(), &|| false).expect("not cancelled");
+
+        let mut expected = seeds;
+        expected.sort_by(seed_order);
+        assert_eq!(merged, expected);
+    }
 
     /// One parity fixture for `coherence_split_edge_adjacency_equals_similarity_recompute_*`:
     /// `(shape_name, component members, explicit symmetric similarity pairs)`.

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -54,6 +54,9 @@ toon-format.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
+# Unicode caseless matching for editor paths on case-insensitive volumes: `to_lowercase` is not
+# case folding (Greek `ς`/`σ` stay distinct) and SQLite's `NOCASE` collation folds ASCII only.
+unicase = "2.9"
 ureq.workspace = true
 # Dictionary-trained zstd compression of stored chunk text (#77 Phase 2). One shared dictionary
 # trained on a corpus sample (zdict_builder) + bulk one-shot compress/decompress per chunk blob.

--- a/crates/rag-rat-core/src/index/change_coupling.rs
+++ b/crates/rag-rat-core/src/index/change_coupling.rs
@@ -89,10 +89,18 @@ struct PairAcc {
     last_at_s: i64,
 }
 
+pub(crate) struct CurrentCoupledFile {
+    pub other_path: String,
+    pub co_change_count: i64,
+    pub this_change_count: i64,
+    pub confidence: f64,
+    pub last_co_change_at_s: i64,
+}
+
 /// Recompute-if-stale gate: the `DerivedIndex` self-heal, mirroring `ensure_fts_fresh` /
-/// `cached_blame`. Cheap stamp SELECT, then a full recompute on mismatch. Idempotent — concurrent
-/// writers serialize on SQLite's write lock and last-writer-wins an identical result; readers see
-/// old-or-new rows, never a mix (the recompute is one transaction).
+/// `cached_blame`. Cheap stamp SELECT, then a full recompute on mismatch. Normal history imports
+/// call this after publishing their cursor in the same write transaction; the lazy path remains for
+/// old databases and out-of-band history writes.
 pub(crate) fn ensure_coupling_fresh(conn: &Connection, now_ms: i64) -> anyhow::Result<()> {
     let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
     if coupling_stamp_current(conn, &repo_id)? {
@@ -117,66 +125,159 @@ fn coupling_stamp_current(conn: &Connection, repo_id: &str) -> anyhow::Result<bo
     Ok(stored.as_deref() == Some(coupling_stamp_value(conn, repo_id)?.as_str()))
 }
 
+/// Read current coupling data without requiring a write-capable connection. The persisted table is
+/// the fast path; when its lazy-derived stamp is stale, derive the same bounded history window in
+/// memory so read-only consumers never return cold or outdated rows.
+pub(crate) fn current_coupled_files_for_path(
+    conn: &Connection,
+    repo_id: &str,
+    path: &str,
+    limit: u32,
+) -> anyhow::Result<Vec<CurrentCoupledFile>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    if coupling_stamp_current(conn, repo_id)? {
+        return Ok(rag_rat_query::coupling::coupled_files_for_path(conn, repo_id, path, limit)?
+            .into_iter()
+            .map(|partner| CurrentCoupledFile {
+                other_path: partner.other_path,
+                co_change_count: partner.co_change_count,
+                this_change_count: partner.this_change_count,
+                confidence: partner.confidence,
+                last_co_change_at_s: partner.last_co_change_at_s,
+            })
+            .collect());
+    }
+
+    let window_commit_count = eligible_window_commit_count(conn, repo_id)?;
+    let (pairs, path_window_count, paths) = accumulate_window_pairs(conn, repo_id)?;
+    let Some(path_id) =
+        paths.iter().position(|candidate| candidate == path).and_then(|id| u32::try_from(id).ok())
+    else {
+        return Ok(Vec::new());
+    };
+    let this_change_count = path_window_count.get(&path_id).copied().unwrap_or(0);
+    let mut candidates = prune_pairs(pairs, &path_window_count, window_commit_count)
+        .into_iter()
+        .filter_map(|pair| {
+            let other_id = if pair.lo == path_id {
+                pair.hi
+            } else if pair.hi == path_id {
+                pair.lo
+            } else {
+                return None;
+            };
+            Some(CurrentCoupledFile {
+                other_path: paths[other_id as usize].clone(),
+                co_change_count: pair.count,
+                this_change_count,
+                confidence: if this_change_count > 0 {
+                    pair.count as f64 / this_change_count as f64
+                } else {
+                    0.0
+                },
+                last_co_change_at_s: pair.last_at_s,
+            })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|a, b| {
+        b.confidence
+            .total_cmp(&a.confidence)
+            .then_with(|| b.co_change_count.cmp(&a.co_change_count))
+            .then_with(|| a.other_path.cmp(&b.other_path))
+    });
+
+    let mut partner_is_live =
+        conn.prepare("SELECT EXISTS(SELECT 1 FROM files WHERE path = ?1 AND generated = 0)")?;
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    let mut current = Vec::with_capacity(limit.min(candidates.len()));
+    for candidate in candidates {
+        let exists: bool = partner_is_live.query_row([&candidate.other_path], |row| row.get(0))?;
+        if exists {
+            current.push(candidate);
+            if current.len() == limit {
+                break;
+            }
+        }
+    }
+    Ok(current)
+}
+
 /// Full recompute for one repo: read the window, accumulate pair + endpoint counts in memory, prune
 /// (support + lift floors — both pure git history), then `DELETE` + batched `INSERT` + stamp in one
-/// transaction. Never patches incrementally — the window slides under append and a history
-/// full-replace invalidates everything anyway, so a bounded full recompute is the simple correct
-/// choice (see the module header).
+/// transaction. When the caller already owns the history publication transaction, the writes join
+/// it rather than opening a nested transaction. Never patches incrementally — the window slides
+/// under append and a history full-replace invalidates everything anyway, so a bounded full
+/// recompute is the simple correct choice (see the module header).
 pub(crate) fn recompute_couplings(
     conn: &Connection,
     repo_id: &str,
     now_ms: i64,
 ) -> anyhow::Result<()> {
-    // Stamp value is captured against the CURRENT head before we write, so a head move mid-flight
-    // is caught by the next read (this recompute stamps the head it actually read).
-    let stamp = coupling_stamp_value(conn, repo_id)?;
+    loop {
+        // Compute outside a new write transaction to avoid holding the shared writer lock across
+        // the bounded history scan. Callers already inside a transaction naturally use its stable
+        // snapshot instead.
+        let stamp = coupling_stamp_value(conn, repo_id)?;
+        let window_commit_count = eligible_window_commit_count(conn, repo_id)?;
+        let (pairs, path_window_count, paths) = accumulate_window_pairs(conn, repo_id)?;
+        let surviving = prune_pairs(pairs, &path_window_count, window_commit_count);
 
-    // The window size actually used (shallow repos have fewer commits) — the base-rate population N
-    // for lift, counted from the eligible-commit CTE directly (by `changed_file_count`). Pure git
-    // history, matching the accumulation below.
-    let window_commit_count = eligible_window_commit_count(conn, repo_id)?;
-
-    let (pairs, path_window_count, paths) = accumulate_window_pairs(conn, repo_id)?;
-
-    let surviving = prune_pairs(pairs, &path_window_count, window_commit_count);
-
-    let tx = conn.unchecked_transaction()?;
-    conn.execute("DELETE FROM git_change_couplings WHERE repo_id = ?1", params![repo_id])?;
-    {
-        let mut insert = conn.prepare(
-            "INSERT INTO git_change_couplings(
-                 repo_id, path_a, path_b, co_change_count, path_a_change_count,
-                 path_b_change_count, window_commit_count, last_co_change_at_s, computed_at_ms
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        )?;
-        for pair in &surviving {
-            // Canonicalize by PATH STRING (the `path_a < path_b` BINARY invariant), not by interned
-            // id — the interner assigns ids in first-seen order, which is unrelated to path order.
-            let path_lo = &paths[pair.lo as usize];
-            let path_hi = &paths[pair.hi as usize];
-            let (path_a, id_a, path_b, id_b) = if path_lo < path_hi {
-                (path_lo, pair.lo, path_hi, pair.hi)
-            } else {
-                (path_hi, pair.hi, path_lo, pair.lo)
-            };
-            let a_count = path_window_count.get(&id_a).copied().unwrap_or(0);
-            let b_count = path_window_count.get(&id_b).copied().unwrap_or(0);
-            insert.execute(params![
-                repo_id,
-                path_a,
-                path_b,
-                pair.count,
-                a_count,
-                b_count,
-                window_commit_count,
-                pair.last_at_s,
-                now_ms,
-            ])?;
+        let tx = if conn.is_autocommit() {
+            Some(rusqlite::Transaction::new_unchecked(
+                conn,
+                rusqlite::TransactionBehavior::Immediate,
+            )?)
+        } else {
+            None
+        };
+        // A history writer may have published after the scan but before BEGIN IMMEDIATE. Never
+        // replace its newer coupling with our stale snapshot; release the lock and derive again.
+        if tx.is_some() && coupling_stamp_value(conn, repo_id)? != stamp {
+            drop(tx);
+            continue;
         }
+
+        conn.execute("DELETE FROM git_change_couplings WHERE repo_id = ?1", params![repo_id])?;
+        {
+            let mut insert = conn.prepare(
+                "INSERT INTO git_change_couplings(
+                     repo_id, path_a, path_b, co_change_count, path_a_change_count,
+                     path_b_change_count, window_commit_count, last_co_change_at_s, computed_at_ms
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )?;
+            for pair in &surviving {
+                // Canonicalize by PATH STRING (the `path_a < path_b` BINARY invariant), not by
+                // interned id — first-seen id order is unrelated to path order.
+                let path_lo = &paths[pair.lo as usize];
+                let path_hi = &paths[pair.hi as usize];
+                let (path_a, id_a, path_b, id_b) = if path_lo < path_hi {
+                    (path_lo, pair.lo, path_hi, pair.hi)
+                } else {
+                    (path_hi, pair.hi, path_lo, pair.lo)
+                };
+                let a_count = path_window_count.get(&id_a).copied().unwrap_or(0);
+                let b_count = path_window_count.get(&id_b).copied().unwrap_or(0);
+                insert.execute(params![
+                    repo_id,
+                    path_a,
+                    path_b,
+                    pair.count,
+                    a_count,
+                    b_count,
+                    window_commit_count,
+                    pair.last_at_s,
+                    now_ms,
+                ])?;
+            }
+        }
+        set_repo_meta(conn, repo_id, COUPLING_STAMP_META, &stamp)?;
+        if let Some(tx) = tx {
+            tx.commit()?;
+        }
+        return Ok(());
     }
-    set_repo_meta(conn, repo_id, COUPLING_STAMP_META, &stamp)?;
-    tx.commit()?;
-    Ok(())
 }
 
 /// Count the eligible commits in the window (`changed_file_count BETWEEN 2 AND cap`, capped at

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -4,7 +4,10 @@ use std::path::{Path, PathBuf};
 use gix::object::tree::diff::{Action, Change};
 use gix::revision::walk::Sorting;
 use rag_rat_base::hash::hex_sha256;
-use rag_rat_db::meta::{delete_repo_meta, repo_meta, scoped_table_row_count, set_repo_meta};
+use rag_rat_db::meta::{
+    bump_lens_enrichment_revision, delete_repo_meta, repo_meta, scoped_table_row_count,
+    set_repo_meta,
+};
 use rag_rat_db::schema;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;

--- a/crates/rag-rat-core/src/index/git_history/apply.rs
+++ b/crates/rag-rat-core/src/index/git_history/apply.rs
@@ -37,10 +37,28 @@ pub(crate) fn record_history_cursors(
     )?;
     let complete = if cursors.complete { "1" } else { "0" };
     set_repo_meta(conn, &repo_id, GIT_HISTORY_INDEXED_COMPLETE_META, complete)?;
+    // Coupling's stamp includes the complete cursor snapshot, so materialize only after all four
+    // cursor keys are published. Production callers own the surrounding history transaction.
+    crate::index::change_coupling::ensure_coupling_fresh(conn, rag_rat_base::time::now_ms())?;
+    bump_lens_enrichment_revision(conn, &repo_id)?;
     Ok(())
 }
 
 pub(crate) fn apply_prepared(
+    conn: &Connection,
+    root: &Path,
+    prepared: PreparedGitHistory,
+) -> anyhow::Result<GitHistoryIndexStatus> {
+    if conn.is_autocommit() {
+        let tx = conn.unchecked_transaction()?;
+        let status = apply_prepared_in_transaction(conn, root, prepared)?;
+        tx.commit()?;
+        return Ok(status);
+    }
+    apply_prepared_in_transaction(conn, root, prepared)
+}
+
+fn apply_prepared_in_transaction(
     conn: &Connection,
     root: &Path,
     prepared: PreparedGitHistory,
@@ -353,5 +371,7 @@ fn clear(conn: &Connection) -> anyhow::Result<()> {
     ] {
         delete_repo_meta(conn, &repo_id, key)?;
     }
+    crate::index::change_coupling::ensure_coupling_fresh(conn, rag_rat_base::time::now_ms())?;
+    bump_lens_enrichment_revision(conn, &repo_id)?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -210,6 +210,7 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            lens_clone_graph_cache: std::sync::Arc::default(),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
@@ -237,6 +238,7 @@ impl IndexDatabase {
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            lens_clone_graph_cache: std::sync::Arc::default(),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
@@ -418,6 +420,7 @@ impl IndexDatabase {
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            lens_clone_graph_cache: std::sync::Arc::default(),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
@@ -582,6 +585,7 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            lens_clone_graph_cache: std::sync::Arc::default(),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -78,13 +78,19 @@ pub use query_api::{
     CloneIneligibilityReason, CloneMember, CloneSymbolSelector, ClonesForSymbolResult,
     DatabaseFileHealth, FindClonesOptions, FindClonesResult, FreelistReclaim,
     FreelistReclaimReport, GcReport, GlobalFtsStatus, GlobalStatus, ImportantSymbolsRequest,
-    MemoryCounts, MemoryKindCounts, OracleShaSnapshots, PapertrailCursor, RepoContent,
-    RepoFreshness, RepoPapertrail, RepoStatus, RoiFactors, SearchRequest, SyncCatchUpReport,
-    TextCloneMatch, WAL_CHECKPOINT_MIN_BYTES, WalCheckpointReport, WorktreeOverlay,
-    reclaim_freelist_at,
+    LensCallees, LensCallers, LensChunkText, LensCloneGraphCache, LensCloneGraphMeta,
+    LensClonePartner, LensCloneRefine, LensCloneRegion, LensCouplingPartner, LensDecisionRecord,
+    LensDispatchDetail, LensFileClones, LensFileCoupling, LensFileGraph, LensFileMemories,
+    LensFileMemory, LensFilePapertrail, LensFileSymbolGraph, LensFileSymbols,
+    LensGraphCallerCounts, LensPapertrailRef, LensStatus, LensSymbol, LensSymbolHop, LensTreemap,
+    LensTreemapFile, LensVersion, MemoryCounts, MemoryKindCounts, OracleShaSnapshots,
+    PapertrailCursor, RepoContent, RepoFreshness, RepoPapertrail, RepoStatus, RoiFactors,
+    SearchRequest, SyncCatchUpReport, TextCloneMatch, WAL_CHECKPOINT_MIN_BYTES,
+    WalCheckpointReport, WorktreeOverlay, reclaim_freelist_at,
 };
 pub use schema::RegisteredRepo;
 pub(crate) use util::*;
+pub(crate) use worktree_overlay::linked_source_root;
 pub use worktree_overlay::{
     OverlayBasisUpdate, OverlayLogicalRebuild, OverlayRefreshTail, WorktreeOverlayReport,
 };
@@ -199,6 +205,25 @@ pub struct IndexDatabase {
     /// connection, so batch tests can assert the once-per-pass rebuild cardinality.
     #[cfg(test)]
     pub(crate) logical_symbol_rebuilds: AtomicUsize,
+    /// #216 lens: a bounded set of filtered clone edge sets + components keyed by generation,
+    /// scope, content, and theta. Treemap and file-clone requests commonly use different theta
+    /// values, so retaining several immutable variants avoids alternating repository-wide scans.
+    pub(crate) lens_clone_graph_cache: std::sync::Arc<query_api::LensCloneGraphCache>,
+}
+
+/// Narrow cancellation capability for a query running on an [`IndexDatabase`] connection.
+pub struct DatabaseInterruptHandle(rusqlite::InterruptHandle);
+
+impl DatabaseInterruptHandle {
+    pub fn interrupt(&self) {
+        self.0.interrupt();
+    }
+}
+
+impl IndexDatabase {
+    pub fn interrupt_handle(&self) -> DatabaseInterruptHandle {
+        DatabaseInterruptHandle(self.storage.connection().get_interrupt_handle())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/query_api/clones/build.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/build.rs
@@ -10,6 +10,7 @@
 //! [`CloneCompleteness::stale_members`]: super::types::CloneCompleteness::stale_members
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rag_rat_clones::NORM_VERSION;
 use rusqlite::{Connection, OptionalExtension};
@@ -35,6 +36,18 @@ pub(crate) fn build_class(
     conn: &Connection,
     pin: Option<i64>,
 ) -> anyhow::Result<Option<CandidateCloneClass>> {
+    let cancelled = AtomicBool::new(false);
+    build_class_cancellable(component, by_id, conn, pin, &cancelled)
+}
+
+pub(crate) fn build_class_cancellable(
+    component: &[i64],
+    by_id: &BTreeMap<i64, &SymbolBag>,
+    conn: &Connection,
+    pin: Option<i64>,
+    cancelled: &AtomicBool,
+) -> anyhow::Result<Option<CandidateCloneClass>> {
+    ensure_not_cancelled(cancelled)?;
     let bags: Vec<&SymbolBag> = component.iter().filter_map(|id| by_id.get(id).copied()).collect();
     if bags.len() != component.len() {
         return Ok(None);
@@ -58,6 +71,7 @@ pub(crate) fn build_class(
     let mut sim_sums = vec![0.0_f64; metric_n]; // for medoid selection
 
     for i in 0..metric_n {
+        ensure_not_cancelled(cancelled)?;
         for j in (i + 1)..metric_n {
             let ov = overlap(metric_bags[i], metric_bags[j]);
             let max_len = metric_bags[i].token_len.max(metric_bags[j].token_len);
@@ -100,6 +114,9 @@ pub(crate) fn build_class(
     // Min similarity of any member to the medoid (within metric_bags).
     let mut similarity_medoid_min = f64::MAX;
     for (i, bag) in metric_bags.iter().enumerate() {
+        if i.is_multiple_of(32) {
+            ensure_not_cancelled(cancelled)?;
+        }
         if i == medoid_idx {
             continue;
         }
@@ -134,6 +151,7 @@ pub(crate) fn build_class(
     // member orderings byte-for-byte identical.
     let mut raw_members: Vec<(i64, i64, CloneMember)> = Vec::with_capacity(total_members);
     for chunk in component.chunks(HYDRATION_CHUNK) {
+        ensure_not_cancelled(cancelled)?;
         let id_placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
         let version_placeholder = format!("?{}", chunk.len() + 1);
         let sql = format!(
@@ -164,10 +182,14 @@ pub(crate) fn build_class(
                 language: row.get(6)?,
             }))
         })?;
-        for row in rows {
+        for (index, row) in rows.enumerate() {
+            if index.is_multiple_of(256) {
+                ensure_not_cancelled(cancelled)?;
+            }
             raw_members.push(row?);
         }
     }
+    ensure_not_cancelled(cancelled)?;
     // Restore the deterministic `symbols.id ASC` order the single-statement path produced.
     raw_members.sort_unstable_by_key(|(symbol_id, _, _)| *symbol_id);
 
@@ -211,6 +233,7 @@ pub(crate) fn build_class(
         .map(|(_, _, m)| format!("{}@{}:{}-{}", m.r#ref, m.path, m.start_line, m.end_line))
         .collect();
     let class_key = class_key_for(&key_material);
+    ensure_not_cancelled(cancelled)?;
 
     // Canonical-ordered member refs (#215 Plan 4b): the qualified `ref` of each member in the SAME
     // canonical `(struct_hash, path, start_byte)` order, capped at the same `MEMBER_VALUE_CAP`,
@@ -255,6 +278,7 @@ pub(crate) fn build_class(
             canonical_member_order_key(a.0, a.1, a.2)
                 .cmp(&canonical_member_order_key(b.0, b.1, b.2))
         });
+        ensure_not_cancelled(cancelled)?;
         ordered.into_iter().take(MEMBER_VALUE_CAP).map(|(_, _, _, r)| r).collect()
     };
 
@@ -289,20 +313,26 @@ pub(crate) fn build_class(
     // Load-bearing factor: 1 + ln(1 + max_fan_in_score) over members. Fan-in proxy via
     // `scoped_weighted_fan_in` (heuristic-only, no oracle data at this call site).
     let oracle = rag_rat_query::load_bearing::OracleContext::none();
-    let max_importance = component
-        .iter()
-        .filter_map(|&id| {
-            rag_rat_query::load_bearing::scoped_weighted_fan_in(conn, id, &oracle)
-                .ok()
-                .flatten()
-                .map(|e| e.score)
-        })
-        .fold(0.0_f64, f64::max);
+    let mut max_importance = 0.0_f64;
+    for (index, &id) in component.iter().enumerate() {
+        if index.is_multiple_of(32) {
+            ensure_not_cancelled(cancelled)?;
+        }
+        if let Some(score) = rag_rat_query::load_bearing::scoped_weighted_fan_in(conn, id, &oracle)
+            .ok()
+            .flatten()
+            .map(|entry| entry.score)
+        {
+            max_importance = max_importance.max(score);
+        }
+    }
     let load_bearing_factor = 1.0 + max_importance.ln_1p();
 
     // Median token_len across all bags in the component.
     let mut token_lens: Vec<i64> = bags.iter().map(|b| b.token_len).collect();
+    ensure_not_cancelled(cancelled)?;
     token_lens.sort_unstable();
+    ensure_not_cancelled(cancelled)?;
     let median_token_len = token_lens[token_lens.len() / 2];
 
     let roi = cross_module_spread as f64
@@ -350,6 +380,11 @@ pub(crate) fn build_class(
         anti_unify_coverage: None,
         canonical_member_refs: Some(canonical_member_refs),
     }))
+}
+
+fn ensure_not_cancelled(cancelled: &AtomicBool) -> anyhow::Result<()> {
+    anyhow::ensure!(!cancelled.load(Ordering::Acquire), "lens request cancelled");
+    Ok(())
 }
 
 /// Count DISTINCT member file paths in `classes` whose on-disk content no longer matches the

--- a/crates/rag-rat-core/src/index/query_api/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/mod.rs
@@ -118,18 +118,21 @@ use rag_rat_clones::refine::cache::{
 };
 use rag_rat_clones::refine::split::coherence_split;
 
-use self::build::{build_class, count_stale_member_paths};
+use self::build::count_stale_member_paths;
+pub(crate) use self::build::{build_class, build_class_cancellable};
 use self::refine_load::{
     load_refine_rows, load_source_discriminators, oracle_callee_coverage_exists,
 };
 use self::resolve::{classify_ineligibility_reason, resolve_selector_to_symbol_id};
 use self::scoring::{
-    apply_refinement, build_completeness, canonical_member_order_key,
-    dampen_unrefined_member_count, min_pairwise_cohesion,
+    apply_refinement, build_completeness, canonical_member_order_key, dampen_unrefined_member_count,
 };
-use self::substrate::{
-    SymbolBag, bucket_edges_by_component, components_from_pairs, load_scoped_baseline_bags,
-    overlap, pairs_for_query, subject_component_bfs,
+pub(crate) use self::scoring::{min_pairwise_cohesion, min_pairwise_cohesion_cancellable};
+pub(crate) use self::substrate::{
+    SymbolBag, bucket_edges_by_component, bucket_edges_by_component_cancellable,
+    candidate_pairs_from_bags_cancellable, components_from_pairs,
+    components_from_pairs_cancellable, load_scoped_baseline_bags, overlap, pairs_for_query,
+    subject_component_bfs,
 };
 use crate::index::IndexDatabase;
 
@@ -441,6 +444,58 @@ impl IndexDatabase {
         Ok(FindClonesResult { classes, completeness })
     }
 
+    fn clone_refinement_cache_key(
+        &self,
+        conn: &Connection,
+        class_ids: &[i64],
+        by_id: &BTreeMap<i64, &SymbolBag>,
+        class: &CandidateCloneClass,
+    ) -> anyhow::Result<Option<(String, RefineMode)>> {
+        // Build the content-addressed key from persisted fingerprints and exact source
+        // discriminators. Missing data makes the class unrefinable; never key a partial set.
+        let struct_hashes: Vec<String> = class_ids
+            .iter()
+            .filter_map(|id| by_id.get(id).map(|b| b.struct_hash.clone()))
+            .collect();
+        if struct_hashes.len() != class_ids.len() {
+            return Ok(None);
+        }
+        let Some(source_discriminators) = load_source_discriminators(conn, class_ids)? else {
+            return Ok(None);
+        };
+        let mode = if oracle_callee_coverage_exists(
+            conn,
+            class_ids,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )? {
+            RefineMode::Scip
+        } else {
+            RefineMode::Baseline
+        };
+        let key = refinement_key(&class.language, mode, &struct_hashes, &source_discriminators);
+        Ok(Some((key, mode)))
+    }
+
+    /// Attach an already-persisted refinement without reparsing source or writing. Lens reads use
+    /// this bounded probe; a cache miss deliberately leaves the class unrefined.
+    pub(crate) fn refine_class_from_cache(
+        &self,
+        conn: &Connection,
+        class_ids: &[i64],
+        by_id: &BTreeMap<i64, &SymbolBag>,
+        class: &mut CandidateCloneClass,
+    ) -> anyhow::Result<()> {
+        let Some((key, mode)) = self.clone_refinement_cache_key(conn, class_ids, by_id, class)?
+        else {
+            return Ok(());
+        };
+        if let Some(refinement) = refine_lookup(conn, &key, mode)? {
+            apply_refinement(class, refinement);
+        }
+        Ok(())
+    }
+
     /// Refine one candidate class IN PLACE (#215 Plan 4a): load the class's refine inputs (re-read,
     /// re-parse, and re-normalize each member to its ordered baseline token sequence), compute the
     /// content-addressed refinement (read-through `clone_refinements` cache), set the
@@ -453,7 +508,7 @@ impl IndexDatabase {
     /// `class_ids` is the class's component (the coherent sub-class) symbol ids; `by_id` supplies
     /// each member's persisted `struct_hash` for the content-addressed key (no extra DB
     /// round-trip).
-    fn refine_class_in_place(
+    pub(crate) fn refine_class_in_place(
         &self,
         conn: &Connection,
         class_ids: &[i64],
@@ -464,63 +519,10 @@ impl IndexDatabase {
         // cell-bounded. Warm cache hits return BEFORE the compute, so they never consume it.
         global_refine_cells: &mut u64,
     ) -> anyhow::Result<()> {
-        // ── Phase 0 (CHEAP, NO RE-PARSE): build the content-addressed key from each member's
-        // persisted struct_hash already in `by_id` — no file I/O, no tree-sitter parse.
-        // If a class member's struct_hash is somehow absent from `by_id` (shouldn't happen for a
-        // coherent class, but defend anyway) the key would be over an incomplete multiset, which
-        // could alias a different class. Fall back to leaving this class un-refined rather than
-        // computing a wrong refinement.
-        let struct_hashes: Vec<String> = class_ids
-            .iter()
-            .filter_map(|id| by_id.get(id).map(|b| b.struct_hash.clone()))
-            .collect();
-        if struct_hashes.len() != class_ids.len() {
-            // Defensive: a member's bag is missing — skip rather than key over a partial multiset.
-            return Ok(());
-        }
-
-        // ── Source discriminators (cheap SELECT, NO RE-PARSE): pin each member's EXACT source
-        // bytes so the content-addressed key discriminates two classes that share a
-        // struct_hash multiset (the NORMALIZED token sequence) but differ in real source.
-        // The 4b cached payload (template, per-member values, signature) is
-        // SOURCE-SPECIFIC; a structure-only key would serve one class's payload to a
-        // structurally-identical-but-source-different class (cache poisoning).
-        // `"{file_sha256}:{start}-{end}"` pins the file content hash + body range →
-        // together they uniquely determine the raw source. This is a SELECT (the same symbols/files
-        // join the bags path already touches), so the warm-probe-before-reparse stays a probe.
-        // If any member's discriminator can't be fetched, leave the class un-refined rather than
-        // key over a partial/structure-only multiset (which could alias a different class).
-        let Some(source_discriminators) = load_source_discriminators(conn, class_ids)? else {
+        let Some((key, mode)) = self.clone_refinement_cache_key(conn, class_ids, by_id, class)?
+        else {
             return Ok(());
         };
-
-        // Refine mode (#275, Plan 3): scip when any member file has CURRENT oracle callee
-        // coverage, else baseline. Probed BEFORE the key because the mode is folded into it — the
-        // two modes address disjoint cache namespaces, so an oracle run can invalidate every
-        // scip-mode row (`invalidate_scip_refinements`) without touching baseline rows. Cheap
-        // (one EXISTS per hydration chunk), so the warm probe stays a probe.
-        let mode = if oracle_callee_coverage_exists(
-            conn,
-            class_ids,
-            &self.active_commit_sha,
-            &self.active_worktree_id,
-        )? {
-            RefineMode::Scip
-        } else {
-            RefineMode::Baseline
-        };
-
-        // Content-addressed key over the member struct_hash multiset + the per-member source
-        // discriminators — NOT the read-side `class.class_key` (location-derived). Two classes with
-        // the same structural content AND the same exact source bodies share a refinement; the key
-        // survives a reindex that reassigns rowids.
-        //
-        // For coherent classes exceeding METRIC_SAMPLE_CAP members, `class.similarity_min` was
-        // derived from the first `METRIC_SAMPLE_CAP` members only (the metric-sample path in
-        // `build_class`), while `key` spans the FULL struct_hash multiset. The gap is not a
-        // determinism break — the sample is id-ASC stable — but Plan-4b should compute confidence
-        // over the full set or fold the sample into the key.
-        let key = refinement_key(&class.language, mode, &struct_hashes, &source_discriminators);
 
         // ── Phase 1 (PURE READ — warm path): probe the content-addressed cache. A SELECT is safe
         // on the MCP's read-only connection; a WARM cache hit never takes the write lock and never

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute/mod.rs
@@ -38,10 +38,11 @@ mod schedule;
 mod storage;
 
 pub(super) use build::make_edge;
-pub(super) use read::precomputed_pairs_if_eligible;
+pub(crate) use read::{build_anchor_index, precomputed_pairs_if_eligible};
+pub(crate) use storage::live_generation_row;
 pub(super) use storage::{
     clone_df_epoch_exists, clone_df_epoch_serves, clone_generation_scope_clause, insert_edge_rows,
-    insert_posting_groups, live_generation_row,
+    insert_posting_groups,
 };
 
 /// θ the graph is precomputed at — the default `find_clones` threshold. Queries at θ ≥ this read
@@ -112,10 +113,10 @@ pub(super) struct PostingGroup {
     pub(super) tokens: Vec<i64>,
 }
 
-pub(super) struct GenerationRow {
-    pub(super) generation: i64,
-    pub(super) source_revision: String,
-    pub(super) normalizer_version: i64,
+pub(crate) struct GenerationRow {
+    pub(crate) generation: i64,
+    pub(crate) source_revision: String,
+    pub(crate) normalizer_version: i64,
     cursor_symbol_id: i64,
     edges_written: u64,
     /// Whether this generation is POSTINGS-AWARE (#296 phase 2): its `clone_subblock_postings` are
@@ -130,7 +131,7 @@ pub(super) struct GenerationRow {
     /// signal: past [`CLONE_GRAPH_DRIFT_REBUILD_FILES`] the quiet gate schedules a full rebuild to
     /// restore sub-block selectivity (df is frozen at the build's epoch, so long-lived generations
     /// slowly lose candidate-pruning efficiency — never correctness).
-    pub(super) delta_files_applied: i64,
+    pub(crate) delta_files_applied: i64,
 }
 
 /// How many delta-absorbed files a live generation tolerates before the background tail owes a

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute/read.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute/read.rs
@@ -17,7 +17,7 @@ use super::*;
 /// `overlap = token_len`, so they survive every θ). A present-but-STALE generation
 /// (content_revision drifted) is still served — the "mildly stale OK" contract; per-edge staleness
 /// is dropped by the `file_sha` join.
-pub(in super::super) fn precomputed_pairs_if_eligible(
+pub(crate) fn precomputed_pairs_if_eligible(
     conn: &Connection,
     by_id: &BTreeMap<i64, &SymbolBag>,
     theta: f64,
@@ -99,7 +99,9 @@ pub(in super::super) fn precomputed_pairs_if_eligible(
 /// `(path, start_byte) -> (symbol_id, file_sha)` over the scoped non-generated symbols — the
 /// inverse of [`resolve_symbol_anchors`], used by the read fast path to resolve content-anchored
 /// edges in RAM (one scan + hash lookups) instead of a per-edge SQL join.
-fn build_anchor_index(conn: &Connection) -> anyhow::Result<HashMap<(String, i64), (i64, String)>> {
+pub(crate) fn build_anchor_index(
+    conn: &Connection,
+) -> anyhow::Result<HashMap<(String, i64), (i64, String)>> {
     let mut stmt = conn.prepare(
         "SELECT s.id, f.path, s.start_byte, f.sha256
            FROM symbols s JOIN files f ON f.id = s.file_id

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute/storage.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute/storage.rs
@@ -131,9 +131,7 @@ pub(in super::super) fn clone_generation_scope_clause(conn: &Connection) -> anyh
 }
 
 /// The live (Complete) generation row, if one is published.
-pub(in super::super) fn live_generation_row(
-    conn: &Connection,
-) -> anyhow::Result<Option<GenerationRow>> {
+pub(crate) fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
     let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
     let Some(live) = rag_rat_db::meta::repo_meta(conn, &repo_id, "clone_graph_live_generation")?
     else {

--- a/crates/rag-rat-core/src/index/query_api/clones/scoring.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/scoring.rs
@@ -11,6 +11,7 @@
 //! ([`build_completeness`]).
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rag_rat_clones::NORM_VERSION;
 
@@ -58,8 +59,21 @@ pub(crate) fn canonical_member_order_key<'a>(
 /// returns several equal-size groups containing the subject, the most internally-cohesive wins).
 /// A 1-member (or empty) class has no pairs → cohesion 1.0 (vacuously fully coherent).
 pub(crate) fn min_pairwise_cohesion(class: &[i64], by_id: &BTreeMap<i64, &SymbolBag>) -> f64 {
+    let cancelled = AtomicBool::new(false);
+    min_pairwise_cohesion_cancellable(class, by_id, &cancelled)
+        .expect("a permanently-clear cancellation flag cannot cancel")
+}
+
+pub(crate) fn min_pairwise_cohesion_cancellable(
+    class: &[i64],
+    by_id: &BTreeMap<i64, &SymbolBag>,
+    cancelled: &AtomicBool,
+) -> Option<f64> {
     let mut min = f64::MAX;
     for i in 0..class.len() {
+        if cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
         for j in (i + 1)..class.len() {
             if let (Some(ba), Some(bb)) = (by_id.get(&class[i]), by_id.get(&class[j])) {
                 let max_len = ba.token_len.max(bb.token_len);
@@ -70,7 +84,7 @@ pub(crate) fn min_pairwise_cohesion(class: &[i64], by_id: &BTreeMap<i64, &Symbol
             }
         }
     }
-    if min == f64::MAX { 1.0 } else { min }
+    Some(if min == f64::MAX { 1.0 } else { min })
 }
 
 /// Anti-unify coverage below which a refined class is strongly penalized in the ROI sort (#256). A

--- a/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
@@ -11,7 +11,9 @@
 //! (arbitrary-text clone check) child modules reuse, guaranteeing the persisted / text-checked set
 //! equals the live [`candidate_pairs_from_bags`] set.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rag_rat_clones::NORM_VERSION;
 use rayon::prelude::*;
@@ -75,20 +77,76 @@ pub(crate) struct TokenPosting {
 /// caller's `min_similarity` widens (or narrows) candidate generation to match the requested
 /// floor, instead of generating at the const [`THETA`] and post-filtering.
 pub(crate) fn candidate_pairs_from_bags(bags: &[SymbolBag], theta: f64) -> Vec<(i64, i64)> {
-    let mut pairs: std::collections::BTreeSet<(i64, i64)> = std::collections::BTreeSet::new();
+    let mut pairs: BTreeSet<(i64, i64)> = BTreeSet::new();
     add_struct_hash_pairs(bags, &mut pairs);
     let candidate = sub_block_candidate_pairs(bags, theta);
     let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
-    // Verify candidates in parallel: `verified_clone` is pure token math (no DB, no shared
-    // mutation; `by_id` is read-only), so the candidate set — the bulk of candidate-gen cost —
-    // fans out across cores. Output stays deterministic: the verified pairs land in the sorted
-    // `pairs` BTreeSet regardless of completion order.
     let verified: Vec<(i64, i64)> = candidate
         .into_par_iter()
         .filter(|&(a, b)| verified_clone(by_id[&a], by_id[&b], theta))
         .collect();
     pairs.extend(verified);
     pairs.into_iter().collect()
+}
+
+pub(crate) fn candidate_pairs_from_bags_cancellable(
+    bags: &[SymbolBag],
+    theta: f64,
+    cancelled: &AtomicBool,
+) -> Option<Vec<(i64, i64)>> {
+    let mut pairs: std::collections::BTreeSet<(i64, i64)> = std::collections::BTreeSet::new();
+    if !add_struct_hash_pairs_cancellable(bags, &mut pairs, cancelled) {
+        return None;
+    }
+    let candidate = sub_block_candidate_pairs_cancellable(bags, theta, cancelled)?;
+    let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+    // Verify candidates in parallel: `verified_clone` is pure token math (no DB, no shared
+    // mutation; `by_id` is read-only), so the candidate set — the bulk of candidate-gen cost —
+    // fans out across cores. The indexed parallel iterator preserves the already-sorted candidate
+    // order, so the final exact+verified union can use a cancellable linear merge.
+    let verified: Vec<(i64, i64)> = candidate
+        .into_par_iter()
+        .filter(|&(a, b)| {
+            !cancelled.load(Ordering::Relaxed) && verified_clone(by_id[&a], by_id[&b], theta)
+        })
+        .collect();
+    if cancelled.load(Ordering::Acquire) {
+        return None;
+    }
+    merge_sorted_pairs_cancellable(pairs, verified, cancelled)
+}
+
+fn merge_sorted_pairs_cancellable(
+    exact: BTreeSet<(i64, i64)>,
+    verified: Vec<(i64, i64)>,
+    cancelled: &AtomicBool,
+) -> Option<Vec<(i64, i64)>> {
+    let mut exact = exact.into_iter().peekable();
+    let mut verified = verified.into_iter().peekable();
+    let mut merged = Vec::new();
+    let mut visits = 0usize;
+    while exact.peek().is_some() || verified.peek().is_some() {
+        if visits.is_multiple_of(1024) && cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
+        visits += 1;
+        let next = match (exact.peek().copied(), verified.peek().copied()) {
+            (Some(a), Some(b)) if a < b => exact.next().expect("peeked exact pair"),
+            (Some(a), Some(b)) if b < a => verified.next().expect("peeked verified pair"),
+            (Some(a), Some(_)) => {
+                exact.next();
+                verified.next();
+                a
+            },
+            (Some(_), None) => exact.next().expect("peeked exact pair"),
+            (None, Some(_)) => verified.next().expect("peeked verified pair"),
+            (None, None) => break,
+        };
+        if merged.last() != Some(&next) {
+            merged.push(next);
+        }
+    }
+    Some(merged)
 }
 
 /// Candidate pairs for a query: the persisted clone-graph FAST PATH (#286) when one is eligible
@@ -296,9 +354,22 @@ pub(crate) fn add_struct_hash_pairs(
     bags: &[SymbolBag],
     pairs: &mut std::collections::BTreeSet<(i64, i64)>,
 ) {
+    let cancelled = AtomicBool::new(false);
+    let completed = add_struct_hash_pairs_cancellable(bags, pairs, &cancelled);
+    debug_assert!(completed);
+}
+
+fn add_struct_hash_pairs_cancellable(
+    bags: &[SymbolBag],
+    pairs: &mut std::collections::BTreeSet<(i64, i64)>,
+    cancelled: &AtomicBool,
+) -> bool {
     // Key: (struct_hash, language) — only same-language symbols can be struct-hash clones.
     let mut by_hash: BTreeMap<(&str, &str), Vec<i64>> = BTreeMap::new();
     for bag in bags {
+        if cancelled.load(Ordering::Relaxed) {
+            return false;
+        }
         by_hash
             .entry((bag.struct_hash.as_str(), bag.language.as_str()))
             .or_default()
@@ -306,11 +377,18 @@ pub(crate) fn add_struct_hash_pairs(
     }
     for ids in by_hash.values() {
         for (i, &a) in ids.iter().enumerate() {
-            for &b in &ids[i + 1..] {
+            if cancelled.load(Ordering::Relaxed) {
+                return false;
+            }
+            for (offset, &b) in ids[i + 1..].iter().enumerate() {
+                if offset.is_multiple_of(1024) && cancelled.load(Ordering::Relaxed) {
+                    return false;
+                }
                 pairs.insert((a.min(b), a.max(b)));
             }
         }
     }
+    true
 }
 
 /// Build the inverted index over sub-block tokens only and emit candidate pairs `(a < b)` for every
@@ -329,28 +407,21 @@ pub(crate) fn add_struct_hash_pairs(
 /// of completion order (returns a sorted `Vec`, not a `BTreeSet`, to keep the merge parallel — a
 /// 4.5M-element `BTreeSet` build is sequential).
 pub(crate) fn sub_block_candidate_pairs(bags: &[SymbolBag], theta: f64) -> Vec<(i64, i64)> {
-    // id → language for the partition guard applied at pair-emit time.
     let lang_of: BTreeMap<i64, &str> =
         bags.iter().map(|b| (b.symbol_id, b.language.as_str())).collect();
-
     let mut inverted: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
     for bag in bags {
         for token_hash in sub_block_tokens(bag, theta) {
             inverted.entry(token_hash).or_default().push(bag.symbol_id);
         }
     }
-
     let mut candidate: Vec<(i64, i64)> = inverted
         .par_iter()
-        // #271: a token in more than HOT_TOKEN_POSTINGS_CAP sub-blocks is non-discriminating — its
-        // K²/2 pairs are noise that fails verify, and real clones are still found via their rarer
-        // shared tokens. Skip it to bound candidate generation on dense corpora.
         .filter(|(_token, ids)| ids.len() <= HOT_TOKEN_POSTINGS_CAP)
         .flat_map_iter(|(_token, ids)| {
-            let mut local: Vec<(i64, i64)> = Vec::new();
+            let mut local = Vec::new();
             for (i, &a) in ids.iter().enumerate() {
                 for &b in &ids[i + 1..] {
-                    // Language partition: skip cross-language pairs.
                     if lang_of[&a] == lang_of[&b] {
                         local.push((a.min(b), a.max(b)));
                     }
@@ -362,6 +433,91 @@ pub(crate) fn sub_block_candidate_pairs(bags: &[SymbolBag], theta: f64) -> Vec<(
     candidate.par_sort_unstable();
     candidate.dedup();
     candidate
+}
+
+fn sub_block_candidate_pairs_cancellable(
+    bags: &[SymbolBag],
+    theta: f64,
+    cancelled: &AtomicBool,
+) -> Option<Vec<(i64, i64)>> {
+    // id → language for the partition guard applied at pair-emit time.
+    let lang_of: BTreeMap<i64, &str> =
+        bags.iter().map(|b| (b.symbol_id, b.language.as_str())).collect();
+
+    let mut inverted: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+    for bag in bags {
+        if cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
+        for token_hash in sub_block_tokens(bag, theta) {
+            inverted.entry(token_hash).or_default().push(bag.symbol_id);
+        }
+    }
+
+    let candidate: Vec<(i64, i64)> = inverted
+        .par_iter()
+        // #271: a token in more than HOT_TOKEN_POSTINGS_CAP sub-blocks is non-discriminating — its
+        // K²/2 pairs are noise that fails verify, and real clones are still found via their rarer
+        // shared tokens. Skip it to bound candidate generation on dense corpora.
+        .filter(|(_token, ids)| ids.len() <= HOT_TOKEN_POSTINGS_CAP)
+        .flat_map_iter(|(_token, ids)| {
+            let mut local: Vec<(i64, i64)> = Vec::new();
+            for (i, &a) in ids.iter().enumerate() {
+                if cancelled.load(Ordering::Relaxed) {
+                    break;
+                }
+                for &b in &ids[i + 1..] {
+                    // Language partition: skip cross-language pairs.
+                    if lang_of[&a] == lang_of[&b] {
+                        local.push((a.min(b), a.max(b)));
+                    }
+                }
+            }
+            local
+        })
+        .collect();
+    if cancelled.load(Ordering::Acquire) {
+        return None;
+    }
+    sort_dedup_pairs_cancellable(candidate, cancelled)
+}
+
+fn sort_dedup_pairs_cancellable(
+    mut pairs: Vec<(i64, i64)>,
+    cancelled: &AtomicBool,
+) -> Option<Vec<(i64, i64)>> {
+    const SORT_CHUNK: usize = 65_536;
+    pairs.par_chunks_mut(SORT_CHUNK).for_each(|chunk| {
+        if !cancelled.load(Ordering::Relaxed) {
+            chunk.sort_unstable();
+        }
+    });
+    if cancelled.load(Ordering::Acquire) {
+        return None;
+    }
+
+    let mut heap = BinaryHeap::new();
+    for chunk in 0..pairs.len().div_ceil(SORT_CHUNK) {
+        let index = chunk * SORT_CHUNK;
+        heap.push(Reverse((pairs[index], chunk, index)));
+    }
+    let mut sorted = Vec::with_capacity(pairs.len());
+    let mut visits = 0usize;
+    while let Some(Reverse((pair, chunk, index))) = heap.pop() {
+        if visits.is_multiple_of(1024) && cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
+        visits += 1;
+        if sorted.last() != Some(&pair) {
+            sorted.push(pair);
+        }
+        let next = index + 1;
+        let chunk_end = ((chunk + 1) * SORT_CHUNK).min(pairs.len());
+        if next < chunk_end {
+            heap.push(Reverse((pairs[next], chunk, next)));
+        }
+    }
+    Some(sorted)
 }
 
 /// A symbol's sub-block: the distinct token hashes whose occurrences reach into the first `p`
@@ -446,6 +602,15 @@ pub(crate) fn overlap(a: &SymbolBag, b: &SymbolBag) -> i64 {
 
 /// Union-find the pairs into components of size >= 2 (sorted for determinism).
 pub(crate) fn components_from_pairs(pairs: &[(i64, i64)]) -> Vec<Vec<i64>> {
+    let cancelled = AtomicBool::new(false);
+    components_from_pairs_cancellable(pairs, &cancelled)
+        .expect("a permanently-clear cancellation flag cannot cancel")
+}
+
+pub(crate) fn components_from_pairs_cancellable(
+    pairs: &[(i64, i64)],
+    cancelled: &AtomicBool,
+) -> Option<Vec<Vec<i64>>> {
     use std::collections::BTreeMap;
 
     fn find(parent: &mut BTreeMap<i64, i64>, x: i64) -> i64 {
@@ -468,7 +633,10 @@ pub(crate) fn components_from_pairs(pairs: &[(i64, i64)]) -> Vec<Vec<i64>> {
     }
 
     let mut parent: BTreeMap<i64, i64> = BTreeMap::new();
-    for &(a, b) in pairs {
+    for (index, &(a, b)) in pairs.iter().enumerate() {
+        if index.is_multiple_of(1024) && cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
         parent.entry(a).or_insert(a);
         parent.entry(b).or_insert(b);
         let (ra, rb) = (find(&mut parent, a), find(&mut parent, b));
@@ -478,18 +646,23 @@ pub(crate) fn components_from_pairs(pairs: &[(i64, i64)]) -> Vec<Vec<i64>> {
     }
     let mut groups: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
     let members: Vec<i64> = parent.keys().copied().collect(); // collect keys first: find() needs &mut parent
-    for member in members {
+    for (index, member) in members.into_iter().enumerate() {
+        if index.is_multiple_of(1024) && cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
         let root = find(&mut parent, member);
         groups.entry(root).or_default().push(member);
     }
-    groups
-        .into_values()
-        .filter(|g| g.len() >= 2)
-        .map(|mut g| {
-            g.sort_unstable();
-            g
-        })
-        .collect()
+    Some(
+        groups
+            .into_values()
+            .filter(|g| g.len() >= 2)
+            .map(|mut g| {
+                g.sort_unstable();
+                g
+            })
+            .collect(),
+    )
 }
 
 /// The `subject` symbol's connected component + its verified θ-edges, computed by a BFS from the
@@ -594,18 +767,34 @@ pub(crate) fn bucket_edges_by_component(
     pairs: &[(i64, i64)],
     components: &[Vec<i64>],
 ) -> Vec<Vec<(i64, i64)>> {
+    let cancelled = AtomicBool::new(false);
+    bucket_edges_by_component_cancellable(pairs, components, &cancelled)
+        .expect("a permanently-clear cancellation flag cannot cancel")
+}
+
+pub(crate) fn bucket_edges_by_component_cancellable(
+    pairs: &[(i64, i64)],
+    components: &[Vec<i64>],
+    cancelled: &AtomicBool,
+) -> Option<Vec<Vec<(i64, i64)>>> {
     let mut node_to_component: BTreeMap<i64, usize> = BTreeMap::new();
     for (idx, component) in components.iter().enumerate() {
+        if cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
         for &node in component {
             node_to_component.insert(node, idx);
         }
     }
     let mut edges_by_component: Vec<Vec<(i64, i64)>> = vec![Vec::new(); components.len()];
-    for &(a, b) in pairs {
+    for (index, &(a, b)) in pairs.iter().enumerate() {
+        if index.is_multiple_of(1024) && cancelled.load(Ordering::Relaxed) {
+            return None;
+        }
         if let Some(&idx) = node_to_component.get(&a) {
             // `a` and `b` are unioned into the same component, so indexing by `a` is correct.
             edges_by_component[idx].push((a, b));
         }
     }
-    edges_by_component
+    Some(edges_by_component)
 }

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -180,7 +180,14 @@ impl IndexDatabase {
         // keyed by `(commit_sha, worktree_id)` directly — nothing cascades it either — so
         // prune a dead checkout's run rows with the SAME live sets, so a run and the
         // edges it produced are dropped together.
-        rag_rat_oracle::prune_edge_oracle_without_live_edge(conn)?;
+        // The Lens enrichment clock is advanced by the writer, not by a per-row `edge_oracle`
+        // trigger: an Oracle pass writes one verdict per resolved edge and gets its single bump
+        // from the `oracle_runs` row it commits alongside them. This sweep writes no run row, so
+        // it advances the clock itself — once, and only when it actually retired a verdict a
+        // connected editor could still be showing.
+        if rag_rat_oracle::prune_edge_oracle_without_live_edge(conn)? > 0 {
+            rag_rat_db::meta::bump_lens_enrichment_revision(conn, &self.active_repo_id)?;
+        }
         // Per-repo (A5): `prune_oracle_runs_outside_scope` now filters `oracle_runs.repo_id` (its
         // own column since V042), so it deletes only THIS repo's run rows that fall outside THIS
         // repo's live sets — a sibling repo's runs are legitimately absent from this repo's live

--- a/crates/rag-rat-core/src/index/query_api/importance.rs
+++ b/crates/rag-rat-core/src/index/query_api/importance.rs
@@ -485,7 +485,7 @@ impl IndexDatabase {
     /// verdict map `important_symbols` uses (a single existence probe short-circuits the
     /// no-oracle-ever path), and hold it for the whole pass so no symbol triggers its own verdict
     /// scan. The returned owned map is borrowed into an [`OracleContext`] per symbol below.
-    fn load_bearing_oracle_effects(
+    pub(super) fn load_bearing_oracle_effects(
         &self,
     ) -> anyhow::Result<
         Option<std::collections::HashMap<i64, rag_rat_query::pagerank::EdgeOracleEffect>>,

--- a/crates/rag-rat-core/src/index/query_api/lens/chunks.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/chunks.rs
@@ -1,0 +1,61 @@
+//! `/api/chunk/text` composition: current-source validation without healing writes.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::index::anchors::{self, AnchorStatus};
+use crate::index::{IndexDatabase, IndexError};
+
+#[derive(Debug, Serialize)]
+pub struct LensChunkText {
+    pub chunk_id: i64,
+    pub text: String,
+}
+
+impl IndexDatabase {
+    /// Validate stored chunk text against current source without mutating the index.
+    pub fn lens_chunk_text(&self, chunk_id: i64) -> anyhow::Result<Option<LensChunkText>> {
+        let Some(chunk) = rag_rat_query::read_chunk(self.storage.connection(), chunk_id)? else {
+            return Ok(None);
+        };
+        let root = if self.active_scope_is_linked_overlay() {
+            crate::index::linked_source_root(
+                self.storage.source_root().ok_or_else(|| {
+                    anyhow::anyhow!("current source root is unavailable for chunk {chunk_id}")
+                })?,
+                PathBuf::from(&self.active_worktree_id).as_path(),
+            )?
+        } else {
+            self.storage
+                .source_root()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("current source root is unavailable for chunk {chunk_id}")
+                })?
+                .to_path_buf()
+        };
+        let current_text = fs::read_to_string(root.join(&chunk.path))
+            .map_err(|_| IndexError::Gone { chunk_id })?;
+        let anchor = self.chunk_anchor(chunk_id)?;
+        let text = match anchors::validate(
+            &chunk.text,
+            usize::try_from(chunk.start_line).unwrap_or(1),
+            usize::try_from(chunk.end_line).unwrap_or(1),
+            &anchor,
+            &current_text,
+        ) {
+            AnchorStatus::Exact => anchors::slice_lines(
+                &current_text,
+                usize::try_from(chunk.start_line).unwrap_or(1),
+                usize::try_from(chunk.end_line).unwrap_or(1),
+            )
+            .ok_or_else(|| IndexError::StaleChunk { chunk_id, path: chunk.path.clone() })?,
+            AnchorStatus::Relocated { text, .. } => text,
+            AnchorStatus::Stale => {
+                anyhow::bail!(IndexError::StaleChunk { chunk_id, path: chunk.path });
+            },
+        };
+        Ok(Some(LensChunkText { chunk_id: chunk.chunk_id, text }))
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/clones.rs
@@ -1,0 +1,740 @@
+//! `/api/file/clones` composition (#216): every cloned symbol in one file,
+//! each mapped to its coherent clone class with partners and — when the class
+//! was refined — the extract-helper payload.
+//!
+//! This is the BATCHED sibling of `clones_for_symbol`: one bag load, one
+//! pair computation, one component walk + coherence split for the whole file
+//! instead of per symbol. The class-formation and subject-subclass selection
+//! rules mirror it exactly (largest containing group, ties by min cohesion).
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use rag_rat_clones::refine::split::coherence_split_cancellable;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+
+use super::super::clones::precompute::{live_generation_row, precomputed_pairs_if_eligible};
+use super::super::clones::{
+    CandidateCloneClass, SymbolBag, THETA, bucket_edges_by_component_cancellable,
+    build_class_cancellable, candidate_pairs_from_bags_cancellable,
+    components_from_pairs_cancellable, load_scoped_baseline_bags,
+    min_pairwise_cohesion_cancellable, overlap,
+};
+use crate::index::IndexDatabase;
+
+/// One cloned region in the requested file (the #216 `clone_regions[]` contract shape).
+#[derive(Debug, Serialize)]
+pub struct LensCloneRegion {
+    pub start_line: i64,
+    pub end_line: i64,
+    pub byte_offset: i64,
+    pub class_id: u64,
+    pub class_key: String,
+    pub symbol: String,
+    pub max_similarity: Option<f64>,
+    pub partners: Vec<LensClonePartner>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refine: Option<LensCloneRefine>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensClonePartner {
+    pub path: String,
+    pub start_line: i64,
+    pub end_line: i64,
+    pub similarity: f64,
+    pub symbol: Option<String>,
+}
+
+/// The extract-helper preview payload from `clone_refinements`, attached only
+/// when the class was actually refined.
+#[derive(Clone, Debug, Serialize)]
+pub struct LensCloneRefine {
+    pub template: String,
+    pub variation_points: serde_json::Value,
+    pub proposed_signature: serde_json::Value,
+    pub confidence: String,
+    pub anti_unify_coverage: f64,
+    pub lcs_ratio: f64,
+    pub refactorability: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensCloneGraphMeta {
+    pub generation: Option<i64>,
+    pub eligible: bool,
+    pub stale: bool,
+    pub source_revision: Option<String>,
+    pub current_revision: Option<String>,
+    pub finished_at_ms: Option<i64>,
+    pub hidden_low_value_classes: usize,
+    pub min_tokens: i64,
+    pub theta: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unavailable_reason: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensFileClones {
+    pub clone_regions: Vec<LensCloneRegion>,
+    #[serde(serialize_with = "serialize_clone_graph_meta")]
+    pub clone_graph: LensCloneGraphMeta,
+}
+
+const MAX_PARTNERS: usize = 25;
+
+#[derive(Default)]
+pub(super) struct CloneFileMetrics {
+    pub(super) partners: HashSet<String>,
+    pub(super) max_similarity: f64,
+}
+
+/// (ref, path, start_line, end_line) for one symbol id.
+type MemberInfo = (Option<String>, String, i64, i64);
+
+/// Every input that determines the resolved graph. `delta_files_applied` is
+/// the persisted mutation epoch for in-place edge rewrites, including
+/// revision-neutral self-heals; the scope fields prevent row-id reuse across
+/// a worktree or files-generation switch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LensCloneGraphCacheKey {
+    clone_generation: Option<i64>,
+    delta_files_applied: i64,
+    content_revision: String,
+    theta_bits: u64,
+    repo_id: String,
+    commit_sha: String,
+    worktree_id: String,
+    files_generation: i64,
+    files_sequence: i64,
+    generated_flags_version: String,
+}
+
+/// One cached clone-graph build: the staleness-filtered, θ-gated edge set
+/// with components. Held on `IndexDatabase` so the interactive file path does
+/// not pay a repository-wide scan per request.
+#[derive(Clone)]
+pub(crate) struct LensCloneGraphCacheEntry {
+    pub(crate) key: LensCloneGraphCacheKey,
+    pub(crate) data: Arc<LensCloneGraphData>,
+}
+
+/// Opaque cache shared by short-lived lens read connections. It retains a small bounded set of
+/// immutable variants because treemap and file-clone reads commonly use different theta values.
+#[derive(Debug, Default)]
+pub struct LensCloneGraphCache(pub(crate) std::sync::Mutex<Vec<LensCloneGraphCacheEntry>>);
+
+const LENS_CLONE_GRAPH_CACHE_ENTRIES: usize = 2;
+
+// SymbolBag has no Debug impl; report shapes, not contents.
+impl std::fmt::Debug for LensCloneGraphCacheEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LensCloneGraphCacheEntry")
+            .field("key", &self.key)
+            .field("components", &self.data.components.len())
+            .field("bags", &self.data.bags.len())
+            .finish()
+    }
+}
+
+// SymbolBag has no Debug impl; the cache key alone carries the diagnostics.
+pub(crate) struct LensCloneGraphData {
+    bags: Vec<SymbolBag>,
+    components: Vec<Vec<i64>>,
+    edges_by_component: Vec<Vec<(i64, i64)>>,
+    member_component: HashMap<i64, usize>,
+}
+
+impl IndexDatabase {
+    pub fn set_lens_clone_graph_cache(&mut self, cache: Arc<LensCloneGraphCache>) {
+        self.lens_clone_graph_cache = cache;
+    }
+
+    /// `/api/file/clones?path=&theta=&min_tokens=` composition.
+    ///
+    /// Classes whose medoid token length falls below `min_tokens` are same-shape
+    /// trivia (enum matchers, accessors — the #960 actionability audit) and are
+    /// hidden, reported via `hidden_low_value_classes`.
+    pub fn lens_file_clones(
+        &self,
+        path: &str,
+        theta: f64,
+        min_tokens: i64,
+    ) -> anyhow::Result<LensFileClones> {
+        let cancelled = AtomicBool::new(false);
+        self.lens_file_clones_with_cancel(path, theta, min_tokens, &cancelled)
+    }
+
+    pub fn lens_file_clones_with_cancel(
+        &self,
+        path: &str,
+        theta: f64,
+        min_tokens: i64,
+        cancelled: &AtomicBool,
+    ) -> anyhow::Result<LensFileClones> {
+        anyhow::ensure!(theta.is_finite(), "theta must be finite");
+        ensure_not_cancelled(cancelled)?;
+        let theta = theta.clamp(THETA, 1.0);
+        let min_tokens = min_tokens.max(0);
+        let conn = self.storage.connection();
+        let (meta, delta_files_applied) = self.lens_clone_graph_meta(conn, theta, min_tokens)?;
+        if !meta.eligible {
+            return Ok(LensFileClones { clone_regions: vec![], clone_graph: meta });
+        }
+
+        // Symbols of the requested file, in the ACTIVE scope (the temp files view).
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.name, s.start_byte, s.start_line, s.end_line FROM symbols s JOIN \
+             files f ON f.id = s.file_id WHERE f.path = ?1 ORDER BY s.start_line, s.id",
+        )?;
+        let file_symbols: Vec<(i64, String, i64, i64, i64)> = stmt
+            .query_map([path], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        if file_symbols.is_empty() {
+            return Ok(LensFileClones { clone_regions: vec![], clone_graph: meta });
+        }
+
+        let Some(data) =
+            self.lens_clone_graph_data(conn, theta, &meta, delta_files_applied, cancelled)?
+        else {
+            // Mirror `clones_for_symbol`'s source choice exactly (persisted graph fast path; a
+            // missing/ineligible graph is honestly unavailable here).
+            return Ok(LensFileClones {
+                clone_regions: vec![],
+                clone_graph: LensCloneGraphMeta { eligible: false, ..meta },
+            });
+        };
+        let LensCloneGraphData { bags, components, edges_by_component, member_component } = &*data;
+        let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+        // Partner similarity, and the seed ranking the coherence split below reads. No
+        // structural-hash special case is needed to score an exact clone as exact: `struct_hash`
+        // and `token_bag` are both derived from the ONE normalized token sequence
+        // `fingerprint_symbol` produces, so symbols identical after normalization have equal bags
+        // and equal `token_len` — `overlap / max_len` is already exactly 1. Pinned by
+        // `lens_file_clones_serves_coherent_class_with_partners`, which asserts 1.0 rather than
+        // merely ≥ θ for a renamed clone.
+        let sim = |a: i64, b: i64| -> f64 {
+            let (ba, bb) = (by_id[&a], by_id[&b]);
+            let max_len = ba.token_len.max(bb.token_len);
+            if max_len == 0 { 1.0 } else { overlap(ba, bb) as f64 / max_len as f64 }
+        };
+
+        // Best coherent sub-class per file symbol (mirrors clones_for_symbol's
+        // subject selection); identical classes shared by several in-file
+        // subjects share one `class_id` so siblings paint one hue. The split
+        // itself runs ONCE per component, not per subject.
+        let mut coherent_by_component: HashMap<usize, Vec<Vec<i64>>> = HashMap::new();
+        let mut refinements_by_class: HashMap<String, Option<LensCloneRefine>> = HashMap::new();
+        // Memoize the built class per coherent subclass: several in-file subjects share one
+        // subclass, and `build_class` re-runs per-member hydration + fan-in queries the lens
+        // never reads differently between subjects of the same class.
+        let mut built_by_subclass: HashMap<Vec<i64>, Option<CandidateCloneClass>> = HashMap::new();
+        // Partner hydration is per SUBCLASS, not per subject: a file that contributes several
+        // symbols to one clone class asks for the same members every time, and each ask is a
+        // chunked row fetch over the whole class. Left uncached that is O(members-in-file ×
+        // class-size) database work for one request — enough to push the clone lane into its
+        // timeout on a file with many sibling clones. Memoized beside `built_by_subclass`, which
+        // already recognizes that subclasses are shared.
+        let mut members_by_subclass: HashMap<Vec<i64>, HashMap<i64, MemberInfo>> = HashMap::new();
+        let mut hidden_keys = std::collections::HashSet::new();
+        let mut regions: Vec<LensCloneRegion> = Vec::new();
+        let mut hidden = 0usize;
+        for &(symbol_id, ref name, start_byte, start_line, end_line) in &file_symbols {
+            ensure_not_cancelled(cancelled)?;
+            let Some(&comp_idx) = member_component.get(&symbol_id) else { continue };
+            if !by_id.contains_key(&symbol_id) {
+                continue; // not fingerprinted (generated / below MIN_TOKENS / non-function)
+            }
+            let coherent = match coherent_by_component.entry(comp_idx) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let Some(split) = coherence_split_cancellable(
+                        &components[comp_idx],
+                        &edges_by_component[comp_idx],
+                        sim,
+                        || cancelled.load(Ordering::Relaxed),
+                    ) else {
+                        anyhow::bail!("lens request cancelled");
+                    };
+                    entry.insert(split)
+                },
+            };
+            let mut subject_subclass: Option<&Vec<i64>> = None;
+            for candidate in coherent.iter().filter(|class| class.contains(&symbol_id)) {
+                ensure_not_cancelled(cancelled)?;
+                let replace = match subject_subclass {
+                    None => true,
+                    Some(best) => {
+                        let ordering = match best.len().cmp(&candidate.len()) {
+                            std::cmp::Ordering::Equal => {
+                                let Some(best_cohesion) =
+                                    min_pairwise_cohesion_cancellable(best, &by_id, cancelled)
+                                else {
+                                    anyhow::bail!("lens request cancelled");
+                                };
+                                let Some(candidate_cohesion) =
+                                    min_pairwise_cohesion_cancellable(candidate, &by_id, cancelled)
+                                else {
+                                    anyhow::bail!("lens request cancelled");
+                                };
+                                best_cohesion
+                                    .partial_cmp(&candidate_cohesion)
+                                    .unwrap_or(std::cmp::Ordering::Equal)
+                            },
+                            ordering => ordering,
+                        };
+                        ordering.then_with(|| candidate.cmp(best)).is_lt()
+                    },
+                };
+                ensure_not_cancelled(cancelled)?;
+                if replace {
+                    subject_subclass = Some(candidate);
+                }
+            }
+            let Some(subclass) = subject_subclass else { continue };
+            ensure_not_cancelled(cancelled)?;
+            let built = match built_by_subclass.entry(subclass.clone()) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let built = build_class_cancellable(
+                        subclass,
+                        &by_id,
+                        conn,
+                        Some(symbol_id),
+                        cancelled,
+                    )?;
+                    entry.insert(built)
+                },
+            };
+            let Some(built) = built.as_mut() else { continue };
+            if built.body_token_len_medoid < min_tokens {
+                // Count hidden CLASSES, not member visits: several in-file
+                // subjects can share one low-token class. Filter BEFORE the
+                // refine pass — trivia classes must not pay anti-unification.
+                if hidden_keys.insert(built.class_key.clone()) {
+                    hidden += 1;
+                }
+                continue;
+            }
+            let refine = match refinements_by_class.get(&built.class_key) {
+                Some(cached) => cached.clone(),
+                None => {
+                    ensure_not_cancelled(cancelled)?;
+                    self.refine_class_from_cache(conn, subclass, &by_id, built)?;
+                    ensure_not_cancelled(cancelled)?;
+                    let refine = built.refined.then(|| LensCloneRefine {
+                        template: built.template.clone().unwrap_or_default(),
+                        variation_points: built
+                            .variation_points
+                            .clone()
+                            .unwrap_or(serde_json::Value::Null),
+                        proposed_signature: built
+                            .proposed_signature
+                            .clone()
+                            .unwrap_or(serde_json::Value::Null),
+                        confidence: built.confidence.clone().unwrap_or_default(),
+                        anti_unify_coverage: built.anti_unify_coverage.unwrap_or(0.0),
+                        lcs_ratio: built.lcs_ratio.unwrap_or(0.0),
+                        refactorability: built.refactorability.unwrap_or(0.0),
+                    });
+                    refinements_by_class.insert(built.class_key.clone(), refine.clone());
+                    refine
+                },
+            };
+            let class_id = stable_class_id(&built.class_key);
+            let info = match members_by_subclass.entry(subclass.clone()) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) =>
+                    entry.insert(member_info(conn, subclass, cancelled)?),
+            };
+            let mut partners = Vec::new();
+            for (index, id) in subclass.iter().enumerate() {
+                if index.is_multiple_of(32) {
+                    ensure_not_cancelled(cancelled)?;
+                }
+                if *id == symbol_id {
+                    continue;
+                }
+                let Some((qref, ppath, sl, el)) = info.get(id) else { continue };
+                partners.push(LensClonePartner {
+                    path: ppath.clone(),
+                    start_line: *sl,
+                    end_line: *el,
+                    similarity: sim(symbol_id, *id),
+                    symbol: qref.as_deref().map(member_name),
+                });
+                if partners.len() == MAX_PARTNERS * 2 {
+                    sort_and_cap_partners(&mut partners);
+                }
+            }
+            ensure_not_cancelled(cancelled)?;
+            sort_and_cap_partners(&mut partners);
+            let max_similarity = partners.iter().map(|p| p.similarity).reduce(f64::max);
+            regions.push(LensCloneRegion {
+                start_line,
+                end_line,
+                byte_offset: start_byte,
+                class_id,
+                class_key: built.class_key.clone(),
+                symbol: name.clone(),
+                max_similarity,
+                partners,
+                refine,
+            });
+        }
+        ensure_not_cancelled(cancelled)?;
+        regions.sort_by_key(|r| r.start_line);
+        ensure_not_cancelled(cancelled)?;
+        Ok(LensFileClones {
+            clone_regions: regions,
+            clone_graph: LensCloneGraphMeta { hidden_low_value_classes: hidden, ..meta },
+        })
+    }
+
+    fn lens_clone_graph_data(
+        &self,
+        conn: &Connection,
+        theta: f64,
+        meta: &LensCloneGraphMeta,
+        delta_files_applied: i64,
+        cancelled: &AtomicBool,
+    ) -> anyhow::Result<Option<Arc<LensCloneGraphData>>> {
+        ensure_not_cancelled(cancelled)?;
+        // Cache check FIRST: only a key miss pays the repository-wide bag load + edge scan +
+        // component build. AUTOINCREMENT covers byte-identical file replacement; the generated
+        // flags version covers the sole in-place clone-membership rewrite.
+        let key = LensCloneGraphCacheKey {
+            clone_generation: meta.generation,
+            delta_files_applied,
+            content_revision: meta.current_revision.clone().unwrap_or_default(),
+            theta_bits: theta.to_bits(),
+            repo_id: self.active_repo_id.clone(),
+            commit_sha: self.active_commit_sha.clone(),
+            worktree_id: self.active_worktree_id.clone(),
+            files_generation: self.active_generation,
+            files_sequence: conn
+                .query_row("SELECT seq FROM sqlite_sequence WHERE name = 'files'", [], |row| {
+                    row.get(0)
+                })
+                .optional()?
+                .unwrap_or(0),
+            generated_flags_version: self
+                .meta(crate::index::GENERATED_FLAGS_VERSION_KEY)?
+                .unwrap_or_default(),
+        };
+        // Single-flight: the lock is held across the build below so a second caller reuses the
+        // entry instead of rebuilding the repository-wide graph. Waiting here costs whatever
+        // resource the caller already holds — for the Lens server that is a bounded database
+        // worker — so callers that share this cache are expected to serialize their ENTRY
+        // upstream, where a waiter holds nothing. This loop stays cancellation-aware for the
+        // callers that do contend.
+        let mut cache = loop {
+            match self.lens_clone_graph_cache.0.try_lock() {
+                Ok(cache) => break cache,
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    ensure_not_cancelled(cancelled)?;
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                },
+                Err(std::sync::TryLockError::Poisoned(error)) => break error.into_inner(),
+            }
+        };
+        if let Some(entry) = cache.iter().find(|entry| entry.key == key) {
+            return Ok(Some(Arc::clone(&entry.data)));
+        }
+        let Some(built) = self.build_lens_clone_graph(conn, theta, cancelled)? else {
+            return Ok(None);
+        };
+        let data = Arc::new(built);
+        if cache.len() == LENS_CLONE_GRAPH_CACHE_ENTRIES {
+            cache.remove(0);
+        }
+        cache.push(LensCloneGraphCacheEntry { key, data: Arc::clone(&data) });
+        Ok(Some(data))
+    }
+
+    /// The cacheable graph build: scoped bags, the staleness-filtered θ-gated pair set,
+    /// components, and edge buckets. Linked overlays use the scope-correct live pair source;
+    /// base scope returns `None` when its persisted graph is missing or ineligible.
+    fn build_lens_clone_graph(
+        &self,
+        conn: &Connection,
+        theta: f64,
+        cancelled: &AtomicBool,
+    ) -> anyhow::Result<Option<LensCloneGraphData>> {
+        let bags = load_scoped_baseline_bags(conn)?;
+        ensure_not_cancelled(cancelled)?;
+        let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+        let pairs = if self.active_scope_is_linked_overlay() {
+            // Persisted edges describe the base checkout. Recompute from the overlay-scoped bags
+            // once per cache key so branch-only and edited clone members are represented safely.
+            let Some(pairs) = candidate_pairs_from_bags_cancellable(&bags, theta, cancelled) else {
+                anyhow::bail!("lens request cancelled");
+            };
+            pairs
+        } else {
+            let Some(pairs) = precomputed_pairs_if_eligible(conn, &by_id, theta)? else {
+                return Ok(None);
+            };
+            pairs
+        };
+        ensure_not_cancelled(cancelled)?;
+        let Some(components) = components_from_pairs_cancellable(&pairs, cancelled) else {
+            anyhow::bail!("lens request cancelled");
+        };
+        let Some(edges_by_component) =
+            bucket_edges_by_component_cancellable(&pairs, &components, cancelled)
+        else {
+            anyhow::bail!("lens request cancelled");
+        };
+        let member_component = components
+            .iter()
+            .enumerate()
+            .flat_map(|(i, c)| c.iter().map(move |m| (*m, i)))
+            .collect();
+        Ok(Some(LensCloneGraphData { bags, components, edges_by_component, member_component }))
+    }
+
+    pub(super) fn lens_overlay_clone_metrics(
+        &self,
+        cancelled: &AtomicBool,
+    ) -> anyhow::Result<HashMap<String, CloneFileMetrics>> {
+        let conn = self.storage.connection();
+        let (meta, delta_files_applied) = self.lens_clone_graph_meta(conn, THETA, 0)?;
+        let Some(data) =
+            self.lens_clone_graph_data(conn, THETA, &meta, delta_files_applied, cancelled)?
+        else {
+            return Ok(HashMap::new());
+        };
+        let by_id: BTreeMap<i64, &SymbolBag> =
+            data.bags.iter().map(|bag| (bag.symbol_id, bag)).collect();
+        ensure_not_cancelled(cancelled)?;
+        let paths: HashMap<i64, String> = conn
+            .prepare(
+                "SELECT symbol.id, file.path FROM symbols symbol JOIN files file ON file.id = \
+                 symbol.file_id",
+            )?
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        ensure_not_cancelled(cancelled)?;
+        let mut metrics = HashMap::new();
+        for edges in &data.edges_by_component {
+            ensure_not_cancelled(cancelled)?;
+            for (edge_index, &(a, b)) in edges.iter().enumerate() {
+                if edge_index.is_multiple_of(1024) {
+                    ensure_not_cancelled(cancelled)?;
+                }
+                let (Some(a_path), Some(b_path), Some(a_bag), Some(b_bag)) =
+                    (paths.get(&a), paths.get(&b), by_id.get(&a), by_id.get(&b))
+                else {
+                    continue;
+                };
+                let max_len = a_bag.token_len.max(b_bag.token_len);
+                let structurally_identical =
+                    a_bag.language == b_bag.language && a_bag.struct_hash == b_bag.struct_hash;
+                let similarity = if structurally_identical || max_len == 0 {
+                    1.0
+                } else {
+                    overlap(a_bag, b_bag) as f64 / max_len as f64
+                };
+                record_clone_metric(&mut metrics, a_path, b_path, similarity);
+                record_clone_metric(&mut metrics, b_path, a_path, similarity);
+            }
+        }
+        Ok(metrics)
+    }
+
+    fn lens_clone_graph_meta(
+        &self,
+        conn: &Connection,
+        theta: f64,
+        min_tokens: i64,
+    ) -> anyhow::Result<(LensCloneGraphMeta, i64)> {
+        if self.active_scope_is_linked_overlay() {
+            let current_revision = self.content_revision().ok();
+            return Ok((
+                LensCloneGraphMeta {
+                    generation: None,
+                    eligible: true,
+                    stale: false,
+                    source_revision: current_revision.clone(),
+                    current_revision,
+                    finished_at_ms: None,
+                    hidden_low_value_classes: 0,
+                    min_tokens,
+                    theta,
+                    unavailable_reason: None,
+                },
+                0,
+            ));
+        }
+        let row = live_generation_row(conn)?;
+        let current_revision = self.content_revision().ok();
+        let Some(r) = row else {
+            return Ok((
+                LensCloneGraphMeta {
+                    generation: None,
+                    eligible: false,
+                    stale: false,
+                    source_revision: None,
+                    current_revision,
+                    finished_at_ms: None,
+                    hidden_low_value_classes: 0,
+                    min_tokens,
+                    theta,
+                    unavailable_reason: Some("missing_generation"),
+                },
+                0,
+            ));
+        };
+        let finished_at_ms: Option<i64> = conn
+            .query_row(
+                "SELECT finished_at_ms FROM clone_graph_generations WHERE generation = ?1",
+                params![r.generation],
+                |row| row.get(0),
+            )
+            .ok()
+            .flatten();
+        let compatible = r.normalizer_version == rag_rat_clones::NORM_VERSION;
+        Ok((
+            LensCloneGraphMeta {
+                generation: Some(r.generation),
+                eligible: compatible,
+                stale: current_revision.as_deref() != Some(r.source_revision.as_str()),
+                source_revision: Some(r.source_revision),
+                current_revision,
+                finished_at_ms,
+                hidden_low_value_classes: 0,
+                min_tokens,
+                theta,
+                // Preserve WHY a present generation cannot serve, so the editor can distinguish
+                // "rebuild needed" from "no clones".
+                unavailable_reason: (!compatible).then_some("normalizer_mismatch"),
+            },
+            r.delta_files_applied,
+        ))
+    }
+}
+
+fn ensure_not_cancelled(cancelled: &AtomicBool) -> anyhow::Result<()> {
+    anyhow::ensure!(!cancelled.load(Ordering::Acquire), "lens request cancelled");
+    Ok(())
+}
+
+pub(super) fn record_clone_metric(
+    metrics: &mut HashMap<String, CloneFileMetrics>,
+    path: &str,
+    partner: &str,
+    similarity: f64,
+) {
+    let metric = metrics.entry(path.to_string()).or_default();
+    if path != partner {
+        metric.partners.insert(partner.to_string());
+    }
+    metric.max_similarity = metric.max_similarity.max(similarity);
+}
+
+fn serialize_clone_graph_meta<S>(
+    meta: &LensCloneGraphMeta,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match (meta.generation, meta.eligible) {
+        (Some(_), _) | (_, true) => meta.serialize(serializer),
+        (None, false) => serializer.serialize_none(),
+    }
+}
+
+/// The read-side class key is 16 hex SHA-256 characters. Its first 13 fit in
+/// JavaScript's exact 53-bit integer range, yielding a stable cross-request UI
+/// color/group id while `class_key` remains the collision-resistant identity.
+fn stable_class_id(class_key: &str) -> u64 {
+    let prefix_len = class_key.len().min(13);
+    u64::from_str_radix(&class_key[..prefix_len], 16).unwrap_or_default()
+}
+
+fn member_name(qualified_ref: &str) -> String {
+    qualified_ref.rsplit("::").next().unwrap_or(qualified_ref).to_string()
+}
+
+fn sort_and_cap_partners(partners: &mut Vec<LensClonePartner>) {
+    partners.sort_by(|a, b| {
+        b.similarity.partial_cmp(&a.similarity).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    partners.truncate(MAX_PARTNERS);
+}
+
+/// `ref@path:start-end` display info per member id, one batched query
+/// (partner ids come from the scoped bags, so main-table joins are in-scope).
+fn member_info(
+    conn: &Connection,
+    subclass: &[i64],
+    cancelled: &AtomicBool,
+) -> anyhow::Result<HashMap<i64, MemberInfo>> {
+    let mut out = HashMap::with_capacity(subclass.len());
+    for member_chunk in subclass.chunks(super::super::clones::HYDRATION_CHUNK) {
+        ensure_not_cancelled(cancelled)?;
+        let marks = member_chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT s.id, ns.value, f.path, s.start_line, s.end_line FROM symbols s JOIN files f \
+             ON f.id = s.file_id LEFT JOIN name_strings ns ON ns.id = s.qualified_name_id WHERE \
+             s.id IN ({marks})"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(member_chunk.iter()), |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                (r.get::<_, Option<String>>(1)?, r.get::<_, String>(2)?, r.get(3)?, r.get(4)?),
+            ))
+        })?;
+        for (index, row) in rows.enumerate() {
+            if index.is_multiple_of(256) {
+                ensure_not_cancelled(cancelled)?;
+            }
+            let (id, info) = row?;
+            out.insert(id, info);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_db::schema;
+
+    use super::*;
+
+    #[test]
+    fn member_info_hydrates_more_than_sqlites_minimum_variable_limit() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               commit_sha, worktree_id)
+             VALUES ('src/lib.rs', 'rust', 'source', 'sha', 0, 0, 'c', '')",
+            [],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        let mut ids = Vec::new();
+        for ordinal in 0..1_001 {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, kind, start_byte, end_byte,
+                                     start_line, end_line)
+                 VALUES (?1, 'rust', ?2, 'function', ?3, ?3 + 1, ?3 + 1, ?3 + 1)",
+                params![file_id, format!("f{ordinal}"), ordinal],
+            )
+            .unwrap();
+            ids.push(conn.last_insert_rowid());
+        }
+        crate::index::install_scope_view(&conn, "c", "").unwrap();
+        let inserted = ids.len();
+        ids.extend(10_000..50_000);
+
+        let info = member_info(&conn, &ids, &AtomicBool::new(false)).unwrap();
+        assert_eq!(info.len(), inserted);
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/enrichments.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/enrichments.rs
@@ -1,0 +1,528 @@
+//! File-scoped memory and change-coupling compositions.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path};
+
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
+use serde::Serialize;
+
+use crate::index::IndexDatabase;
+
+const COUPLING_LIMIT: u32 = 10;
+pub(super) const MEMORY_LIMIT: usize = 50;
+const PAPERTRAIL_LIMIT: u32 = 50;
+
+#[derive(Debug, Serialize)]
+pub struct LensFileCoupling {
+    pub coupling: Vec<LensCouplingPartner>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensCouplingPartner {
+    pub path: String,
+    pub co_changes: i64,
+    pub my_changes: i64,
+    pub confidence: f64,
+    pub last_co_change_at_s: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensFileMemories {
+    pub memories: Vec<LensFileMemory>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensFileMemory {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    pub confidence: String,
+    pub binding_kind: String,
+    pub path: Option<String>,
+    pub line: Option<i64>,
+    pub anchor_status: String,
+    pub summary: Option<String>,
+    pub verdict: Option<String>,
+    pub verdict_direction: Option<String>,
+    pub verdict_evidence: Option<String>,
+    pub checked_against_commit: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensFilePapertrail {
+    pub refs: Vec<LensPapertrailRef>,
+    pub decisions: Vec<LensDecisionRecord>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensPapertrailRef {
+    pub tracker: String,
+    pub project: String,
+    pub item_key: String,
+    pub item_kind: String,
+    pub ref_kind: String,
+    pub source_kind: String,
+    pub source_text: String,
+    pub title: Option<String>,
+    pub url: Option<String>,
+    pub state_normalized: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensDecisionRecord {
+    pub tracker: String,
+    pub project: String,
+    pub item_kind: String,
+    pub item_key: String,
+    pub title: Option<String>,
+    pub url: Option<String>,
+    pub root_issue: Option<String>,
+    pub root_cause: Option<String>,
+    pub decision_chosen: Option<String>,
+    pub outcome_summary: Option<String>,
+    pub outcome_status_model: String,
+    pub outcome_claim_verified: i64,
+    pub decision_provenance_verified: i64,
+    pub fix_edge_source: String,
+    pub line: Option<i64>,
+}
+
+struct ItemDisplay {
+    item_kind: String,
+    title: Option<String>,
+    url: Option<String>,
+    state_normalized: Option<String>,
+}
+
+#[derive(Debug)]
+struct MemoryRow {
+    id: String,
+    kind: String,
+    title: String,
+    body: String,
+    confidence: String,
+    binding_kind: String,
+    path: Option<String>,
+    line: Option<i64>,
+    anchor_status: String,
+}
+
+impl IndexDatabase {
+    /// Materialize the history-derived coupling cache before a read-only Lens server starts.
+    /// Current caches take only the stamp fast path; upgraded indexes pay the bounded rebuild once.
+    pub fn materialize_lens_coupling(&self) -> anyhow::Result<()> {
+        self.ensure_coupling_fresh()
+    }
+
+    pub fn lens_file_coupling(&self, path: &str) -> anyhow::Result<LensFileCoupling> {
+        let coupling = crate::index::change_coupling::current_coupled_files_for_path(
+            self.storage.connection(),
+            &self.active_repo_id,
+            path,
+            COUPLING_LIMIT,
+        )?
+        .into_iter()
+        .map(|partner| LensCouplingPartner {
+            path: partner.other_path,
+            co_changes: partner.co_change_count,
+            my_changes: partner.this_change_count,
+            confidence: (partner.confidence * 1000.0).round() / 1000.0,
+            last_co_change_at_s: partner.last_co_change_at_s,
+        })
+        .collect();
+        Ok(LensFileCoupling { coupling })
+    }
+
+    pub fn lens_file_memories(&self, path: &str) -> anyhow::Result<LensFileMemories> {
+        let conn = self.storage.connection();
+        let rows = list_file_memory_rows(conn, &self.active_repo_id, path)?;
+        let mut dream_states = batch_file_memory_dream_states(conn, &rows)?;
+        let mut memories = Vec::with_capacity(rows.len());
+        for row in rows {
+            let dream = dream_states.remove(&row.id).unwrap_or_default();
+            memories.push(LensFileMemory {
+                id: row.id,
+                kind: row.kind,
+                title: row.title,
+                body: row.body,
+                confidence: row.confidence,
+                binding_kind: row.binding_kind,
+                path: row.path,
+                line: row.line,
+                anchor_status: row.anchor_status,
+                summary: dream.summary,
+                verdict: dream.verdict,
+                verdict_direction: dream.direction,
+                verdict_evidence: dream.evidence_json,
+                checked_against_commit: dream.checked_against_commit,
+            });
+        }
+        Ok(LensFileMemories { memories })
+    }
+
+    pub fn lens_file_papertrail(&self, path: &str) -> anyhow::Result<LensFilePapertrail> {
+        let conn = self.storage.connection();
+        let mut refs = Vec::new();
+        for reference in
+            list_unique_papertrail_refs(conn, &self.active_repo_id, path, PAPERTRAIL_LIMIT)?
+        {
+            let display = item_display(
+                conn,
+                &self.active_repo_id,
+                &reference.tracker,
+                &reference.project,
+                &reference.item_key,
+                Some(&reference.item_kind),
+            )?;
+            let url = display.url.or_else(|| {
+                (reference.tracker == "github").then(|| {
+                    format!(
+                        "https://github.com/{}/issues/{}",
+                        reference.project, reference.item_key
+                    )
+                })
+            });
+            refs.push(LensPapertrailRef {
+                tracker: reference.tracker,
+                project: reference.project,
+                item_key: reference.item_key,
+                item_kind: display.item_kind,
+                ref_kind: reference.ref_kind,
+                source_kind: reference.source_kind,
+                source_text: reference.source_text,
+                title: display.title,
+                url,
+                state_normalized: display.state_normalized,
+            });
+        }
+
+        let mut decisions = Vec::new();
+        for anchored in rag_rat_papertrail::records_for_path(
+            conn,
+            &self.active_repo_id,
+            path,
+            PAPERTRAIL_LIMIT as usize,
+        )? {
+            let record = anchored.record;
+            let display = item_display(
+                conn,
+                &self.active_repo_id,
+                &record.tracker,
+                &record.project,
+                &record.item_key,
+                Some(&record.item_kind),
+            )?;
+            decisions.push(LensDecisionRecord {
+                tracker: record.tracker,
+                project: record.project,
+                item_kind: record.item_kind,
+                item_key: record.item_key,
+                title: display.title,
+                url: display.url,
+                root_issue: record.root_issue,
+                root_cause: record.root_cause,
+                decision_chosen: record.decision_chosen,
+                outcome_summary: record.outcome_summary,
+                // Keep the endpoint contract's field name while surfacing the mechanically
+                // resolved status.
+                outcome_status_model: record.outcome_status.as_db_str().to_string(),
+                outcome_claim_verified: i64::from(record.outcome_claim_verified),
+                decision_provenance_verified: i64::from(record.decision_provenance_verified),
+                fix_edge_source: record.fix_edge_source.as_db_str().to_string(),
+                line: anchored.line,
+            });
+        }
+        Ok(LensFilePapertrail { refs, decisions })
+    }
+}
+
+struct UniquePapertrailRef {
+    tracker: String,
+    project: String,
+    item_key: String,
+    item_kind: String,
+    ref_kind: String,
+    source_kind: String,
+    source_text: String,
+}
+
+/// Resolve nullable provider kinds, collapse repeated textual references by full item identity,
+/// then apply the editor payload cap. Limiting `papertrail_refs` first can let one noisy item evict
+/// every lower-ranked unique item.
+fn list_unique_papertrail_refs(
+    conn: &Connection,
+    repo_id: &str,
+    path: &str,
+    limit: u32,
+) -> anyhow::Result<Vec<UniquePapertrailRef>> {
+    let mut stmt = conn.prepare(
+        "WITH normalized AS MATERIALIZED (
+             SELECT ref.id, ref.tracker, ref.project, ref.item_key,
+                    COALESCE(
+                        ref.item_kind,
+                        (SELECT item.item_kind
+                         FROM papertrail_items item
+                         WHERE item.repo_id = ref.repo_id AND item.tracker = ref.tracker
+                           AND item.project = ref.project AND item.item_key = ref.item_key
+                         ORDER BY CASE item.item_kind WHEN 'issue' THEN 0 ELSE 1 END
+                         LIMIT 1),
+                        'issue'
+                    ) AS item_kind,
+                    ref.ref_kind, ref.source_kind, ref.source_text, ref.discovered_at_ms
+             FROM papertrail_refs ref
+             WHERE ref.repo_id = ?1 AND ref.source_path = ?2
+         ),
+         ranked AS (
+             SELECT *, ROW_NUMBER() OVER (
+                 PARTITION BY tracker, project, item_kind, item_key
+                 ORDER BY discovered_at_ms DESC, id DESC
+             ) AS identity_rank
+             FROM normalized
+         )
+         SELECT tracker, project, item_key, item_kind, ref_kind, source_kind, source_text
+         FROM ranked
+         WHERE identity_rank = 1
+         ORDER BY discovered_at_ms DESC, id DESC
+         LIMIT ?3",
+    )?;
+    let rows = stmt.query_map(params![repo_id, path, i64::from(limit)], |row| {
+        Ok(UniquePapertrailRef {
+            tracker: row.get(0)?,
+            project: row.get(1)?,
+            item_key: row.get(2)?,
+            item_kind: row.get(3)?,
+            ref_kind: row.get(4)?,
+            source_kind: row.get(5)?,
+            source_text: row.get(6)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+fn item_display(
+    conn: &Connection,
+    repo_id: &str,
+    tracker: &str,
+    project: &str,
+    item_key: &str,
+    explicit_kind: Option<&str>,
+) -> anyhow::Result<ItemDisplay> {
+    let row = conn
+        .query_row(
+            "SELECT item_kind, title, url, state_normalized
+             FROM papertrail_items
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_key = ?4
+               AND (?5 IS NULL OR item_kind = ?5)
+             ORDER BY CASE item_kind WHEN 'issue' THEN 0 ELSE 1 END
+             LIMIT 1",
+            params![repo_id, tracker, project, item_key, explicit_kind],
+            |row| {
+                Ok(ItemDisplay {
+                    item_kind: row.get(0)?,
+                    title: row.get(1)?,
+                    url: row.get(2)?,
+                    state_normalized: row.get(3)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row.unwrap_or_else(|| ItemDisplay {
+        item_kind: explicit_kind.unwrap_or("issue").to_string(),
+        title: None,
+        url: None,
+        state_normalized: None,
+    }))
+}
+
+fn list_file_memory_rows(
+    conn: &Connection,
+    repo_id: &str,
+    path: &str,
+) -> anyhow::Result<Vec<MemoryRow>> {
+    let ancestors = directory_ancestors(path);
+    let marks = ancestors.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "WITH requested AS MATERIALIZED (
+             SELECT id FROM files WHERE path = ?1
+         ),
+         matching AS (
+             SELECT m.id, m.kind, m.title, m.body, m.confidence,
+                    b.binding_kind, b.path, b.anchor_status,
+                    COALESCE(
+                        b.start_line,
+                        direct_symbol.start_line,
+                        (SELECT MIN(member.start_line)
+                         FROM logical_symbol_members lsm
+                         JOIN symbols member ON member.id = lsm.symbol_id
+                         WHERE lsm.logical_symbol_id = b.logical_symbol_id
+                           AND member.file_id IN (SELECT id FROM requested)),
+                        bound_chunk.start_line
+                    ) AS line,
+                     b.created_at_ms,
+                     CASE WHEN b.binding_kind = 'dir' THEN 1 ELSE 0 END AS binding_priority
+             FROM repo_memories m
+             JOIN repo_memory_bindings b ON b.memory_id = m.id AND b.repo_id = m.repo_id
+             LEFT JOIN symbols direct_symbol
+               ON direct_symbol.id = b.symbol_id
+              AND direct_symbol.file_id IN (SELECT id FROM requested)
+             LEFT JOIN chunks bound_chunk
+               ON bound_chunk.id = b.chunk_id
+              AND bound_chunk.file_id IN (SELECT id FROM requested)
+             WHERE m.repo_id = ?2 AND m.status = 'active'
+               AND EXISTS (SELECT 1 FROM requested)
+               AND (
+                   b.path = ?1
+                   OR (b.binding_kind = 'dir' AND b.path IN ({marks}))
+                   OR direct_symbol.id IS NOT NULL
+                   OR bound_chunk.id IS NOT NULL
+                   OR EXISTS (
+                       SELECT 1
+                       FROM logical_symbol_members lsm
+                       JOIN symbols member ON member.id = lsm.symbol_id
+                       WHERE lsm.logical_symbol_id = b.logical_symbol_id
+                         AND member.file_id IN (SELECT id FROM requested)
+                   )
+               )
+         ),
+         ranked AS (
+              SELECT *, ROW_NUMBER() OVER (
+                  PARTITION BY id
+                  ORDER BY binding_priority, line IS NULL, line, created_at_ms,
+                           binding_kind, COALESCE(path, '')
+              ) AS rank
+              FROM matching
+          )
+          SELECT id, kind, title, body, confidence, binding_kind, path, line, anchor_status
+          FROM ranked WHERE rank = 1
+          ORDER BY binding_priority, line IS NULL, line, id
+          LIMIT {MEMORY_LIMIT}"
+    );
+    let mut values = vec![path.to_string(), repo_id.to_string()];
+    values.extend(ancestors);
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(values), |row| {
+        Ok(MemoryRow {
+            id: row.get(0)?,
+            kind: row.get(1)?,
+            title: row.get(2)?,
+            body: row.get(3)?,
+            confidence: row.get(4)?,
+            binding_kind: row.get(5)?,
+            path: row.get(6)?,
+            line: row.get(7)?,
+            anchor_status: row.get(8)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+/// Hydrate the bounded editor payload with two set reads instead of two queries per memory.
+/// Evidence freshness remains exact, but only memories carrying a current reality row pay that
+/// check (and the caller caps the population at [`MEMORY_LIMIT`]).
+fn batch_file_memory_dream_states(
+    conn: &Connection,
+    rows: &[MemoryRow],
+) -> rusqlite::Result<HashMap<String, rag_rat_query::memory::CurrentDreamState>> {
+    if rows.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let scope = rag_rat_db::schema::periphery_repo_scope(conn, "memory_summaries")?;
+    let marks = rows.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let content_hashes: HashMap<&str, String> = rows
+        .iter()
+        .map(|row| {
+            (
+                row.id.as_str(),
+                rag_rat_query::memory::evidence::note_content_hash(&row.title, &row.body),
+            )
+        })
+        .collect();
+    let ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+    let mut states = HashMap::new();
+
+    let summary_scope = rag_rat_db::schema::periphery_repo_scope_clause(&scope, "memory_summaries");
+    let summary_sql = format!(
+        "SELECT memory_id, content_hash, summary FROM memory_summaries
+         WHERE memory_id IN ({marks}) AND prompt_version = ?{summary_scope}"
+    );
+    let mut summary_values =
+        ids.iter().cloned().map(rusqlite::types::Value::Text).collect::<Vec<_>>();
+    summary_values.push(rusqlite::types::Value::Text(
+        rag_rat_query::memory::evidence::COMPACT_PROMPT_VERSION.to_string(),
+    ));
+    let mut summary_stmt = conn.prepare(&summary_sql)?;
+    let summaries = summary_stmt.query_map(params_from_iter(summary_values), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+    })?;
+    for summary in summaries {
+        let (id, content_hash, summary) = summary?;
+        if content_hashes.get(id.as_str()) == Some(&content_hash) {
+            states
+                .entry(id)
+                .or_insert_with(rag_rat_query::memory::CurrentDreamState::default)
+                .summary = Some(summary);
+        }
+    }
+
+    let reality_scope = rag_rat_db::schema::periphery_repo_scope_clause(&scope, "memory_reality");
+    let reality_sql = format!(
+        "SELECT memory_id, content_hash, verdict, direction, evidence_json,
+                checked_against_commit, checked_inputs_hash
+         FROM memory_reality
+         WHERE memory_id IN ({marks}) AND prompt_version = ?{reality_scope}"
+    );
+    let mut reality_values = ids.into_iter().map(rusqlite::types::Value::Text).collect::<Vec<_>>();
+    reality_values.push(rusqlite::types::Value::Text(
+        rag_rat_query::memory::evidence::VERDICT_PROMPT_VERSION.to_string(),
+    ));
+    let mut reality_stmt = conn.prepare(&reality_sql)?;
+    let realities = reality_stmt
+        .query_map(params_from_iter(reality_values), |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for (id, content_hash, verdict, direction, evidence_json, commit, stored_inputs) in realities {
+        if content_hashes.get(id.as_str()) != Some(&content_hash) {
+            continue;
+        }
+        let current_inputs =
+            rag_rat_query::memory::evidence::checked_inputs_hash(conn, &id, &scope)?;
+        if stored_inputs.as_deref() != Some(current_inputs.as_str()) {
+            continue;
+        }
+        let state =
+            states.entry(id).or_insert_with(rag_rat_query::memory::CurrentDreamState::default);
+        state.verdict = verdict;
+        state.direction = direction;
+        state.evidence_json = evidence_json;
+        state.checked_against_commit = commit;
+    }
+    Ok(states)
+}
+
+fn directory_ancestors(path: &str) -> Vec<String> {
+    let mut ancestors = HashSet::from([String::new()]);
+    let mut current = String::new();
+    let components = Path::new(path).components().collect::<Vec<_>>();
+    for component in components.iter().take(components.len().saturating_sub(1)) {
+        if let Component::Normal(value) = component {
+            if !current.is_empty() {
+                current.push('/');
+            }
+            current.push_str(&value.to_string_lossy());
+            ancestors.insert(current.clone());
+        }
+    }
+    let mut ancestors = ancestors.into_iter().collect::<Vec<_>>();
+    ancestors.sort();
+    ancestors
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/files.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/files.rs
@@ -1,0 +1,331 @@
+//! Batched, active-scope compositions for `/api/file/symbols` and `/api/file/graph`.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use rag_rat_base::canonical;
+use rag_rat_query::load_bearing::{self, LoadBearingBucket, OracleContext};
+use rusqlite::{Connection, OptionalExtension};
+use serde::Serialize;
+use unicase::UniCase;
+
+use crate::index::IndexDatabase;
+
+#[derive(Debug, Serialize)]
+pub struct LensFileSymbols {
+    pub symbols: Vec<LensSymbol>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensSymbol {
+    pub name: String,
+    pub qname: Option<String>,
+    pub kind: String,
+    pub start_line: i64,
+    pub end_line: i64,
+    pub is_test: bool,
+    pub signature: Option<String>,
+    pub fan_in: u64,
+    pub fan_out: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensFileGraph {
+    pub symbols: Vec<LensFileSymbolGraph>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensFileSymbolGraph {
+    pub name: String,
+    pub qname: Option<String>,
+    pub kind: String,
+    pub start_line: i64,
+    pub end_line: i64,
+    pub is_test: bool,
+    pub callers: LensGraphCallerCounts,
+    pub fan_in_score: f64,
+    pub fan_in_bucket: LoadBearingBucket,
+    pub dispatch: Vec<LensDispatchDetail>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct LensGraphCallerCounts {
+    pub exact: u64,
+    pub syntactic: u64,
+    pub name_only: u64,
+    pub ambiguous: u64,
+    pub tests: u64,
+    pub dispatch: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensDispatchDetail {
+    pub variant: Option<String>,
+    pub direction: &'static str,
+    pub other_name: Option<String>,
+    pub other_path: Option<String>,
+    pub other_line: Option<i64>,
+}
+
+#[derive(Debug)]
+struct FileSymbolRow {
+    id: i64,
+    name: String,
+    qname: Option<String>,
+    kind: String,
+    start_line: i64,
+    end_line: i64,
+    is_test: bool,
+    signature: Option<String>,
+    fan_in: u64,
+    fan_out: u64,
+    callers: LensGraphCallerCounts,
+}
+
+#[derive(Debug)]
+struct DispatchRow {
+    from_symbol_id: Option<i64>,
+    to_symbol_id: Option<i64>,
+    evidence: Option<String>,
+    source_start_line: i64,
+    target_start_line: Option<i64>,
+    from_name: Option<String>,
+    from_path: Option<String>,
+    to_name: Option<String>,
+    to_path: Option<String>,
+}
+
+impl IndexDatabase {
+    /// Return the active-scope spelling for a safe editor path. The fallback scan is enabled only
+    /// when the serving filesystem advertised case-insensitive path semantics.
+    pub fn lens_canonical_file_path(
+        &self,
+        path: &str,
+        case_insensitive: bool,
+    ) -> anyhow::Result<Option<String>> {
+        let conn = self.storage.connection();
+        let exact = conn
+            .query_row("SELECT path FROM files WHERE path = ?1 LIMIT 1", [path], |row| row.get(0))
+            .optional()?;
+        if exact.is_some() || !case_insensitive {
+            return Ok(exact);
+        }
+        // A case-insensitive volume matches names by Unicode case folding, so the comparison has to
+        // fold too. SQLite's built-in `NOCASE` folds ASCII only (`Ä.rs` never reaches the indexed
+        // `ä.rs`), and lowercasing is not folding either — Greek `ς.rs` and `σ.rs` stay distinct
+        // under `to_lowercase` although the filesystem treats them as one name. A miss here empties
+        // every downstream exact-path lane for a file the editor has open. Folding in Rust costs no
+        // more than a SQL predicate: the unique index over `path` collates binary, so any
+        // case-insensitive comparison scans the table anyway. Path order keeps the answer
+        // deterministic when several spellings of one name are indexed.
+        let wanted = folded_path(path);
+        let mut statement = conn.prepare("SELECT path FROM files ORDER BY path")?;
+        let mut rows = statement.query([])?;
+        while let Some(row) = rows.next()? {
+            let candidate: String = row.get(0)?;
+            if folded_path(&candidate) == wanted {
+                return Ok(Some(candidate));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn lens_file_symbols(&self, path: &str) -> anyhow::Result<LensFileSymbols> {
+        let symbols = list_file_symbols_with_graph_counts(self.storage.connection(), path)?
+            .into_iter()
+            .map(|row| LensSymbol {
+                name: row.name,
+                qname: row.qname,
+                kind: row.kind,
+                start_line: row.start_line,
+                end_line: row.end_line,
+                is_test: row.is_test,
+                signature: row.signature,
+                fan_in: row.fan_in,
+                fan_out: row.fan_out,
+            })
+            .collect();
+        Ok(LensFileSymbols { symbols })
+    }
+
+    pub fn lens_file_graph(&self, path: &str) -> anyhow::Result<LensFileGraph> {
+        let rows = list_file_symbols_with_graph_counts(self.storage.connection(), path)?;
+        if rows.is_empty() {
+            return Ok(LensFileGraph { symbols: Vec::new() });
+        }
+        let symbol_ids = rows.iter().map(|row| row.id).collect::<Vec<_>>();
+        let effects = self.load_bearing_oracle_effects()?;
+        let importance = load_bearing::scoped_weighted_fan_in_many(
+            self.storage.connection(),
+            &symbol_ids,
+            &OracleContext { effects: effects.as_ref() },
+        )?;
+        let dispatch = list_file_dispatch_details(self.storage.connection(), path)?;
+        let mut dispatch_by_symbol: HashMap<i64, Vec<LensDispatchDetail>> = HashMap::new();
+        for detail in dispatch {
+            if let Some(symbol_id) = detail.from_symbol_id
+                && symbol_ids.contains(&symbol_id)
+            {
+                dispatch_by_symbol.entry(symbol_id).or_default().push(LensDispatchDetail {
+                    variant: detail.evidence.clone(),
+                    direction: "constructs",
+                    other_name: detail.to_name.clone(),
+                    other_path: detail.to_path.clone(),
+                    other_line: detail.target_start_line,
+                });
+            }
+            if let Some(symbol_id) = detail.to_symbol_id
+                && symbol_ids.contains(&symbol_id)
+            {
+                dispatch_by_symbol.entry(symbol_id).or_default().push(LensDispatchDetail {
+                    variant: detail.evidence,
+                    direction: "handled",
+                    other_name: detail.from_name,
+                    other_path: detail.from_path,
+                    other_line: Some(detail.source_start_line),
+                });
+            }
+        }
+        let symbols = rows
+            .into_iter()
+            .map(|row| {
+                let load = importance.get(&row.id);
+                LensFileSymbolGraph {
+                    name: row.name,
+                    qname: row.qname,
+                    kind: row.kind,
+                    start_line: row.start_line,
+                    end_line: row.end_line,
+                    is_test: row.is_test,
+                    callers: row.callers,
+                    fan_in_score: load.map_or(0.0, |value| value.score),
+                    fan_in_bucket: load.map_or(LoadBearingBucket::Low, |value| value.bucket),
+                    dispatch: dispatch_by_symbol.remove(&row.id).unwrap_or_default(),
+                }
+            })
+            .collect();
+        Ok(LensFileGraph { symbols })
+    }
+}
+
+/// Prepare a path for the comparison a case-insensitive volume performs: NFC first, because a
+/// decomposed spelling (`a` + U+0308) names the same file as the composed `ä` there, then Unicode
+/// case folding through `UniCase`. ASCII paths — nearly every candidate — are already NFC and take
+/// `UniCase`'s allocation-free ASCII comparison.
+fn folded_path(path: &str) -> UniCase<Cow<'_, str>> {
+    let normalized =
+        if path.is_ascii() { Cow::Borrowed(path) } else { Cow::Owned(canonical::nfc(path)) };
+    UniCase::new(normalized)
+}
+
+/// Fetch every symbol and all graph counts for one active-scope file in a single statement. The
+/// materialized `requested` CTE bounds both edge aggregates to this file and keeps result ordering
+/// deterministic for editor overlays.
+fn list_file_symbols_with_graph_counts(
+    conn: &Connection,
+    path: &str,
+) -> anyhow::Result<Vec<FileSymbolRow>> {
+    let mut stmt = conn.prepare(
+        "WITH requested AS MATERIALIZED (
+             SELECT s.id, s.name, ns.value AS qname, s.kind, s.start_line, s.end_line,
+                    s.is_test, s.signature
+             FROM symbols s
+             JOIN files ON files.id = s.file_id
+             LEFT JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE files.path = ?1
+         ),
+         incoming AS (
+             SELECT e.to_symbol_id AS symbol_id,
+                    COUNT(*) AS fan_in,
+                    SUM(CASE WHEN e.confidence = 'Exact' THEN 1 ELSE 0 END) AS exact,
+                    SUM(CASE WHEN e.confidence = 'Syntactic' THEN 1 ELSE 0 END) AS syntactic,
+                    SUM(CASE WHEN e.confidence = 'NameOnly' THEN 1 ELSE 0 END) AS name_only,
+                    SUM(CASE WHEN e.confidence = 'Ambiguous' THEN 1 ELSE 0 END) AS ambiguous,
+                    SUM(CASE WHEN source_symbol.is_test = 1 THEN 1 ELSE 0 END) AS tests,
+                    SUM(CASE WHEN e.edge_kind = 'dispatches' THEN 1 ELSE 0 END) AS dispatch
+             FROM edges e
+             JOIN requested ON requested.id = e.to_symbol_id
+             JOIN files source_file ON source_file.id = e.source_file_id
+             LEFT JOIN symbols source_symbol ON source_symbol.id = e.from_symbol_id
+             GROUP BY e.to_symbol_id
+         ),
+         outgoing AS (
+             SELECT e.from_symbol_id AS symbol_id, COUNT(*) AS fan_out
+             FROM edges e
+             JOIN requested ON requested.id = e.from_symbol_id
+             JOIN symbols target_symbol ON target_symbol.id = e.to_symbol_id
+             JOIN files target_file ON target_file.id = target_symbol.file_id
+             GROUP BY e.from_symbol_id
+         )
+         SELECT requested.id, requested.name, requested.qname, requested.kind,
+                requested.start_line, requested.end_line, requested.is_test, requested.signature,
+                COALESCE(incoming.fan_in, 0), COALESCE(outgoing.fan_out, 0),
+                COALESCE(incoming.exact, 0), COALESCE(incoming.syntactic, 0),
+                COALESCE(incoming.name_only, 0), COALESCE(incoming.ambiguous, 0),
+                COALESCE(incoming.tests, 0), COALESCE(incoming.dispatch, 0)
+         FROM requested
+         LEFT JOIN incoming ON incoming.symbol_id = requested.id
+         LEFT JOIN outgoing ON outgoing.symbol_id = requested.id
+         ORDER BY requested.start_line, requested.id",
+    )?;
+    let rows = stmt.query_map([path], |row| {
+        Ok(FileSymbolRow {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            qname: row.get(2)?,
+            kind: row.get(3)?,
+            start_line: row.get(4)?,
+            end_line: row.get(5)?,
+            is_test: row.get(6)?,
+            signature: row.get(7)?,
+            fan_in: u64::try_from(row.get::<_, i64>(8)?).unwrap_or(0),
+            fan_out: u64::try_from(row.get::<_, i64>(9)?).unwrap_or(0),
+            callers: LensGraphCallerCounts {
+                exact: u64::try_from(row.get::<_, i64>(10)?).unwrap_or(0),
+                syntactic: u64::try_from(row.get::<_, i64>(11)?).unwrap_or(0),
+                name_only: u64::try_from(row.get::<_, i64>(12)?).unwrap_or(0),
+                ambiguous: u64::try_from(row.get::<_, i64>(13)?).unwrap_or(0),
+                tests: u64::try_from(row.get::<_, i64>(14)?).unwrap_or(0),
+                dispatch: u64::try_from(row.get::<_, i64>(15)?).unwrap_or(0),
+            },
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+/// Load all synthesized dispatch edges touching symbols in one active-scope file. Both endpoint
+/// paths are joined through the scoped `files` view, so details cannot cross checkout scope.
+fn list_file_dispatch_details(conn: &Connection, path: &str) -> anyhow::Result<Vec<DispatchRow>> {
+    let mut stmt = conn.prepare(
+        "WITH requested AS MATERIALIZED (
+             SELECT s.id FROM symbols s JOIN files ON files.id = s.file_id WHERE files.path = ?1
+         )
+         SELECT e.from_symbol_id, e.to_symbol_id, e.evidence, e.source_start_line,
+                e.target_start_line, source_symbol.name, source_file.path,
+                target_symbol.name, target_file.path
+         FROM edges e
+         JOIN files source_file ON source_file.id = e.source_file_id
+         JOIN symbols source_symbol
+           ON source_symbol.id = e.from_symbol_id AND source_symbol.file_id = source_file.id
+         JOIN symbols target_symbol ON target_symbol.id = e.to_symbol_id
+         JOIN files target_file ON target_file.id = target_symbol.file_id
+         WHERE e.edge_kind = 'dispatches'
+           AND (e.from_symbol_id IN (SELECT id FROM requested)
+                OR e.to_symbol_id IN (SELECT id FROM requested))
+         ORDER BY e.source_start_line, e.id",
+    )?;
+    let rows = stmt.query_map([path], |row| {
+        Ok(DispatchRow {
+            from_symbol_id: row.get(0)?,
+            to_symbol_id: row.get(1)?,
+            evidence: row.get(2)?,
+            source_start_line: row.get(3)?,
+            target_start_line: row.get(4)?,
+            from_name: row.get(5)?,
+            from_path: row.get(6)?,
+            to_name: row.get(7)?,
+            to_path: row.get(8)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -1,0 +1,189 @@
+//! `/api/symbol/{callers,callees}` compositions over native graph traversal.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, params_from_iter};
+use serde::Serialize;
+
+use crate::index::IndexDatabase;
+
+#[derive(Debug, Serialize)]
+pub struct LensCallers {
+    pub callers: Vec<LensSymbolHop>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensCallees {
+    pub callees: Vec<LensSymbolHop>,
+}
+
+/// Compatibility projection of the #216 endpoint hop. Reindex-churning edge, file, and symbol
+/// row ids are deliberately omitted; `qname`, `path`, and the callsite line are the stable
+/// editor references.
+#[derive(Debug, Serialize)]
+pub struct LensSymbolHop {
+    pub edge_kind: String,
+    pub confidence: String,
+    pub resolution: String,
+    pub source_start_line: i64,
+    pub name: String,
+    pub qname: Option<String>,
+    pub kind: Option<String>,
+    pub path: String,
+}
+
+#[derive(Clone, Debug)]
+struct HopSymbolInfo {
+    name: String,
+    qname: Option<String>,
+    kind: String,
+}
+
+impl IndexDatabase {
+    pub fn lens_symbol_callers(
+        &self,
+        qualified_name: &str,
+        limit: u32,
+    ) -> anyhow::Result<LensCallers> {
+        let hops = self.find_callers_with_options(
+            qualified_name,
+            limit,
+            &rag_rat_query::graph::GraphTraversalOptions::default(),
+        )?;
+        Ok(LensCallers { callers: adapt_hops(self.storage.connection(), hops, true)? })
+    }
+
+    pub fn lens_symbol_callees(
+        &self,
+        qualified_name: &str,
+        limit: u32,
+    ) -> anyhow::Result<LensCallees> {
+        let hops = self.trace_callees_with_options(
+            qualified_name,
+            limit,
+            &rag_rat_query::graph::GraphTraversalOptions::default(),
+        )?;
+        Ok(LensCallees { callees: adapt_hops(self.storage.connection(), hops, false)? })
+    }
+}
+
+pub(super) fn adapt_hops(
+    conn: &Connection,
+    hops: Vec<rag_rat_query::graph::GraphHop>,
+    reverse: bool,
+) -> anyhow::Result<Vec<LensSymbolHop>> {
+    let edge_ids = hops.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();
+    let mut info = symbol_info_for_edges(conn, &edge_ids, reverse)?;
+    if !reverse {
+        let compiler_targets = hops
+            .iter()
+            .filter(|hop| hop.confidence == "compiler")
+            .filter_map(|hop| hop.to_symbol.clone())
+            .collect::<Vec<_>>();
+        let resolved = symbol_info_for_qualified_names(conn, &compiler_targets)?;
+        for hop in &hops {
+            if hop.confidence == "compiler"
+                && let Some(symbol) = hop.to_symbol.as_ref().and_then(|qname| resolved.get(qname))
+            {
+                info.insert(hop.edge_id, symbol.clone());
+            }
+        }
+    }
+    Ok(hops
+        .into_iter()
+        .filter_map(|hop| {
+            // A hop without a callsite has no stable editor anchor — fabricating line 1 of an
+            // empty path would paint a misleading lens.
+            let callsite = hop.callsite?;
+            let (name, qname, kind) = match info.get(&hop.edge_id) {
+                Some(symbol) =>
+                    (symbol.name.clone(), symbol.qname.clone(), Some(symbol.kind.clone())),
+                // File-level callers deliberately have no `from_symbol_id`; traversal still
+                // supplies their indexed path as the source name and their real callsite.
+                None if reverse => (hop.from_symbol?, None, None),
+                None => return None,
+            };
+            Some(LensSymbolHop {
+                edge_kind: hop.edge_kind,
+                confidence: hop.confidence,
+                resolution: hop.resolution,
+                source_start_line: callsite.line,
+                name,
+                qname,
+                kind,
+                path: callsite.path,
+            })
+        })
+        .collect())
+}
+
+/// Resolve every hop's opposite endpoint in one scoped query. Keying by edge id preserves symbols
+/// without qualified names and prevents unresolved fallback names from masquerading as qnames.
+fn symbol_info_for_edges(
+    conn: &Connection,
+    edge_ids: &[i64],
+    reverse: bool,
+) -> anyhow::Result<HashMap<i64, HopSymbolInfo>> {
+    if edge_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let marks = edge_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let other_symbol_id = if reverse { "e.from_symbol_id" } else { "e.to_symbol_id" };
+    let sql = format!(
+        "SELECT e.id, s.name, ns.value, s.kind
+         FROM edges e
+         JOIN files source_file ON source_file.id = e.source_file_id
+         JOIN symbols s ON s.id = {other_symbol_id}
+         JOIN files symbol_file ON symbol_file.id = s.file_id
+         LEFT JOIN name_strings ns ON ns.id = s.qualified_name_id
+         WHERE e.id IN ({marks})
+         ORDER BY e.id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(edge_ids), |row| {
+        Ok((row.get::<_, i64>(0)?, HopSymbolInfo {
+            name: row.get(1)?,
+            qname: row.get(2)?,
+            kind: row.get(3)?,
+        }))
+    })?;
+    let mut info = HashMap::new();
+    for row in rows {
+        let (edge_id, value) = row?;
+        info.entry(edge_id).or_insert(value);
+    }
+    Ok(info)
+}
+
+fn symbol_info_for_qualified_names(
+    conn: &Connection,
+    qualified_names: &[String],
+) -> anyhow::Result<HashMap<String, HopSymbolInfo>> {
+    if qualified_names.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let marks = qualified_names.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT ns.value, s.name, s.kind
+         FROM symbols s
+         JOIN files ON files.id = s.file_id
+         JOIN name_strings ns ON ns.id = s.qualified_name_id
+         WHERE ns.value IN ({marks})
+         ORDER BY s.id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(qualified_names), |row| {
+        let qname = row.get::<_, String>(0)?;
+        Ok((qname.clone(), HopSymbolInfo {
+            name: row.get(1)?,
+            qname: Some(qname),
+            kind: row.get(2)?,
+        }))
+    })?;
+    let mut info = HashMap::new();
+    for row in rows {
+        let (qualified_name, value) = row?;
+        info.entry(qualified_name).or_insert(value);
+    }
+    Ok(info)
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/mod.rs
@@ -1,0 +1,31 @@
+//! The `lens` read module: HTTP-agnostic compositions backing the editor-lens
+//! endpoint contract (#216). Each method mirrors one `/api/*` shape consumed by
+//! the editor extension; the serve layer (MCP thread / `rag-rat serve`) is a
+//! thin serializer over these.
+//!
+//! `mod.rs` is the curated index; compositions live in cohesive siblings.
+
+mod chunks;
+pub(crate) mod clones;
+mod enrichments;
+mod files;
+mod hops;
+mod status;
+mod treemap;
+
+pub use chunks::LensChunkText;
+pub use clones::LensCloneGraphCache;
+pub use enrichments::{
+    LensCouplingPartner, LensDecisionRecord, LensFileCoupling, LensFileMemories, LensFileMemory,
+    LensFilePapertrail, LensPapertrailRef,
+};
+pub use files::{
+    LensDispatchDetail, LensFileGraph, LensFileSymbolGraph, LensFileSymbols, LensGraphCallerCounts,
+    LensSymbol,
+};
+pub use hops::{LensCallees, LensCallers, LensSymbolHop};
+pub use status::{LensStatus, LensVersion};
+pub use treemap::{LensTreemap, LensTreemapFile};
+
+#[cfg(test)]
+mod tests;

--- a/crates/rag-rat-core/src/index/query_api/lens/status.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/status.rs
@@ -1,0 +1,108 @@
+//! Stable status/version shapes for editor clients.
+
+use std::collections::BTreeMap;
+
+use rag_rat_base::config::Config;
+use serde::Serialize;
+
+use crate::index::IndexDatabase;
+
+#[derive(Debug, Serialize)]
+pub struct LensStatus {
+    pub repo_id: String,
+    /// The CHECKOUT this index is serving — empty for the main worktree, the linked worktree's
+    /// path otherwise. A repository's linked worktrees share one `repo_id` by design, so a client
+    /// binding itself to a hosted server needs this to tell them apart: line-anchored memories and
+    /// clone regions describe the checkout they were indexed from, not the repository at large.
+    pub worktree_id: String,
+    pub repo_root: String,
+    pub indexed_root: String,
+    pub case_insensitive_paths: bool,
+    pub live_files_generation: i64,
+    pub clone_graph_generation: Option<i64>,
+    pub indexed_head: Option<String>,
+    pub git_dirty: Option<String>,
+    pub indexed_at_ms: Option<String>,
+    pub schema_version: u32,
+    pub live_file_count: u64,
+    pub counts: BTreeMap<&'static str, u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct LensVersion {
+    pub generation: i64,
+    pub max_indexed_at_ms: i64,
+    pub git_dirty: Option<String>,
+    pub revision: String,
+}
+
+impl IndexDatabase {
+    /// Repository-scoped status in the stable editor-shim shape.
+    pub fn lens_status(
+        &self,
+        config: &Config,
+        indexed_root: String,
+        case_insensitive_paths: bool,
+    ) -> anyhow::Result<LensStatus> {
+        let conn = self.storage.connection();
+        let clone_graph_generation =
+            self.repo_meta("clone_graph_live_generation")?.and_then(|value| value.parse().ok());
+        let live_file_count = count(conn, "SELECT COUNT(*) FROM files")?;
+        let mut counts = BTreeMap::new();
+        counts.insert(
+            "symbols",
+            count(conn, "SELECT COUNT(*) FROM symbols s JOIN files f ON f.id = s.file_id")?,
+        );
+        counts.insert(
+            "edges_data",
+            count(
+                conn,
+                "SELECT COUNT(*) FROM edges_data e JOIN files f ON f.id = e.source_file_id",
+            )?,
+        );
+        let memory_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM repo_memories WHERE repo_id = ?1",
+            [&self.active_repo_id],
+            |row| row.get(0),
+        )?;
+        counts.insert("repo_memories", u64::try_from(memory_count).unwrap_or(0));
+        Ok(LensStatus {
+            repo_id: self.active_repo_id.clone(),
+            worktree_id: self.active_worktree_id.clone(),
+            repo_root: config.root.display().to_string(),
+            indexed_root,
+            case_insensitive_paths,
+            live_files_generation: self.active_generation,
+            clone_graph_generation,
+            indexed_head: self.repo_meta("git_commit")?,
+            git_dirty: self.repo_meta("git_dirty")?,
+            indexed_at_ms: self.repo_meta("indexed_at_ms")?,
+            schema_version: rag_rat_db::schema::status(conn)?.current_version,
+            live_file_count,
+            counts,
+        })
+    }
+
+    /// Cheap freshness token in the stable editor-shim shape.
+    pub fn lens_version(&self) -> anyhow::Result<LensVersion> {
+        let enrichment_revision = self
+            .repo_meta(rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META)?
+            .unwrap_or_else(|| "0".to_string());
+        let clone_graph_generation =
+            self.repo_meta("clone_graph_live_generation")?.unwrap_or_else(|| "none".to_string());
+        Ok(LensVersion {
+            generation: self.active_generation,
+            max_indexed_at_ms: self
+                .repo_meta("indexed_at_ms")?
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(0),
+            git_dirty: self.repo_meta("git_dirty")?,
+            revision: format!("{enrichment_revision}:{clone_graph_generation}"),
+        })
+    }
+}
+
+fn count(conn: &rusqlite::Connection, sql: &str) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(sql, [], |row| row.get(0))?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1,0 +1,1239 @@
+use std::fs;
+use std::path::PathBuf;
+
+use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
+use rag_rat_base::language::Language;
+use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+use rusqlite::params;
+
+use super::hops::adapt_hops;
+use crate::index::IndexDatabase;
+
+const SOURCE: &str = r#"
+pub enum Req { Upsert { id: i64 } }
+
+pub fn target(_id: i64) {}
+
+pub fn caller() { target(1); }
+
+#[test]
+fn target_test() { target(2); }
+
+pub fn enqueue() { send(Req::Upsert { id: 3 }); }
+fn send(_req: Req) {}
+
+pub fn handle(req: Req) {
+    match req {
+        Req::Upsert { id } => target(id),
+    }
+}
+"#;
+
+const OTHER_SOURCE: &str = "pub fn other() {}\n";
+
+const UNICODE_PATH: &str = "src/дом.rs";
+const UNICODE_UPPERCASE_PATH: &str = "src/ДОМ.rs";
+const UNICODE_SOURCE: &str = "pub fn unicode_named() {}\n";
+
+/// Medial and final sigma: two lowercase spellings a case-insensitive volume treats as one name,
+/// which lowercasing alone leaves distinct.
+const FOLDED_PATH: &str = "src/σ.rs";
+const FOLDED_ALIAS_PATH: &str = "src/ς.rs";
+const FOLDED_SOURCE: &str = "pub fn folded_name() {}\n";
+
+/// Composed `ä` and its decomposed `a` + combining diaeresis: one name to a case-insensitive
+/// volume, which also matches names irrespective of Unicode normalization.
+const COMPOSED_PATH: &str = "src/\u{00e4}.rs";
+const DECOMPOSED_PATH: &str = "src/a\u{0308}.rs";
+const COMPOSED_SOURCE: &str = "pub fn composed_name() {}\n";
+
+#[test]
+fn file_compositions_are_ordered_and_batch_graph_signals() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    assert_eq!(
+        db.lens_canonical_file_path("SRC/LIB.RS", true).unwrap().as_deref(),
+        Some("src/lib.rs")
+    );
+    assert_eq!(db.lens_canonical_file_path("SRC/LIB.RS", false).unwrap(), None);
+    // A case-insensitive volume folds the whole Unicode range, not the ASCII subset SQLite's
+    // `NOCASE` collation covers — and it folds rather than lowercases, so two lowercase spellings
+    // of one name still resolve to the indexed one.
+    assert_eq!(
+        db.lens_canonical_file_path(UNICODE_UPPERCASE_PATH, true).unwrap().as_deref(),
+        Some(UNICODE_PATH)
+    );
+    assert_eq!(db.lens_canonical_file_path(UNICODE_UPPERCASE_PATH, false).unwrap(), None);
+    assert_eq!(
+        db.lens_canonical_file_path(FOLDED_ALIAS_PATH, true).unwrap().as_deref(),
+        Some(FOLDED_PATH)
+    );
+    assert_eq!(db.lens_canonical_file_path(FOLDED_ALIAS_PATH, false).unwrap(), None);
+    assert_eq!(
+        db.lens_canonical_file_path(DECOMPOSED_PATH, true).unwrap().as_deref(),
+        Some(COMPOSED_PATH)
+    );
+    assert_eq!(db.lens_canonical_file_path("src/missing.rs", true).unwrap(), None);
+
+    let symbols = db.lens_file_symbols("src/lib.rs").unwrap().symbols;
+    assert!(symbols.windows(2).all(|pair| pair[0].start_line <= pair[1].start_line));
+    let target = symbols.iter().find(|symbol| symbol.name == "target").unwrap();
+    assert!(target.qname.as_deref().is_some_and(|name| name.ends_with("::target")));
+    assert!(target.signature.as_deref().is_some_and(|value| value.contains("target")));
+    assert!(target.fan_in >= 3, "target graph counts: {target:?}");
+
+    let graph = db.lens_file_graph("src/lib.rs").unwrap().symbols;
+    assert!(graph.windows(2).all(|pair| pair[0].start_line <= pair[1].start_line));
+    let target = graph.iter().find(|symbol| symbol.name == "target").unwrap();
+    assert!(
+        target.callers.exact + target.callers.syntactic >= 3,
+        "confidence counts: {:?}",
+        target.callers
+    );
+    assert!(target.callers.tests >= 1, "test counts: {:?}", target.callers);
+    assert!(target.callers.dispatch >= 1, "dispatch counts: {:?}", target.callers);
+    assert!(target.fan_in_score >= 2.0);
+    assert!(target.dispatch.iter().any(|detail| {
+        detail.direction == "handled"
+            && detail.variant.as_deref() == Some("Req::Upsert")
+            && detail.other_name.as_deref() == Some("enqueue")
+    }));
+}
+
+#[test]
+fn hops_and_chunk_text_keep_stable_compatibility_fields_on_read_only_open() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+    let write_error = db
+        .storage
+        .connection()
+        .execute("DELETE FROM chunks WHERE id = -1", [])
+        .expect_err("read-only open must reject writes");
+    assert!(write_error.to_string().contains("readonly"), "{write_error}");
+
+    let target_qname = db
+        .lens_file_symbols("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .find(|symbol| symbol.name == "target")
+        .and_then(|symbol| symbol.qname)
+        .unwrap();
+    let callers = db.lens_symbol_callers(&target_qname, 50).unwrap();
+    assert!(callers.callers.iter().any(|hop| hop.name == "caller"));
+    let wire = serde_json::to_value(&callers).unwrap();
+    let first = wire["callers"].as_array().unwrap().first().unwrap();
+    assert!(first.get("id").is_none());
+    assert!(first.get("sid").is_none());
+    assert!(first.get("source_file_id").is_none());
+
+    let caller_qname = db
+        .lens_file_symbols("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .find(|symbol| symbol.name == "caller")
+        .and_then(|symbol| symbol.qname)
+        .unwrap();
+    assert!(
+        db.lens_symbol_callees(&caller_qname, 50)
+            .unwrap()
+            .callees
+            .iter()
+            .any(|hop| hop.name == "target")
+    );
+
+    let chunk_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id
+             WHERE files.path = 'src/lib.rs' AND chunks.symbol_path = ?1",
+            [caller_qname],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let chunk = db.lens_chunk_text(chunk_id).unwrap().unwrap();
+    assert_eq!(chunk.chunk_id, chunk_id);
+    assert!(chunk.text.contains("target(1)"));
+    assert!(db.lens_chunk_text(i64::MAX).unwrap().is_none());
+}
+
+#[test]
+fn chunk_text_rejects_stale_source_without_healing_the_read_only_index() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+    let chunk_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    fs::write(config.root.join("src/lib.rs"), "completely different source\n").unwrap();
+
+    let error = db.lens_chunk_text(chunk_id).unwrap_err().to_string();
+    assert!(error.contains("StaleChunk"), "{error}");
+}
+
+#[test]
+fn lens_version_tracks_in_place_enrichment_updates() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let memory = crate::memory_write::create_memory(conn, RepoMemoryCreate {
+        kind: "Invariant".into(),
+        title: "Tracked binding".into(),
+        body: "The editor must refresh this location".into(),
+        confidence: "high".into(),
+        created_by: Some("test".into()),
+        source: None,
+        payload_json: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("src/lib.rs".into()),
+            start_line: Some(5),
+            end_line: Some(5),
+            ..RepoMemoryBindTarget::default()
+        },
+    })
+    .unwrap()
+    .memory;
+
+    let before_binding_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE repo_memory_bindings SET start_line = 6, end_line = 6
+         WHERE repo_id = ?1 AND memory_id = ?2",
+        params![db.active_repo_id, memory.memory_id],
+    )
+    .unwrap();
+    let after_binding_update = db.lens_version().unwrap();
+    assert_ne!(before_binding_update.revision, after_binding_update.revision);
+
+    let before_memory_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE repo_memories SET title = 'Tracked binding renamed'
+         WHERE repo_id = ?1 AND id = ?2",
+        params![db.active_repo_id, memory.memory_id],
+    )
+    .unwrap();
+    let after_memory_update = db.lens_version().unwrap();
+    assert_ne!(
+        before_memory_update.revision, after_memory_update.revision,
+        "memory content changes must invalidate even when updated_at_ms is unchanged"
+    );
+
+    conn.execute(
+        "INSERT INTO memory_summaries(
+             memory_id, repo_id, content_hash, summary, prompt_version, generated_at_ms
+         ) VALUES (?1, ?2, 'same-time-summary', 'Before', '1', 7)",
+        params![memory.memory_id, db.active_repo_id],
+    )
+    .unwrap();
+    let before_summary_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE memory_summaries SET summary = 'After'
+         WHERE repo_id = ?1 AND memory_id = ?2",
+        params![db.active_repo_id, memory.memory_id],
+    )
+    .unwrap();
+    let after_summary_update = db.lens_version().unwrap();
+    assert_ne!(
+        before_summary_update.revision, after_summary_update.revision,
+        "summary changes must invalidate even when generated_at_ms is unchanged"
+    );
+
+    conn.execute(
+        "INSERT INTO memory_reality(
+             memory_id, repo_id, content_hash, verdict, prompt_version, checked_at_ms
+         ) VALUES (?1, ?2, 'same-time-reality', 'current', '1', 7)",
+        params![memory.memory_id, db.active_repo_id],
+    )
+    .unwrap();
+    let before_reality_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE memory_reality SET verdict = 'diverged'
+         WHERE repo_id = ?1 AND memory_id = ?2",
+        params![db.active_repo_id, memory.memory_id],
+    )
+    .unwrap();
+    let after_reality_update = db.lens_version().unwrap();
+    assert_ne!(
+        before_reality_update.revision, after_reality_update.revision,
+        "verdict changes must invalidate even when checked_at_ms is unchanged"
+    );
+
+    conn.execute(
+        "INSERT INTO papertrail_distill(
+             tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+             root_issue, fix_edge_source, thread_shape, distilled_at_ms, repo_id
+         ) VALUES ('github', 'owner/repo', 'issue', 'distill', 'hash', 1,
+                   'Before', 'none', 'thin', 7, ?1)",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let before_distill_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE papertrail_distill SET root_issue = 'After'
+         WHERE repo_id = ?1 AND item_key = 'distill'",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let after_distill_update = db.lens_version().unwrap();
+    assert_ne!(
+        before_distill_update.revision, after_distill_update.revision,
+        "distill changes must invalidate even when distilled_at_ms is unchanged"
+    );
+
+    conn.execute(
+        "INSERT INTO clone_graph_generations(
+             generation, status, theta_floor, normalizer_kind, normalizer_version,
+             source_revision, started_at_ms, repo_id
+         ) VALUES (999, 'Complete', 0.7, 'baseline', ?1, 'revision', 7, ?2)",
+        params![rag_rat_clones::NORM_VERSION, db.active_repo_id],
+    )
+    .unwrap();
+    let before_clone_publish = db.lens_version().unwrap();
+    db.set_repo_meta("clone_graph_live_generation", "999").unwrap();
+    let after_clone_publish = db.lens_version().unwrap();
+    assert_ne!(
+        before_clone_publish.revision, after_clone_publish.revision,
+        "publishing an already-created clone generation must invalidate Lens"
+    );
+    conn.execute(
+        "UPDATE clone_graph_generations SET delta_files_applied = delta_files_applied + 1
+         WHERE generation = 999",
+        [],
+    )
+    .unwrap();
+    let after_clone_delta = db.lens_version().unwrap();
+    assert_ne!(
+        after_clone_publish.revision, after_clone_delta.revision,
+        "an in-place live clone-graph delta must invalidate Lens"
+    );
+
+    // Oracle results change graph scores and clone refinement mode, so Lens must see the pass —
+    // but a pass writes one verdict per resolved edge, so the clock is advanced by the run row
+    // those verdicts commit with, not by the verdicts themselves.
+    let before_oracle_result = db.lens_version().unwrap();
+    conn.execute(
+        "INSERT INTO edge_oracle(
+             repo_id, source_path, source_start_byte, source_end_byte, callee_start_byte,
+             callee_end_byte, edge_kind, file_sha, tool, tool_version, scip_symbol, kind,
+             computed_at
+         ) VALUES (?1, 'src/lib.rs', 0, 1, 0, 1, 'calls_name', 'sha', 'scip-test', '1',
+                   'symbol', 'confirm', 7)",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let after_oracle_result = db.lens_version().unwrap();
+    assert_eq!(
+        before_oracle_result.revision, after_oracle_result.revision,
+        "verdict rows are clocked by their transactional writer, not one bump per edge"
+    );
+    conn.execute(
+        "INSERT INTO oracle_runs(
+             repo_id, tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
+         ) VALUES (?1, 'scip-test', '1', 'head', 'active-wt', 7, 'Completed', '{}')",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let after_oracle_run = db.lens_version().unwrap();
+    assert_ne!(
+        after_oracle_result.revision, after_oracle_run.revision,
+        "the run row that publishes a pass's verdicts must invalidate Lens"
+    );
+
+    conn.execute(
+        "INSERT INTO papertrail_items(
+             tracker, project, item_kind, item_key, url, state, \
+         title, body, synced_at_ms, repo_id
+         ) VALUES ('github', 'owner/repo', 'issue', '1', \
+         'https://example.test/1', 'open',
+                   'Issue', 'Body', 1, ?1)",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let before_item_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE papertrail_items SET state = 'closed'
+         WHERE repo_id = ?1 AND tracker = 'github' AND project = 'owner/repo'
+           AND item_kind = 'issue' AND item_key = '1'",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let after_item_update = db.lens_version().unwrap();
+    assert_ne!(before_item_update.revision, after_item_update.revision);
+
+    conn.execute(
+        "DELETE FROM papertrail_items
+         WHERE repo_id = ?1 AND tracker = 'github' AND project = 'owner/repo'
+           AND item_kind = 'issue' AND item_key = '1'",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let after_item_delete = db.lens_version().unwrap();
+    assert_ne!(after_item_update.revision, after_item_delete.revision);
+
+    conn.execute(
+        "INSERT INTO papertrail_refs(
+             tracker, project, item_key, item_kind, ref_kind, source_kind, source_path,
+             source_text, discovered_at_ms, repo_id
+         ) VALUES ('github', 'owner/repo', '1', 'issue', 'mentions', 'path', 'src/lib.rs',
+                   'mentions #1', 1, ?1)",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let before_ref_update = db.lens_version().unwrap();
+    conn.execute(
+        "UPDATE papertrail_refs SET ref_kind = 'fixes'
+         WHERE repo_id = ?1 AND tracker = 'github' AND project = 'owner/repo'
+           AND item_key = '1' AND source_path = 'src/lib.rs'",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    let after_ref_update = db.lens_version().unwrap();
+    assert_ne!(before_ref_update.revision, after_ref_update.revision);
+}
+
+/// The dead-verdict sweep retires `edge_oracle` rows without writing an `oracle_runs` row, so it
+/// is the one verdict writer the run-row clock does not cover. An editor showing an oracle-backed
+/// call still has to learn that the evidence behind it is gone.
+#[test]
+fn lens_version_tracks_swept_oracle_verdicts() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    // No live edge carries this content key, so the global sweep retires it.
+    conn.execute(
+        "INSERT INTO edge_oracle(
+             repo_id, source_path, source_start_byte, source_end_byte, callee_start_byte,
+             callee_end_byte, edge_kind, file_sha, tool, tool_version, scip_symbol, kind,
+             computed_at
+         ) VALUES (?1, 'src/gone.rs', 0, 1, 0, 1, 'calls_name', 'sha', 'scip-test', '1',
+                   'symbol', 'confirm', 7)",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+
+    let before_sweep = db.lens_version().unwrap();
+    db.garbage_collect().unwrap();
+    let after_sweep = db.lens_version().unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM edge_oracle WHERE source_path = 'src/gone.rs'",
+            [],
+            |row| row.get::<_, i64>(0)
+        )
+        .unwrap(),
+        0,
+        "the sweep must retire a verdict no live edge joins to"
+    );
+    assert_ne!(
+        before_sweep.revision, after_sweep.revision,
+        "retiring a verdict must invalidate Lens even though the sweep writes no run row"
+    );
+
+    // Idempotence: a sweep that retires nothing must not churn every connected editor.
+    let after_empty_sweep = db.lens_version().unwrap();
+    db.garbage_collect().unwrap();
+    assert_eq!(
+        after_empty_sweep.revision,
+        db.lens_version().unwrap().revision,
+        "a sweep with nothing to retire must leave the clock alone"
+    );
+}
+
+#[test]
+fn graph_compositions_exclude_edges_with_out_of_scope_endpoints() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let (target_id, target_qname): (i64, String) = conn
+        .query_row(
+            "SELECT s.id, ns.value FROM symbols s
+             JOIN files ON files.id = s.file_id
+             JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE s.name = 'target'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    let (caller_id, caller_file_id, caller_qname): (i64, i64, String) = conn
+        .query_row(
+            "SELECT s.id, s.file_id, ns.value FROM symbols s
+             JOIN files ON files.id = s.file_id
+             JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE s.name = 'caller'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    let before_symbols = db.lens_file_symbols("src/lib.rs").unwrap().symbols;
+    let before_target = before_symbols.iter().find(|symbol| symbol.name == "target").unwrap();
+    let before_caller = before_symbols.iter().find(|symbol| symbol.name == "caller").unwrap();
+    let before_target_fan_in = before_target.fan_in;
+    let before_caller_fan_out = before_caller.fan_out;
+    let before_dispatch = db
+        .lens_file_graph("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .find(|symbol| symbol.name == "target")
+        .unwrap()
+        .callers
+        .dispatch;
+
+    conn.execute(
+        "INSERT INTO main.files(
+             path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+             commit_sha, worktree_id, repo_id, generation
+         ) VALUES ('dead.rs', 'rust', 'source', 'dead-sha', 0, 0, 'dead-commit', '', ?1, ?2)",
+        params![db.active_repo_id, db.active_generation],
+    )
+    .unwrap();
+    let dead_file_id = conn.last_insert_rowid();
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO name_strings(value) VALUES ('dead::caller');
+         INSERT OR IGNORE INTO name_strings(value) VALUES ('dead::target');",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO symbols(
+             file_id, language, name, qualified_name_id, kind,
+             start_byte, end_byte, start_line, end_line
+         ) VALUES (
+             ?1, 'rust', 'dead_caller',
+             (SELECT id FROM name_strings WHERE value = 'dead::caller'),
+             'function', 0, 10, 1, 1
+         )",
+        [dead_file_id],
+    )
+    .unwrap();
+    let dead_caller_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO symbols(
+             file_id, language, name, qualified_name_id, kind,
+             start_byte, end_byte, start_line, end_line
+         ) VALUES (
+             ?1, 'rust', 'dead_target',
+             (SELECT id FROM name_strings WHERE value = 'dead::target'),
+             'function', 11, 20, 2, 2
+         )",
+        [dead_file_id],
+    )
+    .unwrap();
+    let dead_target_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO edges(
+             source_file_id, from_symbol_id, to_symbol_id, to_name,
+             edge_kind, confidence, resolution, source_start_line
+         ) VALUES (?1, ?2, ?3, 'target', 'calls_name', 'Exact', 'exact', 1)",
+        params![dead_file_id, dead_caller_id, target_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(
+             source_file_id, from_symbol_id, to_symbol_id, to_name,
+             edge_kind, confidence, resolution, source_start_line
+         ) VALUES (?1, ?2, ?3, 'dead_target', 'calls_name', 'Exact', 'exact', 1)",
+        params![caller_file_id, caller_id, dead_target_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(
+             source_file_id, from_symbol_id, to_symbol_id, to_name, evidence,
+             edge_kind, confidence, resolution, source_start_line
+         ) VALUES (
+             ?1, ?2, ?3, 'target', 'Dead::Variant',
+             'dispatches', 'Exact', 'dispatch', 1
+         )",
+        params![dead_file_id, dead_caller_id, target_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(
+             source_file_id, from_symbol_id, to_name, target_qualified_name,
+             edge_kind, confidence, resolution, source_start_line
+         ) VALUES (
+             ?1, ?2, 'missing', 'crate::missing',
+             'calls_name', 'NameOnly', 'unresolved', 1
+         )",
+        params![caller_file_id, caller_id],
+    )
+    .unwrap();
+    let unresolved_edge_id =
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get::<_, i64>(0)).unwrap();
+
+    let compiler_hop = rag_rat_query::graph::GraphHop {
+        edge_id: unresolved_edge_id,
+        from_symbol: Some(caller_qname.clone()),
+        to_symbol: Some(target_qname.clone()),
+        edge_kind: "calls_name".into(),
+        confidence: "compiler".into(),
+        edge_confidence: "name_only".into(),
+        target: Some("missing".into()),
+        target_qualified_name: Some(target_qname.clone()),
+        evidence: None,
+        receiver_hint: None,
+        resolution: "exact".into(),
+        resolution_reason: Some("scip:test@1".into()),
+        resolved_external: None,
+        verified_target_symbol: true,
+        shown_by_default: true,
+        callsite: Some(rag_rat_query::graph::Callsite {
+            path: "src/lib.rs".into(),
+            line: 1,
+            span: [1, 1],
+        }),
+        importance: None,
+    };
+    let adapted = adapt_hops(conn, vec![compiler_hop], false).unwrap();
+    assert_eq!(adapted.len(), 1);
+    assert_eq!(adapted[0].name, "target");
+    assert_eq!(adapted[0].qname.as_deref(), Some(target_qname.as_str()));
+
+    let symbols = db.lens_file_symbols("src/lib.rs").unwrap().symbols;
+    let target = symbols.iter().find(|symbol| symbol.name == "target").unwrap();
+    let caller = symbols.iter().find(|symbol| symbol.name == "caller").unwrap();
+    assert_eq!(target.fan_in, before_target_fan_in);
+    assert_eq!(caller.fan_out, before_caller_fan_out);
+    let graph_target = db
+        .lens_file_graph("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .find(|symbol| symbol.name == "target")
+        .unwrap();
+    assert_eq!(graph_target.callers.dispatch, before_dispatch);
+    assert!(graph_target.dispatch.iter().all(|detail| {
+        detail.variant.as_deref() != Some("Dead::Variant")
+            && detail.other_name.as_deref() != Some("dead_caller")
+    }));
+    assert!(
+        db.lens_symbol_callers(&target_qname, 50)
+            .unwrap()
+            .callers
+            .iter()
+            .all(|hop| hop.name != "dead_caller")
+    );
+    assert!(
+        db.lens_symbol_callees(&caller_qname, 50).unwrap().callees.iter().all(|hop| hop
+            .qname
+            .as_deref()
+            != Some("crate::missing")
+            && hop.name != "dead_target")
+    );
+}
+
+#[test]
+fn symbol_callers_preserve_file_level_edges() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let (target_id, target_qname): (i64, String) = conn
+        .query_row(
+            "SELECT symbol.id, name.value
+             FROM symbols symbol
+             JOIN name_strings name ON name.id = symbol.qualified_name_id
+             WHERE symbol.name = 'target'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    let source_file_id: i64 = conn
+        .query_row("SELECT id FROM files WHERE path = 'src/lib.rs'", [], |row| row.get(0))
+        .unwrap();
+    conn.execute(
+        "INSERT INTO edges(
+             source_file_id, from_name, to_symbol_id, to_name,
+             edge_kind, confidence, resolution, source_start_line
+         ) VALUES (?1, 'src/lib.rs', ?2, 'target', 'calls_name', 'Exact', 'exact', 2)",
+        params![source_file_id, target_id],
+    )
+    .unwrap();
+
+    let callers = db.lens_symbol_callers(&target_qname, 50).unwrap().callers;
+    let file_caller = callers.iter().find(|hop| hop.name == "src/lib.rs").unwrap();
+    assert_eq!(file_caller.path, "src/lib.rs");
+    assert_eq!(file_caller.source_start_line, 2);
+    assert_eq!(file_caller.qname, None);
+    assert_eq!(file_caller.kind, None);
+}
+
+#[test]
+fn file_enrichments_scope_memories_and_order_coupling() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let path_memory = crate::memory_write::create_memory(conn, RepoMemoryCreate {
+        kind: "Invariant".into(),
+        title: "Path memory".into(),
+        body: "Keep src/lib.rs stable".into(),
+        confidence: "high".into(),
+        created_by: Some("test".into()),
+        source: None,
+        payload_json: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("src/lib.rs".into()),
+            start_line: Some(5),
+            end_line: Some(5),
+            ..RepoMemoryBindTarget::default()
+        },
+    })
+    .unwrap()
+    .memory;
+    let dir_memory = crate::memory_write::create_memory(conn, RepoMemoryCreate {
+        kind: "Decision".into(),
+        title: "Source directory memory".into(),
+        body: "Applies throughout src".into(),
+        confidence: "medium".into(),
+        created_by: Some("test".into()),
+        source: None,
+        payload_json: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { dir: Some("src".into()), ..RepoMemoryBindTarget::default() },
+    })
+    .unwrap()
+    .memory;
+    crate::memory_write::create_memory(conn, RepoMemoryCreate {
+        kind: "Risk".into(),
+        title: "Other file memory".into(),
+        body: "Must not leak into lib.rs".into(),
+        confidence: "high".into(),
+        created_by: Some("test".into()),
+        source: None,
+        payload_json: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("src/other.rs".into()),
+            ..RepoMemoryBindTarget::default()
+        },
+    })
+    .unwrap();
+
+    let content_hash =
+        rag_rat_query::memory::evidence::note_content_hash(&path_memory.title, &path_memory.body);
+    conn.execute(
+        "INSERT INTO memory_summaries(
+             memory_id, repo_id, content_hash, summary, prompt_version, generated_at_ms
+         ) VALUES (?1, ?2, ?3, 'Compact path summary', ?4, 0)",
+        params![
+            path_memory.memory_id,
+            db.active_repo_id,
+            content_hash,
+            rag_rat_query::memory::evidence::COMPACT_PROMPT_VERSION
+        ],
+    )
+    .unwrap();
+    let inputs = rag_rat_query::memory::evidence::checked_inputs_hash(
+        conn,
+        &path_memory.memory_id,
+        &Some(db.active_repo_id.clone()),
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO memory_reality(
+             memory_id, repo_id, content_hash, verdict, direction, evidence_json,
+             checked_against_commit, checked_inputs_hash, prompt_version, checked_at_ms
+         ) VALUES (?1, ?2, ?3, 'diverged', 'code_ahead', '{\"line\":5}',
+                   '0123456789abcdef', ?4, ?5, 0)",
+        params![
+            path_memory.memory_id,
+            db.active_repo_id,
+            content_hash,
+            inputs,
+            rag_rat_query::memory::evidence::VERDICT_PROMPT_VERSION
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO memory_reality(
+             memory_id, repo_id, content_hash, verdict, direction, evidence_json,
+             checked_inputs_hash, prompt_version, checked_at_ms
+         ) VALUES (?1, ?2, ?3, 'current', 'aligned', '{}', 'stale-inputs', ?4, 0)",
+        params![
+            dir_memory.memory_id,
+            db.active_repo_id,
+            rag_rat_query::memory::evidence::note_content_hash(&dir_memory.title, &dir_memory.body),
+            rag_rat_query::memory::evidence::VERDICT_PROMPT_VERSION
+        ],
+    )
+    .unwrap();
+
+    let memories = db.lens_file_memories("src/lib.rs").unwrap().memories;
+    assert_eq!(memories.len(), 2);
+    assert_eq!(memories[0].title, "Path memory");
+    assert_eq!(memories[0].line, Some(5));
+    assert_eq!(memories[0].summary.as_deref(), Some("Compact path summary"));
+    assert_eq!(memories[0].verdict.as_deref(), Some("diverged"));
+    assert_eq!(memories[0].verdict_direction.as_deref(), Some("code_ahead"));
+    assert_eq!(memories[0].verdict_evidence.as_deref(), Some("{\"line\":5}"));
+    assert_eq!(memories[0].checked_against_commit.as_deref(), Some("0123456789abcdef"));
+    let dir = memories.iter().find(|memory| memory.title == "Source directory memory").unwrap();
+    assert_eq!(dir.binding_kind, "dir");
+    assert_eq!(dir.path.as_deref(), Some("src"));
+    assert_eq!(dir.verdict, None, "stale evidence must suppress structured verdict state");
+    let treemap = db.lens_treemap().unwrap().files;
+    let lib = treemap.iter().find(|file| file.path == "src/lib.rs").unwrap();
+    assert_eq!(lib.memories, 2, "path and directory memories must both count");
+    let other = treemap.iter().find(|file| file.path == "src/other.rs").unwrap();
+    assert_eq!(other.loc, 1, "chunk end_line is already one-based");
+    assert_eq!(other.memories, 2, "directory and direct memories must both count");
+
+    for (hash, at_s, paths) in [
+        ("pair-1", 123, &["src/lib.rs", "src/other.rs"][..]),
+        ("pair-2", 122, &["src/lib.rs", "src/other.rs"][..]),
+        ("lib-only-pair", 121, &["src/lib.rs", "history-only.rs"][..]),
+        ("filler-1", 120, &["filler-a.rs", "filler-b.rs"][..]),
+        ("filler-2", 119, &["filler-c.rs", "filler-d.rs"][..]),
+    ] {
+        conn.execute(
+            "INSERT INTO git_commits(
+                 hash, author_name, author_email, authored_at_s, committed_at_s,
+                 subject, body, changed_file_count, repo_id
+             ) VALUES (?1, 'a', 'a@b', ?2, ?2, 's', '', 2, ?3)",
+            params![hash, at_s, db.active_repo_id],
+        )
+        .unwrap();
+        for path in paths {
+            conn.execute(
+                "INSERT INTO git_file_changes(
+                     commit_hash, path, additions, deletions, change_kind, repo_id
+                 ) VALUES (?1, ?2, 0, 0, 'modified', ?3)",
+                params![hash, path, db.active_repo_id],
+            )
+            .unwrap();
+        }
+    }
+    conn.execute("DELETE FROM repo_meta WHERE repo_id = ?1 AND key = 'git_coupling_stamp'", [
+        &db.active_repo_id
+    ])
+    .unwrap();
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM git_change_couplings", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "the read-only fallback must be exercised before the lazy table is materialized"
+    );
+    drop(db);
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+    let coupling = db.lens_file_coupling("src/lib.rs").unwrap().coupling;
+    assert_eq!(coupling.len(), 1);
+    assert_eq!(coupling[0].path, "src/other.rs");
+    assert_eq!(coupling[0].co_changes, 2);
+    assert_eq!(coupling[0].my_changes, 3);
+    assert_eq!(coupling[0].confidence, 0.667);
+    assert_eq!(coupling[0].last_co_change_at_s, 123);
+}
+
+#[test]
+fn file_memories_cap_the_editor_payload() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    for i in 0..(super::enrichments::MEMORY_LIMIT + 5) {
+        crate::memory_write::create_memory(conn, RepoMemoryCreate {
+            kind: "Invariant".into(),
+            title: format!("Root memory {i:02}"),
+            body: "A root-scoped memory included for every indexed file".into(),
+            confidence: "high".into(),
+            created_by: Some("test".into()),
+            source: None,
+            payload_json: None,
+            tags: Vec::new(),
+            bind: RepoMemoryBindTarget {
+                dir: Some(String::new()),
+                ..RepoMemoryBindTarget::default()
+            },
+        })
+        .unwrap();
+    }
+    crate::memory_write::create_memory(conn, RepoMemoryCreate {
+        kind: "Risk".into(),
+        title: "Direct file memory".into(),
+        body: "Must not be evicted by broader directory memories".into(),
+        confidence: "high".into(),
+        created_by: Some("test".into()),
+        source: None,
+        payload_json: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("src/lib.rs".into()),
+            ..RepoMemoryBindTarget::default()
+        },
+    })
+    .unwrap();
+
+    let memories = db.lens_file_memories("src/lib.rs").unwrap().memories;
+    assert_eq!(memories.len(), super::enrichments::MEMORY_LIMIT);
+    assert_eq!(memories[0].title, "Direct file memory");
+}
+
+#[test]
+fn treemap_drops_clone_edges_with_stale_content_anchors() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let endpoint = |path: &str| {
+        conn.query_row(
+            "SELECT file.id, file.sha256, symbol.start_byte
+             FROM files file
+             JOIN symbols symbol ON symbol.file_id = file.id
+             WHERE file.path = ?1
+             ORDER BY symbol.start_byte LIMIT 1",
+            [path],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?)),
+        )
+        .unwrap()
+    };
+    let (_a_file_id, a_sha, a_start) = endpoint("src/lib.rs");
+    let (b_file_id, b_sha, b_start) = endpoint("src/other.rs");
+    conn.execute(
+        "INSERT INTO clone_graph_generations(
+             generation, status, theta_floor, normalizer_kind, normalizer_version,
+             source_revision, cursor_symbol_id, edges_written, started_at_ms, repo_id
+         ) VALUES (4242, 'Complete', 0.7, 'baseline', ?1, 'test', 0, 1, 0, ?2)",
+        params![rag_rat_clones::NORM_VERSION, db.active_repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_edges(
+             build_generation, a_path, a_start_byte, a_file_sha,
+             b_path, b_start_byte, b_file_sha, overlap,
+             a_token_len, b_token_len, similarity, edge_source
+         ) VALUES (4242, 'src/lib.rs', ?1, ?2, 'src/other.rs', ?3, ?4,
+                   10, 10, 10, 1.0, 'struct_hash')",
+        params![a_start, a_sha, b_start, b_sha],
+    )
+    .unwrap();
+    db.set_repo_meta("clone_graph_live_generation", "4242").unwrap();
+
+    let before = db.lens_treemap().unwrap().files;
+    let lib = before.iter().find(|file| file.path == "src/lib.rs").unwrap();
+    assert_eq!(lib.dup_partners, 1);
+
+    conn.execute(
+        "UPDATE clone_graph_generations SET normalizer_version = ?1 WHERE generation = 4242",
+        [rag_rat_clones::NORM_VERSION + 1],
+    )
+    .unwrap();
+    let incompatible = db.lens_treemap().unwrap().files;
+    let lib = incompatible.iter().find(|file| file.path == "src/lib.rs").unwrap();
+    assert_eq!(lib.dup_partners, 0, "obsolete normalizer generations are ineligible");
+    conn.execute(
+        "UPDATE clone_graph_generations SET normalizer_version = ?1 WHERE generation = 4242",
+        [rag_rat_clones::NORM_VERSION],
+    )
+    .unwrap();
+
+    conn.execute("UPDATE main.files SET sha256 = 'edited' WHERE id = ?1", [b_file_id]).unwrap();
+    let after = db.lens_treemap().unwrap().files;
+    let lib = after.iter().find(|file| file.path == "src/lib.rs").unwrap();
+    assert_eq!(lib.dup_partners, 0);
+    assert_eq!(lib.dup_max_similarity, 0.0);
+}
+
+#[test]
+fn treemap_excludes_same_file_clone_partners_but_keeps_similarity() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let endpoint = |offset: i64| {
+        conn.query_row(
+            "SELECT file.sha256, symbol.start_byte
+             FROM files file
+             JOIN symbols symbol ON symbol.file_id = file.id
+             WHERE file.path = 'src/lib.rs'
+             ORDER BY symbol.start_byte LIMIT 1 OFFSET ?1",
+            [offset],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .unwrap()
+    };
+    let (a_sha, a_start) = endpoint(0);
+    let (b_sha, b_start) = endpoint(1);
+    conn.execute(
+        "INSERT INTO clone_graph_generations(
+             generation, status, theta_floor, normalizer_kind, normalizer_version,
+             source_revision, cursor_symbol_id, edges_written, started_at_ms, repo_id
+         ) VALUES (4242, 'Complete', 0.7, 'baseline', ?1, 'test', 0, 1, 0, ?2)",
+        params![rag_rat_clones::NORM_VERSION, db.active_repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_edges(
+             build_generation, a_path, a_start_byte, a_file_sha,
+             b_path, b_start_byte, b_file_sha, overlap,
+             a_token_len, b_token_len, similarity, edge_source
+         ) VALUES (4242, 'src/lib.rs', ?1, ?2, 'src/lib.rs', ?3, ?4,
+                   7, 8, 8, 0.875, 'token_overlap')",
+        params![a_start, a_sha, b_start, b_sha],
+    )
+    .unwrap();
+    db.set_repo_meta("clone_graph_live_generation", "4242").unwrap();
+
+    let treemap = db.lens_treemap().unwrap().files;
+    let lib = treemap.iter().find(|file| file.path == "src/lib.rs").unwrap();
+    assert_eq!(lib.dup_partners, 0);
+    assert_eq!(lib.dup_max_similarity, 0.875);
+}
+
+#[test]
+fn file_papertrail_resolves_refs_and_selected_decision_anchors() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let repo_id = db.active_repo_id.as_str();
+
+    conn.execute(
+        "INSERT INTO papertrail_items(
+             tracker, project, item_kind, item_key, url, state, \
+         title, body,
+             synced_at_ms, repo_id, state_normalized
+         ) VALUES (
+             \
+         'github', 'o/r', 'issue', '5', 'https://github.com/o/r/issues/5',
+             'open', 'Tracked issue', 'body', 0, ?1, 'open'
+         )",
+        [repo_id],
+    )
+    .unwrap();
+    for (source_text, discovered_at_ms) in [("newest #5", 2), ("older #5", 1)] {
+        conn.execute(
+            "INSERT INTO papertrail_refs(
+                 tracker, project, item_key, item_kind, ref_kind, source_kind,
+                 source_path, source_text, discovered_at_ms, repo_id
+             ) VALUES ('github', 'o/r', '5', NULL, 'annotation', 'file',
+                       'src/lib.rs', ?1, ?2, ?3)",
+            params![source_text, discovered_at_ms, repo_id],
+        )
+        .unwrap();
+    }
+    conn.execute(
+        "INSERT INTO papertrail_refs(
+             tracker, project, item_key, item_kind, ref_kind, source_kind,
+             source_path, source_text, discovered_at_ms, repo_id
+         ) VALUES ('github', 'o/r', '9', NULL, 'annotation', 'file',
+                   'src/lib.rs', 'unmirrored #9', 3, ?1)",
+        [repo_id],
+    )
+    .unwrap();
+
+    let target_logical: i64 = conn
+        .query_row(
+            "SELECT member.logical_symbol_id
+             FROM logical_symbol_members member
+             JOIN symbols symbol ON symbol.id = member.symbol_id
+             WHERE symbol.name = 'target'
+             LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill(
+             tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+             root_issue, root_cause, decision_chosen, outcome_summary, outcome_status_model,
+             fix_edge_source, thread_shape, outcome_claim_verified,
+             decision_provenance_verified, anchors_qualified_count, revert_override,
+             distilled_at_ms, repo_id
+         ) VALUES (
+             'github', 'o/r', 'issue', '5', 'sha256:5', 3,
+             'Root issue', 'Root cause', 'Chosen fix', 'Outcome', 'landed',
+             'provider', 'investigation', 1, 1, 1, 1, 10, ?1
+         )",
+        [repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors(
+             tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id,
+             name, resolved, candidate_ordinal, selected, repo_id
+         ) VALUES ('github', 'o/r', 'issue', '5', 'symbol', ?1,
+                   'target', 1, 0, 1, ?2)",
+        params![rag_rat_base::serde_big_id::format_sym_handle(target_logical), repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill(
+             tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+             root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+             distilled_at_ms, repo_id
+         ) VALUES ('github', 'o/r', 'issue', '7', 'sha256:7', 3,
+                   'File decision', 'text', 'investigation', 1, 20, ?1)",
+        [repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors(
+             tracker, project, item_kind, item_key, anchor_kind, file_path, name,
+             resolved, candidate_ordinal, selected, repo_id
+         ) VALUES ('github', 'o/r', 'issue', '7', 'file', 'src/lib.rs',
+                   'src/lib.rs', 1, 0, 1, ?1)",
+        [repo_id],
+    )
+    .unwrap();
+
+    let papertrail = db.lens_file_papertrail("src/lib.rs").unwrap();
+    assert_eq!(papertrail.refs.len(), 2, "duplicate textual refs collapse by item identity");
+    let issue = papertrail.refs.iter().find(|reference| reference.item_key == "5").unwrap();
+    assert_eq!(issue.item_kind, "issue", "a nullable GitHub ref probes issue before PR");
+    assert_eq!(issue.source_text, "newest #5");
+    assert_eq!(issue.title.as_deref(), Some("Tracked issue"));
+    assert_eq!(issue.state_normalized.as_deref(), Some("open"));
+    let unmirrored = papertrail.refs.iter().find(|reference| reference.item_key == "9").unwrap();
+    assert_eq!(unmirrored.url.as_deref(), Some("https://github.com/o/r/issues/9"));
+
+    assert_eq!(papertrail.decisions.len(), 2);
+    let symbol = papertrail.decisions.iter().find(|decision| decision.item_key == "5").unwrap();
+    assert_eq!(
+        (symbol.tracker.as_str(), symbol.project.as_str(), symbol.item_kind.as_str()),
+        ("github", "o/r", "issue")
+    );
+    assert!(symbol.line.is_some());
+    assert_eq!(symbol.title.as_deref(), Some("Tracked issue"));
+    assert_eq!(
+        symbol.outcome_status_model, "reverted",
+        "the compatibility field carries effective status, not the overridden model claim"
+    );
+    assert_eq!(symbol.outcome_claim_verified, 1);
+    assert_eq!(symbol.decision_provenance_verified, 1);
+    let file = papertrail.decisions.iter().find(|decision| decision.item_key == "7").unwrap();
+    assert_eq!(file.line, None);
+    assert_eq!(file.root_issue.as_deref(), Some("File decision"));
+}
+
+/// A symbol anchor is a claim about where a decision belongs, and the file lane presents it on a
+/// line. It may only surface where its symbol lives in the CURRENT index.
+#[test]
+fn file_papertrail_rejects_decision_anchors_that_do_not_hold_for_the_file() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let repo_id = db.active_repo_id.as_str();
+
+    let logical_symbol = |name: &str| -> i64 {
+        conn.query_row(
+            "SELECT member.logical_symbol_id
+             FROM logical_symbol_members member
+             JOIN symbols symbol ON symbol.id = member.symbol_id
+             WHERE symbol.name = ?1
+             LIMIT 1",
+            [name],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    // `11` is anchored to a symbol that lives in another file; `13` is anchored to a symbol in the
+    // requested file, but a remap left its anchor unresolved.
+    for (item_key, symbol, resolved) in [("11", "other", 1), ("13", "target", 0)] {
+        conn.execute(
+            "INSERT INTO papertrail_distill(
+                 tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                 root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+                 distilled_at_ms, repo_id
+             ) VALUES ('github', 'o/r', 'issue', ?1, 'sha256:' || ?1, 3,
+                       'Decision', 'provider', 'investigation', 1, 30, ?2)",
+            params![item_key, repo_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors(
+                 tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id,
+                 name, resolved, candidate_ordinal, selected, repo_id
+             ) VALUES ('github', 'o/r', 'issue', ?1, 'symbol', ?2, ?3, ?4, 0, 1, ?5)",
+            params![
+                item_key,
+                rag_rat_base::serde_big_id::format_sym_handle(logical_symbol(symbol)),
+                symbol,
+                resolved,
+                repo_id
+            ],
+        )
+        .unwrap();
+    }
+
+    let requested = db.lens_file_papertrail("src/lib.rs").unwrap();
+    assert!(
+        requested.decisions.is_empty(),
+        "neither a foreign-file nor an unresolved anchor may surface: {:?}",
+        requested.decisions
+    );
+    let owning = db.lens_file_papertrail("src/other.rs").unwrap();
+    assert_eq!(
+        owning.decisions.iter().map(|decision| decision.item_key.as_str()).collect::<Vec<_>>(),
+        ["11"],
+        "the anchor surfaces on the file its symbol currently belongs to"
+    );
+    assert!(owning.decisions[0].line.is_some(), "the line is the symbol's current position");
+}
+
+#[test]
+fn file_papertrail_deduplicates_items_before_applying_the_limit() {
+    let (_temp, config) = indexed_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    for ordinal in 0..60 {
+        conn.execute(
+            "INSERT INTO papertrail_refs(
+                 tracker, project, item_key, item_kind, ref_kind, source_kind,
+                 source_path, source_text, discovered_at_ms, repo_id
+             ) VALUES ('github', 'o/r', 'duplicate', 'issue', 'annotation', 'file',
+                       'src/lib.rs', ?1, ?2, ?3)",
+            params![format!("duplicate {ordinal}"), 1_000 + ordinal, db.active_repo_id],
+        )
+        .unwrap();
+    }
+    for ordinal in 0..49 {
+        conn.execute(
+            "INSERT INTO papertrail_refs(
+                 tracker, project, item_key, item_kind, ref_kind, source_kind,
+                 source_path, source_text, discovered_at_ms, repo_id
+             ) VALUES ('github', 'o/r', ?1, 'issue', 'annotation', 'file',
+                       'src/lib.rs', ?2, ?3, ?4)",
+            params![
+                format!("unique-{ordinal}"),
+                format!("unique {ordinal}"),
+                ordinal,
+                db.active_repo_id
+            ],
+        )
+        .unwrap();
+    }
+
+    let refs = db.lens_file_papertrail("src/lib.rs").unwrap().refs;
+    assert_eq!(refs.len(), 50);
+    assert_eq!(refs.iter().filter(|reference| reference.item_key == "duplicate").count(), 1);
+    assert!(refs.iter().any(|reference| reference.item_key == "unique-0"));
+}
+
+fn indexed_config() -> (tempfile::TempDir, Config) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().to_path_buf();
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), SOURCE).unwrap();
+    fs::write(root.join("src/other.rs"), OTHER_SOURCE).unwrap();
+    // Paths whose case aliases only exist outside ASCII. Cyrillic and Greek have no canonical
+    // decomposition, so the indexed spellings survive filesystems that normalize names.
+    fs::write(root.join(UNICODE_PATH), UNICODE_SOURCE).unwrap();
+    fs::write(root.join(FOLDED_PATH), FOLDED_SOURCE).unwrap();
+    fs::write(root.join(COMPOSED_PATH), COMPOSED_SOURCE).unwrap();
+    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root);
+    config.database_key_pinned = true;
+    config.targets = vec![ResolvedTarget {
+        name: "rust".into(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from("src")],
+        include: vec!["**/*.rs".into()],
+        exclude: Vec::new(),
+        kind: TargetKind::Source,
+    }];
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    (temp, config)
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/treemap.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/treemap.rs
@@ -1,0 +1,211 @@
+//! Batched per-file metrics for the editor hotspot treemap.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+use super::super::clones::precompute::{build_anchor_index, live_generation_row};
+use super::clones::{CloneFileMetrics, record_clone_metric};
+use crate::index::IndexDatabase;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct LensTreemap {
+    pub files: Vec<LensTreemapFile>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct LensTreemapFile {
+    pub path: String,
+    pub language: String,
+    pub kind: String,
+    pub loc: i64,
+    pub churn_commits: i64,
+    pub churn_lines: i64,
+    pub fan_in: i64,
+    pub fan_out: i64,
+    pub dup_partners: i64,
+    pub dup_max_similarity: f64,
+    pub memories: i64,
+}
+
+impl IndexDatabase {
+    pub fn lens_treemap(&self) -> anyhow::Result<LensTreemap> {
+        let cancelled = AtomicBool::new(false);
+        self.lens_treemap_with_cancel(&cancelled)
+    }
+
+    pub fn lens_treemap_with_cancel(&self, cancelled: &AtomicBool) -> anyhow::Result<LensTreemap> {
+        ensure_not_cancelled(cancelled)?;
+        let conn = self.storage.connection();
+        let clone_metrics = if self.active_scope_is_linked_overlay() {
+            self.lens_overlay_clone_metrics(cancelled)?
+        } else {
+            let clone_generation = live_generation_row(conn)?
+                .filter(|row| row.normalizer_version == rag_rat_clones::NORM_VERSION)
+                .map(|row| row.generation)
+                .unwrap_or(-1);
+            current_clone_metrics(conn, clone_generation, cancelled)?
+        };
+        ensure_not_cancelled(cancelled)?;
+        let mut stmt = conn.prepare(
+            "WITH
+             loc AS (
+                 SELECT chunk.file_id, MAX(chunk.end_line) AS lines
+                 FROM chunks chunk
+                 JOIN files file ON file.id = chunk.file_id
+                 GROUP BY chunk.file_id
+             ),
+             churn AS (
+                 SELECT path, COUNT(*) AS commits,
+                        SUM(COALESCE(additions, 0) + COALESCE(deletions, 0)) AS lines
+                 FROM git_file_changes
+                 WHERE repo_id = ?1
+                 GROUP BY path
+             ),
+             incoming AS (
+                 SELECT target_file.id AS file_id, COUNT(*) AS count
+                 FROM edges edge
+                 JOIN files source_file ON source_file.id = edge.source_file_id
+                 JOIN symbols target_symbol ON target_symbol.id = edge.to_symbol_id
+                 JOIN files target_file ON target_file.id = target_symbol.file_id
+                 WHERE source_file.id != target_file.id
+                 GROUP BY target_file.id
+             ),
+             outgoing AS (
+                 SELECT source_file.id AS file_id, COUNT(*) AS count
+                 FROM edges edge
+                 JOIN files source_file ON source_file.id = edge.source_file_id
+                 JOIN symbols target_symbol ON target_symbol.id = edge.to_symbol_id
+                 JOIN files target_file ON target_file.id = target_symbol.file_id
+                 WHERE source_file.id != target_file.id
+                 GROUP BY source_file.id
+             ),
+             active_bindings AS MATERIALIZED (
+                 SELECT binding.memory_id, binding.binding_kind, binding.path,
+                        binding.symbol_id, binding.chunk_id, binding.logical_symbol_id
+                 FROM repo_memories memory
+                 JOIN repo_memory_bindings binding
+                   ON binding.memory_id = memory.id AND binding.repo_id = memory.repo_id
+                 WHERE memory.repo_id = ?1 AND memory.status = 'active'
+             ),
+             memory_files AS (
+                 SELECT binding.memory_id, file.id AS file_id
+                 FROM active_bindings binding
+                 JOIN files file ON file.path = binding.path
+                 UNION
+                 SELECT binding.memory_id, file.id
+                 FROM active_bindings binding
+                 JOIN files file
+                   ON binding.binding_kind = 'dir' AND (
+                       binding.path = ''
+                       OR substr(file.path, 1, length(binding.path) + 1) = binding.path || '/'
+                   )
+                 UNION
+                 SELECT binding.memory_id, file.id
+                 FROM active_bindings binding
+                 JOIN symbols symbol ON symbol.id = binding.symbol_id
+                 JOIN files file ON file.id = symbol.file_id
+                 UNION
+                 SELECT binding.memory_id, file.id
+                 FROM active_bindings binding
+                 JOIN chunks chunk ON chunk.id = binding.chunk_id
+                 JOIN files file ON file.id = chunk.file_id
+                 UNION
+                 SELECT binding.memory_id, file.id
+                 FROM active_bindings binding
+                 JOIN logical_symbol_members member
+                   ON member.logical_symbol_id = binding.logical_symbol_id
+                 JOIN symbols symbol ON symbol.id = member.symbol_id
+                 JOIN files file ON file.id = symbol.file_id
+             ),
+             memories AS (
+                 SELECT file_id, COUNT(*) AS count
+                 FROM memory_files
+                 GROUP BY file_id
+             )
+             SELECT file.path, file.language, file.kind,
+                     COALESCE(loc.lines, 0),
+                     COALESCE(churn.commits, 0), COALESCE(churn.lines, 0),
+                     COALESCE(incoming.count, 0), COALESCE(outgoing.count, 0),
+                     COALESCE(memories.count, 0)
+             FROM files file
+             LEFT JOIN loc ON loc.file_id = file.id
+             LEFT JOIN churn ON churn.path = file.path
+             LEFT JOIN incoming ON incoming.file_id = file.id
+             LEFT JOIN outgoing ON outgoing.file_id = file.id
+             LEFT JOIN memories ON memories.file_id = file.id
+             ORDER BY file.path, file.id",
+        )?;
+        let rows = stmt.query_map(params![self.active_repo_id], |row| {
+            let path: String = row.get(0)?;
+            let clones = clone_metrics.get(&path);
+            Ok(LensTreemapFile {
+                path,
+                language: row.get(1)?,
+                kind: row.get(2)?,
+                loc: row.get(3)?,
+                churn_commits: row.get(4)?,
+                churn_lines: row.get(5)?,
+                fan_in: row.get(6)?,
+                fan_out: row.get(7)?,
+                dup_partners: clones.map_or(0, |metric| metric.partners.len() as i64),
+                dup_max_similarity: clones.map_or(0.0, |metric| metric.max_similarity),
+                memories: row.get(8)?,
+            })
+        })?;
+        let files = rows.collect::<rusqlite::Result<_>>()?;
+        ensure_not_cancelled(cancelled)?;
+        Ok(LensTreemap { files })
+    }
+}
+
+fn current_clone_metrics(
+    conn: &Connection,
+    generation: i64,
+    cancelled: &AtomicBool,
+) -> anyhow::Result<HashMap<String, CloneFileMetrics>> {
+    ensure_not_cancelled(cancelled)?;
+    if generation < 0 {
+        return Ok(HashMap::new());
+    }
+    let anchors = build_anchor_index(conn)?;
+    let mut stmt = conn.prepare(
+        "SELECT a_path, a_start_byte, a_file_sha, b_path, b_start_byte, b_file_sha, similarity
+         FROM clone_edges WHERE build_generation = ?1",
+    )?;
+    let rows = stmt.query_map([generation], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, f64>(6)?,
+        ))
+    })?;
+    let mut metrics: HashMap<String, CloneFileMetrics> = HashMap::new();
+    for (index, row) in rows.enumerate() {
+        if index.is_multiple_of(1024) {
+            ensure_not_cancelled(cancelled)?;
+        }
+        let (a_path, a_start, a_sha, b_path, b_start, b_sha, similarity) = row?;
+        let a_anchor = (a_path, a_start);
+        let b_anchor = (b_path, b_start);
+        let Some((_, live_a_sha)) = anchors.get(&a_anchor) else { continue };
+        let Some((_, live_b_sha)) = anchors.get(&b_anchor) else { continue };
+        if live_a_sha != &a_sha || live_b_sha != &b_sha {
+            continue;
+        }
+        record_clone_metric(&mut metrics, &a_anchor.0, &b_anchor.0, similarity);
+        record_clone_metric(&mut metrics, &b_anchor.0, &a_anchor.0, similarity);
+    }
+    Ok(metrics)
+}
+
+fn ensure_not_cancelled(cancelled: &AtomicBool) -> anyhow::Result<()> {
+    anyhow::ensure!(!cancelled.load(Ordering::Acquire), "lens request cancelled");
+    Ok(())
+}

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -18,6 +18,7 @@ mod global_status;
 mod graph;
 mod history;
 mod importance;
+mod lens;
 mod memory;
 mod oracle_runs;
 mod search;
@@ -47,6 +48,16 @@ pub use global_status::{
     RepoFreshness, RepoPapertrail, RepoStatus, WorktreeOverlay,
 };
 pub use importance::ImportantSymbolsRequest;
+pub use lens::clones::{
+    LensCloneGraphMeta, LensClonePartner, LensCloneRefine, LensCloneRegion, LensFileClones,
+};
+pub use lens::{
+    LensCallees, LensCallers, LensChunkText, LensCloneGraphCache, LensCouplingPartner,
+    LensDecisionRecord, LensDispatchDetail, LensFileCoupling, LensFileGraph, LensFileMemories,
+    LensFileMemory, LensFilePapertrail, LensFileSymbolGraph, LensFileSymbols,
+    LensGraphCallerCounts, LensPapertrailRef, LensStatus, LensSymbol, LensSymbolHop, LensTreemap,
+    LensTreemapFile, LensVersion,
+};
 pub use memory::SyncCatchUpReport;
 pub use oracle_runs::OracleShaSnapshots;
 pub use search::SearchRequest;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/change_coupling.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/change_coupling.rs
@@ -94,6 +94,13 @@ fn add_fillers(conn: &Connection, repo_id: &str, count: usize, start_ts: i64) {
     }
 }
 
+fn invalidate_coupling_stamp(conn: &Connection, repo_id: &str) {
+    conn.execute("DELETE FROM repo_meta WHERE repo_id = ?1 AND key = 'git_coupling_stamp'", [
+        repo_id,
+    ])
+    .unwrap();
+}
+
 /// `(path_a, path_b, co, a_count, b_count, window, last_at_s)` rows for a repo, ordered by pair.
 fn coupling_rows(
     conn: &Connection,
@@ -713,6 +720,7 @@ fn impact_report_surfaces_and_gates_coupling_section() {
     add_commit(conn, &repo_id, "c2", 20, &["src/store.rs", "src/helper.rs"]);
     add_commit(conn, &repo_id, "c3", 30, &["ext_a.rs", "ext_b.rs"]);
     add_commit(conn, &repo_id, "c4", 40, &["ext_c.rs", "ext_d.rs"]);
+    invalidate_coupling_stamp(conn, &repo_id);
 
     let selector = rag_rat_query::symbol::SymbolSelector {
         logical_symbol_id: None,
@@ -783,6 +791,7 @@ fn dirty_co_changed_file_counts_toward_stale_files() {
     add_commit(conn, &repo_id, "c2", 20, &["src/store.rs", "src/helper.rs"]);
     add_commit(conn, &repo_id, "c3", 30, &["ext_a.rs", "ext_b.rs"]);
     add_commit(conn, &repo_id, "c4", 40, &["ext_c.rs", "ext_d.rs"]);
+    invalidate_coupling_stamp(conn, &repo_id);
 
     // Dirty the coupled file on disk AFTER indexing — its content hash now differs from the index.
     fs::write(root.join("src/helper.rs"), "pub fn helper_fn() { let _changed = 1; }\n").unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -77,6 +77,161 @@ fn git_history_append_rebuilds_desynced_commit_fts() {
 }
 
 #[test]
+fn history_import_materializes_coupling_and_bumps_lens_once() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // A sibling checkout overlay and a sibling repo share the database. History publication for
+    // the active repo must preserve both while replacing only its own derived coupling rows.
+    conn.execute(
+        "INSERT INTO main.files(
+             path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms,
+             indexed_revision, commit_sha, worktree_id, has_test_code, repo_id, generation
+         ) SELECT 'src/linked_overlay.rs', language, kind, sha256, modified_at_ms, generated,
+                  indexed_at_ms, indexed_revision, '', 'linked-worktree', has_test_code, repo_id,
+                  generation
+             FROM main.files WHERE repo_id = ?1 LIMIT 1",
+        [&db.active_repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+         VALUES ('coupling-sibling', 'coupling sibling', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO git_change_couplings(
+             repo_id, path_a, path_b, co_change_count, path_a_change_count,
+             path_b_change_count, window_commit_count, last_co_change_at_s, computed_at_ms
+         ) VALUES ('coupling-sibling', 'a.rs', 'b.rs', 2, 2, 2, 2, 1, 99)",
+        [],
+    )
+    .unwrap();
+
+    for revision in 0..2 {
+        fs::write(root.join("docs/search.md"), format!("# Title\ncoupling docs {revision}\n"))
+            .unwrap();
+        fs::write(
+            root.join("src/lib.rs"),
+            format!("pub fn tracked_symbol() -> usize {{ {revision} }}\n"),
+        )
+        .unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-m", &format!("Coupled change {revision}")]);
+    }
+    for revision in 0..4 {
+        fs::create_dir_all(root.join("misc")).unwrap();
+        fs::write(root.join(format!("misc/a-{revision}")), "a\n").unwrap();
+        fs::write(root.join(format!("misc/b-{revision}")), "b\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-m", &format!("Filler change {revision}")]);
+    }
+
+    let before_revision = db
+        .repo_meta(rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META)
+        .unwrap()
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+    let plan = crate::index::git_history::prepare_plan(conn, &root);
+    let prepared = crate::index::git_history::prepare_with_plan(&root, plan).unwrap();
+    conn.execute_batch("BEGIN IMMEDIATE").unwrap();
+    let (_status, cursors) =
+        crate::index::git_history::apply_prepared_deferring_cursors(conn, &root, prepared).unwrap();
+    let before_cursor_publication = db
+        .repo_meta(rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META)
+        .unwrap()
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+    assert_eq!(
+        before_cursor_publication, before_revision,
+        "staged history rows remain inert until their cursors publish"
+    );
+    crate::index::git_history::record_history_cursors(
+        conn,
+        &cursors.expect("git history returns cursors"),
+    )
+    .unwrap();
+    let after_revision = db
+        .repo_meta(rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META)
+        .unwrap()
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+    assert_eq!(after_revision, before_revision + 1, "one bulk import advances Lens once");
+    conn.execute_batch("COMMIT").unwrap();
+
+    let (co_changes, computed_at_ms): (i64, i64) = conn
+        .query_row(
+            "SELECT co_change_count, computed_at_ms FROM git_change_couplings
+             WHERE repo_id = ?1 AND path_a = 'docs/search.md' AND path_b = 'src/lib.rs'",
+            [&db.active_repo_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(co_changes, 3);
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM main.files
+             WHERE repo_id = ?1 AND worktree_id = 'linked-worktree'",
+            [&db.active_repo_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        1,
+        "active history publication preserves a sibling checkout overlay"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT computed_at_ms FROM git_change_couplings
+             WHERE repo_id = 'coupling-sibling' AND path_a = 'a.rs' AND path_b = 'b.rs'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        99,
+        "active history publication preserves a sibling repo's coupling"
+    );
+
+    // The production incremental transaction publishes matching file rows with history. This
+    // focused history test bypassed file indexing, so advance its base-row scope to the same HEAD
+    // before opening the real read-only checkout scope.
+    let imported_head = git_output(&root, &["rev-parse", "HEAD"]);
+    conn.execute(
+        "UPDATE main.files SET commit_sha = ?1
+         WHERE repo_id = ?2 AND worktree_id = ''",
+        rusqlite::params![imported_head, db.active_repo_id],
+    )
+    .unwrap();
+
+    drop(db);
+    let read_only = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only");
+    let coupling = read_only.lens_file_coupling("docs/search.md").unwrap().coupling;
+    assert!(coupling.iter().any(|partner| partner.path == "src/lib.rs"));
+    let persisted_after_reads: i64 = read_only
+        .storage
+        .connection()
+        .query_row(
+            "SELECT computed_at_ms FROM git_change_couplings
+             WHERE repo_id = ?1 AND path_a = 'docs/search.md' AND path_b = 'src/lib.rs'",
+            [&read_only.active_repo_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        persisted_after_reads, computed_at_ms,
+        "read-only Lens uses the persisted fast path"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn git_history_falls_back_when_append_rows_are_already_present() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/lens_clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/lens_clones.rs
@@ -1,0 +1,406 @@
+use super::*;
+
+/// Partner hydration is memoized per coherent subclass, so a file contributing SEVERAL symbols to
+/// one clone class fetches its members once instead of once per symbol. A cache keyed wrongly
+/// would be silent — each region would render some other subclass's members — so assert every
+/// region's partners are exactly its own class minus itself.
+#[test]
+fn several_symbols_from_one_file_in_one_class_each_get_their_own_partners() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two members in the requested file, one in a sibling: the requested file's two regions must
+    // each see the other two members, never themselves.
+    fs::write(
+        root.join("src/pair.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub fn \
+         load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/other.rs"),
+        "pub fn load_item(cache: Db) -> i32 { let i = cache.get(30); validate(i); i + 1 }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+
+    let res = db.lens_file_clones("src/pair.rs", 0.7, 0).unwrap();
+    assert_eq!(res.clone_regions.len(), 2, "both in-file members anchor a region: {res:?}");
+    for region in &res.clone_regions {
+        let partners: Vec<&str> =
+            region.partners.iter().filter_map(|p| p.symbol.as_deref()).collect();
+        assert!(
+            !partners.contains(&region.symbol.as_str()),
+            "a region must never partner with itself: {region:?}"
+        );
+        assert_eq!(partners.len(), 2, "each region sees the other two class members: {region:?}");
+    }
+    let symbols: Vec<&str> = res.clone_regions.iter().map(|r| r.symbol.as_str()).collect();
+    assert!(symbols.contains(&"load_user") && symbols.contains(&"load_order"), "{symbols:?}");
+}
+
+/// The refinement payload the editor renders — template, variation points, proposed signature,
+/// and the refactorability scores — is a READ-THROUGH of the `clone_refinements` cache that a
+/// `find_clones` pass populates. The lens never cold-computes it (that would turn an editor read
+/// into a write), so an unrefined index must yield a region with no payload, and a refined one
+/// must carry every field through to the region intact.
+#[test]
+fn lens_file_clones_carries_the_cached_refinement_payload() {
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+    assert_eq!(
+        db.precompute_clone_graph(None).unwrap().status,
+        "Complete",
+        "the lens reads the persisted graph — it must build Complete"
+    );
+
+    let cold = db.lens_file_clones("a/load_user.rs", 0.7, 0).unwrap();
+    assert_eq!(cold.clone_regions.len(), 1, "the renamed clones form one class: {cold:?}");
+    assert!(
+        cold.clone_regions[0].refine.is_none(),
+        "an editor read must not cold-compute a refinement: {:?}",
+        cold.clone_regions[0]
+    );
+
+    // A `find_clones` pass is what populates the cache the lens then serves.
+    let found = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(found.classes[0].refined, "the fixture class must refine");
+
+    let warm = db.lens_file_clones("a/load_user.rs", 0.7, 0).unwrap();
+    let region = &warm.clone_regions[0];
+    let refine = region.refine.as_ref().expect("a cached refinement must reach the lens");
+    assert!(!refine.template.is_empty(), "the editor renders the template: {refine:?}");
+    assert!(!refine.confidence.is_empty(), "the editor labels confidence: {refine:?}");
+    assert!(
+        refine.anti_unify_coverage > 0.0 && refine.anti_unify_coverage <= 1.0,
+        "coverage is a ratio: {refine:?}"
+    );
+    assert!(refine.lcs_ratio > 0.0 && refine.lcs_ratio <= 1.0, "lcs is a ratio: {refine:?}");
+    assert!(refine.refactorability > 0.0, "a refined class is actionable: {refine:?}");
+    assert!(
+        !refine.variation_points.is_null(),
+        "renamed clones vary in their identifiers: {refine:?}"
+    );
+}
+
+/// The lens clones composition mirrors `clones_for_symbol`'s class rules on
+/// the persisted graph: coherent class, partners with similarities, dual
+/// anchoring for same-file pairs, and the min_tokens actionability filter.
+#[test]
+fn lens_file_clones_serves_coherent_class_with_partners() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/c.rs"),
+        "pub fn parse_config(raw: String) -> Vec<u8> { let mut v = Vec::new(); for b in \
+         raw.bytes() { v.push(b ^ 7); } v }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let no_graph = db.lens_file_clones("src/a.rs", 0.7, 0).unwrap();
+    assert!(
+        serde_json::to_value(no_graph).unwrap()["clone_graph"].is_null(),
+        "the shim contract represents an absent generation as clone_graph: null"
+    );
+    assert_eq!(
+        db.precompute_clone_graph(None).unwrap().status,
+        "Complete",
+        "the lens reads the persisted graph — it must build Complete"
+    );
+
+    let ro = IndexDatabase::try_open_config_read_only(&config)
+        .unwrap()
+        .expect("a current index must open read-only");
+    let cold_read = ro.lens_file_clones("src/a.rs", 0.7, 0).unwrap();
+    assert_eq!(
+        cold_read.clone_regions.len(),
+        1,
+        "a missing refinement cache row must not turn the lens read into a write"
+    );
+
+    let res = db.lens_file_clones("src/a.rs", 0.7, 0).unwrap();
+    assert!(res.clone_graph.eligible, "Complete generation is eligible");
+    assert_eq!(res.clone_regions.len(), 1, "one cloned symbol in a.rs: {res:?}");
+    let region = &res.clone_regions[0];
+    assert_eq!(region.symbol, "load_user");
+    assert!(!region.class_key.is_empty());
+    assert_eq!(region.partners.len(), 1, "only the renamed clone partners: {region:?}");
+    let partner = &region.partners[0];
+    assert_eq!(partner.symbol.as_deref(), Some("load_order"));
+    assert_eq!(partner.path, "src/b.rs");
+    // EXACTLY 1.0, not merely ≥ θ. `struct_hash` and `token_bag` are both derived from the one
+    // normalized token sequence in `fingerprint_symbol`, so two symbols that are identical after
+    // normalization — these differ only in identifier names — have equal bags and equal
+    // `token_len`, and `overlap / max_len` is already 1. That is why the similarity closure needs
+    // no structural-hash special case to score an exact clone as exact. A change that decoupled
+    // the bag from the hash (raw tokens, a capped bag) would break it here first.
+    assert_eq!(
+        partner.similarity, 1.0,
+        "identical-after-normalization clones score exact: {partner:?}"
+    );
+
+    // Dual anchoring: the same-file sibling is itself a region with the mirror partner.
+    let res_b = db.lens_file_clones("src/b.rs", 0.7, 0).unwrap();
+    assert_eq!(res_b.clone_regions.len(), 1);
+    assert_eq!(res_b.clone_regions[0].partners[0].symbol.as_deref(), Some("load_user"));
+    assert_eq!(
+        res_b.clone_regions[0].class_key, region.class_key,
+        "both anchors of the pair share one class identity"
+    );
+    assert_eq!(
+        res_b.clone_regions[0].class_id, region.class_id,
+        "class ids are stable across per-file requests"
+    );
+    let cached_graph = db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+
+    // The unrelated function has no coherent class.
+    let res_c = db.lens_file_clones("src/c.rs", 0.7, 0).unwrap();
+    assert!(res_c.clone_regions.is_empty(), "no clones for c.rs: {res_c:?}");
+
+    // The actionability filter hides small classes honestly.
+    let res_h = db.lens_file_clones("src/a.rs", 0.7, 10_000).unwrap();
+    assert!(res_h.clone_regions.is_empty());
+    assert_eq!(res_h.clone_graph.hidden_low_value_classes, 1);
+    let filtered_graph = db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+    assert!(
+        std::sync::Arc::ptr_eq(&cached_graph, &filtered_graph),
+        "min_tokens filters cached classes without rebuilding the repository graph"
+    );
+
+    db.lens_file_clones("src/a.rs", 0.71, 0).unwrap();
+    let changed_theta_graph =
+        db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+    assert!(
+        !std::sync::Arc::ptr_eq(&cached_graph, &changed_theta_graph),
+        "theta changes invalidate the cached edge set"
+    );
+
+    let normalized = db.lens_file_clones("src/a.rs", 0.7, -10).unwrap();
+    assert_eq!(normalized.clone_graph.min_tokens, 0);
+    assert!(db.lens_file_clones("src/a.rs", f64::NAN, 0).is_err());
+
+    db.lens_file_clones("src/a.rs", 0.71, 0).unwrap();
+    let graph_before_mutation =
+        db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+    db.connection()
+        .execute(
+            "UPDATE clone_graph_generations SET delta_files_applied = delta_files_applied + 1 \
+             WHERE generation = ?1",
+            [normalized.clone_graph.generation.unwrap()],
+        )
+        .unwrap();
+    db.lens_file_clones("src/a.rs", 0.71, 0).unwrap();
+    let graph_after_mutation =
+        db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+    assert!(
+        !std::sync::Arc::ptr_eq(&graph_before_mutation, &graph_after_mutation),
+        "in-place graph mutation epochs invalidate cached components"
+    );
+}
+
+#[test]
+fn lens_clone_graph_uses_scope_correct_live_fallback_for_a_linked_overlay() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("crate/src")).unwrap();
+    // `Config::load` canonicalizes the root and the overlay depends on it: the config subdir is
+    // found by stripping `config.root` against a canonicalized workdir, and a non-canonical root
+    // makes that strip fail, scoping the refresh to the wrong directory so it sees no change at
+    // all. The shared fixture builds a `Config` directly and skips that step, which is invisible
+    // wherever the temp directory is already canonical and breaks where it is not — macOS
+    // resolving `/var` to `/private/var`, Windows expanding 8.3 names. Doing it fixture-wide is
+    // the real fix and is #1027; here it is done locally so this test states what it means to.
+    let main = main.canonicalize().unwrap_or_else(|_| main.to_path_buf());
+    fs::write(main.join("crate/src/base.rs"), "pub fn tiny() -> i32 { 0 }\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.join("crate"), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    db.precompute_clone_graph(None).unwrap();
+    let before_overlay = db.lens_version().unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "lens-overlay", linked.to_str().unwrap()]);
+    fs::write(
+        linked.join("crate/src/overlay_a.rs"),
+        "pub fn overlay_user(db: Db) -> i32 { let value = db.get(1); validate(value); value + 1 \
+         }\n",
+    )
+    .unwrap();
+    fs::write(
+        linked.join("crate/src/overlay_b.rs"),
+        "pub fn overlay_order(store: Db) -> i32 { let item = store.get(2); validate(item); item + \
+         1 }\n",
+    )
+    .unwrap();
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    // The overlay must have TARGETED the linked checkout. `index_worktree_overlay` returns `Ok(())`
+    // without doing anything when the path does not resolve to a sibling worktree, so asserting
+    // only on the revision below cannot tell "resolved and found no change" from "never resolved".
+    assert_eq!(
+        db.active_worktree_id,
+        linked.canonicalize().unwrap_or_else(|_| linked.clone()).display().to_string(),
+        "the overlay refresh must scope itself to the linked checkout"
+    );
+    let after_overlay = db.lens_version().unwrap();
+    assert_ne!(
+        before_overlay.revision, after_overlay.revision,
+        "materializing a linked-worktree edit must invalidate connected Lens clients"
+    );
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        after_overlay.revision,
+        db.lens_version().unwrap().revision,
+        "an unchanged overlay refresh must remain write-idle for Lens"
+    );
+
+    let overlay_chunk_id: i64 = db
+        .connection()
+        .query_row(
+            "SELECT chunk.id FROM chunks chunk
+             JOIN files file ON file.id = chunk.file_id
+             WHERE file.path = 'src/overlay_a.rs' LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let overlay_chunk = db.lens_chunk_text(overlay_chunk_id).unwrap().unwrap();
+    assert!(overlay_chunk.text.contains("pub fn overlay_user"));
+
+    let treemap = db.lens_treemap().unwrap().files;
+    let overlay_a = treemap.iter().find(|file| file.path == "src/overlay_a.rs").unwrap();
+    assert_eq!(overlay_a.dup_partners, 1, "branch-only clone must count as a hotspot");
+    assert_eq!(overlay_a.dup_max_similarity, 1.0, "structural-hash edges are exact matches");
+    let treemap_graph = db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+
+    let result = db.lens_file_clones("src/overlay_a.rs", 0.9, 0).unwrap();
+    assert!(result.clone_graph.eligible);
+    assert_eq!(result.clone_regions.len(), 1, "branch-only clone must be served: {result:?}");
+    assert_eq!(result.clone_regions[0].partners.len(), 1);
+    assert_eq!(result.clone_regions[0].partners[0].path, "src/overlay_b.rs");
+    let wire = serde_json::to_value(result).unwrap();
+    assert_eq!(wire["clone_graph"]["eligible"], true);
+    assert_eq!(
+        db.lens_clone_graph_cache.0.lock().unwrap().len(),
+        2,
+        "treemap and configured file-clone theta variants coexist"
+    );
+    db.lens_treemap().unwrap();
+    let cache = db.lens_clone_graph_cache.0.lock().unwrap();
+    assert_eq!(cache.len(), 2, "re-reading the treemap must hit its theta variant");
+    assert!(std::sync::Arc::ptr_eq(&cache[0].data, &treemap_graph));
+    drop(cache);
+
+    db.use_worktree_scope(&config.root, None).unwrap();
+    assert!(
+        db.lens_treemap().unwrap().files.iter().all(|file| !file.path.starts_with("src/overlay_")),
+        "linked-worktree treemap rows must not leak into main"
+    );
+    assert!(
+        db.lens_chunk_text(overlay_chunk_id).unwrap().is_none(),
+        "materializing and versioning a sibling overlay must not leak its rows into main"
+    );
+    assert!(
+        db.lens_file_clones("src/overlay_a.rs", 0.7, 0).unwrap().clone_regions.is_empty(),
+        "the main checkout must not reuse the linked-worktree clone graph cache"
+    );
+}
+
+#[test]
+fn lens_overlay_clone_cache_invalidates_on_byte_identical_target_drift() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(
+        main.join("src/a.h"),
+        "int load_user(Db db) { int value = db_get(db, 1); validate(value); return value + 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        main.join("src/b.h"),
+        "int load_order(Db store) { int item = db_get(store, 2); validate(item); return item + 1; \
+         }\n",
+    )
+    .unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let base_config = source_config_dirs(main.clone(), Language::C, &["src"]);
+    let mut db = IndexDatabase::rebuild(&base_config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "lens-relanguage", linked.to_str().unwrap()]);
+    let branch_config = source_config_dirs(main.clone(), Language::Cpp, &["src"]);
+    db.index_worktree_overlay(&branch_config, &linked, &mut |_| {}).unwrap();
+    let before_revision = db.content_revision().unwrap();
+    assert_eq!(db.lens_file_clones("src/a.h", 0.7, 0).unwrap().clone_regions.len(), 1);
+    let source_graph = db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+
+    let mut tests_config = source_config_dirs(main.clone(), Language::Cpp, &["src"]);
+    tests_config.targets[0].kind = TargetKind::Tests;
+    db.index_worktree_overlay(&tests_config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        db.content_revision().unwrap(),
+        before_revision,
+        "target-identity replacement is intentionally byte-identical"
+    );
+    let language: String = db
+        .connection()
+        .query_row("SELECT language FROM files WHERE path = 'src/a.h'", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(language, "cpp");
+
+    let result = db.lens_file_clones("src/a.h", 0.7, 0).unwrap();
+    assert_eq!(result.clone_regions.len(), 1, "the test-target graph must replace cached ids");
+    let tests_graph = db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+    assert!(
+        !std::sync::Arc::ptr_eq(&source_graph, &tests_graph),
+        "the files sequence must invalidate byte-identical target drift"
+    );
+
+    db.connection()
+        .execute(
+            "UPDATE main.files SET generated = 1 WHERE path = 'src/b.h' AND worktree_id = ?1",
+            [&db.active_worktree_id],
+        )
+        .unwrap();
+    db.connection()
+        .execute("UPDATE index_meta SET value = 'next' WHERE key = ?1", [
+            crate::index::GENERATED_FLAGS_VERSION_KEY,
+        ])
+        .unwrap();
+    assert_eq!(db.content_revision().unwrap(), before_revision);
+    let generated_result = db.lens_file_clones("src/a.h", 0.7, 0).unwrap();
+    assert!(generated_result.clone_regions.is_empty(), "generated partners leave the live corpus");
+    let generated_graph = db.lens_clone_graph_cache.0.lock().unwrap().last().unwrap().data.clone();
+    assert!(
+        !std::sync::Arc::ptr_eq(&tests_graph, &generated_graph),
+        "the generated-flags version must invalidate in-place membership changes"
+    );
+
+    db.use_worktree_scope(&main, None).unwrap();
+    let base_language: String = db
+        .connection()
+        .query_row("SELECT language FROM files WHERE path = 'src/a.h'", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(base_language, "c", "the linked C++ target must not alter main scope");
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -976,6 +976,7 @@ mod git_history_reload;
 mod graph_edges;
 mod head_move_carry;
 mod index_paths;
+mod lens_clones;
 mod migration_gate_wiring;
 mod multi_repo_scope;
 mod orientation_healing;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -394,13 +394,22 @@ fn read_only_open_binds_the_config_repo_over_a_smaller_sibling() {
     let _ = fs::remove_dir_all(&root);
 }
 
-/// All `repo_meta` rows as a sorted `(repo_id, key, value)` list — the snapshot the full-ladder
-/// replay must leave byte-identical (V039/V040 relocate meta, so a no-op replay must move nothing).
+/// All semantic `repo_meta` rows as a sorted `(repo_id, key, value)` list — the snapshot the
+/// full-ladder replay must leave byte-identical (V039/V040 relocate meta, so a no-op replay must
+/// move nothing). The Lens enrichment counter is a write clock, not semantic metadata: replayed
+/// poison-sibling fixture writes may advance it without moving or resurrecting any source row.
 fn dump_repo_meta(conn: &rusqlite::Connection) -> Vec<(String, String, Option<String>)> {
-    let mut stmt =
-        conn.prepare("SELECT repo_id, key, value FROM repo_meta ORDER BY repo_id, key").unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT repo_id, key, value FROM repo_meta
+             WHERE key != ?1
+             ORDER BY repo_id, key",
+        )
+        .unwrap();
     let mut rows: Vec<(String, String, Option<String>)> = stmt
-        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .query_map([rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+        })
         .unwrap()
         .map(Result::unwrap)
         .collect();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -143,9 +143,23 @@ fn migration_038_forward_migrates_a_v037_index() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn, &crate::index::migration_hooks()).expect("apply");
 
-    // Revert to the V037 shape: drop children before the parent (FK), then drop the ledger row.
-    conn.execute_batch("DROP TABLE repo_meta; DROP TABLE repo_roots; DROP TABLE repos;")
-        .expect("revert to V037 shape");
+    // Revert to the V037 shape: remove future triggers before their repo_meta target, drop
+    // children before the parent (FK), then drop the ledger rows.
+    conn.execute_batch(
+        "DROP TRIGGER memory_bindings_lens_revision_insert;
+         DROP TRIGGER memory_bindings_lens_revision_delete;
+         DROP TRIGGER memory_bindings_lens_revision_update;
+         DROP TRIGGER papertrail_items_lens_revision_insert;
+         DROP TRIGGER papertrail_items_lens_revision_delete;
+         DROP TRIGGER papertrail_items_lens_revision_update;
+         DROP TRIGGER papertrail_refs_lens_revision_insert;
+         DROP TRIGGER papertrail_refs_lens_revision_delete;
+         DROP TRIGGER papertrail_refs_lens_revision_update;
+         DROP TABLE repo_meta;
+         DROP TABLE repo_roots;
+         DROP TABLE repos;",
+    )
+    .expect("revert to V037 shape");
     truncate_schema_to(&conn, 37);
     assert_eq!(
         schema::status(&conn).unwrap().state,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1475,8 +1475,6 @@ fn migration_092_normalizes_invite_receipts() {
 /// one-way stream id hashes away, and the column set each anti-echo hash covers.
 #[test]
 fn migration_093_adds_table_sync_projection_state() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 93, "move this pin with the next schema migration");
-
     // Absence is asserted against the PRE-V093 DDL in isolation, never against the full ladder
     // (which now ends at V093 and would make the check vacuous).
     let bare = rusqlite::Connection::open_in_memory().unwrap();
@@ -1580,4 +1578,177 @@ fn migration_091_adds_account_candidate_reservation_targets() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V091");
+}
+
+#[test]
+fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 94, "move this pin with the next schema migration");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_refs(
+             tracker, project, item_key, item_kind, ref_kind, source_kind, source_path,
+             source_text, discovered_at_ms, repo_id
+         ) VALUES ('github', 'owner/repo', '1', 'issue', 'reference', 'path', 'src/lib.rs',
+                   'mentions #1', 1, '__unassigned__')",
+        [],
+    )
+    .unwrap();
+    let revision = || {
+        conn.query_row(
+            "SELECT CAST(value AS INTEGER) FROM repo_meta
+             WHERE repo_id = '__unassigned__' AND key = ?1",
+            [rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(revision(), 1);
+
+    conn.execute(
+        "UPDATE papertrail_refs SET ref_kind = 'closing' WHERE repo_id = '__unassigned__'",
+        [],
+    )
+    .unwrap();
+    assert_eq!(revision(), 2, "an in-place promotion increments the clock");
+    conn.execute("DELETE FROM papertrail_refs WHERE repo_id = '__unassigned__'", []).unwrap();
+    assert_eq!(revision(), 3, "deletion increments the clock");
+
+    let trigger_count = |prefix: &str| {
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE ?1",
+            [format!("{prefix}%")],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        trigger_count("git_file_changes_lens_revision_"),
+        0,
+        "bulk history writes must not carry per-row Lens triggers"
+    );
+    conn.execute(
+        "INSERT INTO git_commits(
+             hash, author_name, author_email, authored_at_s, committed_at_s,
+             subject, body, changed_file_count, repo_id
+         ) VALUES ('bulk', 'a', 'a@b', 1, 1, 'bulk', '', 2, '__unassigned__')",
+        [],
+    )
+    .unwrap();
+    for path in ["src/a.rs", "src/b.rs"] {
+        conn.execute(
+            "INSERT INTO git_file_changes(
+                 commit_hash, path, additions, deletions, change_kind, repo_id
+             ) VALUES ('bulk', ?1, 0, 0, 'modified', '__unassigned__')",
+            [path],
+        )
+        .unwrap();
+    }
+    assert_eq!(revision(), 3, "history rows are clocked by their transactional writer");
+
+    conn.execute(
+        "INSERT INTO oracle_runs(
+             repo_id, tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
+         ) VALUES ('__unassigned__', 'scip', '1', 'head', 'active-wt', 1, 'complete', '{}')",
+        [],
+    )
+    .unwrap();
+    assert_eq!(revision(), 4, "a zero-verdict Oracle run invalidates Lens");
+    conn.execute("UPDATE oracle_runs SET status = 'failed' WHERE repo_id = '__unassigned__'", [])
+        .unwrap();
+    assert_eq!(revision(), 5, "Oracle run updates invalidate Lens");
+    conn.execute("DELETE FROM oracle_runs WHERE repo_id = '__unassigned__'", []).unwrap();
+    assert_eq!(revision(), 6, "Oracle run deletion invalidates Lens");
+
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+         VALUES ('oracle-sibling', 'oracle sibling', 0)",
+        [],
+    )
+    .unwrap();
+    rag_rat_db::meta::set_repo_meta(
+        &conn,
+        "oracle-sibling",
+        rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+        "20",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO oracle_runs(
+             repo_id, tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
+         ) VALUES ('oracle-sibling', 'scip', '1', 'branch-head', 'linked-wt', 2, 'complete', '{}')",
+        [],
+    )
+    .unwrap();
+    let sibling_revision: i64 = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM repo_meta
+             WHERE repo_id = 'oracle-sibling' AND key = ?1",
+            [rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(sibling_revision, 21, "the run clocks its owning repo");
+    assert_eq!(revision(), 6, "a sibling repo's linked-worktree run stays isolated");
+
+    schema::apply_lens_enrichment_revision(&conn).unwrap();
+    assert_eq!(trigger_count("oracle_runs_lens_revision_"), 3);
+    assert_eq!(trigger_count("git_file_changes_lens_revision_"), 0);
+    conn.execute(
+        "INSERT INTO oracle_runs(
+             repo_id, tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
+         ) VALUES ('__unassigned__', 'scip', '2', 'head', 'active-wt', 3, 'complete', '{}')",
+        [],
+    )
+    .unwrap();
+    assert_eq!(revision(), 7, "V093 replay must not duplicate Oracle triggers");
+
+    // An Oracle pass writes one `edge_oracle` verdict per resolved edge inside the transaction
+    // that commits its run row. Clocking those rows individually would advance the revision
+    // hundreds of thousands of times for one publication, so the verdicts carry no trigger at all
+    // and the run row is what Lens sees.
+    assert_eq!(
+        trigger_count("edge_oracle_lens_revision_"),
+        0,
+        "bulk verdict writes must not carry per-row Lens triggers"
+    );
+    let before_verdicts = revision();
+    for callee_start in 0..64 {
+        conn.execute(
+            "INSERT INTO edge_oracle(
+                 repo_id, source_path, source_start_byte, source_end_byte,
+                 callee_start_byte, callee_end_byte, edge_kind, file_sha,
+                 tool, tool_version, resolved_symbol_id, scip_symbol, kind, computed_at
+             ) VALUES ('__unassigned__', 'src/a.rs', 0, 1, ?1, ?1, 'calls_name', 'sha',
+                       'scip', '1', NULL, 'sym', 'confirm', 0)",
+            [callee_start],
+        )
+        .unwrap();
+    }
+    conn.execute("UPDATE edge_oracle SET kind = 'upgrade' WHERE repo_id = '__unassigned__'", [])
+        .unwrap();
+    conn.execute("DELETE FROM edge_oracle WHERE repo_id = '__unassigned__'", []).unwrap();
+    assert_eq!(
+        revision(),
+        before_verdicts,
+        "verdict rows are clocked by their transactional writer, not one bump per edge"
+    );
+
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+         VALUES ('retired', 'retired', 0)",
+        [],
+    )
+    .unwrap();
+    rag_rat_db::meta::set_repo_meta(&conn, "retired", "clone_graph_live_generation", "7").unwrap();
+    rag_rat_db::meta::set_repo_meta(
+        &conn,
+        "retired",
+        rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+        "1",
+    )
+    .unwrap();
+    conn.execute("DELETE FROM repos WHERE repo_id = 'retired'", [])
+        .expect("retiring a repo with Lens metadata must not reinsert rows during FK cascade");
 }

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -30,7 +30,7 @@ pub use discovery::WorktreeOverlayReport;
 use discovery::fold_status_candidates;
 use discovery::resolve_overlay_scope;
 pub(crate) use discovery::{
-    CommittedDeltaSource, ResolvedOverlayScope, compute_linked_worktree_delta,
+    CommittedDeltaSource, ResolvedOverlayScope, compute_linked_worktree_delta, linked_source_root,
 };
 
 /// `repo_meta` key prefix for a linked worktree's overlay refresh basis (#577): one key per

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -56,7 +56,7 @@ pub struct WorktreeOverlayReport {
 /// derived. Shared by the delta computation (path rebasing) and the read step (source root) so the
 /// two can't drift (#219 review).
 fn linked_config_subdir_and_root(
-    config: &Config,
+    config_root: &Path,
     base_repo: &gix::Repository,
     linked_repo: &gix::Repository,
     linked_path: &Path,
@@ -71,11 +71,20 @@ fn linked_config_subdir_and_root(
             base_workdir.canonicalize().unwrap_or_else(|_| base_workdir.to_path_buf())
         })
         .and_then(|base_workdir| {
-            config.root.strip_prefix(&base_workdir).ok().map(Path::to_path_buf)
+            config_root.strip_prefix(&base_workdir).ok().map(Path::to_path_buf)
         })
         .unwrap_or_default();
     let linked_config_root = linked_workdir.join(&config_subdir);
     (config_subdir, linked_config_root)
+}
+
+pub(crate) fn linked_source_root(
+    config_root: &Path,
+    linked_path: &Path,
+) -> anyhow::Result<PathBuf> {
+    let base_repo = rag_rat_base::repo_discover::discover_repo(config_root)?;
+    let linked_repo = rag_rat_base::repo_discover::discover_repo(linked_path)?;
+    Ok(linked_config_subdir_and_root(config_root, &base_repo, &linked_repo, linked_path).1)
 }
 
 /// A linked-worktree overlay's resolved identity plus the opened repositories it was resolved
@@ -110,7 +119,7 @@ pub(super) fn resolve_overlay_scope(
     let base_repo = rag_rat_base::repo_discover::discover_repo(&config.root)?;
     let linked_repo = rag_rat_base::repo_discover::discover_repo(linked_path)?;
     let (config_subdir, source_root) =
-        linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
+        linked_config_subdir_and_root(&config.root, &base_repo, &linked_repo, linked_path);
     Ok(Some(ResolvedOverlayScope {
         base_sha,
         worktree_id,

--- a/crates/rag-rat-core/src/index/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/lifecycle.rs
@@ -126,6 +126,7 @@ impl IndexDatabase {
         let result = (|| -> anyhow::Result<()> {
             self.refresh_packages(&source_root)?;
             self.resolve_overlay_edges(&worktree_id)?;
+            self.bump_lens_enrichment_revision()?;
             Ok(())
         })();
         match result {
@@ -243,6 +244,19 @@ impl IndexDatabase {
             // review).
             self.resolve_overlay_edges(worktree_id)?;
         }
+        if counts.any_changed() || manifest_changed {
+            self.bump_lens_enrichment_revision()?;
+        }
+        Ok(())
+    }
+
+    fn bump_lens_enrichment_revision(&self) -> anyhow::Result<()> {
+        self.storage.connection().execute(
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, '1')
+             ON CONFLICT(repo_id, key) DO UPDATE SET
+                 value = CAST(COALESCE(value, '0') AS INTEGER) + 1",
+            params![self.active_repo_id, rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META],
+        )?;
         Ok(())
     }
 

--- a/crates/rag-rat-db/src/meta.rs
+++ b/crates/rag-rat-db/src/meta.rs
@@ -20,6 +20,23 @@ pub const WATCH_SHUTDOWN_RECONCILE_PENDING_META: &str = "watch_shutdown_reconcil
 /// without one watcher process masking another's (see `record_watch_placement_failures`).
 pub const WATCH_PLACEMENT_FAILURES_META: &str = "watch_placement_failures";
 pub const BASE_SCOPE_DISCOVERED_META: &str = "files_base_scope_discovered";
+/// Monotonic per-repo clock maintained by schema triggers and transactional bulk writers for
+/// Lens-visible enrichment rows.
+pub const LENS_ENRICHMENT_REVISION_META: &str = "lens_enrichment_revision";
+
+/// Advance the per-repo Lens enrichment write clock once for one logical transaction.
+pub fn bump_lens_enrichment_revision(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, '1')
+         ON CONFLICT(repo_id, key) DO UPDATE SET
+             value = CAST(COALESCE(value, '0') AS INTEGER) + 1",
+        params![repo_id, LENS_ENRICHMENT_REVISION_META],
+    )?;
+    Ok(())
+}
 
 pub fn target_scope_fingerprint(targets: &[ResolvedTarget]) -> String {
     let mut input = String::new();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1379,6 +1379,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_091_ID => Some(91),
             MIGRATION_092_ID => Some(92),
             MIGRATION_093_ID => Some(93),
+            MIGRATION_094_ID => Some(94),
             _ => None,
         })
         .max()
@@ -1481,6 +1482,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_091_ID
             | MIGRATION_092_ID
             | MIGRATION_093_ID
+            | MIGRATION_094_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1580,6 +1582,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_091_ID => migration.checksum != MIGRATION_091_CHECKSUM,
         MIGRATION_092_ID => migration.checksum != MIGRATION_092_CHECKSUM,
         MIGRATION_093_ID => migration.checksum != MIGRATION_093_CHECKSUM,
+        MIGRATION_094_ID => migration.checksum != MIGRATION_094_CHECKSUM,
         _ => false,
     }
 }
@@ -6208,6 +6211,106 @@ pub fn apply_account_candidate_reservation_targets(conn: &Connection) -> rusqlit
     Ok(())
 }
 
+/// V093: maintain one O(1) Lens enrichment revision per repository. The revision is deliberately
+/// a counter, not a timestamp: multiple writes in one millisecond, in-place promotions, and clone
+/// graph publication must still invalidate connected editors.
+pub fn apply_lens_enrichment_revision(conn: &Connection) -> rusqlite::Result<()> {
+    // History imports and Oracle passes advance the clock once at their transaction boundary
+    // instead of once per written row. Both write their table in bulk inside a single
+    // transaction — an Oracle run rewrites a verdict for every resolved edge, hundreds of
+    // thousands of them on a large index — and Lens freshness only needs the one revision change
+    // the publication makes visible. `edge_oracle` gets that bump from the `oracle_runs` row its
+    // run commits alongside the verdicts; the dead-checkout verdict sweep, which writes no run
+    // row, bumps the clock itself. Always remove the per-row triggers so replaying this migration
+    // repairs a database initialized by an older build.
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS git_file_changes_lens_revision_insert;
+         DROP TRIGGER IF EXISTS git_file_changes_lens_revision_delete;
+         DROP TRIGGER IF EXISTS git_file_changes_lens_revision_update;
+         DROP TRIGGER IF EXISTS edge_oracle_lens_revision_insert;
+         DROP TRIGGER IF EXISTS edge_oracle_lens_revision_delete;
+         DROP TRIGGER IF EXISTS edge_oracle_lens_revision_update;",
+    )?;
+    for (table, trigger_prefix) in [
+        ("repo_memories", "memories_lens_revision"),
+        ("repo_memory_bindings", "memory_bindings_lens_revision"),
+        ("memory_reality", "memory_reality_lens_revision"),
+        ("memory_summaries", "memory_summaries_lens_revision"),
+        ("papertrail_items", "papertrail_items_lens_revision"),
+        ("papertrail_refs", "papertrail_refs_lens_revision"),
+        ("papertrail_distill", "papertrail_distill_lens_revision"),
+        ("papertrail_distill_anchors", "papertrail_distill_anchors_lens_revision"),
+        ("clone_refinements", "clone_refinements_lens_revision"),
+        ("oracle_runs", "oracle_runs_lens_revision"),
+    ] {
+        create_repo_scoped_lens_revision_triggers(conn, table, trigger_prefix)?;
+    }
+
+    let key = crate::meta::LENS_ENRICHMENT_REVISION_META;
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS clone_graph_generations_lens_revision_insert;
+         DROP TRIGGER IF EXISTS clone_graph_generations_lens_revision_delete;
+         DROP TRIGGER IF EXISTS clone_graph_generations_lens_revision_update;",
+    )?;
+    if column_exists(conn, "clone_graph_generations", "repo_id")? {
+        conn.execute_batch(&format!(
+            "CREATE TRIGGER clone_graph_generations_lens_revision_insert
+             AFTER INSERT ON clone_graph_generations
+             WHEN EXISTS (
+                 SELECT 1 FROM repo_meta
+                 WHERE repo_id = NEW.repo_id AND key = 'clone_graph_live_generation'
+                   AND CAST(value AS INTEGER) = NEW.generation
+             )
+             BEGIN
+                 INSERT INTO repo_meta(repo_id, key, value) VALUES (NEW.repo_id, '{key}', '1')
+                 ON CONFLICT(repo_id, key) DO UPDATE SET
+                     value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+             END;
+         CREATE TRIGGER clone_graph_generations_lens_revision_delete
+             AFTER DELETE ON clone_graph_generations
+             WHEN EXISTS (
+                 SELECT 1 FROM repo_meta
+                 WHERE repo_id = OLD.repo_id AND key = 'clone_graph_live_generation'
+                   AND CAST(value AS INTEGER) = OLD.generation
+             )
+             BEGIN
+                 INSERT INTO repo_meta(repo_id, key, value) VALUES (OLD.repo_id, '{key}', '1')
+                 ON CONFLICT(repo_id, key) DO UPDATE SET
+                     value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+             END;
+         CREATE TRIGGER clone_graph_generations_lens_revision_update
+             AFTER UPDATE ON clone_graph_generations
+             BEGIN
+                 INSERT INTO repo_meta(repo_id, key, value)
+                 SELECT NEW.repo_id, '{key}', '1'
+                 WHERE EXISTS (
+                     SELECT 1 FROM repo_meta
+                     WHERE repo_id = NEW.repo_id AND key = 'clone_graph_live_generation'
+                       AND CAST(value AS INTEGER) = NEW.generation
+                 )
+                 ON CONFLICT(repo_id, key) DO UPDATE SET
+                     value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+                 INSERT INTO repo_meta(repo_id, key, value)
+                 SELECT OLD.repo_id, '{key}', '1'
+                 WHERE (OLD.repo_id != NEW.repo_id OR OLD.generation != NEW.generation)
+                   AND EXISTS (
+                       SELECT 1 FROM repo_meta
+                       WHERE repo_id = OLD.repo_id AND key = 'clone_graph_live_generation'
+                         AND CAST(value AS INTEGER) = OLD.generation
+                   )
+                  ON CONFLICT(repo_id, key) DO UPDATE SET
+                      value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+             END;"
+        ))?;
+    }
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS clone_graph_pointer_lens_revision_insert;
+         DROP TRIGGER IF EXISTS clone_graph_pointer_lens_revision_delete;
+         DROP TRIGGER IF EXISTS clone_graph_pointer_lens_revision_update;",
+    )?;
+    Ok(())
+}
+
 /// V092 (#949): stop duplicating every enrollment receipt in the invite row.
 ///
 /// Each consumed invite used to store the complete signed account bootstrap (`receipt_bytes`),
@@ -6340,6 +6443,58 @@ pub fn apply_table_sync_projection_state(conn: &Connection) -> rusqlite::Result<
              WHERE pending_reason IS NOT NULL;",
     )?;
     tx.commit()
+}
+
+fn create_repo_scoped_lens_revision_triggers(
+    conn: &Connection,
+    table: &str,
+    trigger_prefix: &str,
+) -> rusqlite::Result<()> {
+    let key = crate::meta::LENS_ENRICHMENT_REVISION_META;
+    conn.execute_batch(&format!(
+        "DROP TRIGGER IF EXISTS {trigger_prefix}_insert;
+         DROP TRIGGER IF EXISTS {trigger_prefix}_delete;
+         DROP TRIGGER IF EXISTS {trigger_prefix}_update;"
+    ))?;
+    if !column_exists(conn, table, "repo_id")? {
+        return Ok(());
+    }
+    conn.execute_batch(&format!(
+        "CREATE TRIGGER {trigger_prefix}_insert
+                  AFTER INSERT ON {table}
+                 BEGIN
+                     INSERT INTO repo_meta(repo_id, key, value)
+                     SELECT NEW.repo_id, '{key}', '1'
+                     WHERE EXISTS (SELECT 1 FROM repos WHERE repo_id = NEW.repo_id)
+                     ON CONFLICT(repo_id, key) DO UPDATE SET
+                         value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+                 END;
+             CREATE TRIGGER {trigger_prefix}_delete
+                 AFTER DELETE ON {table}
+                 BEGIN
+                     INSERT INTO repo_meta(repo_id, key, value)
+                     SELECT OLD.repo_id, '{key}', '1'
+                     WHERE EXISTS (SELECT 1 FROM repos WHERE repo_id = OLD.repo_id)
+                     ON CONFLICT(repo_id, key) DO UPDATE SET
+                         value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+                 END;
+             CREATE TRIGGER {trigger_prefix}_update
+                 AFTER UPDATE ON {table}
+                 BEGIN
+                     INSERT INTO repo_meta(repo_id, key, value)
+                     SELECT NEW.repo_id, '{key}', '1'
+                     WHERE EXISTS (SELECT 1 FROM repos WHERE repo_id = NEW.repo_id)
+                     ON CONFLICT(repo_id, key) DO UPDATE SET
+                         value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+                     INSERT INTO repo_meta(repo_id, key, value)
+                     SELECT OLD.repo_id, '{key}', '1'
+                     WHERE OLD.repo_id != NEW.repo_id
+                       AND EXISTS (SELECT 1 FROM repos WHERE repo_id = OLD.repo_id)
+                     ON CONFLICT(repo_id, key) DO UPDATE SET
+                         value = CAST(COALESCE(value, '0') AS INTEGER) + 1;
+                  END;"
+    ))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -18,14 +18,14 @@ pub use migrations::{
     apply_distill_safe_input_snapshot, apply_dream_findings, apply_edge_string_interning,
     apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
     apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
-    apply_github_repo_id_scoping, apply_memory_model_failures_table,
-    apply_memory_verification_tables, apply_move_per_repo_meta, apply_oplog_device_identity,
-    apply_oplog_device_x25519, apply_oplog_local_account, apply_oplog_storage,
-    apply_oplog_stream_scoping, apply_oracle_tables, apply_papertrail_binding_health,
-    apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
-    apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
-    apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
-    apply_sync_invites, apply_sync_invites_normalized_receipts,
+    apply_github_repo_id_scoping, apply_lens_enrichment_revision,
+    apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
+    apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
+    apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
+    apply_papertrail_binding_health, apply_papertrail_distill_substrate,
+    apply_papertrail_mirror_resume_state, apply_papertrail_provider_neutral_schema,
+    apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
+    apply_scip_moniker_anchors, apply_sync_invites, apply_sync_invites_normalized_receipts,
     apply_sync_origin_and_edge_tombstone, apply_table_sync_projection_state,
     apply_table_sync_tables,
 };
@@ -50,7 +50,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 93;
+pub const LATEST_SCHEMA_VERSION: u32 = 94;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -707,6 +707,16 @@ const MIGRATION_093_DESCRIPTION: &str =
      stored entry cannot be replayed at all; and sync_published_rows.projector_version, since the \
      anti-echo hash covers the hashing binary's column set and is meaningless without that set's \
      identity";
+const MIGRATION_094_ID: &str = "094_lens_enrichment_revision";
+const MIGRATION_094_CHECKSUM: &str =
+    "sha256:rag-rat-lens-enrichment-revision-v94-transactional-history-and-oracle";
+const MIGRATION_094_DESCRIPTION: &str =
+    "Add SQLite triggers that increment a per-repo repo_meta revision when Lens-visible memories, \
+     dream state, papertrail records, clone refinements, Oracle runs, or the live clone graph \
+     change. Bulk writers whose transaction touches one row per indexed edge or commit — \
+     git-history imports and Oracle verdict passes — increment the same clock once at their \
+     transaction boundary instead of once per row. The Lens SSE freshness probe reads only O(1) \
+     indexed rows instead of rescanning enrichment and files tables every polling interval";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1461,6 +1471,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_093_CHECKSUM,
         description: MIGRATION_093_DESCRIPTION,
         apply: MigrationFn::Plain(apply_table_sync_projection_state),
+    },
+    Migration {
+        id: MIGRATION_094_ID,
+        checksum: MIGRATION_094_CHECKSUM,
+        description: MIGRATION_094_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_lens_enrichment_revision),
     },
 ];
 

--- a/crates/rag-rat-mcp/Cargo.toml
+++ b/crates/rag-rat-mcp/Cargo.toml
@@ -17,6 +17,10 @@ rag-rat-db.workspace = true
 rag-rat-dream.workspace = true
 rag-rat-papertrail.workspace = true
 anyhow.workspace = true
+axum.workspace = true
+futures-util.workspace = true
+getrandom.workspace = true
+gix.workspace = true
 rag-rat-core = { workspace = true }
 rag-rat-oracle.workspace = true
 rag-rat-query.workspace = true
@@ -24,19 +28,26 @@ rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["sync", "io-util", "time"] }
+tokio = { workspace = true, features = ["sync", "io-util", "net", "time"] }
 tracing.workspace = true
+url.workspace = true
 
-# `net` / `signal` are consumed only by the unix-gated hot-upgrade (`upgrade.rs`) and hook listener
-# (`agent_hook.rs::listener`) — dead on non-unix targets, so gate them there (#54).
+# `signal` is consumed only by the unix-gated hot-upgrade (`upgrade.rs`); `net` is cross-platform
+# because the shared editor HTTP router accepts a Tokio listener.
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
-tokio = { workspace = true, features = ["net", "time", "signal"] }
+tokio = { workspace = true, features = ["signal"] }
+
+# The Lens discovery file holds a bearer token for a loopback service every local account can
+# reach. Unix keeps it private with mode bits; Windows needs an explicit owner-only DACL.
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
 
 [dev-dependencies]
 # Already built transitively via rag-rat-core; a direct dev-dep lets the busy-retry test (#220)
 # construct a SQLITE_BUSY error to drive `with_busy_retry`.
 rusqlite.workspace = true
+tower = { version = "0.5", features = ["util"] }
 
 [features]
 default = ["fastembed", "model2vec"]

--- a/crates/rag-rat-mcp/src/http.rs
+++ b/crates/rag-rat-mcp/src/http.rs
@@ -267,16 +267,23 @@ async fn status(
 const VERSION_CACHE_TTL: Duration = Duration::from_secs(1);
 
 async fn cached_lens_version(
-    state: HttpState,
+    mut state: HttpState,
 ) -> Result<rag_rat_core::index::LensVersion, ApiError> {
-    // Keep the async mutex through the bounded worker call so aligned SSE pollers share one fill.
+    // Keep the async mutex through the bounded worker call so aligned SSE pollers share one fill,
+    // and charge the wait for it against the request's own deadline exactly as the treemap does.
+    // A fill whose `run_db` sits behind two occupied workers can hold this lock for the full
+    // permit timeout; without the charge every queued `/api/version` and opening `/api/events`
+    // would then start a FRESH full-length attempt, so latency grows by one timeout per waiting
+    // client instead of staying bounded by `ServeOptions::timeout`.
     let version_cache = state.version_cache.clone();
-    let mut cache = version_cache.lock().await;
+    let (mut cache, remaining) =
+        acquire_within_budget(&version_cache, state.options.timeout).await?;
     if let Some((computed_at, version)) = cache.as_ref()
         && computed_at.elapsed() < VERSION_CACHE_TTL
     {
         return Ok(version.clone());
     }
+    state.options.timeout = remaining;
     let version = run_db(state, |db, _, _| Ok(db.lens_version()?)).await?;
     *cache = Some((Instant::now(), version.clone()));
     Ok(version)

--- a/crates/rag-rat-mcp/src/http.rs
+++ b/crates/rag-rat-mcp/src/http.rs
@@ -1,0 +1,762 @@
+//! Shared HTTP router for editor-facing read APIs.
+
+use std::convert::Infallible;
+use std::future::{Future, IntoFuture};
+use std::path::{Component, Path};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use axum::extract::{Query, Request, State};
+use axum::http::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    AUTHORIZATION, ORIGIN, VARY,
+};
+use axum::http::{HeaderValue, Method, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use rag_rat_base::config::Config;
+use rag_rat_core::IndexDatabase;
+use rag_rat_core::index::LensCloneGraphCache;
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_WORKERS: usize = 2;
+const DEFAULT_THETA: f64 = 0.7;
+const DEFAULT_MIN_TOKENS: i64 = 100;
+const DEFAULT_HOP_LIMIT: u32 = 50;
+const MAX_HOP_LIMIT: u32 = 500;
+
+#[derive(Clone, Debug)]
+pub struct ServeOptions {
+    pub timeout: Duration,
+    pub blocking_workers: usize,
+    pub workspace_root: Option<std::path::PathBuf>,
+    pub indexed_root: String,
+    pub case_insensitive_paths: bool,
+    pub auth_token: Option<String>,
+    pub allowed_origins: Vec<String>,
+    pub control: ServeControl,
+}
+
+impl Default for ServeOptions {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_TIMEOUT,
+            blocking_workers: DEFAULT_WORKERS,
+            workspace_root: None,
+            indexed_root: String::new(),
+            case_insensitive_paths: false,
+            auth_token: None,
+            allowed_origins: Vec::new(),
+            control: ServeControl::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ServeControl {
+    stopping: Arc<AtomicBool>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl ServeControl {
+    pub fn stop(&self) {
+        self.stopping.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    pub async fn stopped(&self) {
+        loop {
+            let notified = self.notify.notified();
+            if self.stopping.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub(crate) fn is_stopping(&self) -> bool {
+        self.stopping.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Clone)]
+struct HttpState {
+    config: Config,
+    options: ServeOptions,
+    blocking_workers: Arc<Semaphore>,
+    clone_graph_cache: Arc<LensCloneGraphCache>,
+    // Bounded global freshness cache: without it every SSE client pays 16 COUNT/MAX scans every
+    // 2s through a fresh read-only connection. One entry per router collapses that to ~1
+    // version computation per second regardless of client count.
+    version_cache: Arc<tokio::sync::Mutex<Option<(Instant, rag_rat_core::index::LensVersion)>>>,
+    treemap_cache: Arc<tokio::sync::Mutex<Option<(Instant, rag_rat_core::index::LensTreemap)>>>,
+    // Admission control for the repository-wide clone graph, held OUTSIDE the worker pool. The
+    // graph is single-flighted by a cache shared across requests, but a waiter that blocks for it
+    // on a database worker holds a permit while doing nothing: two cold clone reads — two visible
+    // editors in a linked worktree is enough — would occupy both default permits, one building and
+    // one waiting, and no independent graph, memory, coupling, or papertrail read could start
+    // until the build finished. Serializing entry here means the waiter holds no permit and no
+    // connection, so at most one worker is ever inside a clone-graph build.
+    clone_graph_gate: Arc<tokio::sync::Mutex<()>>,
+}
+
+/// Build the editor API router. The state deliberately owns no database handle: every request
+/// opens and drops its read-only connection on a bounded blocking worker.
+pub fn router(config: Config, options: ServeOptions) -> Router {
+    let workers = options.blocking_workers.max(1);
+    let state = HttpState {
+        config,
+        options,
+        blocking_workers: Arc::new(Semaphore::new(workers)),
+        clone_graph_cache: Arc::default(),
+        version_cache: Arc::default(),
+        treemap_cache: Arc::default(),
+        clone_graph_gate: Arc::default(),
+    };
+    Router::new()
+        .route("/api/health", get(health))
+        .route("/api/status", get(status))
+        .route("/api/version", get(version))
+        .route("/api/events", get(events))
+        .route("/api/treemap", get(treemap))
+        .route("/api/file/symbols", get(file_symbols))
+        .route("/api/file/graph", get(file_graph))
+        .route("/api/file/coupling", get(file_coupling))
+        .route("/api/file/memories", get(file_memories))
+        .route("/api/file/papertrail", get(file_papertrail))
+        .route("/api/file/clones", get(file_clones))
+        .route("/api/symbol/callers", get(symbol_callers))
+        .route("/api/symbol/callees", get(symbol_callees))
+        .route("/api/chunk/text", get(chunk_text))
+        .layer(middleware::from_fn_with_state(state.clone(), authorize_and_apply_cors))
+        .with_state(state)
+}
+
+async fn authorize_and_apply_cors(
+    State(state): State<HttpState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let origin = request.headers().get(ORIGIN).cloned();
+    let allowed_origin = origin.as_ref().filter(|origin| {
+        origin.to_str().ok().is_some_and(|value| {
+            state.options.allowed_origins.iter().any(|allowed| allowed == value)
+        })
+    });
+    if origin.is_some() && allowed_origin.is_none() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse { error: "origin is not allowed".into() }),
+        )
+            .into_response();
+    }
+    if request.method() == Method::OPTIONS {
+        let mut response = StatusCode::NO_CONTENT.into_response();
+        apply_cors_headers(response.headers_mut(), allowed_origin);
+        if allowed_origin.is_some() {
+            // Chrome's Private Network Access blocks public-page → loopback requests unless the
+            // preflight opts in. Safe to emit here: `allowed_origin` is exact-allowlisted, and
+            // every route still requires the bearer token.
+            response.headers_mut().insert(
+                axum::http::HeaderName::from_static("access-control-allow-private-network"),
+                HeaderValue::from_static("true"),
+            );
+        }
+        return response;
+    }
+    if let Some(expected) = state.options.auth_token.as_deref() {
+        let supplied = request
+            .headers()
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "));
+        if !supplied.is_some_and(|value| tokens_equal(value, expected)) {
+            // A disallowed-origin 403 above stays header-free; an ALLOWED origin must still see
+            // CORS headers on its 401 or the browser reports an opaque network error and the
+            // client cannot distinguish "re-prompt for token" from "server down".
+            let mut response =
+                (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error: "unauthorized".into() }))
+                    .into_response();
+            apply_cors_headers(response.headers_mut(), allowed_origin);
+            return response;
+        }
+    }
+    let mut response = next.run(request).await;
+    apply_cors_headers(response.headers_mut(), allowed_origin);
+    response
+}
+
+fn apply_cors_headers(headers: &mut axum::http::HeaderMap, origin: Option<&HeaderValue>) {
+    let Some(origin) = origin else { return };
+    headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, origin.clone());
+    headers.insert(ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static("GET, OPTIONS"));
+    headers.insert(
+        ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderValue::from_static("authorization, content-type"),
+    );
+    headers.insert(VARY, HeaderValue::from_static("Origin"));
+}
+
+fn tokens_equal(actual: &str, expected: &str) -> bool {
+    if actual.len() != expected.len() {
+        return false;
+    }
+    actual.bytes().zip(expected.bytes()).fold(0_u8, |diff, (a, b)| diff | (a ^ b)) == 0
+}
+
+/// Serve a pre-built shared router on an already-bound listener.
+pub async fn serve(
+    listener: TcpListener,
+    config: Config,
+    options: ServeOptions,
+    shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
+) -> std::io::Result<()> {
+    if !listener.local_addr()?.ip().is_loopback()
+        && options.auth_token.as_deref().is_none_or(str::is_empty)
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "non-loopback HTTP serving requires bearer authentication",
+        ));
+    }
+    let control = options.control.clone();
+    let app = router(config, options);
+    let (trigger, graceful) = tokio::sync::oneshot::channel();
+    let server = axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            let _ = graceful.await;
+        })
+        .into_future();
+    tokio::pin!(server);
+    tokio::select! {
+        result = &mut server => result,
+        result = shutdown => {
+            result?;
+            control.stop();
+            let _ = trigger.send(());
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "HTTP shutdown timed out"))?
+        },
+    }
+}
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok" })
+}
+
+async fn status(
+    State(state): State<HttpState>,
+) -> Result<Json<rag_rat_core::index::LensStatus>, ApiError> {
+    let indexed_root = state.options.indexed_root.clone();
+    let case_insensitive_paths = state.options.case_insensitive_paths;
+    run_db(state, move |db, config, _| {
+        Ok(db.lens_status(config, indexed_root, case_insensitive_paths)?)
+    })
+    .await
+    .map(Json)
+}
+
+const VERSION_CACHE_TTL: Duration = Duration::from_secs(1);
+
+async fn cached_lens_version(
+    state: HttpState,
+) -> Result<rag_rat_core::index::LensVersion, ApiError> {
+    // Keep the async mutex through the bounded worker call so aligned SSE pollers share one fill.
+    let version_cache = state.version_cache.clone();
+    let mut cache = version_cache.lock().await;
+    if let Some((computed_at, version)) = cache.as_ref()
+        && computed_at.elapsed() < VERSION_CACHE_TTL
+    {
+        return Ok(version.clone());
+    }
+    let version = run_db(state, |db, _, _| Ok(db.lens_version()?)).await?;
+    *cache = Some((Instant::now(), version.clone()));
+    Ok(version)
+}
+
+async fn version(
+    State(state): State<HttpState>,
+) -> Result<Json<rag_rat_core::index::LensVersion>, ApiError> {
+    cached_lens_version(state).await.map(Json)
+}
+
+async fn events(
+    State(state): State<HttpState>,
+) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let initial = cached_lens_version(state.clone()).await?;
+    let mut interval = tokio::time::interval(Duration::from_secs(2));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let stream = futures_util::stream::unfold(
+        (state, Some(initial), true, interval),
+        |(state, mut last, emit_initial, mut interval)| async move {
+            loop {
+                if state.options.control.is_stopping() {
+                    return None;
+                }
+                let version = if emit_initial {
+                    last.clone().expect("initial version is present")
+                } else {
+                    tokio::select! {
+                        () = state.options.control.stopped() => return None,
+                        _ = interval.tick() => {},
+                    }
+                    let Ok(version) = cached_lens_version(state.clone()).await else {
+                        return None;
+                    };
+                    if last.as_ref() == Some(&version) {
+                        continue;
+                    }
+                    version
+                };
+                let Ok(event) = Event::default().event("version").json_data(&version) else {
+                    continue;
+                };
+                last = Some(version);
+                return Some((Ok::<_, Infallible>(event), (state, last, false, interval)));
+            }
+        },
+    );
+    Ok(Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(16)).text("hb")))
+}
+
+/// Wait for `gate`, charging the wait against `budget` and returning what survived it.
+///
+/// Every wait a handler adds before `run_db` has to come out of the same deadline the caller is
+/// holding open, exactly as `run_db` charges its own permit wait against it. Otherwise a queue
+/// stacks one full timeout on the next and answers long after the caller stopped listening.
+async fn acquire_within_budget<T>(
+    gate: &tokio::sync::Mutex<T>,
+    budget: Duration,
+) -> Result<(tokio::sync::MutexGuard<'_, T>, Duration), ApiError> {
+    let waiting = Instant::now();
+    let Ok(guard) = tokio::time::timeout(budget, gate.lock()).await else {
+        return Err(ApiError::Timeout);
+    };
+    let Some(remaining) = budget.checked_sub(waiting.elapsed()) else {
+        return Err(ApiError::Timeout);
+    };
+    Ok((guard, remaining))
+}
+
+async fn treemap(
+    State(mut state): State<HttpState>,
+) -> Result<Json<rag_rat_core::index::LensTreemap>, ApiError> {
+    // Keep the async mutex through the bounded worker call so concurrent callers share ONE fill,
+    // like the version cache above. The treemap rescans the live clone graph — and derives overlay
+    // metrics on a linked worktree — so a stampede after the TTL expires would occupy the database
+    // workers and stall the interactive file lanes behind it.
+    let treemap_cache = state.treemap_cache.clone();
+    let (mut cache, budget) = acquire_within_budget(&treemap_cache, state.options.timeout).await?;
+    if let Some((computed_at, treemap)) = cache.as_ref()
+        && computed_at.elapsed() < VERSION_CACHE_TTL
+    {
+        return Ok(Json(treemap.clone()));
+    }
+    // A cold treemap builds the same repository-wide clone graph `/api/file/clones` does, so it
+    // queues on the same gate. Lock order is cache then gate, and nothing takes them the other way
+    // round.
+    let clone_graph_gate = state.clone_graph_gate.clone();
+    let (_clone_graph, remaining) = acquire_within_budget(&clone_graph_gate, budget).await?;
+    state.options.timeout = remaining;
+    let treemap =
+        run_db(state, |db, _, cancelled| Ok(db.lens_treemap_with_cancel(cancelled)?)).await?;
+    *cache = Some((Instant::now(), treemap.clone()));
+    Ok(Json(treemap))
+}
+
+async fn file_clones(
+    State(mut state): State<HttpState>,
+    Query(query): Query<FileClonesQuery>,
+) -> Result<Json<rag_rat_core::index::LensFileClones>, ApiError> {
+    let path = query.path.ok_or_else(|| ApiError::bad_query("missing query parameter `path`"))?;
+    validate_relative_path(&path)?;
+    let theta = query.theta.unwrap_or(DEFAULT_THETA);
+    if !theta.is_finite() || !(DEFAULT_THETA..=1.0).contains(&theta) {
+        return Err(ApiError::bad_query("`theta` must be finite and in [0.7, 1.0]"));
+    }
+    let min_tokens = query.min_tokens.unwrap_or(DEFAULT_MIN_TOKENS);
+    if min_tokens < 0 {
+        return Err(ApiError::bad_query("`min_tokens` must be non-negative"));
+    }
+    let case_insensitive = state.options.case_insensitive_paths;
+    // Queue for the clone graph BEFORE taking a database worker. A cache hit costs one vector
+    // scan, so serializing the visible editors' clone lanes here is cheap; letting them queue on
+    // the worker pool instead is what starves every other lane during a cold build.
+    let clone_graph_gate = state.clone_graph_gate.clone();
+    let (_clone_graph, remaining) =
+        acquire_within_budget(&clone_graph_gate, state.options.timeout).await?;
+    state.options.timeout = remaining;
+    run_db(state, move |db, _, cancelled| {
+        let path = canonical_file_path(db, path, case_insensitive)?;
+        Ok(db.lens_file_clones_with_cancel(&path, theta, min_tokens, cancelled)?)
+    })
+    .await
+    .map(Json)
+}
+
+async fn file_symbols(
+    State(state): State<HttpState>,
+    Query(query): Query<FileQuery>,
+) -> Result<Json<rag_rat_core::index::LensFileSymbols>, ApiError> {
+    let path = required_path(query.path)?;
+    let case_insensitive = state.options.case_insensitive_paths;
+    run_db(state, move |db, _, _| {
+        let path = canonical_file_path(db, path, case_insensitive)?;
+        Ok(db.lens_file_symbols(&path)?)
+    })
+    .await
+    .map(Json)
+}
+
+async fn file_graph(
+    State(state): State<HttpState>,
+    Query(query): Query<FileQuery>,
+) -> Result<Json<rag_rat_core::index::LensFileGraph>, ApiError> {
+    let path = required_path(query.path)?;
+    let case_insensitive = state.options.case_insensitive_paths;
+    run_db(state, move |db, _, _| {
+        let path = canonical_file_path(db, path, case_insensitive)?;
+        Ok(db.lens_file_graph(&path)?)
+    })
+    .await
+    .map(Json)
+}
+
+async fn file_coupling(
+    State(state): State<HttpState>,
+    Query(query): Query<FileQuery>,
+) -> Result<Json<rag_rat_core::index::LensFileCoupling>, ApiError> {
+    let path = required_path(query.path)?;
+    let case_insensitive = state.options.case_insensitive_paths;
+    run_db(state, move |db, _, _| {
+        let path = canonical_file_path(db, path, case_insensitive)?;
+        Ok(db.lens_file_coupling(&path)?)
+    })
+    .await
+    .map(Json)
+}
+
+async fn file_memories(
+    State(state): State<HttpState>,
+    Query(query): Query<FileQuery>,
+) -> Result<Json<rag_rat_core::index::LensFileMemories>, ApiError> {
+    let path = required_path(query.path)?;
+    let case_insensitive = state.options.case_insensitive_paths;
+    run_db(state, move |db, _, _| {
+        let path = canonical_file_path(db, path, case_insensitive)?;
+        Ok(db.lens_file_memories(&path)?)
+    })
+    .await
+    .map(Json)
+}
+
+async fn file_papertrail(
+    State(state): State<HttpState>,
+    Query(query): Query<FileQuery>,
+) -> Result<Json<rag_rat_core::index::LensFilePapertrail>, ApiError> {
+    let path = required_path(query.path)?;
+    let case_insensitive = state.options.case_insensitive_paths;
+    run_db(state, move |db, _, _| {
+        let path = canonical_file_path(db, path, case_insensitive)?;
+        Ok(db.lens_file_papertrail(&path)?)
+    })
+    .await
+    .map(Json)
+}
+
+async fn symbol_callers(
+    State(state): State<HttpState>,
+    Query(query): Query<SymbolHopQuery>,
+) -> Result<Json<rag_rat_core::index::LensCallers>, ApiError> {
+    let qname = required_qname(query.qname)?;
+    let limit = hop_limit(query.limit.as_deref());
+    run_db(state, move |db, _, _| Ok(db.lens_symbol_callers(&qname, limit)?)).await.map(Json)
+}
+
+async fn symbol_callees(
+    State(state): State<HttpState>,
+    Query(query): Query<SymbolHopQuery>,
+) -> Result<Json<rag_rat_core::index::LensCallees>, ApiError> {
+    let qname = required_qname(query.qname)?;
+    let limit = hop_limit(query.limit.as_deref());
+    run_db(state, move |db, _, _| Ok(db.lens_symbol_callees(&qname, limit)?)).await.map(Json)
+}
+
+async fn chunk_text(
+    State(state): State<HttpState>,
+    Query(query): Query<ChunkTextQuery>,
+) -> Result<Json<rag_rat_core::index::LensChunkText>, ApiError> {
+    let raw =
+        query.chunk_id.ok_or_else(|| ApiError::bad_query("missing query parameter `chunk_id`"))?;
+    let chunk_id = raw
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| ApiError::bad_query("`chunk_id` must be a positive integer"))?;
+    run_db(state, move |db, _, _| Ok(db.lens_chunk_text(chunk_id)?))
+        .await?
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound("unknown chunk_id".into()))
+}
+
+fn required_path(path: Option<String>) -> Result<String, ApiError> {
+    let path = path.ok_or_else(|| ApiError::bad_query("missing query parameter `path`"))?;
+    validate_relative_path(&path)?;
+    Ok(path)
+}
+
+fn canonical_file_path(
+    db: &IndexDatabase,
+    path: String,
+    case_insensitive: bool,
+) -> anyhow::Result<String> {
+    Ok(db.lens_canonical_file_path(&path, case_insensitive)?.unwrap_or(path))
+}
+
+fn required_qname(qname: Option<String>) -> Result<String, ApiError> {
+    let qname = qname.ok_or_else(|| ApiError::bad_query("missing query parameter `qname`"))?;
+    if qname.is_empty() {
+        return Err(ApiError::bad_query("`qname` must not be empty"));
+    }
+    Ok(qname)
+}
+
+fn hop_limit(raw: Option<&str>) -> u32 {
+    raw.and_then(|value| value.parse::<i64>().ok())
+        .map(|value| value.clamp(i64::from(1), i64::from(MAX_HOP_LIMIT)) as u32)
+        .unwrap_or(DEFAULT_HOP_LIMIT)
+}
+
+fn validate_relative_path(raw: &str) -> Result<(), ApiError> {
+    if raw.is_empty() {
+        return Err(ApiError::bad_query("`path` must not be empty"));
+    }
+    let path = Path::new(raw);
+    if path.components().any(|component| {
+        matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+    }) {
+        return Err(ApiError::bad_query("`path` must be a repository-relative path"));
+    }
+    Ok(())
+}
+
+/// Stops the blocking database task when a request ends WITHOUT reaching its own timeout — the
+/// client disconnected, or the whole request future was dropped. Cancellation is two-sided: the
+/// cooperative flag ends loops between statements, and the SQLite interrupt ends a single long
+/// statement. The interrupt handle is published by the task once it has opened the connection, so
+/// a cancellation that arrives first waits for it on a detached task rather than being lost.
+struct CancelOnDrop {
+    cancelled: Arc<AtomicBool>,
+    interrupt: Option<tokio::sync::oneshot::Receiver<rag_rat_core::index::DatabaseInterruptHandle>>,
+}
+
+impl CancelOnDrop {
+    fn cancel(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+        let Some(mut interrupt) = self.interrupt.take() else { return };
+        match interrupt.try_recv() {
+            Ok(handle) => handle.interrupt(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                // Dropping a request future happens on the runtime, but never assume it: a spawn
+                // outside one panics, and a lost interrupt is better than a panicking drop.
+                if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                    runtime.spawn(async move {
+                        if let Ok(handle) = interrupt.await {
+                            handle.interrupt();
+                        }
+                    });
+                }
+            },
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {},
+        }
+    }
+
+    /// The task finished on its own; there is nothing left to cancel.
+    fn disarm(&mut self) {
+        self.interrupt = None;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.interrupt.is_some() {
+            self.cancel();
+        }
+    }
+}
+
+async fn run_db<T: Send + 'static>(
+    state: HttpState,
+    operation: impl FnOnce(&IndexDatabase, &Config, &AtomicBool) -> Result<T, DbError> + Send + 'static,
+) -> Result<T, ApiError> {
+    let started = Instant::now();
+    let permit = tokio::time::timeout(
+        state.options.timeout,
+        Arc::clone(&state.blocking_workers).acquire_owned(),
+    )
+    .await
+    .map_err(|_| ApiError::Timeout)?
+    .map_err(|_| ApiError::Unavailable("database worker pool is unavailable".into()))?;
+    let Some(run_budget) = state.options.timeout.checked_sub(started.elapsed()) else {
+        return Err(ApiError::Timeout);
+    };
+    let config = state.config;
+    let workspace_root = state.options.workspace_root;
+    let clone_graph_cache = state.clone_graph_cache;
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let task_cancelled = Arc::clone(&cancelled);
+    let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel();
+    let mut handle = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        if !config.database.is_file() {
+            return Err(DbError::Unavailable("index database does not exist".into()));
+        }
+        let mut db = IndexDatabase::try_open_config_read_only(&config)
+            .map_err(DbError::Internal)?
+            .ok_or_else(|| {
+                DbError::Unavailable("index is not ready for read-only access".into())
+            })?;
+        if let Some(workspace_root) = workspace_root.as_deref() {
+            db.use_worktree_scope(&config.root, Some(workspace_root)).map_err(DbError::Internal)?;
+        }
+        db.set_lens_clone_graph_cache(clone_graph_cache);
+        let _ = interrupt_tx.send(db.interrupt_handle());
+        if task_cancelled.load(Ordering::Acquire) {
+            return Err(DbError::Unavailable("database request was cancelled".into()));
+        }
+        operation(&db, &config, &task_cancelled)
+    });
+    // The timeout is not the only way this request ends: axum DROPS the request future when the
+    // client disconnects, and the editor now aborts a file lane the moment an index change makes
+    // its answer irrelevant. Dropping the `JoinHandle` only detaches the blocking task, so without
+    // this guard a repository-wide clone or treemap scan would keep running — holding one of the
+    // two default worker permits — for a reader that has gone away.
+    let mut cancel =
+        CancelOnDrop { cancelled: Arc::clone(&cancelled), interrupt: Some(interrupt_rx) };
+    let deadline = tokio::time::sleep(run_budget);
+    tokio::pin!(deadline);
+    let result = tokio::select! {
+        result = &mut handle => {
+            cancel.disarm();
+            Some(result)
+        },
+        () = &mut deadline => {
+            // `spawn_blocking` aborts only while still queued. Once running, the SQLite interrupt
+            // and cooperative flag stop it; while queued, abort drops the captured permit
+            // immediately instead of starving later requests behind work that never started.
+            cancel.cancel();
+            handle.abort();
+            let _ = tokio::time::timeout(Duration::from_secs(1), &mut handle).await;
+            None
+        },
+    };
+    match result {
+        None => Err(ApiError::Timeout),
+        Some(Err(error)) => {
+            tracing::error!(target: "rag_rat_mcp::http", %error, "database worker failed");
+            Err(ApiError::Internal)
+        },
+        Some(Ok(Err(DbError::Unavailable(message)))) => Err(ApiError::Unavailable(message)),
+        Some(Ok(Err(DbError::Internal(error)))) => {
+            // Expected editor-facing staleness (a chunk whose file was edited or deleted since
+            // the editor cached it) is a 404, not a server failure — editors hold stale chunk ids
+            // after every save, so a 500 + error log per cached id is pure noise.
+            if matches!(
+                error.downcast_ref::<rag_rat_core::index::IndexError>(),
+                Some(
+                    rag_rat_core::index::IndexError::Gone { .. }
+                        | rag_rat_core::index::IndexError::StaleChunk { .. }
+                )
+            ) {
+                return Err(ApiError::NotFound("chunk is stale or its file was deleted".into()));
+            }
+            tracing::error!(target: "rag_rat_mcp::http", %error, "HTTP database read failed");
+            Err(ApiError::Internal)
+        },
+        Some(Ok(Ok(value))) => Ok(value),
+    }
+}
+
+#[derive(Debug)]
+enum DbError {
+    Unavailable(String),
+    Internal(anyhow::Error),
+}
+
+impl From<anyhow::Error> for DbError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Internal(error)
+    }
+}
+
+#[derive(Debug)]
+enum ApiError {
+    BadQuery(String),
+    NotFound(String),
+    Unavailable(String),
+    Timeout,
+    Internal,
+}
+
+impl ApiError {
+    fn bad_query(message: impl Into<String>) -> Self {
+        Self::BadQuery(message.into())
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            Self::BadQuery(message) => (StatusCode::BAD_REQUEST, message),
+            Self::NotFound(message) => (StatusCode::NOT_FOUND, message),
+            Self::Unavailable(message) => (StatusCode::SERVICE_UNAVAILABLE, message),
+            Self::Timeout => (StatusCode::GATEWAY_TIMEOUT, "database request timed out".into()),
+            Self::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".into()),
+        };
+        (status, Json(ErrorResponse { error: message })).into_response()
+    }
+}
+
+#[derive(Deserialize)]
+struct FileClonesQuery {
+    path: Option<String>,
+    theta: Option<f64>,
+    min_tokens: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct FileQuery {
+    path: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SymbolHopQuery {
+    qname: Option<String>,
+    limit: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ChunkTextQuery {
+    chunk_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -1,0 +1,738 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use axum::Json;
+use axum::body::{Body, to_bytes};
+use axum::extract::{Query, State};
+use axum::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, ORIGIN};
+use axum::http::{HeaderValue, Method, Request, StatusCode};
+use axum::response::IntoResponse;
+use futures_util::StreamExt;
+use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
+use rag_rat_base::language::Language;
+use rag_rat_core::IndexDatabase;
+use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::{
+    FileClonesQuery, HttpState, ServeControl, ServeOptions, file_clones, hop_limit, router, run_db,
+    serve,
+};
+
+#[tokio::test]
+async fn serve_control_observes_a_stop_that_precedes_the_waiter() {
+    let control = ServeControl::default();
+    control.stop();
+    tokio::time::timeout(Duration::from_millis(100), control.stopped())
+        .await
+        .expect("a pre-triggered stop must not lose its notification");
+}
+
+#[tokio::test]
+async fn non_loopback_serving_requires_authentication() {
+    let (_root, config) = test_config();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let error = serve(
+        listener,
+        config,
+        ServeOptions::default(),
+        std::future::pending::<std::io::Result<()>>(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+}
+
+#[tokio::test]
+async fn health_is_available_without_opening_the_database() {
+    let (_root, config) = test_config();
+    let response = router(config, ServeOptions::default())
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("access-control-allow-origin").is_none(),
+        "unauthenticated loopback serving must not opt arbitrary browser origins into reading"
+    );
+    assert_eq!(json_body(response).await, serde_json::json!({"status": "ok"}));
+}
+
+#[tokio::test]
+async fn bearer_auth_and_exact_origin_are_enforced() {
+    let (_root, config) = test_config();
+    let app = router(config, ServeOptions {
+        auth_token: Some("test-token".into()),
+        allowed_origins: vec!["https://lens.example".into()],
+        ..ServeOptions::default()
+    });
+
+    let unauthorized = app
+        .clone()
+        .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    let forbidden = app
+        .clone()
+        .oneshot(
+            Request::get("/api/health")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header(ORIGIN, "https://attacker.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+    let allowed = app
+        .oneshot(
+            Request::get("/api/health")
+                .header(AUTHORIZATION, "Bearer test-token")
+                .header(ORIGIN, "https://lens.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(allowed.status(), StatusCode::OK);
+    assert_eq!(
+        allowed.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://lens.example"))
+    );
+}
+
+#[tokio::test]
+async fn an_allowed_origin_sees_cors_headers_on_auth_failure() {
+    let (_root, config) = test_config();
+    let app = router(config, ServeOptions {
+        auth_token: Some("test-token".into()),
+        allowed_origins: vec!["https://lens.example".into()],
+        ..ServeOptions::default()
+    });
+    let response = app
+        .oneshot(
+            Request::get("/api/health")
+                .header(ORIGIN, "https://lens.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://lens.example")),
+        "an allowed origin must read its own 401 instead of an opaque browser CORS error"
+    );
+}
+
+/// A CORS preflight cannot carry the bearer token, so it must be answered BEFORE the auth check
+/// or a browser extension host can never reach the API at all. Chrome additionally blocks a
+/// public page from reaching loopback unless the preflight opts into Private Network Access —
+/// emitted only for an exact-allowlisted origin, never by default.
+#[tokio::test]
+async fn cors_preflight_is_answered_before_auth_and_opts_into_private_network_access() {
+    let (_root, config) = test_config();
+    let app = router(config, ServeOptions {
+        auth_token: Some("test-token".into()),
+        allowed_origins: vec!["https://lens.example".into()],
+        ..ServeOptions::default()
+    });
+    let private_network =
+        axum::http::HeaderName::from_static("access-control-allow-private-network");
+
+    // Allowed origin: answered without a token, with CORS headers and the PNA opt-in.
+    let allowed = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::OPTIONS)
+                .uri("/api/file/memories")
+                .header(ORIGIN, "https://lens.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        allowed.status(),
+        StatusCode::NO_CONTENT,
+        "a preflight carries no credentials and must not 401"
+    );
+    assert_eq!(
+        allowed.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://lens.example"))
+    );
+    assert_eq!(
+        allowed.headers().get(&private_network),
+        Some(&HeaderValue::from_static("true")),
+        "Chrome blocks public-page → loopback without this opt-in"
+    );
+
+    // No origin: still answered, but nothing is opted into.
+    let originless = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::OPTIONS)
+                .uri("/api/file/memories")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(originless.status(), StatusCode::NO_CONTENT);
+    assert!(
+        originless.headers().get(&private_network).is_none(),
+        "a request with no allowed origin must not widen private-network access"
+    );
+
+    // Disallowed origin: refused at the origin gate, ahead of the preflight answer.
+    let forbidden = app
+        .oneshot(
+            Request::builder()
+                .method(Method::OPTIONS)
+                .uri("/api/file/memories")
+                .header(ORIGIN, "https://attacker.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+    assert!(forbidden.headers().get(&private_network).is_none());
+}
+
+#[tokio::test]
+async fn events_emits_the_current_version_as_sse() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn current() {}\n").unwrap();
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let update_config = config.clone();
+
+    let control = ServeControl::default();
+    let response =
+        router(config, ServeOptions { control: control.clone(), ..ServeOptions::default() })
+            .oneshot(Request::get("/api/events").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("text/event-stream"))
+    );
+    let mut body = response.into_body().into_data_stream();
+    let chunk = tokio::time::timeout(Duration::from_secs(5), body.next())
+        .await
+        .expect("initial version event timeout")
+        .expect("SSE body ended")
+        .expect("SSE body error");
+    let event = String::from_utf8(chunk.to_vec()).unwrap();
+    assert!(event.contains("event: version"), "{event}");
+    assert!(event.contains("\"generation\":"), "{event}");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(2_500), body.next()).await.is_err(),
+        "an unchanged version must not emit a duplicate event"
+    );
+    let db = IndexDatabase::open_config(&update_config).unwrap();
+    db.memory_create(RepoMemoryCreate {
+        kind: "Invariant".into(),
+        title: "Refresh the lens".into(),
+        body: "A memory-only write must notify connected clients".into(),
+        confidence: "high".into(),
+        created_by: Some("test".into()),
+        source: None,
+        payload_json: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("src/lib.rs".into()),
+            ..RepoMemoryBindTarget::default()
+        },
+    })
+    .unwrap();
+    drop(db);
+    let memory_change = tokio::time::timeout(Duration::from_secs(5), body.next())
+        .await
+        .expect("memory change event timeout")
+        .expect("SSE body ended")
+        .expect("SSE body error");
+    let memory_change = String::from_utf8(memory_change.to_vec()).unwrap();
+    assert!(memory_change.contains("event: version"), "{memory_change}");
+
+    fs::write(root.join("src/lib.rs"), "pub fn changed() {}\n").unwrap();
+    drop(IndexDatabase::rebuild(&update_config).unwrap());
+    let changed = tokio::time::timeout(Duration::from_secs(5), body.next())
+        .await
+        .expect("changed version event timeout")
+        .expect("SSE body ended")
+        .expect("SSE body error");
+    let changed = String::from_utf8(changed.to_vec()).unwrap();
+    assert!(changed.contains("event: version"), "{changed}");
+    assert_ne!(changed, event, "a changed index emits a new version token");
+    control.stop();
+    let end = tokio::time::timeout(Duration::from_millis(100), body.next())
+        .await
+        .expect("SSE shutdown must not wait for the polling interval");
+    assert!(end.is_none(), "SSE body must end when serving stops");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn events_ends_when_a_version_probe_can_no_longer_open_the_index() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn current() {}\n").unwrap();
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let database = config.database.clone();
+
+    let response = router(config, ServeOptions::default())
+        .oneshot(Request::get("/api/events").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let mut body = response.into_body().into_data_stream();
+    tokio::time::timeout(Duration::from_secs(5), body.next())
+        .await
+        .expect("initial version event timeout")
+        .expect("SSE body ended before its initial version")
+        .expect("SSE body error");
+
+    fs::remove_file(database).unwrap();
+    let end = tokio::time::timeout(Duration::from_secs(5), body.next())
+        .await
+        .expect("failed version probes must close the SSE stream");
+    assert!(end.is_none(), "a failed version probe must disconnect the client");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn clones_rejects_invalid_theta_and_paths() {
+    let (_root, config) = test_config();
+    let app = router(config, ServeOptions::default());
+    for uri in [
+        "/api/file/clones?path=src/a.rs&theta=nan",
+        "/api/file/clones?path=src/a.rs&theta=0.2",
+        "/api/file/clones?path=../secret.rs",
+        "/api/file/clones?path=",
+    ] {
+        let response =
+            app.clone().oneshot(Request::get(uri).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+    }
+}
+
+#[tokio::test]
+async fn new_routes_reject_missing_or_invalid_parameters() {
+    let (_root, config) = test_config();
+    let app = router(config, ServeOptions::default());
+    for uri in [
+        "/api/file/symbols",
+        "/api/file/graph?path=../secret.rs",
+        "/api/file/coupling",
+        "/api/file/memories?path=../secret.rs",
+        "/api/file/papertrail",
+        "/api/symbol/callers",
+        "/api/symbol/callees?qname=",
+        "/api/chunk/text",
+        "/api/chunk/text?chunk_id=nope",
+        "/api/chunk/text?chunk_id=0",
+    ] {
+        let response =
+            app.clone().oneshot(Request::get(uri).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+        assert!(json_body(response).await["error"].is_string(), "{uri}");
+    }
+    assert_eq!(hop_limit(None), 50);
+    assert_eq!(hop_limit(Some("invalid")), 50);
+    assert_eq!(hop_limit(Some("0")), 1);
+    assert_eq!(hop_limit(Some("-9")), 1);
+    assert_eq!(hop_limit(Some("9999")), 500);
+}
+
+#[tokio::test]
+async fn symbol_graph_hops_and_chunk_routes_preserve_endpoint_wrappers() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Req { Upsert { id: i64 } }
+pub fn target(_id: i64) {}
+pub fn caller() { target(1); }
+#[test]
+fn target_test() { target(2); }
+pub fn enqueue() { send(Req::Upsert { id: 3 }); }
+fn send(_req: Req) {}
+pub fn handle(req: Req) {
+    match req { Req::Upsert { id } => target(id) }
+}
+"#,
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let target_qname = db
+        .symbols("target", None, 10)
+        .unwrap()
+        .into_iter()
+        .find(|hit| hit.name == "target")
+        .unwrap()
+        .qualified_name;
+    let caller_qname = db
+        .symbols("caller", None, 10)
+        .unwrap()
+        .into_iter()
+        .find(|hit| hit.name == "caller")
+        .unwrap()
+        .qualified_name;
+    let chunk_id = db
+        .search("caller", 10, false)
+        .unwrap()
+        .into_iter()
+        .find(|hit| hit.symbol_path.as_deref() == Some(caller_qname.as_str()))
+        .unwrap()
+        .chunk_id;
+    drop(db);
+
+    let app = router(config, ServeOptions::default());
+    let symbols = get_json(&app, "/api/file/symbols?path=src/lib.rs").await;
+    let symbol_rows = symbols["symbols"].as_array().unwrap();
+    assert!(symbol_rows.windows(2).all(|pair| {
+        pair[0]["start_line"].as_i64().unwrap() <= pair[1]["start_line"].as_i64().unwrap()
+    }));
+    let target = symbol_rows.iter().find(|row| row["name"] == "target").unwrap();
+    for field in [
+        "name",
+        "qname",
+        "kind",
+        "start_line",
+        "end_line",
+        "is_test",
+        "signature",
+        "fan_in",
+        "fan_out",
+    ] {
+        assert!(target.get(field).is_some(), "missing symbol field {field}: {target}");
+    }
+
+    let graph = get_json(&app, "/api/file/graph?path=src/lib.rs").await;
+    let target =
+        graph["symbols"].as_array().unwrap().iter().find(|row| row["name"] == "target").unwrap();
+    assert!(
+        target["callers"]["exact"].as_u64().unwrap()
+            + target["callers"]["syntactic"].as_u64().unwrap()
+            >= 3
+    );
+    assert!(target["callers"]["tests"].as_u64().unwrap() >= 1);
+    assert!(target["callers"]["dispatch"].as_u64().unwrap() >= 1);
+    assert!(target["fan_in_score"].as_f64().unwrap() >= 2.0);
+    assert!(target["dispatch"].as_array().unwrap().iter().any(|row| row["direction"] == "handled"));
+
+    let coupling = get_json(&app, "/api/file/coupling?path=src/lib.rs").await;
+    assert_eq!(coupling, serde_json::json!({"coupling": []}));
+    let memories = get_json(&app, "/api/file/memories?path=src/lib.rs").await;
+    assert_eq!(memories, serde_json::json!({"memories": []}));
+    let papertrail = get_json(&app, "/api/file/papertrail?path=src/lib.rs").await;
+    assert_eq!(papertrail, serde_json::json!({"refs": [], "decisions": []}));
+
+    let callers =
+        get_json(&app, &format!("/api/symbol/callers?qname={target_qname}&limit=9999")).await;
+    assert!(callers["callers"].as_array().unwrap().iter().any(|row| row["name"] == "caller"));
+    assert!(callers["callers"][0].get("id").is_none());
+    assert!(callers["callers"][0].get("source_file_id").is_none());
+
+    let callees =
+        get_json(&app, &format!("/api/symbol/callees?qname={caller_qname}&limit=invalid")).await;
+    assert!(callees["callees"].as_array().unwrap().iter().any(|row| row["name"] == "target"));
+
+    let chunk = get_json(&app, &format!("/api/chunk/text?chunk_id={chunk_id}")).await;
+    assert_eq!(chunk["chunk_id"], chunk_id);
+    assert!(chunk["text"].as_str().unwrap().contains("target(1)"));
+    let missing = app
+        .clone()
+        .oneshot(
+            Request::get("/api/chunk/text?chunk_id=9223372036854775807")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    assert_eq!(json_body(missing).await, serde_json::json!({"error": "unknown chunk_id"}));
+
+    // A chunk cached before an on-disk edit is expected editor-facing staleness, not a server
+    // failure — it must surface as 404 without an error log, never 500.
+    fs::write(root.join("src/lib.rs"), "pub fn replaced_entirely() {}\n").unwrap();
+    let stale = app
+        .oneshot(
+            Request::get(format!("/api/chunk/text?chunk_id={chunk_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), StatusCode::NOT_FOUND);
+    assert!(
+        json_body(stale).await["error"].as_str().unwrap().contains("stale"),
+        "stale chunk must report as a 404"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn clones_uses_the_native_lens_composition() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(db: Db) -> i32 { let u = db.get(20); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.precompute_clone_graph(None).unwrap();
+    drop(db);
+
+    let app = router(config, ServeOptions {
+        indexed_root: "crate".into(),
+        case_insensitive_paths: true,
+        ..ServeOptions::default()
+    });
+    let status = app
+        .clone()
+        .oneshot(Request::get("/api/status").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status_code = status.status();
+    let status = json_body(status).await;
+    assert_eq!(status_code, StatusCode::OK, "{status}");
+    assert_eq!(status["repo_root"], root.display().to_string());
+    assert_eq!(status["indexed_root"], "crate");
+    // The checkout a hosted client binds itself to: a repository's linked worktrees share one
+    // `repo_id`, so without this the client cannot tell them apart. Compare against the CANONICAL
+    // path, which is what the server derives it from: the platforms that hand a process a
+    // non-canonical temp path — macOS resolving `/var` to `/private/var`, Windows expanding an 8.3
+    // name like `RUNNER~1` — would otherwise fail this on a value that is perfectly correct.
+    assert_eq!(
+        status["worktree_id"],
+        root.canonicalize().unwrap_or_else(|_| root.clone()).display().to_string(),
+    );
+    assert_eq!(status["case_insensitive_paths"], true);
+    assert_eq!(status["live_file_count"], 2);
+
+    let version = app
+        .clone()
+        .oneshot(Request::get("/api/version").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(version.status(), StatusCode::OK);
+    assert!(json_body(version).await["max_indexed_at_ms"].as_i64().unwrap() > 0);
+
+    let treemap = get_json(&app, "/api/treemap").await;
+    assert_eq!(treemap["files"].as_array().unwrap().len(), 2);
+    let first = &treemap["files"][0];
+    for field in [
+        "path",
+        "language",
+        "kind",
+        "loc",
+        "churn_commits",
+        "churn_lines",
+        "fan_in",
+        "fan_out",
+        "dup_partners",
+        "dup_max_similarity",
+        "memories",
+    ] {
+        assert!(first.get(field).is_some(), "missing treemap field {field}: {first}");
+    }
+
+    let response = app
+        .oneshot(
+            Request::get("/api/file/clones?path=SRC/A.RS&theta=0.7&min_tokens=0")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_body(response).await;
+    assert_eq!(body["clone_regions"][0]["symbol"], "load_user");
+    assert_eq!(body["clone_regions"][0]["partners"][0]["path"], "src/b.rs");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn blocking_database_work_obeys_the_timeout() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let options = ServeOptions {
+        timeout: Duration::from_millis(10),
+        blocking_workers: 1,
+        ..ServeOptions::default()
+    };
+    let mut state = HttpState {
+        config,
+        options,
+        blocking_workers: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        clone_graph_cache: std::sync::Arc::default(),
+        version_cache: std::sync::Arc::default(),
+        treemap_cache: std::sync::Arc::default(),
+        clone_graph_gate: std::sync::Arc::default(),
+    };
+    let error = run_db(state.clone(), |db, _, cancelled| {
+        while !cancelled.load(Ordering::Acquire) {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        db.lens_treemap_with_cancel(cancelled)?;
+        Ok(())
+    })
+    .await
+    .unwrap_err();
+    assert_eq!(error.into_response().status(), StatusCode::GATEWAY_TIMEOUT);
+    state.options.timeout = Duration::from_secs(1);
+    run_db(state, |_, _, _| Ok(()))
+        .await
+        .expect("a cooperatively cancelled request must release the sole worker permit");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn dropping_a_request_cancels_its_database_work() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let state = HttpState {
+        config,
+        options: ServeOptions { blocking_workers: 1, ..ServeOptions::default() },
+        blocking_workers: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        clone_graph_cache: std::sync::Arc::default(),
+        version_cache: std::sync::Arc::default(),
+        treemap_cache: std::sync::Arc::default(),
+        clone_graph_gate: std::sync::Arc::default(),
+    };
+    let cancelled_observed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let task_observed = std::sync::Arc::clone(&cancelled_observed);
+    let mut request = Box::pin(run_db(state.clone(), move |_, _, cancelled| {
+        while !cancelled.load(Ordering::Acquire) {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        task_observed.store(true, Ordering::Release);
+        Ok(())
+    }));
+    // Poll far enough for the blocking work to start, then drop the future the way axum drops a
+    // request whose client disconnected — the editor aborts a file lane on every index change.
+    assert!(tokio::time::timeout(Duration::from_millis(250), &mut request).await.is_err());
+    drop(request);
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !cancelled_observed.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("a dropped request must cancel the database work it started");
+    run_db(state, |_, _, _| Ok(()))
+        .await
+        .expect("cancelling the abandoned work releases the sole worker permit");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// A clone read that is waiting its turn at the repository-wide graph must wait OUTSIDE the
+/// database worker pool. Two visible editors are enough to produce two cold clone reads, and if
+/// the loser waits on a worker it holds a permit while doing nothing — starving every independent
+/// graph, memory, coupling, and papertrail lane behind it for the length of the build.
+#[tokio::test]
+async fn a_queued_clone_read_holds_no_database_worker() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let state = HttpState {
+        config,
+        options: ServeOptions {
+            timeout: Duration::from_secs(10),
+            blocking_workers: 1,
+            ..ServeOptions::default()
+        },
+        blocking_workers: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        clone_graph_cache: std::sync::Arc::default(),
+        version_cache: std::sync::Arc::default(),
+        treemap_cache: std::sync::Arc::default(),
+        clone_graph_gate: std::sync::Arc::default(),
+    };
+
+    // Stand in for a cold clone-graph build already in flight.
+    let building = std::sync::Arc::clone(&state.clone_graph_gate).lock_owned().await;
+    let mut queued = Box::pin(file_clones(
+        State(state.clone()),
+        Query(FileClonesQuery { path: Some("src/a.rs".into()), theta: None, min_tokens: None }),
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), &mut queued).await.is_err(),
+        "the second clone read must park behind the in-flight build"
+    );
+
+    // The sole worker is what an independent lane needs, and the parked read must not be holding
+    // it.
+    tokio::time::timeout(Duration::from_secs(5), run_db(state, |_, _, _| Ok(())))
+        .await
+        .expect("a queued clone read must leave the database worker free")
+        .expect("the independent read must succeed while the clone read waits");
+
+    drop(building);
+    let Json(clones) =
+        queued.await.expect("the queued clone read completes once the build releases the graph");
+    assert!(clones.clone_regions.is_empty(), "a one-function corpus has no clone regions");
+    let _ = fs::remove_dir_all(root);
+}
+
+async fn json_body(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn get_json(app: &axum::Router, uri: &str) -> Value {
+    let response =
+        app.clone().oneshot(Request::get(uri).body(Body::empty()).unwrap()).await.unwrap();
+    let status = response.status();
+    let body = json_body(response).await;
+    assert_eq!(status, StatusCode::OK, "{uri}: {body}");
+    body
+}
+
+fn test_config() -> (PathBuf, Config) {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let root = std::env::temp_dir().join(format!(
+        "rag-rat-http-test-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root.clone());
+    config.database_key_pinned = true;
+    config.targets = vec![ResolvedTarget {
+        name: "rust".into(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from("src")],
+        include: vec!["**/*.rs".into()],
+        exclude: Vec::new(),
+        kind: TargetKind::Source,
+    }];
+    (root, config)
+}

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -1,0 +1,1435 @@
+//! Elected Lens HTTP server lifecycle for active MCP and standalone serving.
+
+use std::fs::{self, OpenOptions};
+use std::future::Future;
+use std::io::Write as _;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::ops::RangeInclusive;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::Context as _;
+use rag_rat_base::config::Config;
+use rag_rat_base::locks::FileLock;
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use crate::http::{self, ServeControl, ServeOptions};
+
+const DISCOVERY_SCHEMA: &str = "rag-rat-lens-discovery";
+const DISCOVERY_VERSION: u32 = 1;
+const LENS_PORTS: RangeInclusive<u16> = 18120..=18129;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+struct LensDiscovery {
+    schema: String,
+    version: u32,
+    url: String,
+    host: String,
+    port: u16,
+    pid: u32,
+    repo_id: Option<String>,
+    indexed_root: String,
+    case_insensitive_paths: bool,
+    ownership_token: String,
+}
+
+impl LensDiscovery {
+    fn new(
+        address: SocketAddr,
+        repo_id: Option<String>,
+        indexed_root: String,
+        case_insensitive_paths: bool,
+        ownership_token: String,
+    ) -> Self {
+        let host = address.ip().to_string();
+        let port = address.port();
+        Self {
+            schema: DISCOVERY_SCHEMA.to_string(),
+            version: DISCOVERY_VERSION,
+            url: format!("http://{address}"),
+            host,
+            port,
+            pid: std::process::id(),
+            repo_id,
+            indexed_root,
+            case_insensitive_paths,
+            ownership_token,
+        }
+    }
+}
+
+struct DiscoveryGuard {
+    path: PathBuf,
+    ownership_token: String,
+}
+
+impl DiscoveryGuard {
+    fn publish(path: PathBuf, discovery: &LensDiscovery) -> anyhow::Result<Self> {
+        let case_insensitive = discovery.case_insensitive_paths;
+        refuse_tracked_discovery(&path, case_insensitive)?;
+        prepare_discovery_parent(&path)?;
+        // The discovery file carries a bearer credential. Establish the ignore rule before the
+        // credential exists so a first-run `git add -A` cannot stage it.
+        ignore_sockets_dir(&path, case_insensitive)?;
+        let mut contents = serde_json::to_vec_pretty(discovery)?;
+        contents.push(b'\n');
+        write_atomic(&path, &contents)?;
+        Ok(Self { path, ownership_token: discovery.ownership_token.clone() })
+    }
+}
+
+fn refuse_tracked_discovery(discovery_path: &Path, case_insensitive: bool) -> anyhow::Result<()> {
+    if tracked_runtime_path(discovery_path, case_insensitive)? {
+        anyhow::bail!(
+            "refusing to overwrite tracked lens discovery file {}",
+            discovery_path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Report whether a lens runtime path is tracked in the repository index. `case_insensitive` is
+/// the serving filesystem's own answer, probed at startup: casefolded Linux directories and
+/// network mounts collapse `.RAG-RAT/lens.json` onto the lowercase runtime path exactly like
+/// Windows and macOS do, so the alias lookup cannot be selected by build target. It stays off for
+/// case-sensitive volumes, where a differently-cased tracked file is an unrelated file and
+/// refusing over it would keep Lens from starting.
+fn tracked_runtime_path(path: &Path, case_insensitive: bool) -> anyhow::Result<bool> {
+    let Some(rag_rat_dir) = path
+        .ancestors()
+        .find(|ancestor| ancestor.file_name().is_some_and(|name| name == ".rag-rat"))
+    else {
+        return Ok(false);
+    };
+    let workspace_root = rag_rat_dir.parent().context("lens runtime directory has no workspace")?;
+    let repo = match rag_rat_base::repo_discover::discover_repo(workspace_root) {
+        Ok(repo) => repo,
+        Err(_error) if !workspace_root.join(".git").exists() => return Ok(false),
+        Err(error) =>
+            return Err(anyhow::Error::msg(error.to_string()))
+                .with_context(|| format!("opening Git repository at {}", workspace_root.display())),
+    };
+    let workdir = repo.workdir().context("lens discovery requires a non-bare Git worktree")?;
+    let relative = path.strip_prefix(workdir).with_context(|| {
+        format!(
+            "lens runtime path {} is outside Git worktree {}",
+            path.display(),
+            workdir.display()
+        )
+    })?;
+    let relative = gix::path::to_unix_separators_on_windows(gix::path::into_bstr(relative));
+    let index = repo.index_or_empty()?;
+    if index.entry_by_path(relative.as_ref()).is_some() {
+        return Ok(true);
+    }
+    if !case_insensitive {
+        return Ok(false);
+    }
+    let lookup = index.prepare_icase_backing();
+    Ok(index.entry_by_path_icase(relative.as_ref(), true, &lookup).is_some())
+}
+
+fn prepare_discovery_parent(discovery_path: &Path) -> anyhow::Result<()> {
+    let sockets_dir = discovery_path.parent().context("lens discovery path has no parent")?;
+    let rag_rat_dir = sockets_dir.parent().context("lens sockets path has no parent")?;
+    ensure_real_directory(rag_rat_dir)?;
+    ensure_real_directory(sockets_dir)?;
+    restrict_directory_to_owner(sockets_dir)?;
+    Ok(())
+}
+
+/// Keep the directory that holds the discovery credential readable only by the account running the
+/// server.
+///
+/// A checkout can live anywhere — a shared drive, `C:\projects`, a directory whose ACL a previous
+/// tool widened — and the file inside carries the bearer token for a loopback service every local
+/// account can reach. Inheriting the parent's permissions is therefore not good enough on either
+/// platform; both branches replace them outright.
+fn restrict_directory_to_owner(directory: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        fs::set_permissions(directory, fs::Permissions::from_mode(0o700))?;
+    }
+    #[cfg(windows)]
+    windows_acl::restrict_to_current_user(directory, windows_acl::Inheritance::ToChildren)?;
+    #[cfg(not(any(unix, windows)))]
+    let _ = directory;
+    Ok(())
+}
+
+fn ensure_real_directory(path: &Path) -> anyhow::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            anyhow::bail!("refusing symlinked lens runtime directory {}", path.display())
+        },
+        Ok(metadata) if !metadata.is_dir() => {
+            anyhow::bail!("lens runtime path is not a directory: {}", path.display())
+        },
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound =>
+            fs::create_dir(path).with_context(|| format!("creating {}", path.display())),
+        Err(error) => Err(error).with_context(|| format!("inspecting {}", path.display())),
+    }
+}
+
+fn ignore_sockets_dir(discovery_path: &Path, case_insensitive: bool) -> anyhow::Result<()> {
+    let Some(rag_rat_dir) = discovery_path.parent().and_then(Path::parent) else {
+        return Ok(());
+    };
+    let gitignore = rag_rat_dir.join(".gitignore");
+    if fs::symlink_metadata(&gitignore).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        anyhow::bail!("refusing symlinked lens ignore file {}", gitignore.display());
+    }
+    let existing = match fs::read_to_string(&gitignore) {
+        Ok(existing) => existing,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(error).with_context(|| format!("reading {}", gitignore.display()));
+        },
+    };
+    // Keep the protective rules last: later negations must not make either the generated ignore
+    // file or the credential stageable.
+    let last_rules = existing
+        .lines()
+        .map(str::trim)
+        .rev()
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .take(2)
+        .collect::<Vec<_>>();
+    let sockets_last = last_rules
+        .first()
+        .is_some_and(|line| *line == "sockets/" || *line == "/sockets/" || *line == "sockets");
+    let ignore_file_before_it =
+        last_rules.get(1).is_some_and(|line| *line == ".gitignore" || *line == "/.gitignore");
+    if sockets_last && ignore_file_before_it {
+        return Ok(());
+    }
+    let mut updated = existing;
+    if !updated.is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated.push_str("/.gitignore\nsockets/\n");
+    if tracked_runtime_path(&gitignore, case_insensitive)? {
+        anyhow::bail!("refusing to modify tracked lens ignore file {}", gitignore.display());
+    }
+    fs::write(&gitignore, updated)?;
+    Ok(())
+}
+
+impl Drop for DiscoveryGuard {
+    fn drop(&mut self) {
+        let owned = fs::read(&self.path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<LensDiscovery>(&bytes).ok())
+            .is_some_and(|discovery| discovery.ownership_token == self.ownership_token);
+        if owned {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub struct LensServerHandle {
+    control: ServeControl,
+    _task: JoinHandle<()>,
+}
+
+impl Drop for LensServerHandle {
+    fn drop(&mut self) {
+        self.control.stop();
+    }
+}
+
+pub(crate) fn spawn(config: Config) -> Option<LensServerHandle> {
+    if std::env::var_os("RAG_RAT_NO_LENS").is_some() {
+        return None;
+    }
+    let control = ServeControl::default();
+    let task_control = control.clone();
+    let task = tokio::spawn(async move {
+        // A persistent startup failure (uncreatable locks dir, busy port range) must not warn
+        // once per second forever: back off exponentially up to a minute and reset on success.
+        let mut retry_after_ms = 1_000_u64;
+        loop {
+            if task_control.is_stopping() {
+                return;
+            }
+            match run(config.clone(), task_control.clone()).await {
+                Ok(()) => retry_after_ms = 1_000,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "rag_rat_mcp::lens_server",
+                        %error,
+                        retry_after_ms,
+                        "lens HTTP server unavailable; retrying while MCP continues"
+                    );
+                    tokio::select! {
+                        () = task_control.stopped() => return,
+                        () = tokio::time::sleep(std::time::Duration::from_millis(retry_after_ms)) => {},
+                    }
+                    retry_after_ms = (retry_after_ms * 2).min(60_000);
+                },
+            }
+        }
+    });
+    Some(LensServerHandle { control, _task: task })
+}
+
+async fn run(config: Config, control: ServeControl) -> anyhow::Result<()> {
+    run_on_ports(config, LENS_PORTS, control).await
+}
+
+async fn run_on_ports(
+    config: Config,
+    ports: impl IntoIterator<Item = u16>,
+    control: ServeControl,
+) -> anyhow::Result<()> {
+    let workspace_root = workspace_root(&config);
+    let lock_path = rag_rat_base::locks::lens_server_lock_path_for(&config, &workspace_root);
+    let mut election_logged = false;
+    let _election_lock = loop {
+        if let Some(lock) = FileLock::try_acquire(&lock_path)? {
+            break lock;
+        }
+        if !election_logged {
+            election_logged = true;
+            tracing::info!(
+                target: "rag_rat_mcp::lens_server",
+                "another process owns the lens election for this worktree; standing by"
+            );
+        }
+        tokio::select! {
+            () = control.stopped() => return Ok(()),
+            () = tokio::time::sleep(std::time::Duration::from_millis(250)) => {},
+        }
+    };
+
+    let db = rag_rat_core::IndexDatabase::open_config(&config)?;
+    db.materialize_lens_coupling()?;
+    drop(db);
+    let listener = bind_first_free(ports).await?;
+    let ownership_token = ownership_token()?;
+    let repo_id = rag_rat_base::repo_identity::resolve_repo_identity(
+        &config.root,
+        config.repo_id_override.as_deref(),
+    )
+    .ok()
+    .map(|identity| identity.repo_id);
+    let indexed_root = indexed_root_relative(&config, &workspace_root)?;
+    let discovery = LensDiscovery::new(
+        listener.local_addr()?,
+        repo_id,
+        indexed_root,
+        path_case_insensitive(&workspace_root),
+        ownership_token.clone(),
+    );
+    let discovery_path = lens_discovery_path(&workspace_root);
+    let _discovery = DiscoveryGuard::publish(discovery_path.clone(), &discovery)
+        .with_context(|| format!("publishing lens discovery at {}", discovery_path.display()))?;
+
+    tracing::info!(
+        target: "rag_rat_mcp::lens_server",
+        url = %discovery.url,
+        discovery = %discovery_path.display(),
+        "lens HTTP server listening"
+    );
+    let origins = origins_from_env()?;
+    let options = ServeOptions {
+        workspace_root: Some(workspace_root),
+        indexed_root: discovery.indexed_root.clone(),
+        case_insensitive_paths: discovery.case_insensitive_paths,
+        auth_token: Some(ownership_token),
+        allowed_origins: origins,
+        control: control.clone(),
+        ..ServeOptions::default()
+    };
+    let shutdown_control = control.clone();
+    http::serve(listener, config, options, async move {
+        shutdown_control.stopped().await;
+        Ok(())
+    })
+    .await
+    .context("serving lens HTTP API")
+}
+
+pub async fn serve_standalone(
+    config: Config,
+    workspace_root: PathBuf,
+    address: SocketAddr,
+    auth_token: String,
+    allowed_origins: Vec<String>,
+    election_lock: FileLock,
+    shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
+) -> anyhow::Result<()> {
+    // The caller acquires the election lock before any side effects (index heal, watcher) so a
+    // contended worktree fails fast.
+    let _election_lock = election_lock;
+    let db = rag_rat_core::IndexDatabase::open_config(&config)?;
+    db.materialize_lens_coupling()?;
+    drop(db);
+    let listener = TcpListener::bind(address).await?;
+    let repo_id = rag_rat_base::repo_identity::resolve_repo_identity(
+        &config.root,
+        config.repo_id_override.as_deref(),
+    )
+    .ok()
+    .map(|identity| identity.repo_id);
+    let indexed_root = indexed_root_relative(&config, &workspace_root)?;
+    let discovery = LensDiscovery::new(
+        listener.local_addr()?,
+        repo_id,
+        indexed_root,
+        path_case_insensitive(&workspace_root),
+        auth_token.clone(),
+    );
+    // Only loopback standalone serving publishes discovery: a non-loopback bind advertises an
+    // address the extension refuses to dial, and the file would carry the hosted bearer token
+    // into a workspace file it could be committed from.
+    let _discovery = if listener.local_addr()?.ip().is_loopback() {
+        Some(DiscoveryGuard::publish(lens_discovery_path(&workspace_root), &discovery)?)
+    } else {
+        eprintln!(
+            "non-loopback serve is plain HTTP — terminate TLS in a trusted reverse proxy; no \
+             workspace discovery file published"
+        );
+        None
+    };
+    eprintln!("rag-rat serve listening on {}", discovery.url);
+    let control = ServeControl::default();
+    let options = ServeOptions {
+        workspace_root: Some(workspace_root),
+        indexed_root: discovery.indexed_root.clone(),
+        case_insensitive_paths: discovery.case_insensitive_paths,
+        auth_token: Some(auth_token),
+        allowed_origins,
+        control: control.clone(),
+        ..ServeOptions::default()
+    };
+    http::serve(listener, config, options, shutdown).await?;
+    Ok(())
+}
+
+fn lens_runtime_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".rag-rat").join("sockets")
+}
+
+fn lens_discovery_path(workspace_root: &Path) -> PathBuf {
+    lens_runtime_dir(workspace_root).join("lens.json")
+}
+
+fn indexed_root_relative(config: &Config, workspace_root: &Path) -> anyhow::Result<String> {
+    let active_root = config
+        .source_root_reanchored_from
+        .as_deref()
+        .filter(|root| root.starts_with(workspace_root));
+    let relative = active_root
+        .and_then(|root| root.strip_prefix(workspace_root).ok())
+        .or_else(|| {
+            let repo = rag_rat_base::repo_discover::discover_repo(&config.root).ok()?;
+            config.root.strip_prefix(repo.workdir()?).ok()
+        })
+        .or_else(|| config.root.strip_prefix(workspace_root).ok())
+        .with_context(|| {
+            format!(
+                "indexed root {} is not within worktree {}",
+                config.root.display(),
+                workspace_root.display()
+            )
+        })?;
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) =>
+                parts.push(part.to_str().with_context(|| {
+                    format!("indexed root is not UTF-8: {}", relative.display())
+                })?),
+            Component::CurDir => {},
+            _ => anyhow::bail!("indexed root is not worktree-relative: {}", relative.display()),
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+fn path_case_insensitive(path: &Path) -> bool {
+    let Ok(canonical) = path.canonicalize() else { return false };
+    if path_has_case_alias(&canonical) {
+        return true;
+    }
+    let Ok(entries) = canonical.read_dir() else { return false };
+    entries.filter_map(Result::ok).any(|entry| path_has_case_alias(&entry.path()))
+}
+
+fn path_has_case_alias(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else { return false };
+    let mut toggled = name.as_bytes().to_vec();
+    let Some(index) = toggled.iter().position(u8::is_ascii_alphabetic) else { return false };
+    toggled[index] = if toggled[index].is_ascii_lowercase() {
+        toggled[index].to_ascii_uppercase()
+    } else {
+        toggled[index].to_ascii_lowercase()
+    };
+    let Ok(toggled) = String::from_utf8(toggled) else { return false };
+    let Ok(canonical) = path.canonicalize() else { return false };
+    path.parent()
+        .and_then(|parent| parent.join(toggled).canonicalize().ok())
+        .is_some_and(|alias| alias == canonical)
+}
+
+async fn bind_first_free(ports: impl IntoIterator<Item = u16>) -> anyhow::Result<TcpListener> {
+    let mut last_error = None;
+    for port in ports {
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        match TcpListener::bind(address).await {
+            Ok(listener) => return Ok(listener),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .await
+        .map_err(|error| {
+            last_error.map(anyhow::Error::from).unwrap_or_else(|| anyhow::Error::from(error))
+        })
+        .context("binding a loopback lens port")
+}
+
+pub fn ownership_token() -> anyhow::Result<String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| anyhow::anyhow!("generating lens ownership token: {error}"))?;
+    let mut token = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(token, "{byte:02x}");
+    }
+    Ok(token)
+}
+
+/// The worktree where discovery, election keys, and source scoping anchor: the reanchored linked
+/// worktree when config resolution recorded one; else the LAUNCHING linked worktree when the
+/// process cwd is a sibling of `config.root`'s repo (a config-less branch worktree nested under
+/// the main checkout — the election must never collide with main's); else the git worktree TOP
+/// (so a subdir-rooted `[index] root` still publishes where the extension probes); else the
+/// config root in non-git trees.
+pub fn workspace_root(config: &Config) -> PathBuf {
+    if let Some(reanchored) = config.source_root_reanchored_from.clone() {
+        return rag_rat_base::repo_discover::discover_repo(&reanchored)
+            .ok()
+            .and_then(|repo| repo.workdir().map(Path::to_path_buf))
+            .unwrap_or(reanchored);
+    }
+    if let Ok(cwd) = std::env::current_dir()
+        && let Some(linked) = validated_linked_worktree(&config.root, &cwd)
+    {
+        return linked;
+    }
+    rag_rat_base::repo_discover::discover_repo(&config.root)
+        .ok()
+        .and_then(|repo| repo.workdir().map(Path::to_path_buf))
+        .unwrap_or_else(|| config.root.clone())
+}
+
+/// `candidate` is a LINKED worktree (its per-worktree git dir differs from the common dir) of the
+/// same repository as `root`. Mirrors `git_context::validated_sibling_worktree` — a main worktree,
+/// a foreign repo, or an unreadable path returns `None` so the caller falls back to base scope
+/// rather than serving the wrong repo.
+fn validated_linked_worktree(root: &Path, candidate: &Path) -> Option<PathBuf> {
+    let repo = rag_rat_base::repo_discover::discover_repo(candidate).ok()?;
+    let git_dir = repo.git_dir().canonicalize().ok()?;
+    let common_dir = repo.common_dir().canonicalize().ok()?;
+    if git_dir == common_dir {
+        return None;
+    }
+    let root_common =
+        rag_rat_base::repo_discover::discover_repo(root).ok()?.common_dir().canonicalize().ok()?;
+    if common_dir != root_common {
+        return None;
+    }
+    repo.workdir().map(Path::to_path_buf)
+}
+
+fn origins_from_env() -> anyhow::Result<Vec<String>> {
+    match std::env::var("RAG_RAT_LENS_ORIGINS") {
+        Ok(value) => parse_lens_origins(&value),
+        Err(_) => Ok(Vec::new()),
+    }
+}
+
+/// Parse the comma-separated browser-origin allowlist. Split out from the environment read so the
+/// rules that decide which origins may reach the API are testable without mutating process-global
+/// state — one entry that fails to canonicalize rejects the whole list rather than being dropped,
+/// which is what keeps a typo from silently narrowing the allowlist instead of failing startup.
+fn parse_lens_origins(value: &str) -> anyhow::Result<Vec<String>> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(canonical_lens_origin)
+        .collect()
+}
+
+fn canonical_lens_origin(raw: &str) -> anyhow::Result<String> {
+    let parsed = url::Url::parse(raw)
+        .with_context(|| format!("invalid origin in RAG_RAT_LENS_ORIGINS: `{raw}`"))?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.path() != "/"
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        anyhow::bail!("invalid origin in RAG_RAT_LENS_ORIGINS: `{raw}`");
+    }
+    Ok(parsed.origin().ascii_serialization())
+}
+
+/// Owner-only file permissions on Windows, where there is no `chmod`.
+///
+/// Unix keeps the discovery credential private with mode bits. Windows has only the ACL, and a new
+/// file inherits its parent's — so on a shared drive, a widened `C:\projects`, or any directory a
+/// previous tool opened up, the bearer token for a loopback service every local account can reach
+/// would be readable by all of them. This replaces the inherited permissions with a *protected*
+/// DACL naming exactly one trustee: the account running the server.
+#[cfg(windows)]
+mod windows_acl {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::path::Path;
+
+    use anyhow::Context as _;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_SUCCESS, HANDLE, LocalFree, WIN32_ERROR,
+    };
+    use windows_sys::Win32::Security::Authorization::{
+        EXPLICIT_ACCESS_W, GRANT_ACCESS, NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, SetEntriesInAclW,
+        SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+    };
+    use windows_sys::Win32::Security::{
+        ACE_FLAGS, ACL, DACL_SECURITY_INFORMATION, GetTokenInformation, NO_INHERITANCE,
+        PROTECTED_DACL_SECURITY_INFORMATION, SUB_CONTAINERS_AND_OBJECTS_INHERIT, TOKEN_QUERY,
+        TOKEN_USER, TokenUser,
+    };
+    use windows_sys::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    /// Whether the granted access also seeds what the directory's children inherit.
+    #[derive(Clone, Copy)]
+    pub(super) enum Inheritance {
+        /// For the credential file itself: the ACE governs this object and nothing else.
+        None,
+        /// For the directory: files and subdirectories created inside start owner-only too.
+        ToChildren,
+    }
+
+    impl Inheritance {
+        fn flags(self) -> ACE_FLAGS {
+            match self {
+                Self::None => NO_INHERITANCE,
+                Self::ToChildren => SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+            }
+        }
+    }
+
+    /// A borrowed process token, closed on every exit path.
+    struct ProcessToken(HANDLE);
+
+    impl Drop for ProcessToken {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` came from a successful `OpenProcessToken` and is closed once.
+            unsafe { CloseHandle(self.0) };
+        }
+    }
+
+    /// An ACL allocated by `SetEntriesInAclW`, which the caller must release with `LocalFree`.
+    struct LocalAcl(*mut ACL);
+
+    impl Drop for LocalAcl {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: `SetEntriesInAclW` allocates with `LocalAlloc`, so this is the matching
+                // free, performed once.
+                unsafe { LocalFree(self.0.cast()) };
+            }
+        }
+    }
+
+    pub(super) fn restrict_to_current_user(
+        path: &Path,
+        inheritance: Inheritance,
+    ) -> anyhow::Result<()> {
+        let token = open_process_token(path)?;
+        // `TOKEN_USER` carries its SID inline, so its size is only known after asking.
+        let user = token_user(&token, path)?;
+        // SAFETY: `user` holds a well-formed `TOKEN_USER` written by `GetTokenInformation`, so its
+        // prefix is a valid `TOKEN_USER`. Reading it out copies the struct; the `Sid` it carries
+        // still points into `user`, which outlives every use below.
+        let sid = unsafe { user.as_ptr().cast::<TOKEN_USER>().read_unaligned().User.Sid };
+
+        let access = EXPLICIT_ACCESS_W {
+            grfAccessPermissions: FILE_ALL_ACCESS,
+            grfAccessMode: GRANT_ACCESS,
+            grfInheritance: inheritance.flags(),
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_USER,
+                ptstrName: sid.cast(),
+            },
+        };
+
+        // A null `oldacl` builds the ACL from this one entry alone rather than merging it into
+        // whatever the object already carries — the point is to drop the inherited grants, not to
+        // add ours alongside them.
+        let mut acl: *mut ACL = std::ptr::null_mut();
+        // SAFETY: one entry is described by `access`, whose SID stays alive in `user` for the
+        // duration of the call; `acl` receives a fresh `LocalAlloc` allocation on success.
+        let status = unsafe { SetEntriesInAclW(1, &access, std::ptr::null(), &mut acl) };
+        let acl = LocalAcl(acl);
+        check(status, path, "building the owner-only permissions for")?;
+
+        let wide = wide_path(path);
+        // `PROTECTED_DACL_SECURITY_INFORMATION` is the load-bearing flag: without it the parent's
+        // inheritable grants are re-applied on top of ours and the file stays readable.
+        // SAFETY: `wide` is NUL-terminated and outlives the call; `acl.0` is the ACL just built;
+        // the owner, group, and SACL pointers are null because only the DACL is being replaced.
+        let status = unsafe {
+            SetNamedSecurityInfoW(
+                wide.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                acl.0,
+                std::ptr::null(),
+            )
+        };
+        check(status, path, "applying owner-only permissions to")
+    }
+
+    fn open_process_token(path: &Path) -> anyhow::Result<ProcessToken> {
+        let mut handle: HANDLE = std::ptr::null_mut();
+        // SAFETY: the pseudo-handle from `GetCurrentProcess` needs no cleanup, and
+        // `OpenProcessToken` writes a real handle through `handle` when it reports success.
+        let opened = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle) };
+        if opened == 0 {
+            return Err(std::io::Error::last_os_error()).with_context(|| {
+                format!("reading this process's identity to secure {}", path.display())
+            });
+        }
+        Ok(ProcessToken(handle))
+    }
+
+    fn token_user(token: &ProcessToken, path: &Path) -> anyhow::Result<Vec<u8>> {
+        let mut needed = 0u32;
+        // SAFETY: a null buffer of length zero is the documented size probe; it fails with
+        // `ERROR_INSUFFICIENT_BUFFER` and writes the required length through `needed`.
+        unsafe { GetTokenInformation(token.0, TokenUser, std::ptr::null_mut(), 0, &mut needed) };
+        let mut buffer = vec![0u8; needed.max(1) as usize];
+        // SAFETY: `buffer` is at least `needed` bytes, which is what the probe above asked for.
+        let read = unsafe {
+            GetTokenInformation(token.0, TokenUser, buffer.as_mut_ptr().cast(), needed, &mut needed)
+        };
+        if read == 0 {
+            return Err(std::io::Error::last_os_error()).with_context(|| {
+                format!("reading this process's identity to secure {}", path.display())
+            });
+        }
+        Ok(buffer)
+    }
+
+    /// Fail closed: a credential we could not lock down must not be published. Callers surface
+    /// this as a startup error rather than serving a token any local account can read.
+    fn check(status: WIN32_ERROR, path: &Path, doing: &str) -> anyhow::Result<()> {
+        if status == ERROR_SUCCESS {
+            return Ok(());
+        }
+        Err(std::io::Error::from_raw_os_error(status as i32))
+            .with_context(|| format!("{doing} {}", path.display()))
+    }
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    /// What the object's DACL actually says, for tests: a call that reports success is not
+    /// evidence that the inherited grants are gone.
+    #[cfg(test)]
+    pub(super) struct AppliedDacl {
+        /// How many trustees the object grants access to. Owner-only means exactly one.
+        pub(super) ace_count: u32,
+        /// Whether inheritance from the parent directory is blocked. Without this the parent's
+        /// grants are re-applied on top and the credential stays readable.
+        pub(super) protected: bool,
+    }
+
+    #[cfg(test)]
+    pub(super) fn applied_dacl(path: &Path) -> anyhow::Result<AppliedDacl> {
+        use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+        use windows_sys::Win32::Security::{
+            ACL_SIZE_INFORMATION, AclSizeInformation, GetAclInformation,
+            GetSecurityDescriptorControl, PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+        };
+
+        let wide = wide_path(path);
+        let mut dacl: *mut ACL = std::ptr::null_mut();
+        let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        // SAFETY: `wide` is NUL-terminated; the owner/group/SACL outputs are null because only the
+        // DACL was asked for. On success `descriptor` owns the returned `dacl`.
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                wide.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut dacl,
+                std::ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        let descriptor = LocalAcl(descriptor.cast());
+        check(status, path, "reading the applied permissions of")?;
+
+        let mut sizes = ACL_SIZE_INFORMATION::default();
+        // SAFETY: `dacl` points inside the live `descriptor`, and `sizes` is the layout
+        // `AclSizeInformation` writes.
+        let read = unsafe {
+            GetAclInformation(
+                dacl,
+                std::ptr::from_mut(&mut sizes).cast(),
+                u32::try_from(std::mem::size_of::<ACL_SIZE_INFORMATION>())?,
+                AclSizeInformation,
+            )
+        };
+        anyhow::ensure!(read != 0, "reading the ACE count of {}", path.display());
+
+        let mut control = 0u16;
+        let mut revision = 0u32;
+        // SAFETY: `descriptor.0` is the live descriptor returned above.
+        let read = unsafe {
+            GetSecurityDescriptorControl(descriptor.0.cast(), &mut control, &mut revision)
+        };
+        anyhow::ensure!(read != 0, "reading the descriptor control of {}", path.display());
+
+        Ok(AppliedDacl { ace_count: sizes.AceCount, protected: control & SE_DACL_PROTECTED != 0 })
+    }
+}
+
+static TEMP_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Atomically publish `contents` at `path` via a fully-synced sibling temp file + rename. The
+/// temp name must carry NO secret (the bearer token lives only in the file's contents): the
+/// parent dirs are world-listable under a default umask and crash residue must not leak it.
+fn write_atomic(path: &Path, contents: &[u8]) -> anyhow::Result<()> {
+    let parent = path.parent().filter(|parent| !parent.as_os_str().is_empty());
+    if let Some(parent) = parent {
+        fs::create_dir_all(parent)?;
+        // The discovery dir holds a bearer credential file; keep it owner-only like the file.
+        restrict_directory_to_owner(parent)?;
+    }
+    let dir = parent.unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().map(|name| name.to_string_lossy()).unwrap_or_default();
+    let sequence = TEMP_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let temp = dir.join(format!(".{file_name}.{}.{sequence}.tmp", std::process::id()));
+
+    let write_result = (|| -> anyhow::Result<()> {
+        let mut options = OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temp)?;
+        // Lock the credential down BEFORE its bytes exist. On Unix the open mode already did it;
+        // on Windows the fresh file carries whatever it inherited, so replace that outright rather
+        // than trusting the directory ACE set above to have been inherited.
+        #[cfg(windows)]
+        windows_acl::restrict_to_current_user(&temp, windows_acl::Inheritance::None)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp);
+        return Err(error);
+    }
+    #[cfg(windows)]
+    if path.exists() {
+        // `std::fs::rename` cannot replace an existing destination on Windows. The election lock
+        // proves there is no live cooperating owner, so remove only the crash-stale artifact;
+        // publication itself remains a rename of the fully-synced sibling temp file.
+        fs::remove_file(path)?;
+    }
+    if let Err(error) = fs::rename(&temp, path) {
+        let _ = fs::remove_file(&temp);
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_dir() -> PathBuf {
+        let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir()
+            .join(format!("rag-rat-lens-server-test-{}-{sequence}", std::process::id()));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn discovery_serializes_and_publishes_atomically() {
+        let root = temp_dir();
+        let path = root.join("sockets/lens.json");
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            Some("repo-1".into()),
+            "crate".into(),
+            true,
+            "owner-1".into(),
+        );
+        let guard = DiscoveryGuard::publish(path.clone(), &discovery).unwrap();
+
+        let decoded: LensDiscovery = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(decoded, discovery);
+        assert_eq!(decoded.schema, DISCOVERY_SCHEMA);
+        assert_eq!(decoded.version, DISCOVERY_VERSION);
+        assert_eq!(decoded.indexed_root, "crate");
+        assert!(decoded.case_insensitive_paths);
+        assert_eq!(fs::read_to_string(root.join(".gitignore")).unwrap(), "/.gitignore\nsockets/\n");
+        // The file holds a bearer token for a loopback service every local account can reach, so
+        // neither platform may leave it at whatever the checkout's directory happened to grant.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+        }
+        #[cfg(windows)]
+        for secured in [path.as_path(), path.parent().unwrap()] {
+            let dacl = windows_acl::applied_dacl(secured).unwrap();
+            assert_eq!(
+                dacl.ace_count,
+                1,
+                "{} must grant access to exactly one trustee",
+                secured.display()
+            );
+            assert!(
+                dacl.protected,
+                "{} must block the parent directory's inherited grants",
+                secured.display()
+            );
+        }
+        let residue: Vec<_> = fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path() != path)
+            .collect();
+        assert!(residue.is_empty(), "atomic publish left temp files behind: {residue:?}");
+
+        drop(guard);
+        assert!(!path.exists(), "owned discovery should be removed on cleanup");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn discovery_ignore_rule_wins_over_existing_negations() {
+        let root = temp_dir();
+        fs::write(root.join(".gitignore"), "sockets/\n!sockets/\n!sockets/lens.json\n").unwrap();
+        let path = root.join("sockets/lens.json");
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "owner-1".into(),
+        );
+        let guard = DiscoveryGuard::publish(path, &discovery).unwrap();
+
+        assert!(
+            fs::read_to_string(root.join(".gitignore"))
+                .unwrap()
+                .ends_with("/.gitignore\nsockets/\n")
+        );
+        drop(guard);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn discovery_does_not_dirty_a_clean_repository() {
+        let root = temp_dir();
+        let status = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let path = root.join(".rag-rat/sockets/lens.json");
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "owner-1".into(),
+        );
+
+        let guard = DiscoveryGuard::publish(path, &discovery).unwrap();
+        drop(guard);
+
+        let output = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty(), "discovery dirtied the repository");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn environment_origins_are_canonicalized_like_cli_origins() {
+        assert_eq!(
+            canonical_lens_origin("HTTPS://Lens.Example:443/").unwrap(),
+            "https://lens.example"
+        );
+        assert!(canonical_lens_origin("https://lens.example/path").is_err());
+    }
+
+    #[test]
+    fn the_origin_allowlist_canonicalizes_every_entry_or_rejects_the_list() {
+        assert_eq!(
+            parse_lens_origins("HTTPS://Lens.Example:443/ , https://vscode.dev").unwrap(),
+            vec!["https://lens.example".to_string(), "https://vscode.dev".to_string()],
+            "entries are trimmed and canonicalized independently"
+        );
+        assert_eq!(parse_lens_origins("").unwrap(), Vec::<String>::new());
+        assert_eq!(
+            parse_lens_origins(" , ,, ").unwrap(),
+            Vec::<String>::new(),
+            "separator noise is not an origin"
+        );
+        // Fail the whole list, not just the bad entry: silently dropping one would narrow the
+        // allowlist at startup and present as an unexplained CORS failure much later.
+        assert!(parse_lens_origins("https://lens.example,https://lens.example/path").is_err());
+        assert!(parse_lens_origins("https://lens.example,not a url").is_err());
+    }
+
+    #[test]
+    fn discovery_refuses_to_modify_a_tracked_runtime_ignore_file() {
+        let root = temp_dir();
+        let path = root.join(".rag-rat/sockets/lens.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let gitignore = root.join(".rag-rat/.gitignore");
+        fs::write(&gitignore, "existing-rule\n").unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = std::process::Command::new("git")
+            .args(["add", ".rag-rat/.gitignore"])
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "owner-1".into(),
+        );
+
+        let error = match DiscoveryGuard::publish(path, &discovery) {
+            Ok(_) => panic!("tracked runtime ignore file was modified"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("tracked lens ignore file"), "{error}");
+        assert_eq!(fs::read_to_string(gitignore).unwrap(), "existing-rule\n");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn discovery_refuses_to_overwrite_a_tracked_credential_path() {
+        let root = temp_dir();
+        let path = root.join(".rag-rat/sockets/lens.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "tracked placeholder\n").unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = std::process::Command::new("git")
+            .args(["add", ".rag-rat/sockets/lens.json"])
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "owner-1".into(),
+        );
+
+        let error = match DiscoveryGuard::publish(path.clone(), &discovery) {
+            Ok(_) => panic!("tracked discovery path was overwritten"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("tracked lens discovery file"), "{error}");
+        assert_eq!(fs::read_to_string(path).unwrap(), "tracked placeholder\n");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn discovery_refuses_a_case_aliased_tracked_credential_path() {
+        let root = temp_dir();
+        let tracked_path = track_case_aliased_credential(&root);
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            // A case-insensitive filesystem — casefolded Linux and network mounts included, not
+            // only Windows and macOS — resolves this tracked spelling onto the lowercase path.
+            true,
+            "owner-1".into(),
+        );
+
+        let error =
+            match DiscoveryGuard::publish(root.join(".rag-rat/sockets/lens.json"), &discovery) {
+                Ok(_) => panic!("case-aliased tracked discovery path was overwritten"),
+                Err(error) => error.to_string(),
+            };
+        assert!(error.contains("tracked lens discovery file"), "{error}");
+        assert_eq!(fs::read_to_string(tracked_path).unwrap(), "tracked placeholder\n");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn case_sensitive_serving_publishes_beside_a_differently_cased_tracked_path() {
+        let root = temp_dir();
+        let tracked_path = track_case_aliased_credential(&root);
+        if path_case_insensitive(&root) {
+            // The alias is literally the same file here, so there is nothing to publish beside.
+            let _ = fs::remove_dir_all(root);
+            return;
+        }
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "owner-1".into(),
+        );
+
+        let path = root.join(".rag-rat/sockets/lens.json");
+        let guard = DiscoveryGuard::publish(path.clone(), &discovery)
+            .expect("an unrelated tracked spelling must not block a case-sensitive worktree");
+        assert!(path.exists());
+        assert_eq!(fs::read_to_string(tracked_path).unwrap(), "tracked placeholder\n");
+        drop(guard);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    /// Track `.rag-rat/sockets/Lens.json` in a fresh repository and return its path.
+    fn track_case_aliased_credential(root: &Path) -> PathBuf {
+        let tracked_path = root.join(".rag-rat/sockets/Lens.json");
+        fs::create_dir_all(tracked_path.parent().unwrap()).unwrap();
+        fs::write(&tracked_path, "tracked placeholder\n").unwrap();
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "--quiet"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            std::process::Command::new("git")
+                .args(["add", ".rag-rat/sockets/Lens.json"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+        tracked_path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_refuses_a_symlinked_runtime_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir();
+        let outside = temp_dir();
+        symlink(&outside, root.join("sockets")).unwrap();
+        let path = root.join("sockets/lens.json");
+        let discovery = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "owner-1".into(),
+        );
+
+        let error = match DiscoveryGuard::publish(path, &discovery) {
+            Ok(_) => panic!("symlinked runtime directory was accepted"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("symlinked lens runtime directory"), "{error}");
+        assert!(!outside.join("lens.json").exists());
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(outside);
+    }
+
+    #[test]
+    fn subdirectory_index_root_is_relative_to_the_active_worktree() {
+        let root = temp_dir();
+        fs::create_dir_all(root.join("crate/src")).unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let config = test_config(root.join("crate"));
+
+        assert_eq!(workspace_root(&config), root);
+        assert_eq!(indexed_root_relative(&config, &root).unwrap(), "crate");
+
+        let main_root = temp_dir();
+        let mut config = test_config(main_root.join("crate"));
+        config.source_root_reanchored_from = Some(root.join("crate"));
+
+        assert_eq!(workspace_root(&config), root);
+        assert_eq!(indexed_root_relative(&config, &root).unwrap(), "crate");
+        let _ = fs::remove_dir_all(main_root);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn path_case_sensitivity_follows_the_actual_filesystem() {
+        let root = temp_dir();
+        let numeric_root = root.join("123");
+        fs::create_dir(&numeric_root).unwrap();
+        let probe = numeric_root.join("CaseProbe");
+        fs::create_dir(&probe).unwrap();
+        let alias = numeric_root.join("caseProbe");
+        let expected = alias
+            .canonicalize()
+            .ok()
+            .zip(probe.canonicalize().ok())
+            .is_some_and(|(alias, probe)| alias == probe);
+
+        assert_eq!(path_case_insensitive(&probe), expected);
+        assert_eq!(path_case_insensitive(&numeric_root), expected);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cleanup_only_removes_discovery_owned_by_the_guard() {
+        let root = temp_dir();
+        let path = root.join("lens.json");
+        let predecessor = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18120),
+            None,
+            String::new(),
+            false,
+            "predecessor".into(),
+        );
+        let guard = DiscoveryGuard::publish(path.clone(), &predecessor).unwrap();
+        let successor = LensDiscovery::new(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 18121),
+            None,
+            String::new(),
+            false,
+            "successor".into(),
+        );
+        let mut successor_bytes = serde_json::to_vec(&successor).unwrap();
+        successor_bytes.push(b'\n');
+        write_atomic(&path, &successor_bytes).unwrap();
+
+        drop(guard);
+        let remaining: LensDiscovery = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(remaining, successor, "predecessor cleanup deleted successor discovery");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn second_contender_loses_nonblocking_election() {
+        let root = temp_dir();
+        let path = root.join("lens.lock");
+        let first = FileLock::try_acquire(&path).unwrap().expect("first contender should win");
+        assert!(FileLock::try_acquire(&path).unwrap().is_none());
+        drop(first);
+        assert!(FileLock::try_acquire(&path).unwrap().is_some());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn port_scan_falls_back_after_a_busy_candidate() {
+        let busy = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let busy_port = busy.local_addr().unwrap().port();
+        let available = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let available_port = available.local_addr().unwrap().port();
+        drop(available);
+
+        let selected = bind_first_free([busy_port, available_port]).await.unwrap();
+        assert_eq!(selected.local_addr().unwrap().port(), available_port);
+    }
+
+    #[tokio::test]
+    async fn active_task_publishes_and_cleans_up_on_abort() {
+        let root = temp_dir();
+        let mut config = test_config(root.clone());
+        config.allow_empty = true;
+        drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'git_coupling_stamp'", []).unwrap();
+        drop(conn);
+        let available = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = available.local_addr().unwrap().port();
+        drop(available);
+
+        let control = ServeControl::default();
+        let task = tokio::spawn(run_on_ports(config.clone(), [port], control));
+        let path = lens_discovery_path(&root);
+        for _ in 0..100 {
+            if path.is_file() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(path.is_file(), "active lens task did not publish discovery");
+        let discovery: LensDiscovery = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(discovery.port, port);
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM repo_meta WHERE key = 'git_coupling_stamp')",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .unwrap(),
+            "Lens startup must materialize stale coupling before serving read-only requests"
+        );
+        drop(conn);
+
+        task.abort();
+        let _ = task.await;
+        assert!(!path.exists(), "aborting the active task must clean up its discovery");
+        assert!(
+            FileLock::try_acquire(&rag_rat_base::locks::lens_server_lock_path_for(&config, &root))
+                .unwrap()
+                .is_some(),
+            "aborting the active task must release its election lock"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    /// Standalone serving publishes the discovery file ONLY for a loopback bind. The file carries
+    /// the bearer token into a directory inside the workspace, and a non-loopback serve is the
+    /// hosted shape: its address is one the extension refuses to dial anyway, so writing the
+    /// credential there would be pure exposure. Both branches serve either way.
+    #[tokio::test]
+    async fn standalone_serving_publishes_discovery_only_for_a_loopback_bind() {
+        for (bind_ip, publishes) in
+            [(IpAddr::V4(Ipv4Addr::LOCALHOST), true), (IpAddr::V4(Ipv4Addr::UNSPECIFIED), false)]
+        {
+            let root = temp_dir();
+            let mut config = test_config(root.clone());
+            config.allow_empty = true;
+            drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
+            // Claim a port, then release it so `serve_standalone` binds that exact one — its
+            // chosen address is not otherwise observable from here.
+            let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+            let port = probe.local_addr().unwrap().port();
+            drop(probe);
+
+            let election = FileLock::try_acquire(&root.join("election.lock"))
+                .unwrap()
+                .expect("an uncontended election lock");
+            let (stop, wait_for_stop) = tokio::sync::oneshot::channel::<()>();
+            let served = tokio::spawn(serve_standalone(
+                config.clone(),
+                root.clone(),
+                SocketAddr::new(bind_ip, port),
+                "standalone-token".to_string(),
+                Vec::new(),
+                election,
+                async move {
+                    let _ = wait_for_stop.await;
+                    Ok(())
+                },
+            ));
+
+            // Publication happens before the listener is served, so a port that answers means the
+            // decision has already been made either way.
+            let mut serving = false;
+            for _ in 0..200 {
+                if tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, port)).await.is_ok() {
+                    serving = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            assert!(serving, "standalone serve never accepted on {bind_ip}:{port}");
+
+            let discovery_path = lens_discovery_path(&root);
+            assert_eq!(
+                discovery_path.is_file(),
+                publishes,
+                "{bind_ip} bind: discovery file presence must follow loopback-ness"
+            );
+            if publishes {
+                let published: LensDiscovery =
+                    serde_json::from_slice(&fs::read(&discovery_path).unwrap()).unwrap();
+                assert_eq!(published.port, port);
+                assert_eq!(published.ownership_token, "standalone-token");
+                assert!(published.url.contains(&port.to_string()));
+            }
+
+            let _ = stop.send(());
+            tokio::time::timeout(std::time::Duration::from_secs(10), served)
+                .await
+                .expect("standalone serve must return once its shutdown future resolves")
+                .expect("the serve task must not panic")
+                .expect("a clean shutdown is not an error");
+            let _ = fs::remove_dir_all(root);
+        }
+    }
+
+    fn test_config(root: PathBuf) -> Config {
+        Config {
+            database: root.join(".rag-rat/index.sqlite"),
+            root,
+            targets: Vec::new(),
+            llm: Default::default(),
+            watch: Default::default(),
+            log: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            trackers: Vec::new(),
+            papertrail: Default::default(),
+            sync: Default::default(),
+            repo_id_override: Some("test-repo".into()),
+            database_key_pinned: true,
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        }
+    }
+}

--- a/crates/rag-rat-mcp/src/lib.rs
+++ b/crates/rag-rat-mcp/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod agent_hook;
 mod blocking;
+pub mod http;
+pub mod lens_server;
 mod output_trim;
 pub mod server;
 pub mod tools;

--- a/crates/rag-rat-mcp/src/server/runtime.rs
+++ b/crates/rag-rat-mcp/src/server/runtime.rs
@@ -22,7 +22,8 @@ pub async fn run_stdio(
         // Keep the index fresh while a session is connected; dropping the watcher on shutdown
         // runs a final timeout-skip pass. (Hot-upgrade is Unix-only.)
         let _watcher = rag_rat_core::watch::Watcher::spawn(config.clone());
-        let service = RagRatService::new(config, output_format).serve(stdio()).await?;
+        let service = RagRatService::new(config.clone(), output_format).serve(stdio()).await?;
+        let _lens_server = crate::lens_server::spawn(config);
         service.waiting().await?;
         Ok(())
     }
@@ -40,9 +41,8 @@ pub async fn run_stdio_dormant(output_format: rag_rat_core::OutputFormat) -> any
     Ok(())
 }
 
-/// Aborts a spawned task when dropped. Used to tear down the hook listener on normal EOF
-/// shutdown so its socket + election lock release promptly (a hot-`exec` replaces the process
-/// image instead, so the task vanishes and the successor re-elects).
+/// Aborts the Unix hook-listener task on shutdown. A hot-`exec` replaces the process image instead,
+/// and the successor re-elects after close-on-exec releases the descriptors.
 #[cfg(unix)]
 struct AbortOnDrop(tokio::task::JoinHandle<()>);
 
@@ -101,6 +101,11 @@ async fn run_stdio_unix(
     // aborts the task so the socket + election lock release promptly; on a hot-`exec` the process
     // image is replaced (task vanishes) and the new process re-elects.
     let _hook_listener = AbortOnDrop(crate::agent_hook::spawn_listener(config.clone()));
+
+    // The loopback editor API belongs to the same ACTIVE lifecycle as the watcher and hook
+    // listener. The task fails open: election, bind, or publication errors are warnings and never
+    // terminate the stdio MCP service.
+    let _lens_server = crate::lens_server::spawn(config.clone());
 
     // Arm the SIGUSR1 hot-upgrade handler only when an install target is configured.
     if let Some(install_path) = install_path {

--- a/crates/rag-rat-papertrail/src/api.rs
+++ b/crates/rag-rat-papertrail/src/api.rs
@@ -765,7 +765,7 @@ pub fn refs_for_path(
          source_commit, source_text
         FROM papertrail_refs
         WHERE source_path = ?1 AND repo_id = ?3
-        ORDER BY id DESC
+        ORDER BY discovered_at_ms DESC, id DESC
         LIMIT ?2
         ",
     )?;

--- a/crates/rag-rat-papertrail/src/distill_read.rs
+++ b/crates/rag-rat-papertrail/src/distill_read.rs
@@ -99,6 +99,14 @@ pub struct DriveByRecord {
     pub record: DistilledRecord,
 }
 
+/// A selected distilled record anchored to one current file. Symbol anchors carry their current
+/// display line; file anchors use `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathDistilledRecord {
+    pub record: DistilledRecord,
+    pub line: Option<i64>,
+}
+
 impl DriveByRecord {
     pub fn new(record: DistilledRecord) -> Self {
         Self { unreviewed: true, record }
@@ -136,14 +144,13 @@ pub fn distilled_record_for_thread(
 /// loaded directly for the anchor's OWN record-owning thread (no coalesce redirect — the anchor
 /// always sits on the thread that owns the record). Repo-scoped.
 ///
-/// LIMITATION (eventual consistency): the anchor's stored token is a snapshot of the symbol's id at
-/// mining time and is NOT rewritten by the logical-id relocation engine (which covers only the
-/// memory/moniker tables). A code reindex that REMAPS a logical id can leave the token stale until
-/// that thread's next distill regeneration refreshes it (the distill input hash includes the token,
-/// so a re-extract on mirror sync heals it). In that window a moved symbol may miss its record, or
-/// — if an id is reused — a stale anchor may surface the PREVIOUS occupant's record. The drive-by
-/// is labeled unreviewed/best-effort; the durable fix (extend the relocation engine to the anchor
-/// token, or validate at the caller) is tracked separately.
+/// RELOCATION: the anchor stores the logical id as the opaque `sym_<hex>` TEXT handle rather than
+/// the i64 every other reference column holds, which is exactly why an early remap pass skipped it
+/// and a stale token could surface the previous occupant's record (#810). It is now rewritten with
+/// every other durable reference when an id is remapped, and cleared to NULL with `resolved = 0`
+/// when the remap has no winner — so a `selected` and `resolved` anchor names the symbol it was
+/// mined for. The drive-by is still labeled unreviewed because the record's text is
+/// model-distilled, not because the anchor might point somewhere else.
 pub fn records_for_symbol(
     conn: &Connection,
     repo_id: &str,
@@ -195,6 +202,71 @@ pub fn records_for_symbol(
         // between the SELECT and this load could otherwise return a coalesced partner's record.
         if let Some(record) = load_record(conn, repo_id, &key)? {
             records.push(record);
+        }
+    }
+    Ok(records)
+}
+
+/// Distilled records selected for a current file, either through an exact file anchor or a symbol
+/// anchor whose logical-symbol member currently belongs to that file. Repo-scoped and newest first.
+///
+/// A symbol anchor is admitted only when it is `resolved = 1` AND its token still joins a LIVE
+/// `logical_symbol_members` row whose symbol sits in the requested file, so the returned `line` is
+/// that symbol's position in the current index rather than a mining-time snapshot. That check plus
+/// the remap rewrite described on [`records_for_symbol`] is what keeps a decision off a file it no
+/// longer belongs to: an anchor whose symbol moved away simply stops matching here.
+pub fn records_for_path(
+    conn: &Connection,
+    repo_id: &str,
+    path: &str,
+    limit: usize,
+) -> anyhow::Result<Vec<PathDistilledRecord>> {
+    if limit == 0 || !rag_rat_db::schema::table_exists(conn, "papertrail_distill")? {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "WITH requested AS MATERIALIZED (
+             SELECT id FROM files WHERE path = ?2
+         )
+         SELECT anchor.tracker, anchor.project, anchor.item_kind, anchor.item_key,
+                MIN(CASE WHEN anchor.anchor_kind = 'symbol' THEN symbol.start_line END) AS line
+         FROM papertrail_distill_anchors anchor
+         JOIN papertrail_distill record
+           ON record.repo_id = anchor.repo_id AND record.tracker = anchor.tracker
+          AND record.project = anchor.project AND record.item_kind = anchor.item_kind
+          AND record.item_key = anchor.item_key
+         LEFT JOIN logical_symbol_members member
+           ON anchor.anchor_kind = 'symbol'
+          AND anchor.logical_symbol_id = 'sym_' || format('%x', member.logical_symbol_id)
+         LEFT JOIN symbols symbol
+           ON symbol.id = member.symbol_id AND symbol.file_id IN (SELECT id FROM requested)
+         WHERE anchor.repo_id = ?1 AND anchor.selected = 1
+           AND EXISTS (SELECT 1 FROM requested)
+           AND (
+               (anchor.anchor_kind = 'file' AND anchor.file_path = ?2)
+               OR (anchor.anchor_kind = 'symbol' AND anchor.resolved = 1 AND symbol.id IS NOT NULL)
+           )
+         GROUP BY anchor.tracker, anchor.project, anchor.item_kind, anchor.item_key
+         ORDER BY MAX(record.distilled_at_ms) DESC, anchor.tracker, anchor.project,
+                  anchor.item_kind, anchor.item_key
+         LIMIT ?3",
+    )?;
+    let keys = stmt.query_map(params![repo_id, path, i64::try_from(limit)?], |row| {
+        Ok((
+            RecordKey {
+                tracker: row.get(0)?,
+                project: row.get(1)?,
+                item_kind: row.get(2)?,
+                item_key: row.get(3)?,
+            },
+            row.get::<_, Option<i64>>(4)?,
+        ))
+    })?;
+    let mut records = Vec::new();
+    for key in keys {
+        let (key, line) = key?;
+        if let Some(record) = load_record(conn, repo_id, &key)? {
+            records.push(PathDistilledRecord { record, line });
         }
     }
     Ok(records)

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -28,8 +28,8 @@ pub use distill::{
     AnchorKind, DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape,
 };
 pub use distill_read::{
-    CoalescedThread, DistilledRecord, DriveByRecord, RecordKey, RejectedAlternative,
-    distilled_record_for_thread, records_for_symbol,
+    CoalescedThread, DistilledRecord, DriveByRecord, PathDistilledRecord, RecordKey,
+    RejectedAlternative, distilled_record_for_thread, records_for_path, records_for_symbol,
 };
 pub use distill_status::{EffectiveStatusInputs, effective_status, no_fix_edge};
 pub use evidence::{refs, *};

--- a/crates/rag-rat-query/src/load_bearing.rs
+++ b/crates/rag-rat-query/src/load_bearing.rs
@@ -21,9 +21,9 @@
 //! per-symbol verdict scan); when no oracle run exists for the active checkout the factor is `1.0`
 //! (pure heuristic) and costs nothing — the caller gates on a run existing.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
-use rusqlite::Connection;
+use rusqlite::{Connection, params_from_iter};
 use serde::Serialize;
 
 use crate::pagerank::{COMPILER_FACTOR, EdgeOracleEffect, confidence_factor, edge_weight};
@@ -259,6 +259,64 @@ pub fn scoped_weighted_fan_in(
     }))
 }
 
+/// Batched sibling of [`scoped_weighted_fan_in`]. It preserves the same active-scope, visibility,
+/// weighting, and oracle semantics while loading requested symbols' in-edges in bounded queries.
+pub fn scoped_weighted_fan_in_many(
+    conn: &Connection,
+    symbol_ids: &[i64],
+    oracle: &OracleContext<'_>,
+) -> anyhow::Result<HashMap<i64, ImportanceEnrichment>> {
+    if symbol_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let unique_symbol_ids = symbol_ids.iter().copied().collect::<BTreeSet<_>>();
+    let unique_symbol_ids = unique_symbol_ids.into_iter().collect::<Vec<_>>();
+    let mut scores: HashMap<i64, (f64, bool)> = HashMap::new();
+    for symbol_chunk in unique_symbol_ids.chunks(900) {
+        let marks = symbol_chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT d.id, d.to_symbol_id, ek.value, cf.value
+             FROM edges_data d
+             JOIN files ON files.id = d.source_file_id
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
+             JOIN name_strings cf ON cf.id = d.confidence_id
+             WHERE d.to_symbol_id IN ({marks}) AND d.hidden = 0"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(symbol_chunk), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?;
+        for row in rows {
+            let (edge_id, symbol_id, kind, confidence) = row?;
+            let Some(contribution) =
+                in_edge_contribution(&kind, &confidence, edge_id, symbol_id, oracle)
+            else {
+                continue;
+            };
+            let score = scores.entry(symbol_id).or_default();
+            score.0 += contribution.weight;
+            score.1 |= contribution.compiler;
+        }
+    }
+    Ok(scores
+        .into_iter()
+        .map(|(symbol_id, (score, compiler))| {
+            (symbol_id, ImportanceEnrichment {
+                label: ImportanceEnrichment::LABEL,
+                signal: ImportanceEnrichment::SIGNAL,
+                score: crate::round_score(score),
+                bucket: LoadBearingBucket::from_score(score),
+                oracle_tier: compiler.then_some(OracleTier::Compiler),
+            })
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use rag_rat_core::index::install_scope_view;
@@ -423,6 +481,20 @@ mod tests {
         let leaf = add_symbol(&conn, f, "leaf", "a::leaf");
         install_scope_view(&conn, "c", "").unwrap();
         assert!(fan_in(&conn, leaf).is_none(), "a symbol nothing depends on has no fan-in");
+    }
+
+    #[test]
+    fn batched_fan_in_accepts_more_than_sqlites_variable_limit() {
+        let conn = scoped_conn();
+        let file = add_file(&conn, "a.rs", "c", "");
+        let caller = add_symbol(&conn, file, "caller", "a::caller");
+        let target = add_symbol(&conn, file, "target", "a::target");
+        add_edge(&conn, file, caller, target, "calls_name", "Exact");
+        install_scope_view(&conn, "c", "").unwrap();
+        let targets = (1..=40_000).collect::<Vec<_>>();
+
+        let scores = scoped_weighted_fan_in_many(&conn, &targets, &OracleContext::none()).unwrap();
+        assert_eq!(scores.get(&target).map(|score| score.score), Some(1.0));
     }
 
     #[test]

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -257,6 +257,72 @@ pub(crate) fn ids_to_memories(
     }
     Ok(memories)
 }
+
+#[derive(Debug, Default)]
+pub struct CurrentDreamState {
+    pub summary: Option<String>,
+    pub verdict: Option<String>,
+    pub direction: Option<String>,
+    pub evidence_json: Option<String>,
+    pub checked_against_commit: Option<String>,
+}
+
+/// Raw dream state for the memory's current note and evidence inputs. Unlike the compact renderer,
+/// this preserves the individual verdict fields for structured consumers.
+pub fn current_dream_state(
+    conn: &Connection,
+    memory_id: &str,
+    title: &str,
+    body: &str,
+) -> rusqlite::Result<CurrentDreamState> {
+    use rag_rat_db::schema;
+
+    let content_hash = crate::memory::evidence::note_content_hash(title, body);
+    let scope = schema::periphery_repo_scope(conn, "memory_summaries")?;
+    let summary_clause = schema::periphery_repo_scope_clause(&scope, "memory_summaries");
+    let summary = conn
+        .query_row(
+            &format!(
+                "SELECT summary FROM memory_summaries WHERE memory_id = ?1 AND content_hash = ?2 \
+                 AND prompt_version = ?3{summary_clause}"
+            ),
+            params![memory_id, content_hash, crate::memory::evidence::COMPACT_PROMPT_VERSION],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let reality_clause = schema::periphery_repo_scope_clause(&scope, "memory_reality");
+    let reality = conn
+        .query_row(
+            &format!(
+                "SELECT verdict, direction, evidence_json, checked_against_commit, \
+                        checked_inputs_hash
+                 FROM memory_reality
+                 WHERE memory_id = ?1 AND content_hash = ?2 AND prompt_version = \
+                       ?3{reality_clause}"
+            ),
+            params![memory_id, content_hash, crate::memory::evidence::VERDICT_PROMPT_VERSION],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((verdict, direction, evidence_json, checked_against_commit, stored_inputs)) = reality
+    else {
+        return Ok(CurrentDreamState { summary, ..CurrentDreamState::default() });
+    };
+    let current_inputs = crate::memory::evidence::checked_inputs_hash(conn, memory_id, &scope)?;
+    if stored_inputs.as_deref() != Some(current_inputs.as_str()) {
+        return Ok(CurrentDreamState { summary, ..CurrentDreamState::default() });
+    }
+    Ok(CurrentDreamState { summary, verdict, direction, evidence_json, checked_against_commit })
+}
+
 /// The dream summary + verdict marker for a memory's CURRENT note (title+body) — the `[memory]
 /// surface = "summary"` hydration (dream v2 passes 1 & 2). Returns `(summary, verdict_marker)`:
 ///   - `summary` is the `memory_summaries.summary` keyed on the memory's current `content_hash`
@@ -275,69 +341,10 @@ pub fn current_summary_and_verdict(
     title: &str,
     body: &str,
 ) -> rusqlite::Result<(Option<String>, Option<String>)> {
-    use rag_rat_db::schema;
-    // The dream freshness key is over the WHOLE note (title+body) — recompute it exactly as the
-    // queue / verdict pass / compaction pass stamp it.
-    let content_hash = crate::memory::evidence::note_content_hash(title, body);
-    // Scope both sibling reads by the active repo (both carry `repo_id`, V045). One probe suffices
-    // — they scope to the same active repo id.
-    let scope = schema::periphery_repo_scope(conn, "memory_summaries")?;
-    let summary_clause = schema::periphery_repo_scope_clause(&scope, "memory_summaries");
-    // Gate the summary on the SAME identity the compaction queue treats as "covered": current
-    // content_hash AND current `COMPACT_PROMPT_VERSION`. Without the version predicate a summary
-    // produced by an obsolete compact prompt/guards keeps surfacing while the memory waits
-    // behind the compaction budget (or a model failure) for a fresh one.
-    let summary: Option<String> = conn
-        .query_row(
-            &format!(
-                "SELECT summary FROM memory_summaries WHERE memory_id = ?1 AND content_hash = ?2 \
-                 AND prompt_version = ?3{summary_clause}"
-            ),
-            params![memory_id, content_hash, crate::memory::evidence::COMPACT_PROMPT_VERSION],
-            |r| r.get(0),
-        )
-        .optional()?;
-    let reality_clause = schema::periphery_repo_scope_clause(&scope, "memory_reality");
-    // Gate the verdict marker on the current verdict `PROMPT_VERSION` too (the SQL predicate), so a
-    // verdict from an obsolete prompt is not shown while the queue waits to re-check it. The
-    // remaining stale checks — content_hash (the WHERE) and the evidence-pack hash (below) — mirror
-    // the queue and divergence finder exactly.
-    let reality: Option<(Option<String>, Option<String>, Option<String>)> = conn
-        .query_row(
-            &format!(
-                "SELECT verdict, checked_against_commit, checked_inputs_hash FROM memory_reality \
-                 WHERE memory_id = ?1 AND content_hash = ?2 AND prompt_version = \
-                 ?3{reality_clause}"
-            ),
-            params![memory_id, content_hash, crate::memory::evidence::VERDICT_PROMPT_VERSION],
-            |r| {
-                Ok((
-                    r.get::<_, Option<String>>(0)?,
-                    r.get::<_, Option<String>>(1)?,
-                    r.get::<_, Option<String>>(2)?,
-                ))
-            },
-        )
-        .optional()?;
-    // Gate the marker on the evidence-pack hash the SAME way the queue and divergence finder do: a
-    // verdict is only shown when the memory's current evidence (bound files + identifier
-    // resolutions) still matches what it was checked against, so an evidence change (before a
-    // re-verify) drops the marker instead of showing a verdict checked against prior code. The
-    // hash is recomputed ONLY when a body- and prompt-matching verdict row exists (the rare
-    // case), so surfacing an unverified memory pays nothing.
-    let verdict_marker = match reality {
-        Some((verdict, commit, stored_inputs)) => {
-            let current_inputs =
-                crate::memory::evidence::checked_inputs_hash(conn, memory_id, &scope)?;
-            if stored_inputs.as_deref() == Some(current_inputs.as_str()) {
-                render_verdict_marker(verdict.as_deref(), commit.as_deref())
-            } else {
-                None
-            }
-        },
-        None => None,
-    };
-    Ok((summary, verdict_marker))
+    let state = current_dream_state(conn, memory_id, title, body)?;
+    let marker =
+        render_verdict_marker(state.verdict.as_deref(), state.checked_against_commit.as_deref());
+    Ok((state.summary, marker))
 }
 
 /// A plain-text drive-by verdict marker (no emoji, matching the mechanical rendering style). A

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.vsix
+.vscode-test-web/

--- a/editors/vscode/.vscode/launch.json
+++ b/editors/vscode/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension (desktop host)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/node/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    },
+    {
+      "name": "Run Web Extension (webworker host)",
+      "type": "extensionHost",
+      "debugWebWorkerHost": true,
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionDevelopmentKind=web"
+      ],
+      "outFiles": ["${workspaceFolder}/dist/web/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
+}

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+.gitignore
+src/**
+test/**
+node_modules/**
+esbuild.js
+package-lock.json
+tsconfig.json
+*.vsix

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kristaps Karlsons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,52 @@
+# rag-rat Lens (VS Code / Cursor extension)
+
+Read-only editor lens over the rag-rat repo index — issue #216. One shared
+TypeScript source builds to both extension hosts: Node (desktop VS Code /
+Cursor) and web worker (vscode.dev, Codespaces, Cursor web).
+
+## Develop
+
+```bash
+npm install
+npm run watch          # esbuild: dist/node + dist/web, rebuilds on change
+```
+
+Start the authenticated backend from the repository root:
+
+```bash
+rag-rat mcp
+```
+
+Then F5 ("Run Web Extension (webworker host)") opens an Extension Development Host; extension
+code changes need a debug restart / Reload Window (no hot-swap in the host).
+
+## Features (MVP)
+
+- Status bar with live indexed-file count
+- Clone-class overlays and extraction previews
+- Memory CodeLens, hovers, diagnostics, and detail documents
+- Call-graph, coupling, issue, and decision lenses
+- Sidebar views for clone classes, memories, and tracker rationale
+- SSE-driven refresh when the index or enrichment data changes
+
+The extension discovers the loopback URL, bearer token, and indexed subdirectory from
+`.rag-rat/sockets/lens.json` (local file-system workspaces only). You can open either the Git
+worktree top or the configured indexed root; discovery walks trusted local ancestors and accepts
+only the opened folder or its nearest Git worktree boundary. For a hosted server, run
+**rag-rat Lens: Configure Server**; the URL is stored in settings and the bearer token in VS Code
+SecretStorage. The same command records which repository AND which checkout that server serves for
+the opened workspace — a repository's linked worktrees share one identity, and every line a server
+reports belongs to the working tree it indexed — and asks for the indexed root: leave it empty to
+follow the server's own metadata, or answer `.` when the opened folder is already the indexed
+subdirectory. All of it is stored per (server, workspace) pair, so a second workspace or endpoint
+never inherits the first one's mapping, and a server that moves to another checkout stops being
+served rather than reporting another tree's lines.
+Browser extension hosts (vscode.dev, Codespaces
+web UI) also require their exact
+Origin in the server's `--allow-origin` / `RAG_RAT_LENS_ORIGINS` allowlist, and Chrome requires
+the server to opt into Private Network Access — the Rust server emits that header on preflights
+from allowed origins.
+
+Lens currently requires a single-root workspace. Desktop, remote, and virtual
+workspace document schemes are supported; multi-root windows fail closed so
+data from two repository servers cannot be mixed.

--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -1,0 +1,47 @@
+// Dual esbuild: one shared TS source -> Node (desktop) + webworker (web/Cursor-remote) bundles.
+// `vscode` stays external in both (provided by the extension host).
+const esbuild = require('esbuild');
+
+const production = process.argv.includes('--production');
+const watch = process.argv.includes('--watch');
+
+/** @type {import('esbuild').BuildOptions} */
+const shared = {
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  format: 'cjs',
+  minify: production,
+  sourcemap: !production,
+  sourcesContent: false,
+  external: ['vscode'],
+  logLevel: 'warning',
+};
+
+const nodeConfig = {
+  ...shared,
+  platform: 'node',
+  outfile: 'dist/node/extension.js',
+};
+
+const webConfig = {
+  ...shared,
+  platform: 'browser',
+  outfile: 'dist/web/extension.js',
+  define: { global: 'globalThis' },
+};
+
+async function main() {
+  const ctxs = await Promise.all([esbuild.context(nodeConfig), esbuild.context(webConfig)]);
+  if (watch) {
+    await Promise.all(ctxs.map((c) => c.watch()));
+    console.log('[watch] node + web');
+  } else {
+    await Promise.all(ctxs.map((c) => c.rebuild()));
+    await Promise.all(ctxs.map((c) => c.dispose()));
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/editors/vscode/media/lens.svg
+++ b/editors/vscode/media/lens.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="16.2" y1="16.2" x2="21" y2="21"/><circle cx="11" cy="11" r="2.5" fill="currentColor" stroke="none"/></svg>

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,526 @@
+{
+  "name": "rag-rat-lens",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rag-rat-lens",
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/vscode": "^1.85.0",
+        "esbuild": "^0.28.1",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,199 @@
+{
+  "name": "rag-rat-lens",
+  "displayName": "rag-rat Lens",
+  "description": "Read-only lens over the rag-rat repo index: clone classes, repo memories, call-graph trust data, co-change coupling, tracker rationale. VS Code + Cursor, desktop and web.",
+  "version": "0.0.1",
+  "publisher": "rag-rat",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cq27-dev/rag-rat",
+    "directory": "editors/vscode"
+  },
+  "bugs": "https://github.com/cq27-dev/rag-rat/issues",
+  "homepage": "https://github.com/cq27-dev/rag-rat#readme",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Visualization",
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./dist/node/extension.js",
+  "browser": "./dist/web/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "Automatic server discovery reads a workspace-local credential file."
+    },
+    "virtualWorkspaces": {
+      "supported": true
+    }
+  },
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "rag-rat-lens",
+          "title": "rag-rat Lens",
+          "icon": "media/lens.svg"
+        }
+      ]
+    },
+    "views": {
+      "rag-rat-lens": [
+        {
+          "id": "rag-rat-lens.cloneClasses",
+          "name": "Clone Classes"
+        },
+        {
+          "id": "rag-rat-lens.memories",
+          "name": "Memories"
+        },
+        {
+          "id": "rag-rat-lens.papertrail",
+          "name": "Issues & Decisions"
+        }
+      ]
+    },
+    "menus": {
+      "editor/context": [
+        {
+          "command": "rag-rat-lens.toggleOverlays",
+          "group": "rag-rat@1"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "rag-rat-lens.showCallers",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.showDispatch",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.showCoupling",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.showRefs",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.showDecision",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.showExtract",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.showMemories",
+          "when": "false"
+        },
+        {
+          "command": "rag-rat-lens.openLocation",
+          "when": "false"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "rag-rat-lens.toggleOverlays",
+        "title": "rag-rat Lens: Toggle Overlays"
+      },
+      {
+        "command": "rag-rat-lens.refresh",
+        "title": "rag-rat Lens: Refresh Overlays"
+      },
+      {
+        "command": "rag-rat-lens.configureServer",
+        "title": "rag-rat Lens: Configure Server"
+      },
+      {
+        "command": "rag-rat-lens.showLog",
+        "title": "rag-rat Lens: Show Log"
+      },
+      {
+        "command": "rag-rat-lens.showCallers",
+        "title": "rag-rat Lens: Show Callers"
+      },
+      {
+        "command": "rag-rat-lens.showDispatch",
+        "title": "rag-rat Lens: Show Dispatch"
+      },
+      {
+        "command": "rag-rat-lens.showCoupling",
+        "title": "rag-rat Lens: Show Coupling"
+      },
+      {
+        "command": "rag-rat-lens.showRefs",
+        "title": "rag-rat Lens: Show Issue/PR Refs"
+      },
+      {
+        "command": "rag-rat-lens.showDecision",
+        "title": "rag-rat Lens: Show Decision Record"
+      },
+      {
+        "command": "rag-rat-lens.showExtract",
+        "title": "rag-rat Lens: Show Extract Helper Preview"
+      },
+      {
+        "command": "rag-rat-lens.showMemories",
+        "title": "rag-rat Lens: Show Memories"
+      },
+      {
+        "command": "rag-rat-lens.openLocation",
+        "title": "rag-rat Lens: Open Location"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "rag-rat-lens.toggleOverlays",
+        "key": "ctrl+alt+r",
+        "mac": "cmd+alt+r"
+      }
+    ],
+    "configuration": {
+      "title": "rag-rat Lens",
+      "properties": {
+        "rag-rat-lens.serverUrl": {
+          "type": "string",
+          "default": "",
+          "scope": "machine",
+          "description": "Hosted Lens server URL. Leave empty to discover the authenticated server from .rag-rat/sockets/lens.json; use 'rag-rat Lens: Configure Server' to store its bearer token securely."
+        },
+        "rag-rat-lens.cloneTheta": {
+          "type": "number",
+          "default": 0.9,
+          "minimum": 0.7,
+          "maximum": 1,
+          "description": "Similarity floor for clone overlays (find_clones' min_similarity). 0.7 = recall (boilerplate-heavy), 0.9 = near-clones only."
+        },
+        "rag-rat-lens.cloneMinTokens": {
+          "type": "integer",
+          "default": 100,
+          "minimum": 0,
+          "description": "Hide clone classes whose medoid body is smaller than this many tokens. ~100 keeps only actionable (refactor-worthy) duplication; enum matchers and trivial accessors sit at 28-86. 0 shows everything."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run package",
+    "compile": "npm run check-types && node esbuild.js",
+    "watch": "node esbuild.js --watch",
+    "package": "npm run check-types && node esbuild.js --production",
+    "check-types": "tsc --noEmit",
+    "test": "node --test test/*.test.cjs"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "esbuild": "^0.28.1",
+    "typescript": "^5.6.0"
+  }
+}

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -1,0 +1,468 @@
+// Typed client for the rag-rat Lens server contract.
+// Runs in both extension hosts: Node 22 desktop and the web worker (fetch is global in both).
+
+import type { LensEndpoint, LensEndpointResolver } from './discovery';
+
+export interface Status {
+  repo_id: string;
+  repo_root: string;
+  indexed_root: string;
+  case_insensitive_paths: boolean;
+  live_files_generation: number;
+  clone_graph_generation: number | null;
+  indexed_head: string | null;
+  live_file_count: number;
+}
+
+export interface FileSymbol {
+  name: string;
+  qname: string | null;
+  kind: string;
+  start_line: number;
+  end_line: number;
+  is_test: boolean;
+  signature: string | null;
+  fan_in: number;
+  fan_out: number;
+}
+
+export interface CloneRefine {
+  template: string;
+  proposed_signature: unknown;
+  variation_points: unknown;
+  confidence: string;
+  anti_unify_coverage: number;
+  lcs_ratio: number;
+  refactorability: number;
+}
+
+export interface ClonePartner {
+  path: string;
+  start_line: number | null;
+  end_line: number | null;
+  similarity: number;
+  /** Name of the partner symbol (from exact anchor resolution). */
+  symbol: string | null;
+}
+
+export interface CloneRegion {
+  /** Cloned region in the requested file (null lines when outside any symbol). */
+  start_line: number | null;
+  end_line: number | null;
+  byte_offset: number;
+  /** Connected-component id over the generation's clone graph; siblings share it. */
+  class_id: number | null;
+  /** Name of the cloned symbol in the requested file. */
+  symbol?: string | null;
+  max_similarity: number | null;
+  /** Sibling regions in other files, best similarity first. */
+  partners: ClonePartner[];
+  /** Persisted refine payload, present when the Lens component matches the pipeline class exactly. */
+  refine?: CloneRefine;
+}
+
+export interface FileMemory {
+  id: string;
+  kind: string;
+  title: string;
+  body: string;
+  confidence: string;
+  binding_kind: string;
+  path: string | null;
+  /** Resolved display line (1-based) via the binding's symbol/chunk; null = file/dir-scoped. */
+  line: number | null;
+  anchor_status: string;
+  /** LLM-compacted overview (dream --compact), gated on content freshness; null when absent/stale. */
+  summary: string | null;
+  /** Dream verify verdict ('current' | 'diverged'), freshness-gated; null when unverified. */
+  verdict: string | null;
+  /** note_ahead | code_ahead | unknown — which side moved since the verdict. */
+  verdict_direction: string | null;
+  /** JSON array of per-check strings from the dream verify pass. */
+  verdict_evidence: string | null;
+  checked_against_commit: string | null;
+}
+
+export interface SymbolGraph {
+  name: string;
+  qname: string | null;
+  kind: string;
+  start_line: number;
+  end_line: number;
+  is_test: boolean;
+  callers: { exact: number; syntactic: number; name_only: number; ambiguous: number; tests: number; dispatch: number };
+  fan_in_score: number;
+  fan_in_bucket: 'low' | 'medium' | 'high' | 'critical';
+  dispatch: { variant: string | null; direction: 'constructs' | 'handled'; other_name: string | null; other_path: string | null; other_line: number | null }[];
+}
+
+export interface CouplingPartner {
+  path: string;
+  co_changes: number;
+  my_changes: number;
+  confidence: number;
+  last_co_change_at_s: number;
+}
+
+export interface PapertrailRef {
+  tracker: string;
+  project: string;
+  item_key: string;
+  item_kind: string;
+  ref_kind: string;
+  source_kind: string;
+  source_text: string;
+  title: string | null;
+  url: string | null;
+  state_normalized: string | null;
+}
+
+export interface DecisionRecord {
+  item_key: string;
+  title: string | null;
+  url: string | null;
+  root_issue: string | null;
+  root_cause: string | null;
+  decision_chosen: string | null;
+  outcome_summary: string | null;
+  outcome_status_model: string | null;
+  outcome_claim_verified: number;
+  decision_provenance_verified: number;
+  fix_edge_source: string;
+  /** Resolved line of the symbol anchor; null = file-level. */
+  line: number | null;
+}
+
+export interface VersionToken {
+  generation: number;
+  max_indexed_at_ms: number;
+  git_dirty: string | null;
+  revision: string;
+}
+
+export class LensClient {
+  constructor(private readonly resolver: LensEndpointResolver) {}
+
+  private async get<T>(
+    route: string,
+    params?: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const endpoint = await this.resolver.resolve();
+    try {
+      return await this.request<T>(endpoint, route, params, signal);
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      this.resolver.invalidate();
+      const replacement = await this.resolver.resolve();
+      if (replacement.baseUrl === endpoint.baseUrl && replacement.token === endpoint.token) {
+        throw error;
+      }
+      return this.request<T>(replacement, route, params, signal);
+    }
+  }
+
+  private async request<T>(
+    endpoint: LensEndpoint,
+    route: string,
+    params?: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const url = new URL(route, endpoint.baseUrl);
+    for (const [k, v] of Object.entries(params ?? {})) {
+      url.searchParams.set(k, v);
+    }
+    // The caller's signal rides alongside the timeout: a request whose answer has already been
+    // discarded — an index change while a repository-wide clone scan is running — should stop
+    // costing the server, not run to completion for a reader that has gone away.
+    const res = await fetch(url.toString(), {
+      headers: requestHeaders(endpoint),
+      signal: eitherSignal(AbortSignal.timeout(35_000), signal),
+    });
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 200);
+      throw new Error(`${route} -> ${res.status}: ${body}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  health(): Promise<{ status: string }> {
+    return this.get('/api/health');
+  }
+  status(): Promise<Status> {
+    return this.get('/api/status');
+  }
+  version(): Promise<VersionToken> {
+    return this.get('/api/version');
+  }
+  async fileSymbols(path: string): Promise<FileSymbol[]> {
+    return (await this.get<{ symbols: FileSymbol[] }>('/api/file/symbols', { path })).symbols;
+  }
+  async fileClones(path: string, theta?: number, minTokens?: number): Promise<CloneRegion[]> {
+    return (await this.fileClonesFull(path, theta, minTokens)).clone_regions;
+  }
+
+  async fileClonesFull(
+    path: string,
+    theta?: number,
+    minTokens?: number,
+    signal?: AbortSignal,
+  ): Promise<{ clone_regions: CloneRegion[]; clone_graph?: Record<string, unknown> }> {
+    const params: Record<string, string> = { path };
+    if (theta != null) {
+      params.theta = String(theta);
+    }
+    if (minTokens != null) {
+      params.min_tokens = String(minTokens);
+    }
+    // The clone payload is the drift-prone boundary (nullable max_similarity, arbitrary refine
+    // JSON). Validate and coerce at the edge so a hosted server version can never crash the
+    // rendering lanes with `undefined.toFixed`.
+    return validateFileClones(await this.get<unknown>('/api/file/clones', params, signal));
+  }
+  async fileMemories(path: string, signal?: AbortSignal): Promise<FileMemory[]> {
+    return (await this.get<{ memories: FileMemory[] }>('/api/file/memories', { path }, signal))
+      .memories;
+  }
+  async fileSymbolGraph(path: string, signal?: AbortSignal): Promise<SymbolGraph[]> {
+    return (await this.get<{ symbols: SymbolGraph[] }>('/api/file/graph', { path }, signal)).symbols;
+  }
+  async fileCoupling(path: string, signal?: AbortSignal): Promise<CouplingPartner[]> {
+    return (await this.get<{ coupling: CouplingPartner[] }>('/api/file/coupling', { path }, signal))
+      .coupling;
+  }
+  async filePapertrail(
+    path: string,
+    signal?: AbortSignal,
+  ): Promise<{ refs: PapertrailRef[]; decisions: DecisionRecord[] }> {
+    return this.get('/api/file/papertrail', { path }, signal);
+  }
+  async symbolCallers(qname: string, limit = 50): Promise<unknown[]> {
+    return (await this.get<{ callers: unknown[] }>('/api/symbol/callers', { qname, limit: String(limit) })).callers;
+  }
+
+  async watchVersions(signal: AbortSignal, onVersion: (version: VersionToken) => void): Promise<void> {
+    const attempt = new AbortController();
+    const abortAttempt = () => attempt.abort(signal.reason);
+    if (signal.aborted) {
+      abortAttempt();
+    } else {
+      signal.addEventListener('abort', abortAttempt, { once: true });
+    }
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    try {
+      const endpoint = await this.resolver.resolve();
+      // `readWithTimeout` below only guards reads, which start AFTER response headers arrive. A
+      // reverse proxy that accepts the connection and then never responds would park this `fetch`
+      // with no deadline at all: it never rejects, so the reconnect loop never runs another
+      // attempt and live refresh stays dead for the rest of the session even once the proxy
+      // recovers — while REST requests keep working, so nothing else notices.
+      const connectTimer = setTimeout(
+        () => attempt.abort(new Error(`/api/events sent no response headers for ${SSE_CONNECT_MS / 1000}s`)),
+        SSE_CONNECT_MS,
+      );
+      let response: Response;
+      try {
+        response = await fetch(new URL('/api/events', endpoint.baseUrl), {
+          headers: requestHeaders(endpoint, 'text/event-stream'),
+          signal: attempt.signal,
+        });
+      } finally {
+        // Headers arrived (or the attempt failed): the stall timeout owns the connection now, and
+        // leaving this armed would abort a healthy stream mid-flight.
+        clearTimeout(connectTimer);
+      }
+      if (!response.ok) {
+        throw new Error(`/api/events -> ${response.status}: ${(await response.text()).slice(0, 200)}`);
+      }
+      reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('/api/events returned no response body');
+      }
+      const decoder = new TextDecoder();
+      let buffered = '';
+      while (!signal.aborted) {
+        const { done, value } = await readWithTimeout(reader, () => attempt.abort());
+        if (done) {
+          break;
+        }
+        buffered += decoder.decode(value, { stream: true });
+        let boundary = eventBoundary(buffered);
+        while (boundary) {
+          const block = buffered.slice(0, boundary.index);
+          buffered = buffered.slice(boundary.index + boundary.length);
+          const event = parseVersionEvent(block);
+          if (event) {
+            onVersion(event);
+          }
+          boundary = eventBoundary(buffered);
+        }
+      }
+      if (!signal.aborted) {
+        this.resolver.invalidate();
+        throw new Error('/api/events disconnected');
+      }
+    } finally {
+      signal.removeEventListener('abort', abortAttempt);
+      if (reader) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Fetch aborts can error the body before cancellation observes it.
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Abort when either signal does. `AbortSignal.any` would say this in one line, but it arrived in
+ * Node 20 and the extension still supports VS Code 1.85, whose desktop host is Node 18 — calling
+ * it there would throw before the request was ever made.
+ */
+export function eitherSignal(deadline: AbortSignal, caller?: AbortSignal): AbortSignal {
+  if (!caller) {
+    return deadline;
+  }
+  const linked = new AbortController();
+  const first = [deadline, caller].find((signal) => signal.aborted);
+  if (first) {
+    linked.abort(first.reason);
+    return linked.signal;
+  }
+  for (const signal of [deadline, caller]) {
+    signal.addEventListener('abort', () => linked.abort(signal.reason), { once: true });
+  }
+  return linked.signal;
+}
+
+function requestHeaders(endpoint: LensEndpoint, accept = 'application/json'): HeadersInit {
+  return endpoint.token
+    ? { Accept: accept, Authorization: `Bearer ${endpoint.token}` }
+    : { Accept: accept };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function numberOr(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+export function validateFileClones(value: unknown): {
+  clone_regions: CloneRegion[];
+  clone_graph?: Record<string, unknown>;
+} {
+  const root = isRecord(value) ? value : {};
+  return {
+    clone_regions: Array.isArray(root.clone_regions)
+      ? root.clone_regions.filter(isRecord).map(coerceRegion)
+      : [],
+    clone_graph: isRecord(root.clone_graph) ? root.clone_graph : undefined,
+  };
+}
+
+function coerceRegion(value: Record<string, unknown>): CloneRegion {
+  const refine = isRecord(value.refine) ? value.refine : undefined;
+  return {
+    start_line: numberOrNull(value.start_line),
+    end_line: numberOrNull(value.end_line),
+    byte_offset: numberOr(value.byte_offset, 0),
+    class_id: numberOrNull(value.class_id),
+    symbol: stringOrNull(value.symbol),
+    max_similarity: numberOrNull(value.max_similarity),
+    partners: Array.isArray(value.partners) ? value.partners.filter(isRecord).map(coercePartner) : [],
+    refine: refine
+      ? {
+          template: typeof refine.template === 'string' ? refine.template : '',
+          proposed_signature: refine.proposed_signature,
+          variation_points: refine.variation_points,
+          confidence: typeof refine.confidence === 'string' ? refine.confidence : '',
+          anti_unify_coverage: numberOr(refine.anti_unify_coverage, 0),
+          lcs_ratio: numberOr(refine.lcs_ratio, 0),
+          refactorability: numberOr(refine.refactorability, 0),
+        }
+      : undefined,
+  };
+}
+
+function coercePartner(value: Record<string, unknown>): ClonePartner {
+  return {
+    path: stringOrNull(value.path) ?? '',
+    start_line: numberOrNull(value.start_line),
+    end_line: numberOrNull(value.end_line),
+    similarity: numberOr(value.similarity, 0),
+    symbol: stringOrNull(value.symbol),
+  };
+}
+
+// > 2× the server's 16s keep-alive interval: a silent half-open connection (sleep/wake, VPN,
+// NAT drop) otherwise parks `reader.read()` forever and refresh silently dies.
+const SSE_STALL_MS = 40_000;
+
+// Establishing the stream is a normal request — it should answer as fast as `/api/status` does.
+// Shorter than SSE_STALL_MS because nothing is streaming yet: this bounds only the wait for
+// response headers, after which the stall timeout takes over for the life of the connection.
+export const SSE_CONNECT_MS = 15_000;
+
+export function readWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  abortAttempt: () => void,
+  timeoutMs = SSE_STALL_MS,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      abortAttempt();
+      void reader.cancel().catch(() => undefined);
+      reject(new Error(`/api/events produced no data for ${timeoutMs / 1000}s`));
+    }, timeoutMs);
+    reader.read().then(
+      (result) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function parseVersionEvent(block: string): VersionToken | undefined {
+  const lines = block.split(/\r\n|\r|\n/);
+  if (!lines.some((line) => line === 'event: version')) {
+    return undefined;
+  }
+  const data = lines
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice(5).trimStart())
+    .join('\n');
+  return data ? (JSON.parse(data) as VersionToken) : undefined;
+}
+
+function eventBoundary(buffered: string): { index: number; length: number } | undefined {
+  const match = /\r\n\r\n|\n\n|\r\r/.exec(buffered);
+  return match ? { index: match.index, length: match[0].length } : undefined;
+}

--- a/editors/vscode/src/diagnostics.ts
+++ b/editors/vscode/src/diagnostics.ts
@@ -1,0 +1,71 @@
+// Diagnostics: diverged memories as warnings, stale/gone anchors as info.
+// Refreshed alongside the overlays on the same file-memories data lane.
+import * as vscode from 'vscode';
+import type { FileMemory } from './client';
+import { verdictDirectionLabel } from './verdict';
+
+/**
+ * Diagnostics belong to a DOCUMENT, not to an editor: they sit in the Problems panel whether or
+ * not the tab is showing, which is why every entry here is keyed by document URI and why an
+ * invalidation has to reach the documents no editor is currently displaying.
+ */
+export class LensDiagnostics implements vscode.Disposable {
+  private collection = vscode.languages.createDiagnosticCollection('rag-rat-lens');
+
+  apply(document: vscode.TextDocument, memories: FileMemory[]): void {
+    const diagnostics: vscode.Diagnostic[] = [];
+    for (const m of memories) {
+      const line = Math.min(Math.max(0, (m.line ?? 1) - 1), document.lineCount - 1);
+      const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
+      if (m.verdict === 'diverged') {
+        const direction = verdictDirectionLabel(m.verdict_direction);
+        diagnostics.push(
+          new vscode.Diagnostic(
+            range,
+            `rag-rat memory diverged: ${m.title} (${direction})`,
+            vscode.DiagnosticSeverity.Warning,
+          ),
+        );
+      } else if (m.anchor_status === 'stale' || m.anchor_status === 'gone') {
+        diagnostics.push(
+          new vscode.Diagnostic(
+            range,
+            `rag-rat memory anchor ${m.anchor_status}: ${m.title}`,
+            vscode.DiagnosticSeverity.Information,
+          ),
+        );
+      }
+    }
+    this.collection.set(document.uri, diagnostics);
+  }
+
+  clearUri(uri: vscode.Uri): void {
+    this.collection.delete(uri);
+  }
+
+  /**
+   * Drop every document's entries except `keep` — the documents a refresh is about to rewrite.
+   * Anything else is a claim about an index state that no longer exists, and it would otherwise sit
+   * in the Problems panel until its tab happens to be selected.
+   */
+  retainOnly(keep: readonly vscode.Uri[]): void {
+    const kept = new Set(keep.map((uri) => uri.toString()));
+    const stale: vscode.Uri[] = [];
+    this.collection.forEach((uri) => {
+      if (!kept.has(uri.toString())) {
+        stale.push(uri);
+      }
+    });
+    for (const uri of stale) {
+      this.collection.delete(uri);
+    }
+  }
+
+  clear(): void {
+    this.collection.clear();
+  }
+
+  dispose(): void {
+    this.collection.dispose();
+  }
+}

--- a/editors/vscode/src/discovery.ts
+++ b/editors/vscode/src/discovery.ts
@@ -1,0 +1,473 @@
+import * as vscode from 'vscode';
+import {
+  indexedPath,
+  indexedRootPrefixForDiscovery,
+  normalizeRelativePath,
+  workspacePath,
+} from './workspace_paths';
+
+export interface LensEndpoint {
+  baseUrl: string;
+  token?: string;
+}
+
+interface LensDiscovery {
+  schema: string;
+  version: number;
+  url: string;
+  indexed_root: string;
+  case_insensitive_paths: boolean;
+  ownership_token: string;
+}
+
+interface LensServerStatus {
+  repo_id: string;
+  /** The checkout the server indexes — empty for a main worktree, the linked worktree otherwise. */
+  worktree_id: string;
+  indexed_root: string;
+  case_insensitive_paths: boolean;
+}
+
+interface DiscoveryCandidate {
+  uri: vscode.Uri;
+  workspacePath: string;
+}
+
+/**
+ * What "rag-rat Lens: Configure Server" recorded for one (server, workspace) pair. The indexed-root
+ * override lives here rather than in a machine-wide setting: it describes how *this* workspace sits
+ * inside *that* server's index, so a second workspace or endpoint must not inherit it.
+ */
+interface HostedAssociation {
+  repoId: string;
+  /**
+   * The CHECKOUT that was bound, not just the repository. A repository's linked worktrees share
+   * one `repo_id`, so `repoId` alone would keep accepting a server that has moved to a different
+   * checkout — and its memories, clones, and graph data are anchored to that checkout's lines.
+   */
+  worktreeId: string;
+  indexedRoot?: string;
+}
+
+const DISCOVERY_TTL_MS = 2_000;
+
+/** A discovery file pointing off-loopback is a hard boundary violation, never "try next folder". */
+class NonLoopbackDiscoveryError extends Error {}
+
+/**
+ * Which folders this resolution describes. Every cached resolution is keyed by it, because a
+ * resolution is a statement about a WORKSPACE and a server, never about a server alone: a
+ * single-root window can replace its folder without reloading the extension host, and a cache
+ * keyed only on the base URL would keep serving the previous folder's indexed-root and checkout
+ * mapping — painting one repository's signals over the new one's same-named files.
+ */
+function workspaceKey(): string {
+  return (vscode.workspace.workspaceFolders ?? [])
+    .map((folder) => folder.uri.toString())
+    .join(' ');
+}
+
+interface ConfiguredMapping {
+  baseUrl: string;
+  workspace: string;
+  indexedRootPrefix: string;
+  caseInsensitivePaths: boolean;
+}
+
+/**
+ * One completed resolution, returned rather than written straight to the resolver's fields. The
+ * path mapping used to be installed as a side effect partway through resolving, which left no
+ * moment at which it could be checked against the workspace it describes.
+ */
+interface Resolution {
+  endpoint: LensEndpoint;
+  indexedRootPrefix: string;
+  caseInsensitivePaths: boolean;
+  configuredMapping: ConfiguredMapping | undefined;
+}
+
+export class LensEndpointResolver {
+  private cached: { endpoint: LensEndpoint; at: number; workspace: string } | undefined;
+  private configuredMapping: ConfiguredMapping | undefined;
+  private indexedRootPrefix = '';
+  private caseInsensitivePaths = false;
+  /** Bumped by `invalidate()` so a resolution started before it cannot publish after it. */
+  private generation = 0;
+
+  constructor(
+    private readonly config: vscode.WorkspaceConfiguration,
+    private readonly secrets: vscode.SecretStorage,
+  ) {}
+
+  invalidate(): void {
+    this.generation += 1;
+    this.cached = undefined;
+    this.configuredMapping = undefined;
+  }
+
+  async resolve(): Promise<LensEndpoint> {
+    const workspace = workspaceKey();
+    const generation = this.generation;
+    if (
+      this.cached &&
+      this.cached.workspace === workspace &&
+      Date.now() - this.cached.at < DISCOVERY_TTL_MS
+    ) {
+      return this.cached.endpoint;
+    }
+    const resolved = await this.resolveUncached();
+    // Resolving awaits filesystem and network I/O, and the world can move under it: a folder can
+    // be replaced, or a settings change can call `invalidate()`. Publishing then would install the
+    // PREVIOUS workspace's indexed-root mapping over the current one, and every path computed
+    // from it afterwards would name a file in the wrong repository. Only the resolution that
+    // still describes where we are may publish; the caller retries, and the folder/settings change
+    // that superseded this one triggers its own reload anyway.
+    if (this.generation !== generation || workspaceKey() !== workspace) {
+      throw new Error('Lens server resolution was superseded by a workspace or settings change');
+    }
+    this.indexedRootPrefix = resolved.indexedRootPrefix;
+    this.caseInsensitivePaths = resolved.caseInsensitivePaths;
+    this.configuredMapping = resolved.configuredMapping;
+    this.cached = { endpoint: resolved.endpoint, at: Date.now(), workspace };
+    return resolved.endpoint;
+  }
+
+  private async resolveUncached(): Promise<Resolution> {
+    requireSingleRootWorkspace();
+    // Only the user-level value may select a remote host: a checked-out repository must never be
+    // able to redirect the SecretStorage bearer token through workspace settings.
+    const configuredUrl = this.config.inspect<string>('serverUrl')?.globalValue?.trim() ?? '';
+    if (configuredUrl) {
+      const baseUrl = normalizeServerUrl(configuredUrl);
+      const token = (await this.secrets.get(serverTokenSecret(baseUrl)))?.trim() || undefined;
+      // Reuse only when BOTH halves match. The association is stored per (server, workspace), so a
+      // mapping cached under one workspace says nothing about the next one's indexed root.
+      const workspace = workspaceKey();
+      const mapping =
+        this.configuredMapping?.baseUrl === baseUrl &&
+        this.configuredMapping.workspace === workspace
+          ? this.configuredMapping
+          : {
+              workspace,
+              ...(await configuredWorkspaceMapping(this.secrets, baseUrl, token)),
+            };
+      return {
+        endpoint: { baseUrl, token },
+        indexedRootPrefix: mapping.indexedRootPrefix,
+        caseInsensitivePaths: mapping.caseInsensitivePaths,
+        configuredMapping: mapping,
+      };
+    }
+    if (!vscode.workspace.isTrusted) {
+      throw new Error('workspace trust is required for automatic Lens server discovery');
+    }
+
+    for (const folder of discoveryFolders()) {
+      // On web/virtual workspaces the fs is virtual, so a committed
+      // `.rag-rat/sockets/lens.json` would be repository content — an attacker-controlled
+      // redirect target for a browser-issued loopback request. Web hosts must use the
+      // explicitly configured global server URL instead.
+      if (folder.uri.scheme !== 'file') {
+        continue;
+      }
+      for (const candidate of await discoveryCandidates(folder)) {
+        const uri = vscode.Uri.joinPath(candidate.uri, '.rag-rat', 'sockets', 'lens.json');
+        try {
+          const bytes = await vscode.workspace.fs.readFile(uri);
+          const discovery = JSON.parse(new TextDecoder().decode(bytes)) as Partial<LensDiscovery>;
+          if (
+            discovery.schema !== 'rag-rat-lens-discovery' ||
+            discovery.version !== 1 ||
+            typeof discovery.url !== 'string' ||
+            typeof discovery.indexed_root !== 'string' ||
+            typeof discovery.case_insensitive_paths !== 'boolean' ||
+            typeof discovery.ownership_token !== 'string' ||
+            !discovery.ownership_token
+          ) {
+            continue;
+          }
+          const prefix = indexedRootPrefixForDiscovery(
+            discovery.indexed_root,
+            candidate.workspacePath,
+            discovery.case_insensitive_paths,
+          );
+          if (prefix === undefined) {
+            continue;
+          }
+          const baseUrl = normalizeServerUrl(discovery.url);
+          const host = new URL(baseUrl).hostname;
+          if (!isLoopbackHost(host)) {
+            throw new NonLoopbackDiscoveryError(
+              `refusing non-loopback Lens discovery URL ${baseUrl}`,
+            );
+          }
+          return {
+            endpoint: { baseUrl, token: discovery.ownership_token },
+            indexedRootPrefix: prefix,
+            caseInsensitivePaths: discovery.case_insensitive_paths,
+            // Automatic discovery carries no hosted association to remember.
+            configuredMapping: undefined,
+          };
+        } catch (error) {
+          if (error instanceof NonLoopbackDiscoveryError) {
+            throw error;
+          }
+        }
+      }
+    }
+    throw new Error(
+      'no Lens discovery file found; start `rag-rat mcp` in a local workspace or run "rag-rat Lens: Configure Server"',
+    );
+  }
+
+  /**
+   * The indexed path whose CONTENT this document currently shows, or `undefined` when there is
+   * none to speak for.
+   *
+   * Every per-document surface — overlays, diagnostics, hovers, both CodeLens providers, and the
+   * sidebar's active-file view — asks this one question and renders nothing when the answer is
+   * `undefined`. That makes it the single gate for "may line-anchored index data be shown here",
+   * which is why the unsaved-buffer check belongs here and not in each of them.
+   *
+   * A dirty buffer has no answer. Every fact the server can offer for it — a clone region, a
+   * memory binding, a coupling partner — is anchored to line numbers in the SAVED file, and one
+   * inserted line above puts every one of them on the wrong statement. Worse, an edit can delete
+   * the very code a warning is about while the warning stays on screen. The index has never seen
+   * these bytes, so the honest answer is silence until the file is saved and reindexed.
+   */
+  pathOf(document: vscode.TextDocument): string | undefined {
+    if (
+      vscode.workspace.workspaceFolders?.length !== 1 ||
+      !vscode.workspace.getWorkspaceFolder(document.uri) ||
+      document.isDirty
+    ) {
+      return undefined;
+    }
+    return indexedPath(
+      vscode.workspace.asRelativePath(document.uri, false),
+      this.indexedRootPrefix,
+      this.caseInsensitivePaths,
+    );
+  }
+
+  uriOf(path: string): vscode.Uri | undefined {
+    const folder = vscode.workspace.workspaceFolders?.length === 1
+      ? vscode.workspace.workspaceFolders[0]
+      : undefined;
+    const relative = workspacePath(path, this.indexedRootPrefix);
+    if (!folder || relative === undefined) {
+      return undefined;
+    }
+    return vscode.Uri.joinPath(folder.uri, ...relative.split('/'));
+  }
+}
+
+function discoveryFolders(): readonly vscode.WorkspaceFolder[] {
+  return vscode.workspace.workspaceFolders ?? [];
+}
+
+async function discoveryCandidates(folder: vscode.WorkspaceFolder): Promise<DiscoveryCandidate[]> {
+  const candidates: DiscoveryCandidate[] = [{ uri: folder.uri, workspacePath: '' }];
+  const workspaceSegments: string[] = [];
+  let uri = folder.uri;
+  while (true) {
+    if (await exists(vscode.Uri.joinPath(uri, '.git'))) {
+      if (uri.toString() !== folder.uri.toString()) {
+        candidates.push({ uri, workspacePath: workspaceSegments.join('/') });
+      }
+      break;
+    }
+    const segment = uri.path.split('/').filter(Boolean).at(-1);
+    const parent = vscode.Uri.joinPath(uri, '..');
+    if (!segment || parent.toString() === uri.toString()) {
+      break;
+    }
+    workspaceSegments.unshift(segment);
+    uri = parent;
+  }
+  return candidates;
+}
+
+async function exists(uri: vscode.Uri): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function requireSingleRootWorkspace(): void {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  if (folders.length !== 1) {
+    throw new Error('rag-rat Lens currently requires a single-root workspace');
+  }
+}
+
+export function normalizeServerUrl(raw: string): string {
+  const url = new URL(raw);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Lens server URL must use http or https');
+  }
+  if (url.protocol === 'http:' && !isLoopbackHost(url.hostname)) {
+    throw new Error('non-loopback Lens server URLs must use https');
+  }
+  if (url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('Lens server URL must not include a path, query, or fragment');
+  }
+  // `url.origin` would silently drop embedded credentials, leaving the extension to call an
+  // endpoint the user believes is authenticated by them. Say so instead — the server authenticates
+  // with the bearer token this command stores, which is also why it rejects credentials in its own
+  // origin allowlist.
+  if (url.username || url.password) {
+    throw new Error('Lens server URL must not embed credentials; the bearer token authenticates');
+  }
+  return url.origin;
+}
+
+export function serverTokenSecret(baseUrl: string): string {
+  return `rag-rat-lens.serverToken:${encodeURIComponent(normalizeServerUrl(baseUrl))}`;
+}
+
+export function obsoleteServerTokenSecret(
+  previousUrl: string,
+  normalizedUrl: string,
+): string | undefined {
+  if (!previousUrl) {
+    return undefined;
+  }
+  const previousKey = serverTokenSecret(previousUrl);
+  const nextKey = normalizedUrl ? serverTokenSecret(normalizedUrl) : undefined;
+  return previousKey === nextKey ? undefined : previousKey;
+}
+
+async function configuredWorkspaceMapping(
+  secrets: vscode.SecretStorage,
+  baseUrl: string,
+  token: string | undefined,
+): Promise<{ baseUrl: string; indexedRootPrefix: string; caseInsensitivePaths: boolean }> {
+  const status = await fetchServerStatus(baseUrl, token);
+  const association = await readHostedAssociation(baseUrl, secrets);
+  if (!association) {
+    throw new Error(
+      'hosted Lens server is not associated with this workspace; run "rag-rat Lens: Configure Server"',
+    );
+  }
+  // Both halves, because a repository's linked worktrees share one `repo_id`: a server that has
+  // moved to another checkout still answers with the repository this workspace was bound to, while
+  // every line it reports belongs to a different working tree.
+  if (association.repoId !== status.repo_id || association.worktreeId !== status.worktree_id) {
+    throw new Error(
+      'hosted Lens server no longer serves the checkout this workspace was associated with; run "rag-rat Lens: Configure Server"',
+    );
+  }
+  const indexedRootPrefix = normalizeRelativePath(association.indexedRoot ?? status.indexed_root);
+  if (indexedRootPrefix === undefined) {
+    throw new Error('Lens indexed root must be a safe workspace-relative path');
+  }
+  return {
+    baseUrl,
+    indexedRootPrefix,
+    caseInsensitivePaths: status.case_insensitive_paths,
+  };
+}
+
+async function fetchServerStatus(
+  baseUrl: string,
+  token: string | undefined,
+): Promise<LensServerStatus> {
+  const response = await fetch(new URL('/api/status', baseUrl), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`/api/status -> ${response.status}`);
+  }
+  const status = (await response.json()) as Partial<LensServerStatus>;
+  if (
+    typeof status.repo_id !== 'string' ||
+    !status.repo_id ||
+    typeof status.worktree_id !== 'string' ||
+    typeof status.indexed_root !== 'string' ||
+    typeof status.case_insensitive_paths !== 'boolean'
+  ) {
+    throw new Error('/api/status returned invalid workspace metadata');
+  }
+  return status as LensServerStatus;
+}
+
+function workspaceIdentity(): string {
+  requireSingleRootWorkspace();
+  return vscode.workspace.workspaceFolders![0].uri.toString();
+}
+
+export function hostedRepoAssociationSecret(baseUrl: string, workspaceUri: string): string {
+  return `rag-rat-lens.serverRepo:${encodeURIComponent(normalizeServerUrl(baseUrl))}:${encodeURIComponent(workspaceUri)}`;
+}
+
+/** Read this workspace's association with `baseUrl`; an unreadable record fails closed as absent. */
+export async function readHostedAssociation(
+  baseUrl: string,
+  secrets: vscode.SecretStorage,
+): Promise<HostedAssociation | undefined> {
+  const raw = await secrets.get(hostedRepoAssociationSecret(baseUrl, workspaceIdentity()));
+  if (!raw) {
+    return undefined;
+  }
+  let parsed: Partial<HostedAssociation>;
+  try {
+    parsed = JSON.parse(raw) as Partial<HostedAssociation>;
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed.repoId !== 'string' || !parsed.repoId) {
+    return undefined;
+  }
+  // A record without the checkout half predates that binding and cannot be checked against the
+  // server; fail closed and let the user re-associate rather than trust the weaker claim.
+  if (typeof parsed.worktreeId !== 'string') {
+    return undefined;
+  }
+  if (parsed.indexedRoot !== undefined && typeof parsed.indexedRoot !== 'string') {
+    return undefined;
+  }
+  return {
+    repoId: parsed.repoId,
+    worktreeId: parsed.worktreeId,
+    indexedRoot: parsed.indexedRoot,
+  };
+}
+
+export async function associateHostedWorkspace(
+  baseUrl: string,
+  token: string | undefined,
+  secrets: vscode.SecretStorage,
+  indexedRootOverride?: string,
+): Promise<void> {
+  const status = await fetchServerStatus(baseUrl, token);
+  if (
+    indexedRootOverride !== undefined &&
+    normalizeRelativePath(indexedRootOverride) === undefined
+  ) {
+    throw new Error('Lens indexed root must be a safe workspace-relative path');
+  }
+  const association: HostedAssociation = {
+    repoId: status.repo_id,
+    worktreeId: status.worktree_id,
+    indexedRoot: indexedRootOverride,
+  };
+  await secrets.store(
+    hostedRepoAssociationSecret(baseUrl, workspaceIdentity()),
+    JSON.stringify(association),
+  );
+}
+
+export function isLoopbackHost(host: string): boolean {
+  if (host === 'localhost' || host === '[::1]') {
+    return true;
+  }
+  const octets = host.split('.');
+  return octets.length === 4
+    && octets[0] === '127'
+    && octets.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -12,7 +12,7 @@ import {
 } from './discovery';
 import { LensDiagnostics } from './diagnostics';
 import { GraphHoverProvider } from './hover';
-import { registerSignalCommands, SignalLensProvider } from './lenses';
+import { registerSignalCommands, SignalLensProvider, withdrawLensDocuments } from './lenses';
 import { MEMORY_DOC_SCHEME, MemoryCodeLensProvider, MemoryDocProvider, showMemoriesQuickPick } from './memories';
 import { logError, logInfo, showLog } from './output';
 import { LensOverlays } from './overlays';
@@ -258,10 +258,13 @@ export function activate(context: vscode.ExtensionContext): void {
       overlays.clear(editor);
     }
     diagnostics.clear();
-    // Open memory documents are signals too. They are the one surface where staleness leaves no
-    // trace — a decoration on a moved line looks wrong, a rendered memory body does not — so they
-    // have to be withdrawn on the same path, not left showing an unreachable server's claim.
+    // Open documents are signals too. They are the surfaces where staleness leaves no trace — a
+    // decoration on a moved line looks wrong, a rendered memory body or extraction proposal does
+    // not — so they are withdrawn on the same path rather than left showing an unreachable
+    // server's claim. `rag-rat-doc:` documents especially: nothing ever refetches them, because
+    // the command that produced them has already returned.
     memoryDocs.withdraw();
+    withdrawLensDocuments();
   }
 
   let streamController = new AbortController();

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,525 @@
+// Shared entry point for BOTH extension hosts (Node desktop + web worker).
+// Everything here must stay runtime-neutral: vscode API + fetch only.
+import * as vscode from 'vscode';
+import { LensClient } from './client';
+import {
+  associateHostedWorkspace,
+  LensEndpointResolver,
+  normalizeServerUrl,
+  obsoleteServerTokenSecret,
+  readHostedAssociation,
+  serverTokenSecret,
+} from './discovery';
+import { LensDiagnostics } from './diagnostics';
+import { GraphHoverProvider } from './hover';
+import { registerSignalCommands, SignalLensProvider } from './lenses';
+import { MEMORY_DOC_SCHEME, MemoryCodeLensProvider, MemoryDocProvider, showMemoriesQuickPick } from './memories';
+import { logError, logInfo, showLog } from './output';
+import { LensOverlays } from './overlays';
+import { registerSidebar } from './sidebar';
+import { FileStore } from './store';
+
+const RECONNECT_MIN_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+const WORKSPACE_DOCUMENTS: vscode.DocumentSelector = [{ pattern: '**/*' }];
+
+export function activate(context: vscode.ExtensionContext): void {
+  const config = vscode.workspace.getConfiguration('rag-rat-lens');
+  const resolver = new LensEndpointResolver(config, context.secrets);
+  const client = new LensClient(resolver);
+  const store = new FileStore(
+    client,
+    () => config.get<number>('cloneTheta', 0.9),
+    () => config.get<number>('cloneMinTokens', 100),
+    (document) => resolver.pathOf(document),
+    // Identity, not just address: a restarted local server mints a fresh ownership token, and its
+    // index may be a different one than the values already fetched came from.
+    async () => {
+      const endpoint = await resolver.resolve();
+      return `${endpoint.baseUrl} ${endpoint.token ?? ''}`;
+    },
+  );
+  const overlays = new LensOverlays();
+  const diagnostics = new LensDiagnostics();
+  const codeLens = new MemoryCodeLensProvider(store);
+  const memoryDocs = new MemoryDocProvider(store);
+  const signalLens = new SignalLensProvider(store);
+  registerSignalCommands(context, client);
+  const hover = new GraphHoverProvider(store);
+  const sidebar = registerSidebar(context, store);
+
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+  status.command = 'rag-rat-lens.refresh';
+  status.text = '$(pulse) rag-rat: …';
+  status.show();
+
+  type StatusProbe =
+    | { ok: true; status: Awaited<ReturnType<typeof client.status>> }
+    | { ok: false; error: unknown };
+
+  /**
+   * Ask the REST surface whether it is answering. This — not the event stream — decides whether
+   * data is available: a reverse proxy that buffers or blocks `/api/events` leaves every other
+   * endpoint working, and treating that as "offline" would empty every view for a server that is
+   * answering fine. A dead stream costs live refresh, which the status bar says out loud.
+   *
+   * The probe publishes nothing on its own, so a reload that has been superseded while its request
+   * was in flight can drop the answer instead of overwriting a newer one.
+   */
+  async function probeStatus(): Promise<StatusProbe> {
+    try {
+      return { ok: true, status: await client.status() };
+    } catch (error) {
+      return { ok: false, error };
+    }
+  }
+
+  function publishStatus(probe: StatusProbe): void {
+    if (!probe.ok) {
+      status.text = '$(pulse) rag-rat: offline';
+      status.tooltip = 'Lens server unavailable; start `rag-rat mcp` or configure a server URL';
+      logError('status', probe.error);
+      setDataOnline(false);
+      return;
+    }
+    const head = (probe.status.indexed_head ?? '').slice(0, 8);
+    const generation = probe.status.live_files_generation;
+    status.text = `$(pulse) rag-rat: ${probe.status.live_file_count} files${eventsOnline ? '' : ' (paused)'}`;
+    status.tooltip = eventsOnline
+      ? `rag-rat lens — gen ${generation}, head ${head}`
+      : `rag-rat lens — gen ${generation}, head ${head}\nLive updates unavailable; click to refresh`;
+    setDataOnline(true);
+  }
+
+  async function refreshEditor(editor: vscode.TextEditor | undefined): Promise<void> {
+    if (!editor) {
+      return;
+    }
+    const path = store.pathOf(editor.document);
+    rendered.set(editor.document.uri.toString(), path);
+    if (!path) {
+      overlays.clear(editor);
+      diagnostics.clearUri(editor.document.uri);
+      return;
+    }
+    const loaded = await store.dataFor(editor.document);
+    const failure = store.failure(path);
+    if (failure) {
+      // Present for a partially loaded file too — one lane can fail while the rest answer.
+      logError(`overlays ${path}`, failure);
+    }
+    if (!loaded) {
+      // A disconnect must clear hidden editors as they become visible. Epoch invalidation (an SSE
+      // refresh racing an in-flight load) stays untouched and resolves on the next request. A
+      // document that stopped being indexable mid-load — the buffer went dirty — is cleared
+      // outright: `dataFor` withheld the answer precisely so it could not be drawn.
+      if (store.shouldClearSignals(path) || store.pathOf(editor.document) !== path) {
+        overlays.clear(editor);
+        diagnostics.clearUri(editor.document.uri);
+      }
+      return;
+    }
+    if (overlays.isEnabled) {
+      overlays.apply(editor, loaded.data.clones, loaded.path);
+    } else {
+      overlays.clear(editor);
+    }
+    diagnostics.apply(editor.document, loaded.data.memories);
+  }
+
+  async function refreshVisibleEditors(): Promise<void> {
+    await Promise.all(vscode.window.visibleTextEditors.map((editor) => refreshEditor(editor)));
+  }
+
+  /**
+   * The indexed path each document was last DRAWN for, `undefined` when its surfaces were
+   * withheld. Compared against `pathOf` to decide whether anything needs redrawing.
+   *
+   * This records what happened, rather than mirroring VS Code's dirty flag. Mirroring means
+   * predicting which events imply a transition, and the list is longer than it looks: a save, a
+   * revert, an undo back to the saved content, a close that discards edits. Each one missed
+   * leaves a document stuck — either showing the saved file's signals over a dirty buffer, or
+   * silent forever after a revert. Reading `pathOf` and comparing cannot miss a transition,
+   * because it asks the same question the surfaces ask.
+   */
+  const rendered = new Map<string, string | undefined>();
+
+  /**
+   * Redraw everything that speaks for one document after its indexability changed. The CodeLens
+   * providers need telling — VS Code caches lenses until a provider fires its change event —
+   * while overlays, diagnostics, hovers, and the sidebar follow from `refreshEditor` re-asking
+   * `pathOf`.
+   */
+  async function redrawDocument(document: vscode.TextDocument): Promise<void> {
+    const key = document.uri.toString();
+    const path = store.pathOf(document);
+    // Record FIRST, and whether or not an editor is showing this document. A workspace edit or a
+    // rename can dirty a document with no visible editor; leaving the record stale would make
+    // every later keystroke re-run this for no effect.
+    rendered.set(key, path);
+    if (!path) {
+      // Diagnostics are owned per URI and shown in the Problems panel whether the document is
+      // visible or not, so withholding has to reach them even when there is nothing to draw into.
+      diagnostics.clearUri(document.uri);
+    }
+    refreshViews();
+    await Promise.all(
+      vscode.window.visibleTextEditors
+        .filter((editor) => editor.document.uri.toString() === key)
+        .map((editor) => refreshEditor(editor)),
+    );
+  }
+
+  /** Drop cached index data. Fires no requests — refetching is the pipeline's job, after the gate. */
+  function discardIndexData(endpointChanged: boolean): void {
+    if (endpointChanged) {
+      store.reset();
+    } else {
+      store.invalidate();
+    }
+  }
+
+  /**
+   * Re-drive EVERY surface that reads index data. This list is the whole set: the tree views, the
+   * CodeLens providers, the open `rag-rat-memory:` documents, and the visible editors' overlays
+   * and diagnostics.
+   *
+   * It exists so surfaces cannot end up on different sides of the reachability gate. They used to
+   * be driven from two places — some before the status probe and some after — and a surface
+   * refreshed before it is pointless: the store refuses every lane while offline, so it reads
+   * `undefined` and keeps whatever it was already showing. `refreshViews` happened to recover
+   * because `setDataOnline` calls it again; the memory documents had no second caller, so an
+   * offline-to-online transition left them on their pre-outage content until the next version
+   * event. Add new surfaces HERE, not to a caller.
+   */
+  async function refreshIndexSurfaces(): Promise<void> {
+    refreshViews();
+    await Promise.all([memoryDocs.refresh(), refreshVisibleEditors()]);
+  }
+
+  /**
+   * Everything that reads index data: the file-data cache, the views over it, the memory
+   * documents, the status bar, and the signals on open documents. Every "the index moved under us"
+   * path goes through this one call so no site can refresh a subset and leave a stale surface
+   * behind — the status bar's file count is the one that drifted that way.
+   *
+   * Only visible editors are re-fetched (each file costs five requests, and an index change is a
+   * per-save event), so a hidden document's diagnostics are DROPPED rather than refreshed: they
+   * would otherwise keep asserting a memory verdict from an index state that no longer exists,
+   * with nothing to correct them until that tab is next selected.
+   *
+   * The status probe runs FIRST because it is what publishes reachability: the file lanes are
+   * refused while the store is offline, so fetching them concurrently would race the answer.
+   *
+   * Reloads overlap — a stream failure starts one, then the stream reconnects and starts another —
+   * so only the newest may publish. A superseded probe that rejects afterwards would otherwise
+   * take a reachable server offline and clear what the newer one just loaded, with no further
+   * event coming to undo it.
+   */
+  async function reloadIndexData(options: { endpointChanged?: boolean } = {}): Promise<boolean> {
+    const generation = ++reloadGeneration;
+    discardIndexData(options.endpointChanged === true);
+    // Repaint the now-empty views immediately so a slow probe does not leave stale content on
+    // screen; the real refetch happens below, once reachability is published.
+    refreshViews();
+    diagnostics.retainOnly(vscode.window.visibleTextEditors.map((editor) => editor.document.uri));
+    const probe = await probeStatus();
+    if (generation !== reloadGeneration) {
+      return probe.ok;
+    }
+    publishStatus(probe);
+    if (!probe.ok) {
+      clearSignals();
+      return false;
+    }
+    // Symmetric with `clearSignals()` on the failure path: the server is answering, so memory
+    // documents may render real content again. It has to happen HERE, where reachability is
+    // actually known, and not as a side effect inside the refresh — with no memory documents open
+    // that refresh iterates nothing, and a withdrawal made while none were open would never lift.
+    memoryDocs.restore();
+    await refreshIndexSurfaces();
+    return true;
+  }
+
+  function refreshViews(): void {
+    sidebar.refresh();
+    codeLens.refresh();
+    signalLens.refresh();
+  }
+
+  function setDataOnline(online: boolean): void {
+    store.setOnline(online);
+    refreshViews();
+  }
+
+  /** Offline or re-pointed: no open document's signals are trustworthy, visible or not. */
+  function clearSignals(): void {
+    for (const editor of vscode.window.visibleTextEditors) {
+      overlays.clear(editor);
+    }
+    diagnostics.clear();
+    // Open memory documents are signals too. They are the one surface where staleness leaves no
+    // trace — a decoration on a moved line looks wrong, a rendered memory body does not — so they
+    // have to be withdrawn on the same path, not left showing an unreachable server's claim.
+    memoryDocs.withdraw();
+  }
+
+  let streamController = new AbortController();
+  let lastVersion = '';
+  let eventsOnline = false;
+  let eventFailureLogged = false;
+  let reloadGeneration = 0;
+  async function watchVersions(signal: AbortSignal): Promise<void> {
+    let reconnectMs = RECONNECT_MIN_MS;
+    while (!signal.aborted) {
+      try {
+        await client.watchVersions(signal, (version) => {
+          reconnectMs = RECONNECT_MIN_MS;
+          const reconnected = !eventsOnline;
+          if (!eventsOnline) {
+            eventsOnline = true;
+            eventFailureLogged = false;
+            void reloadIndexData();
+          }
+          const token = JSON.stringify(version);
+          if (!reconnected && lastVersion && token !== lastVersion) {
+            void reloadIndexData();
+          }
+          lastVersion = token;
+        });
+      } catch (error) {
+        if (!signal.aborted) {
+          eventsOnline = false;
+          resolver.invalidate();
+          // A dead stream is not a dead server. Reload through the status probe: if REST answers,
+          // the data stays usable and the status bar reports that refresh is manual until the
+          // stream returns; if it does not, the probe is what takes everything offline.
+          void reloadIndexData();
+          if (!eventFailureLogged) {
+            logError('events', error);
+            eventFailureLogged = true;
+          }
+          await delay(reconnectMs, signal);
+          reconnectMs = Math.min(reconnectMs * 2, RECONNECT_MAX_MS);
+        }
+      }
+    }
+  }
+
+  /**
+   * Re-point the event stream. Signals go with it because every caller has just changed WHICH
+   * server answers, but reachability is left to the status probe in the reload that follows —
+   * declaring the store offline here would make the manual refresh command unable to load anything
+   * until the stream happened to connect.
+   */
+  function restartEvents(): void {
+    streamController.abort();
+    streamController = new AbortController();
+    lastVersion = '';
+    eventsOnline = false;
+    clearSignals();
+    void watchVersions(streamController.signal);
+  }
+
+  context.subscriptions.push(
+    status,
+    overlays,
+    diagnostics,
+    codeLens,
+    signalLens,
+    vscode.commands.registerCommand('rag-rat-lens.toggleOverlays', async () => {
+      const on = overlays.toggle();
+      void vscode.window.showInformationMessage(`rag-rat lens overlays ${on ? 'on' : 'off'}`);
+      await refreshVisibleEditors();
+    }),
+    vscode.commands.registerCommand('rag-rat-lens.refresh', async () => {
+      // Re-resolving discovery can land on a different server, so nothing previously fetched is
+      // carried over — this is also the user's escape hatch when something looks wrong.
+      resolver.invalidate();
+      restartEvents();
+      await reloadIndexData({ endpointChanged: true });
+    }),
+    vscode.commands.registerCommand('rag-rat-lens.configureServer', async () => {
+      const previousUrl = config.inspect<string>('serverUrl')?.globalValue?.trim() ?? '';
+      const serverUrl = await vscode.window.showInputBox({
+        prompt: 'Hosted rag-rat Lens server URL (leave empty to use workspace discovery)',
+        value: previousUrl,
+        ignoreFocusOut: true,
+      });
+      if (serverUrl === undefined) {
+        return;
+      }
+      const token = serverUrl.trim()
+        ? await vscode.window.showInputBox({
+            prompt: 'Bearer token',
+            password: true,
+            ignoreFocusOut: true,
+          })
+        : '';
+      if (token === undefined) {
+        return;
+      }
+      let normalizedUrl = '';
+      try {
+        normalizedUrl = serverUrl.trim() ? normalizeServerUrl(serverUrl) : '';
+      } catch (error) {
+        void vscode.window.showErrorMessage(
+          `Invalid Lens server URL: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return;
+      }
+      if (normalizedUrl) {
+        // The override describes how this workspace sits inside this server's index, so it is
+        // asked for — and stored — per association instead of once per machine.
+        // Prefill only: an unreadable association is reported by the association call below.
+        const previousRoot = await readHostedAssociation(normalizedUrl, context.secrets)
+          .then((association) => association?.indexedRoot)
+          .catch(() => undefined);
+        const indexedRoot = await vscode.window.showInputBox({
+          prompt:
+            'Indexed root relative to this workspace (empty to use server metadata; "." when the opened folder is already the indexed root)',
+          value: previousRoot ?? '',
+          ignoreFocusOut: true,
+        });
+        if (indexedRoot === undefined) {
+          return;
+        }
+        try {
+          await associateHostedWorkspace(
+            normalizedUrl,
+            token.trim() || undefined,
+            context.secrets,
+            indexedRoot.trim() || undefined,
+          );
+        } catch (error) {
+          void vscode.window.showErrorMessage(
+            `Could not associate Lens server with this workspace: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return;
+        }
+        const secretKey = serverTokenSecret(normalizedUrl);
+        if (token.trim()) {
+          await context.secrets.store(secretKey, token.trim());
+        } else {
+          await context.secrets.delete(secretKey);
+        }
+      }
+      await config.update('serverUrl', normalizedUrl, vscode.ConfigurationTarget.Global);
+      // Never leave the previous origin's credential behind after a URL change — a stale secret
+      // must not follow the extension to a new server.
+      const obsoleteSecret = obsoleteServerTokenSecret(previousUrl, normalizedUrl);
+      if (obsoleteSecret) {
+        await context.secrets.delete(obsoleteSecret);
+      }
+      resolver.invalidate();
+      restartEvents();
+      await reloadIndexData({ endpointChanged: true });
+    }),
+    vscode.commands.registerCommand(
+      'rag-rat-lens.openLocation',
+      async ({ path, line }: { path: string; line: number }) => {
+        const uri = isSafeRepoPath(path) ? resolver.uriOf(path) : undefined;
+        if (!uri) {
+          return;
+        }
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(doc);
+        const pos = new vscode.Position(Math.max(0, line - 1), 0);
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+      },
+    ),
+    vscode.commands.registerCommand('rag-rat-lens.showLog', () => showLog()),
+    vscode.commands.registerCommand('rag-rat-lens.showMemories', (
+      memories: Parameters<typeof showMemoriesQuickPick>[0],
+      path: Parameters<typeof showMemoriesQuickPick>[1],
+    ) =>
+      showMemoriesQuickPick(memories, path, memoryDocs),
+    ),
+    vscode.languages.registerCodeLensProvider(WORKSPACE_DOCUMENTS, codeLens),
+    vscode.languages.registerCodeLensProvider(WORKSPACE_DOCUMENTS, signalLens),
+    vscode.languages.registerHoverProvider(WORKSPACE_DOCUMENTS, hover),
+    vscode.workspace.registerTextDocumentContentProvider(MEMORY_DOC_SCHEME, memoryDocs),
+    memoryDocs,
+    vscode.window.onDidChangeActiveTextEditor((editor) => refreshEditor(editor)),
+    // Dirtiness decides whether a document has an indexed path at all, so a change that flips it
+    // has to redraw. Only the TRANSITION does work: a keystroke in an already-dirty buffer changes
+    // nothing about what may be shown, and redrawing per keystroke would clear and rebuild every
+    // decoration in the file for no reason. Reverting is a change too, so restoring the saved
+    // content restores its surfaces through this same path.
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      const key = event.document.uri.toString();
+      if (rendered.has(key) && store.pathOf(event.document) !== rendered.get(key)) {
+        void redrawDocument(event.document);
+      }
+    }),
+    // Saving is deliberately NOT special-cased. The buffer is clean again, so the dirty gate
+    // reopens and the file's signals return from whatever the store last fetched — which may still
+    // describe the pre-save contents until the watcher reindexes and the version event repaints.
+    // Withholding across that window was tried and removed: no index-wide signal proves that THIS
+    // file was reindexed, so every variant either released too early or, when a fast watcher's
+    // version event beat the save callback, left the file silent forever. A bounded, self-
+    // correcting staleness window is the better failure. Closing it needs the server to report the
+    // content its answer was computed from — see #1021.
+    vscode.workspace.onDidCloseTextDocument((doc) => {
+      diagnostics.clearUri(doc.uri);
+      // What was drawn for a closed document is not a fact about the next one opened at that URI —
+      // closing a dirty buffer discards the edits, so it reopens clean. Dropping it also keeps the
+      // map from growing across a long session.
+      rendered.delete(doc.uri.toString());
+      if (doc.uri.scheme === MEMORY_DOC_SCHEME) {
+        memoryDocs.forget(doc.uri);
+      }
+    }),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('rag-rat-lens')) {
+        resolver.invalidate();
+        restartEvents();
+        void reloadIndexData({ endpointChanged: true });
+      }
+    }),
+    // A replaced folder is a different repository even when the server URL is identical, so every
+    // cached path mapping and payload has to go. The resolver's caches are workspace-keyed and
+    // would refuse to serve the old mapping anyway; this is what makes the surfaces reflect it
+    // now rather than at the next version event.
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      resolver.invalidate();
+      restartEvents();
+      void reloadIndexData({ endpointChanged: true });
+    }),
+    { dispose: () => streamController.abort() },
+  );
+
+  void reloadIndexData().then((ok) =>
+    logInfo(ok ? 'lens server connected' : 'lens server offline at startup')
+  );
+  void watchVersions(streamController.signal);
+}
+
+export function deactivate(): void {}
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+// Server responses are repository-intelligence data, not filesystem authority: a hosted server
+// must never steer the extension outside the workspace root.
+function isSafeRepoPath(path: string): boolean {
+  if (!path || path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)) {
+    return false;
+  }
+  return !path.split(/[\\/]+/).some((segment) => segment === '..');
+}

--- a/editors/vscode/src/hover.ts
+++ b/editors/vscode/src/hover.ts
@@ -1,0 +1,59 @@
+// Symbol hovers: graph trust data at a glance — caller decomposition,
+// load-bearing bucket, dispatch variants — without opening a quick pick.
+import * as vscode from 'vscode';
+import type { FileStore } from './store';
+
+export class GraphHoverProvider implements vscode.HoverProvider {
+  constructor(private readonly store: FileStore) {}
+
+  async provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): Promise<vscode.Hover | undefined> {
+    const loaded = await this.store.dataFor(document);
+    if (!loaded) {
+      return undefined;
+    }
+    const d = loaded.data;
+    const line = position.line + 1;
+    const s = d.symbols.find((x) => x.start_line === line);
+    if (!s) {
+      return undefined;
+    }
+    const total = s.callers.exact + s.callers.syntactic + s.callers.name_only + s.callers.ambiguous;
+    const md = new vscode.MarkdownString('', true);
+    md.isTrusted = { enabledCommands: ['rag-rat-lens.showCallers'] };
+    const parts = [
+      `**${escapeMarkdown(s.kind)}** \`${escapeMarkdown(s.name)}\``,
+      s.fan_in_bucket !== 'low' ? `**⚑ ${s.fan_in_bucket} load** (fan-in ${s.fan_in_score})` : null,
+      total > 0
+        ? `⤴ ${total} callers — ${[
+            s.callers.exact ? `${s.callers.exact} exact` : '',
+            s.callers.syntactic ? `${s.callers.syntactic} syntactic` : '',
+            s.callers.name_only ? `${s.callers.name_only} name-only` : '',
+            s.callers.ambiguous ? `${s.callers.ambiguous} ambiguous` : '',
+            s.callers.tests ? `${s.callers.tests} test` : '',
+            s.callers.dispatch ? `${s.callers.dispatch} dispatch` : '',
+          ]
+            .filter(Boolean)
+            .join(' · ')}`
+        : '_no static callers (never proof of dead code)_',
+    ].filter(Boolean);
+    md.appendMarkdown(parts.join('  \n'));
+    if (s.qname) {
+      const args = encodeURIComponent(JSON.stringify([s.qname, s.name]));
+      md.appendMarkdown(`  \n[show callers](command:rag-rat-lens.showCallers?${args})`);
+    }
+    if (s.dispatch.length) {
+      const variants = [
+        ...new Set(s.dispatch.map((x) => x.variant).filter((value): value is string => Boolean(value))),
+      ];
+      md.appendMarkdown(`  \n⇄ dispatch: ${variants.map(escapeMarkdown).join(', ')}`);
+    }
+    return new vscode.Hover(md, new vscode.Range(position.line, 0, position.line, 0));
+  }
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replace(/[\\`*_{}[\]()<>#+\-.!|]/g, '\\$&');
+}

--- a/editors/vscode/src/lenses.ts
+++ b/editors/vscode/src/lenses.ts
@@ -1,0 +1,366 @@
+// High-signal CodeLenses over the Lens graph/coupling/papertrail endpoints:
+// trust-decomposed callers, load-bearing bucket, actor dispatch, co-change
+// coupling, issues/PRs per file, distill decision records, extract-helper
+// preview for refined clone classes.
+import * as vscode from 'vscode';
+import type {
+  CloneRegion,
+  CouplingPartner,
+  DecisionRecord,
+  LensClient,
+  PapertrailRef,
+  SymbolGraph,
+} from './client';
+import type { FileStore } from './store';
+
+const DOC_SCHEME = 'rag-rat-doc';
+const docContents = new Map<string, string>();
+const DOC_CACHE_LIMIT = 200;
+let docSeq = 0;
+
+export class LensDocProvider implements vscode.TextDocumentContentProvider {
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    return docContents.get(uri.path) ?? 'not found';
+  }
+}
+
+function openDoc(title: string, markdown: string): Thenable<void> {
+  const key = `/${docSeq++}-${encodeURIComponent(title)}.md`;
+  docContents.set(key, markdown);
+  // Evict the oldest entry (Map preserves insertion order) so a long session's quick-pick docs
+  // cannot grow the map without bound.
+  if (docContents.size > DOC_CACHE_LIMIT) {
+    const oldest = docContents.keys().next().value;
+    if (oldest) {
+      docContents.delete(oldest);
+    }
+  }
+  return vscode.workspace
+    .openTextDocument(vscode.Uri.parse(`${DOC_SCHEME}:${key}`))
+    .then((doc) => vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true))
+    .then(() => undefined);
+}
+
+export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChangeCodeLenses = this.changed.event;
+
+  constructor(private readonly store: FileStore) {}
+
+  refresh(): void {
+    this.changed.fire();
+  }
+
+  dispose(): void {
+    this.changed.dispose();
+  }
+
+  async provideCodeLenses(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
+    const loaded = await this.store.dataFor(document);
+    if (!loaded) {
+      return [];
+    }
+    const d = loaded.data;
+    const lenses: vscode.CodeLens[] = [];
+    for (const s of d.symbols) {
+      const line = Math.min(Math.max(0, s.start_line - 1), document.lineCount - 1);
+      const range = new vscode.Range(line, 0, line, 0);
+      const total = s.callers.exact + s.callers.syntactic + s.callers.name_only + s.callers.ambiguous;
+      if (total > 0 && s.qname) {
+        const tiers = [
+          s.callers.exact ? `${s.callers.exact} exact` : '',
+          s.callers.syntactic ? `${s.callers.syntactic} syntactic` : '',
+          s.callers.name_only ? `${s.callers.name_only} name-only` : '',
+          s.callers.ambiguous ? `${s.callers.ambiguous} ambiguous` : '',
+          s.callers.tests ? `${s.callers.tests} test` : '',
+          s.callers.dispatch ? `${s.callers.dispatch} dispatch` : '',
+        ]
+          .filter(Boolean)
+          .join(' · ');
+        lenses.push(
+          new vscode.CodeLens(range, {
+            title:
+              `⤴ ${total} (${tiers})` +
+              (s.fan_in_bucket === 'critical' || s.fan_in_bucket === 'high'
+                ? `  ⚑${s.fan_in_bucket} load`
+                : ''),
+            command: 'rag-rat-lens.showCallers',
+            arguments: [s.qname, s.name],
+          }),
+        );
+      } else if (s.fan_in_bucket === 'critical' || s.fan_in_bucket === 'high') {
+        lenses.push(new vscode.CodeLens(range, { title: `⚑${s.fan_in_bucket} load`, command: '' }));
+      }
+      if (s.dispatch.length > 0) {
+        const variants = [...new Set(s.dispatch.map((x) => x.variant).filter(Boolean))];
+        lenses.push(
+          new vscode.CodeLens(range, {
+            title: `⇄ ${variants.slice(0, 2).join(', ')}${variants.length > 2 ? ` +${variants.length - 2}` : ''}`,
+            command: 'rag-rat-lens.showDispatch',
+            arguments: [s.dispatch, s.name],
+          }),
+        );
+      }
+    }
+    if (d.coupling.length > 0) {
+      const top = d.coupling[0];
+      lenses.push(
+        new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+          title: `⇄ usually changes with ${basename(top.path)} (${Math.round(top.confidence * 100)}%)${d.coupling.length > 1 ? ` +${d.coupling.length - 1}` : ''}`,
+          command: 'rag-rat-lens.showCoupling',
+          arguments: [d.coupling],
+        }),
+      );
+    }
+    if (d.refs.length > 0) {
+      const open = d.refs.filter((r) => r.state_normalized === 'open').length;
+      lenses.push(
+        new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+          title: `# ${d.refs.length} issue/PR refs${open ? ` (${open} open)` : ''}`,
+          command: 'rag-rat-lens.showRefs',
+          arguments: [d.refs],
+        }),
+      );
+    }
+    for (const dec of d.decisions) {
+      const line = Math.min(Math.max(0, (dec.line ?? 1) - 1), document.lineCount - 1);
+      const verified = dec.outcome_claim_verified && dec.decision_provenance_verified;
+      lenses.push(
+        new vscode.CodeLens(new vscode.Range(line, 0, line, 0), {
+          title: `§ decision: #${dec.item_key} ${(dec.title ?? '').slice(0, 60)}${verified ? ' ✓' : ''}`,
+          command: 'rag-rat-lens.showDecision',
+          arguments: [dec],
+        }),
+      );
+    }
+    for (const region of d.clones) {
+      const refine = region.refine;
+      if (!refine || region.start_line == null) {
+        continue;
+      }
+      const line = Math.min(Math.max(0, region.start_line - 1), document.lineCount - 1);
+      const params = proposedSignature(refine.proposed_signature).params.length;
+      lenses.push(
+        new vscode.CodeLens(new vscode.Range(line, 0, line, 0), {
+          title: `⚒ extract helper (${params} params · refactorability ${refine.refactorability.toFixed(2)})`,
+          command: 'rag-rat-lens.showExtract',
+          arguments: [region],
+        }),
+      );
+    }
+    return lenses;
+  }
+}
+
+function basename(p: string): string {
+  return p.split('/').pop() ?? p;
+}
+
+interface CallerRow {
+  name: string;
+  qname: string | null;
+  path: string;
+  source_start_line: number;
+  edge_kind: string;
+  confidence: string;
+}
+
+export function registerSignalCommands(
+  context: vscode.ExtensionContext,
+  client: LensClient,
+): void {
+  const openLocation = async (path: string | null, line: number | null) => {
+    if (!path) {
+      return;
+    }
+    await vscode.commands.executeCommand('rag-rat-lens.openLocation', { path, line: line ?? 1 });
+  };
+
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(DOC_SCHEME, new LensDocProvider()),
+
+    vscode.commands.registerCommand('rag-rat-lens.showCallers', async (qname: string, name: string) => {
+      const rows = (await client.symbolCallers(qname)) as CallerRow[];
+      const picked = await vscode.window.showQuickPick(
+        rows.map((r) => ({
+          label: `$(symbol-method) ${r.name}`,
+          description: `${r.confidence} · ${r.edge_kind}`,
+          detail: `${r.path}:${r.source_start_line}`,
+          row: r,
+        })),
+        { placeHolder: `${rows.length} callers of ${name}` },
+      );
+      if (picked) {
+        await openLocation(picked.row.path, picked.row.source_start_line);
+      }
+    }),
+
+    vscode.commands.registerCommand(
+      'rag-rat-lens.showDispatch',
+      async (items: SymbolGraph['dispatch'], name: string) => {
+        const picked = await vscode.window.showQuickPick(
+          items.map((d) => ({
+            label: `$(radio-tower) ${d.variant ?? '?'} — ${d.direction}`,
+            description: d.other_name ?? '',
+            detail: `${d.other_path}:${d.other_line ?? '?'}`,
+            item: d,
+          })),
+          { placeHolder: `dispatch edges of ${name}` },
+        );
+        if (picked) {
+          await openLocation(picked.item.other_path, picked.item.other_line);
+        }
+      },
+    ),
+
+    vscode.commands.registerCommand('rag-rat-lens.showCoupling', async (partners: CouplingPartner[]) => {
+      const picked = await vscode.window.showQuickPick(
+        partners.map((p) => ({
+          label: `$(git-compare) ${p.path}`,
+          description: `${Math.round(p.confidence * 100)}% · ${p.co_changes}/${p.my_changes} co-changes`,
+          partner: p,
+        })),
+        { placeHolder: 'files that usually change together (lift-curated)' },
+      );
+      if (picked) {
+        await openLocation(picked.partner.path, 1);
+      }
+    }),
+
+    vscode.commands.registerCommand('rag-rat-lens.showRefs', async (refs: PapertrailRef[]) => {
+      const picked = await vscode.window.showQuickPick(
+        refs.map((r) => ({
+          label: `$(issues) #${r.item_key} ${r.title ?? ''}`,
+          description: `${r.item_kind} · ${r.state_normalized ?? '?'} · ${r.ref_kind}`,
+          detail: r.source_text.slice(0, 120),
+          ref: r,
+        })),
+        { placeHolder: 'tracker items referencing this file' },
+      );
+      const uri = externalUri(picked?.ref.url ?? null);
+      if (uri) {
+        await vscode.env.openExternal(uri);
+      }
+    }),
+
+    vscode.commands.registerCommand('rag-rat-lens.showDecision', (d: DecisionRecord) => {
+      const verified = d.outcome_claim_verified && d.decision_provenance_verified;
+      return openDoc(
+        `decision-${d.item_key}`,
+        [
+          `# Decision record: #${d.item_key} ${d.title ?? ''}`,
+          '',
+          `**status** ${d.outcome_status_model ?? '?'} · **verified facets** ${verified ? 'both' : 'partial/none'} · **fix edge** ${d.fix_edge_source} · ${d.url ?? ''}`,
+          '',
+          '## Root issue',
+          '',
+          d.root_issue ?? '_none recorded_',
+          '',
+          '## Root cause',
+          '',
+          d.root_cause ?? '_none recorded_',
+          '',
+          '## Decision',
+          '',
+          d.decision_chosen ?? '_none recorded_',
+          '',
+          '## Outcome',
+          '',
+          d.outcome_summary ?? '_none recorded_',
+          '',
+        ].join('\n'),
+      );
+    }),
+
+    vscode.commands.registerCommand('rag-rat-lens.showExtract', (region: CloneRegion) => {
+      const r = region.refine;
+      if (!r) {
+        return undefined;
+      }
+      const signature = proposedSignature(r.proposed_signature);
+      const params = signature.params.map(
+        (p, i) => `- \`${p.name ?? `arg${i}`}\`: \`${p.type_text ?? '?'}\` _(${p.confidence ?? '?'})_`,
+      );
+      const vars = variationPoints(r.variation_points).map(
+        (v) =>
+          `- \`${v.metavar_id ?? '?'}\` ${v.extraction_role ?? ''} → ${(v.per_member_values ?? [])
+            .map((x) => `\`${x}\``)
+            .join(', ')}`,
+      );
+      return openDoc(
+        `extract-${region.symbol ?? 'helper'}`,
+        [
+          `# Extract helper preview — ${region.symbol ?? ''}`,
+          '',
+          `**refactorability** ${r.refactorability.toFixed(2)} · **coverage** ${r.anti_unify_coverage.toFixed(2)} · **lcs** ${r.lcs_ratio.toFixed(2)} · **confidence** ${r.confidence}`,
+          '',
+          '## Proposed signature',
+          '',
+          '```rust',
+          signature.text ?? 'fn extracted(…)',
+          '```',
+          '',
+          ...(params.length ? ['## Parameters', '', ...params, ''] : []),
+          '## Template (⟨mN⟩ = variation points)',
+          '',
+          '```rust',
+          r.template,
+          '```',
+          '',
+          ...(vars.length ? ['## Variation points', '', ...vars, ''] : []),
+          '_Name is a placeholder; closure/type params and low-confidence metavars need human review._',
+        ].join('\n'),
+      );
+    }),
+  );
+}
+
+interface ProposedSignature {
+  text?: string;
+  params: { name?: string; type_text?: string; confidence?: string }[];
+}
+
+interface VariationPoint {
+  metavar_id?: string;
+  extraction_role?: string;
+  per_member_values?: string[];
+}
+
+function proposedSignature(value: unknown): ProposedSignature {
+  if (!isRecord(value)) {
+    return { params: [] };
+  }
+  const params = Array.isArray(value.params)
+    ? value.params.filter(isRecord).map((param) => ({
+        name: typeof param.name === 'string' ? param.name : undefined,
+        type_text: typeof param.type_text === 'string' ? param.type_text : undefined,
+        confidence: typeof param.confidence === 'string' ? param.confidence : undefined,
+      }))
+    : [];
+  return { text: typeof value.text === 'string' ? value.text : undefined, params };
+}
+
+function variationPoints(value: unknown): VariationPoint[] {
+  return Array.isArray(value)
+    ? value.filter(isRecord).map((point) => ({
+        metavar_id: typeof point.metavar_id === 'string' ? point.metavar_id : undefined,
+        extraction_role:
+          typeof point.extraction_role === 'string' ? point.extraction_role : undefined,
+        per_member_values: Array.isArray(point.per_member_values)
+          ? point.per_member_values.filter((item): item is string => typeof item === 'string')
+          : undefined,
+      }))
+    : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function externalUri(raw: string | null): vscode.Uri | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const uri = vscode.Uri.parse(raw);
+  return uri.scheme === 'https' || uri.scheme === 'http' ? uri : undefined;
+}

--- a/editors/vscode/src/lenses.ts
+++ b/editors/vscode/src/lenses.ts
@@ -14,31 +14,77 @@ import type {
 import type { FileStore } from './store';
 
 const DOC_SCHEME = 'rag-rat-doc';
-const docContents = new Map<string, string>();
 const DOC_CACHE_LIMIT = 200;
-let docSeq = 0;
 
+/** Shown in place of a document whose server is gone — see `LensDocProvider.withdraw`. */
+const WITHDRAWN_DOC = [
+  '# Unavailable',
+  '',
+  'The Lens server that produced this is no longer being served.',
+  'Re-run the command once the server is reachable again.',
+].join('\n');
+
+/**
+ * Backing store for the read-only `rag-rat-doc:` documents — decision records and extraction
+ * proposals opened from a CodeLens.
+ *
+ * The contents belong to the PROVIDER rather than the module, so their lifetime is the registered
+ * provider's and a test can exercise one without reaching into shared state.
+ */
 export class LensDocProvider implements vscode.TextDocumentContentProvider {
+  private readonly contents = new Map<string, string>();
+  private readonly changed = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this.changed.event;
+  private sequence = 0;
+
   provideTextDocumentContent(uri: vscode.Uri): string {
-    return docContents.get(uri.path) ?? 'not found';
+    return this.contents.get(uri.path) ?? 'not found';
+  }
+
+  /** Render `markdown` as a new document and show it beside the editor. */
+  open(title: string, markdown: string): Thenable<void> {
+    const key = `/${this.sequence++}-${encodeURIComponent(title)}.md`;
+    this.contents.set(key, markdown);
+    // Evict the oldest entry (Map preserves insertion order) so a long session's quick-pick docs
+    // cannot grow the map without bound.
+    if (this.contents.size > DOC_CACHE_LIMIT) {
+      const oldest = this.contents.keys().next().value;
+      if (oldest) {
+        this.contents.delete(oldest);
+      }
+    }
+    return vscode.workspace
+      .openTextDocument(vscode.Uri.parse(`${DOC_SCHEME}:${key}`))
+      .then((doc) => vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true))
+      .then(() => undefined);
+  }
+
+  /**
+   * Withdraw every open `rag-rat-doc:` document.
+   *
+   * These render a decision record or an extraction proposal from ONE server and one checkout, and
+   * unlike every other surface they are never refetched — the command that produced them has
+   * already returned. An endpoint change or an outage would otherwise leave them presenting the
+   * previous server's answer indefinitely, after everything around them has been cleared. Replaced
+   * rather than deleted, because an absent key already means "no such document".
+   */
+  withdraw(): void {
+    for (const key of [...this.contents.keys()]) {
+      this.contents.set(key, WITHDRAWN_DOC);
+      this.changed.fire(vscode.Uri.parse(`${DOC_SCHEME}:${key}`));
+    }
   }
 }
 
+/** The registered provider, so the extension can withdraw its documents on an endpoint change. */
+let lensDocs: LensDocProvider | undefined;
+
+export function withdrawLensDocuments(): void {
+  lensDocs?.withdraw();
+}
+
 function openDoc(title: string, markdown: string): Thenable<void> {
-  const key = `/${docSeq++}-${encodeURIComponent(title)}.md`;
-  docContents.set(key, markdown);
-  // Evict the oldest entry (Map preserves insertion order) so a long session's quick-pick docs
-  // cannot grow the map without bound.
-  if (docContents.size > DOC_CACHE_LIMIT) {
-    const oldest = docContents.keys().next().value;
-    if (oldest) {
-      docContents.delete(oldest);
-    }
-  }
-  return vscode.workspace
-    .openTextDocument(vscode.Uri.parse(`${DOC_SCHEME}:${key}`))
-    .then((doc) => vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true))
-    .then(() => undefined);
+  return lensDocs ? lensDocs.open(title, markdown) : Promise.resolve();
 }
 
 export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
@@ -177,7 +223,7 @@ export function registerSignalCommands(
   };
 
   context.subscriptions.push(
-    vscode.workspace.registerTextDocumentContentProvider(DOC_SCHEME, new LensDocProvider()),
+    vscode.workspace.registerTextDocumentContentProvider(DOC_SCHEME, (lensDocs = new LensDocProvider())),
 
     vscode.commands.registerCommand('rag-rat-lens.showCallers', async (qname: string, name: string) => {
       const rows = (await client.symbolCallers(qname)) as CallerRow[];

--- a/editors/vscode/src/memories.ts
+++ b/editors/vscode/src/memories.ts
@@ -1,0 +1,267 @@
+// Clickable memory affordance: a CodeLens above each line that carries repo
+// memories ("◆ N bound memories") -> QuickPick -> full memory in a read-only doc.
+import * as vscode from 'vscode';
+import type { FileMemory } from './client';
+import type { FileStore } from './store';
+import { verdictDirectionLabel } from './verdict';
+
+export const MEMORY_DOC_SCHEME = 'rag-rat-memory';
+
+export class MemoryCodeLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChangeCodeLenses = this.changed.event;
+
+  constructor(private readonly store: FileStore) {}
+
+  refresh(): void {
+    this.changed.fire();
+  }
+
+  dispose(): void {
+    this.changed.dispose();
+  }
+
+  async provideCodeLenses(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
+    const loaded = await this.store.dataFor(document);
+    const memories = loaded?.data.memories;
+    if (!loaded || !memories) {
+      return [];
+    }
+    const path = loaded.path;
+    const byLine = new Map<number, FileMemory[]>();
+    for (const m of memories) {
+      const line = Math.min(Math.max(0, (m.line ?? 1) - 1), document.lineCount - 1);
+      const list = byLine.get(line) ?? [];
+      list.push(m);
+      byLine.set(line, list);
+    }
+    const lenses: vscode.CodeLens[] = [];
+    for (const [line, list] of byLine) {
+      lenses.push(
+        new vscode.CodeLens(new vscode.Range(line, 0, line, 0), {
+          title: `◆ ${list.length} bound ${list.length === 1 ? 'memory' : 'memories'}`,
+          command: 'rag-rat-lens.showMemories',
+          arguments: [list, path],
+        }),
+      );
+    }
+    return lenses;
+  }
+}
+
+export async function showMemoriesQuickPick(
+  memories: FileMemory[],
+  path: string,
+  documents: MemoryDocProvider,
+): Promise<void> {
+  const picked = await vscode.window.showQuickPick(
+    memories.map((m) => ({
+      label: `$(bookmark) ${m.kind}: ${m.title}`,
+      description: `${m.confidence} · ${m.anchor_status} · ${m.binding_kind}`,
+      memory: m,
+    })),
+    { placeHolder: 'repo memories on this line' },
+  );
+  if (!picked) {
+    return;
+  }
+  // Re-read by id rather than rendering the captured object. These items were built when the
+  // CodeLens was, and the index can move while the picker sits open — the refresh that would have
+  // corrected the document has then already run, so a stale render survives until the NEXT index
+  // change. Worse, a memory deleted in the meantime would be put back on screen as though it still
+  // existed.
+  const outcome = await documents.openPicked(picked.memory.id, path);
+  if (outcome.kind !== 'ready') {
+    void vscode.window.showInformationMessage(
+      outcome.kind === 'absent'
+        ? 'That memory could not be opened — it may have been removed, or the lookup for this file failed.'
+        : 'The Lens server is not answering, so that memory cannot be opened.',
+    );
+    return;
+  }
+  const doc = await vscode.workspace.openTextDocument(outcome.uri);
+  await vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true);
+}
+
+function renderMemoryDoc(m: FileMemory): string {
+  const head = [
+    `# ${m.title}`,
+    '',
+    `**kind** ${m.kind}  ·  **confidence** ${m.confidence}  ·  **anchor** ${m.anchor_status}  ·  **binding** ${m.binding_kind}`,
+    '',
+  ];
+  const verdict = verdictSection(m);
+  if (m.summary) {
+    return [...head, '## Excerpt', '', m.summary, '', '## Verbatim', '', m.body, '', ...verdict].join('\n');
+  }
+  return [...head, m.body, '', ...verdict].join('\n');
+}
+
+function verdictSection(m: FileMemory): string[] {
+  if (!m.verdict) {
+    return [];
+  }
+  const direction = m.verdict === 'diverged' || m.verdict_direction
+    ? ` (${verdictDirectionLabel(m.verdict_direction)})`
+    : '';
+  const lines = [
+    '## Verdict',
+    '',
+    `**${m.verdict}**${direction}${m.checked_against_commit ? ` · checked against \`${m.checked_against_commit.slice(0, 8)}\`` : ''}`,
+    '',
+  ];
+  if (m.verdict_evidence) {
+    try {
+      const checks = JSON.parse(m.verdict_evidence) as string[];
+      lines.push(...checks.map((c) => `- ${c}`), '');
+    } catch {
+      /* evidence_json is informational */
+    }
+  }
+  return lines;
+}
+
+/** What opening a picked memory produced — see `MemoryDocProvider.openPicked`. */
+export type MemoryPick =
+  | { kind: 'ready'; uri: vscode.Uri }
+  /** Not in the payload we got back. Deliberately NOT called "deleted" — see `openPicked`. */
+  | { kind: 'absent' }
+  | { kind: 'unavailable' };
+
+/** Shown in place of a memory document while the server that produced it is unreachable. */
+const UNAVAILABLE_DOC = [
+  '# Memory unavailable',
+  '',
+  'The Lens server is not answering, so this memory cannot be shown.',
+  'It will reappear when the server is reachable again.',
+].join('\n');
+
+export class MemoryDocProvider implements vscode.TextDocumentContentProvider, vscode.Disposable {
+  private readonly contents = new Map<string, string>();
+  private readonly sourcePaths = new Map<string, string>();
+  private readonly changed = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this.changed.event;
+  /** Bumped by `withdraw()` so a refresh started before it cannot publish after it. */
+  private epoch = 0;
+  /**
+   * Whether the server behind these documents is currently unreachable. Withdrawal has to be a
+   * STATE, not a one-off rewrite: a memory can be re-rendered from a `FileMemory` captured before
+   * the outage — an open QuickPick, a CodeLens or tree command still clickable — which would put
+   * the unreachable server's body back on screen without anyone contacting it.
+   */
+  private withdrawn = false;
+
+  constructor(private readonly store: FileStore) {}
+
+  /**
+   * Open the memory `id` as it stands NOW, re-read from `path` after a picker resolved.
+   *
+   * `absent` does NOT mean deleted, and the caller must not say that it does. `FileStore.data`
+   * merges five independently-settling lanes: when the memory lane alone fails it substitutes the
+   * previous value for up to a minute, and an empty list once that expires. So a memory missing
+   * here may have been removed from the index, or its lookup may simply have failed — and one
+   * present here may be up to a minute old. Only `undefined` from the store is authoritative, and
+   * only about the server as a whole. Telling a lane's answer from its fallback needs provenance
+   * the store does not yet expose — #1026.
+   *
+   * What this DOES guarantee is that nothing is rendered from the object the picker captured, so a
+   * memory the index no longer holds cannot be put back on screen as though it did.
+   */
+  async openPicked(id: string, path: string): Promise<MemoryPick> {
+    const data = await this.store.data(path);
+    if (!data) {
+      return { kind: 'unavailable' };
+    }
+    const memory = data.memories.find((candidate) => candidate.id === id);
+    return memory ? { kind: 'ready', uri: this.update(memory, path) } : { kind: 'absent' };
+  }
+
+  update(memory: FileMemory, path: string): vscode.Uri {
+    const uri = memoryUri(memory.id);
+    // Track the source path either way, so a reconnect knows which file to restore this from.
+    this.sourcePaths.set(memory.id, path);
+    this.contents.set(memory.id, this.withdrawn ? UNAVAILABLE_DOC : renderMemoryDoc(memory));
+    this.changed.fire(uri);
+    return uri;
+  }
+
+  async refresh(): Promise<void> {
+    // A refresh in flight when the server drops out would otherwise restore the very content
+    // `withdraw()` just replaced. Same discipline as everywhere else here: an async result may
+    // only publish if the state it was computed under still holds.
+    const epoch = this.epoch;
+    const byPath = new Map<string, string[]>();
+    for (const [id, path] of this.sourcePaths) {
+      const ids = byPath.get(path) ?? [];
+      ids.push(id);
+      byPath.set(path, ids);
+    }
+    await Promise.all([...byPath].map(async ([path, ids]) => {
+      const data = await this.store.data(path);
+      if (!data || this.epoch !== epoch) {
+        return;
+      }
+      const current = new Map(data.memories.map((memory) => [memory.id, memory]));
+      for (const id of ids) {
+        const memory = current.get(id);
+        if (memory) {
+          this.update(memory, path);
+        } else {
+          this.contents.delete(id);
+          this.changed.fire(memoryUri(id));
+        }
+      }
+    }));
+  }
+
+  /**
+   * Withdraw every open memory document's content, keeping its source path so a reconnect can
+   * restore it.
+   *
+   * An open `rag-rat-memory:` document is a rendered claim from one server about one memory —
+   * its body, its verdict, the commit it was checked against. When that server stops answering,
+   * or the extension is pointed at a different one, the claim is no longer backed by anything,
+   * and `refresh()` cannot correct it: with no data to compare against it leaves the previous
+   * contents in place. Left alone the document keeps presenting the old server's memory
+   * indefinitely, which is the one surface where staleness is invisible — there is no line
+   * number to look wrong against.
+   */
+  /** The server is answering again: render real content once more. Contents follow on refresh. */
+  restore(): void {
+    this.withdrawn = false;
+  }
+
+  withdraw(): void {
+    this.epoch += 1;
+    this.withdrawn = true;
+    for (const id of [...this.contents.keys()]) {
+      // REPLACED, not deleted: an absent entry already means "this memory is gone from the index",
+      // which `refresh()` produces when a memory really was removed. An outage is a different
+      // statement and must not be reported as a deletion.
+      this.contents.set(id, UNAVAILABLE_DOC);
+      this.changed.fire(memoryUri(id));
+    }
+  }
+
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    return this.contents.get(memoryId(uri)) ?? 'memory not found';
+  }
+
+  forget(uri: vscode.Uri): void {
+    const id = memoryId(uri);
+    this.contents.delete(id);
+    this.sourcePaths.delete(id);
+  }
+
+  dispose(): void {
+    this.changed.dispose();
+  }
+}
+
+function memoryUri(id: string): vscode.Uri {
+  return vscode.Uri.parse(`${MEMORY_DOC_SCHEME}:/${encodeURIComponent(id)}.md`);
+}
+
+function memoryId(uri: vscode.Uri): string {
+  return decodeURIComponent(uri.path.replace(/^\//, '').replace(/\.md$/, ''));
+}

--- a/editors/vscode/src/output.ts
+++ b/editors/vscode/src/output.ts
@@ -1,0 +1,18 @@
+// One output channel for the whole extension: client failures, status
+// transitions, poll anomalies. Replaces the silent `catch {}` lanes.
+import * as vscode from 'vscode';
+
+const channel = vscode.window.createOutputChannel('rag-rat Lens');
+
+export function logInfo(message: string): void {
+  channel.appendLine(`[info] ${message}`);
+}
+
+export function logError(context: string, error: unknown): void {
+  const detail = error instanceof Error ? `${error.message}` : String(error);
+  channel.appendLine(`[error] ${context}: ${detail}`);
+}
+
+export function showLog(): void {
+  channel.show(true);
+}

--- a/editors/vscode/src/overlays.ts
+++ b/editors/vscode/src/overlays.ts
@@ -1,0 +1,202 @@
+// In-file overlays: clone-class ranges — one hue per coherent class of the
+// clone graph, so siblings light up in the same color; neutral gray for
+// regions with no near-clone group. Memory signals live in the CodeLens,
+// sidebar, and diagnostics lanes, not in decorations.
+import * as vscode from 'vscode';
+import type { CloneRegion } from './client';
+
+// Distinct hues, cycled by class_id; enough that adjacent classes rarely collide.
+const CLONE_HUES = [280, 200, 340, 160, 20, 100, 240, 300, 0, 60];
+
+export class LensOverlays implements vscode.Disposable {
+  private enabled = false;
+  private cloneTypes = new Map<string, vscode.TextEditorDecorationType>();
+
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  toggle(): boolean {
+    this.enabled = !this.enabled;
+    if (!this.enabled) {
+      for (const editor of vscode.window.visibleTextEditors) {
+        this.clear(editor);
+      }
+    }
+    return this.enabled;
+  }
+
+  clear(editor: vscode.TextEditor | undefined): void {
+    if (!editor) {
+      return;
+    }
+    for (const t of this.cloneTypes.values()) {
+      editor.setDecorations(t, []);
+    }
+  }
+
+  apply(editor: vscode.TextEditor, clones: CloneRegion[], path: string): void {
+    if (!this.enabled) {
+      return;
+    }
+    const cloneBuckets = new Map<string, vscode.DecorationOptions[]>();
+    for (const region of mergeRegions(editor, clones)) {
+      const cls = region.class_id ?? -1;
+      const heading = region.class_id != null
+        ? `**clone class ${cls}** · near-clone group`
+        : '**similar code** (no near-clone group)';
+      const hover = new vscode.MarkdownString('', true);
+      hover.isTrusted = { enabledCommands: ['rag-rat-lens.openLocation'] };
+      hover.supportThemeIcons = true;
+      hover.appendMarkdown(
+        `${heading}\n\n${region.partners.length} similar region${region.partners.length === 1 ? '' : 's'} · ` +
+          `best similarity ${region.max_similarity.toFixed(2)}\n\n`,
+      );
+      for (const p of region.partners.slice(0, 8)) {
+        const where = p.path === path ? 'this file' : p.path;
+        const name = p.symbol ? ` · ${p.symbol}` : '';
+        const label = `${where}${spanText(p.start_line, p.end_line)}${name} (${p.similarity.toFixed(2)})`;
+        const args = encodeURIComponent(JSON.stringify([{ path: p.path, line: p.start_line ?? 1 }]));
+        hover.appendMarkdown(
+          `- [${escapeMarkdown(label)}](command:rag-rat-lens.openLocation?${args} "open")\n`,
+        );
+      }
+      if (region.partners.length > 8) {
+        hover.appendMarkdown(`- … +${region.partners.length - 8} more`);
+      }
+      const style = cls < 0 ? -1 : cls % CLONE_HUES.length;
+      const key = `${style}:${simTier(region.max_similarity)}`;
+      const bucket = cloneBuckets.get(key) ?? [];
+      bucket.push({
+        range: inclusiveLineRange(editor.document, region.start_line, region.end_line),
+        hoverMessage: hover,
+      });
+      cloneBuckets.set(key, bucket);
+    }
+    for (const [key, t] of this.cloneTypes) {
+      if (!cloneBuckets.has(key)) {
+        editor.setDecorations(t, []);
+      }
+    }
+    for (const [key, options] of cloneBuckets) {
+      const [styleS, tierS] = key.split(':');
+      editor.setDecorations(this.cloneTypeFor(Number(styleS), Number(tierS)), options);
+    }
+  }
+
+  private cloneTypeFor(style: number, tier: number): vscode.TextEditorDecorationType {
+    const key = `${style}:${tier}`;
+    let t = this.cloneTypes.get(key);
+    if (!t) {
+      // Strength by similarity tier: exact/near clones pop, weak matches stay faint.
+      const alpha = tier === 2 ? 0.18 : tier === 1 ? 0.11 : 0.06;
+      if (style < 0) {
+        // No tight (>=0.9) clone class: neutral gray 'similar code elsewhere' tint.
+        t = vscode.window.createTextEditorDecorationType({
+          isWholeLine: true,
+          backgroundColor: `hsla(0, 0%, 55%, ${alpha})`,
+          overviewRulerColor: 'hsla(0, 0%, 55%, 0.5)',
+          overviewRulerLane: vscode.OverviewRulerLane.Left,
+        });
+      } else {
+        const hue = CLONE_HUES[style];
+        t = vscode.window.createTextEditorDecorationType({
+          isWholeLine: true,
+          backgroundColor: `hsla(${hue}, 70%, 55%, ${alpha})`,
+          border: tier === 2 ? `1px solid hsla(${hue}, 70%, 55%, 0.5)` : undefined,
+          overviewRulerColor: `hsla(${hue}, 70%, 55%, 0.8)`,
+          overviewRulerLane: vscode.OverviewRulerLane.Left,
+        });
+      }
+      this.cloneTypes.set(key, t);
+    }
+    return t;
+  }
+
+  dispose(): void {
+    for (const t of this.cloneTypes.values()) {
+      t.dispose();
+    }
+  }
+}
+
+export function inclusiveLineRange(
+  document: vscode.TextDocument,
+  startLine: number,
+  endLine: number,
+): vscode.Range {
+  const lastDocumentLine = Math.max(0, document.lineCount - 1);
+  const start = Math.min(Math.max(0, startLine - 1), lastDocumentLine);
+  const end = Math.min(Math.max(start, endLine - 1), lastDocumentLine);
+  return new vscode.Range(start, 0, end, document.lineAt(end).text.length);
+}
+
+interface MergedRegion {
+  start_line: number;
+  end_line: number;
+  class_id: number | null;
+  max_similarity: number;
+  partners: CloneRegion['partners'];
+}
+
+// Sub-block edges produce several overlapping candidate spans per area; for
+// display, union overlapping line intervals only within the same coherent class.
+function mergeRegions(editor: vscode.TextEditor, regions: CloneRegion[]): MergedRegion[] {
+  const normalized = regions
+    .map((r) => {
+      const start = r.start_line != null ? r.start_line : editor.document.positionAt(r.byte_offset).line + 1;
+      const end = r.end_line != null ? r.end_line : start;
+      return {
+        start_line: start,
+        end_line: Math.max(start, end),
+        class_id: r.class_id,
+        max_similarity: r.max_similarity ?? 0,
+        partners: r.partners,
+      };
+    })
+    .sort((a, b) => a.start_line - b.start_line || b.max_similarity - a.max_similarity);
+  const merged: MergedRegion[] = [];
+  for (const r of normalized) {
+    const last = merged[merged.length - 1];
+    if (
+      last &&
+      r.class_id != null &&
+      r.class_id === last.class_id &&
+      r.start_line <= last.end_line
+    ) {
+      last.end_line = Math.max(last.end_line, r.end_line);
+      if (r.max_similarity > last.max_similarity) {
+        last.max_similarity = r.max_similarity;
+        last.class_id = r.class_id;
+      }
+      const seen = new Set(last.partners.map((p) => `${p.path}:${p.start_line}`));
+      for (const p of r.partners) {
+        const key = `${p.path}:${p.start_line}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          last.partners.push(p);
+        }
+      }
+      last.partners.sort((a, b) => b.similarity - a.similarity);
+      last.partners = last.partners.slice(0, 12);
+    } else {
+      merged.push({ ...r, partners: [...r.partners] });
+    }
+  }
+  return merged;
+}
+
+function simTier(sim: number): number {
+  return sim >= 0.95 ? 2 : sim >= 0.85 ? 1 : 0;
+}
+
+function spanText(start: number | null, end: number | null): string {
+  if (start == null) {
+    return '';
+  }
+  return end != null && end !== start ? `:${start}-${end}` : `:${start}`;
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replace(/[\\`*_{}[\]()<>#+\-.!|]/g, '\\$&');
+}

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -1,0 +1,317 @@
+// Sidebar tree views: per-file Clone Classes, Memories, and Issues & Decisions.
+// All three refresh off the active editor and the index-version poll, and all
+// read from the shared per-file FileStore (no per-view fetching).
+import * as vscode from 'vscode';
+import type { CloneRegion, DecisionRecord, PapertrailRef } from './client';
+import type { FileData, FileStore } from './store';
+
+class Item extends vscode.TreeItem {
+  constructor(
+    label: string,
+    options?: {
+      description?: string;
+      tooltip?: string | vscode.MarkdownString;
+      command?: vscode.Command;
+      icon?: vscode.ThemeIcon;
+      children?: Item[];
+      contextValue?: string;
+    },
+  ) {
+    super(
+      label,
+      options?.children?.length
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.None,
+    );
+    this.description = options?.description;
+    this.tooltip = options?.tooltip;
+    this.command = options?.command;
+    this.iconPath = options?.icon;
+    this.contextValue = options?.contextValue;
+    if (options?.children?.length) {
+      // TreeDataProvider children are carried via getChildren on the item itself.
+      (this as { children?: Item[] }).children = options.children;
+    }
+  }
+  children?: Item[];
+}
+
+/**
+ * How many times a tree load may be re-aimed at a newly active editor before giving up. Each
+ * attempt awaits a real load, so the bound exists to end an unwinnable race with a user paging
+ * through files, not to prevent a hot loop.
+ */
+const STALE_LOAD_RETRIES = 4;
+
+abstract class FileView implements vscode.TreeDataProvider<Item> {
+  private emitter = new vscode.EventEmitter<Item | undefined>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  constructor(protected readonly store: FileStore) {}
+
+  refresh(): void {
+    this.emitter.fire(undefined);
+  }
+
+  getTreeItem(element: Item): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: Item): Promise<Item[]> {
+    if (element) {
+      return element.children ?? [];
+    }
+    // These views describe the ACTIVE file, so an answer about a document that stopped being
+    // active is wrong however good the data is. Rather than discard it — which would let a slow
+    // load, resolving after a newer one, blank the tree the newer one just filled — re-ask about
+    // wherever the user now is. Whichever request settles last then still describes the current
+    // editor, so the outcome no longer depends on completion order.
+    for (let attempt = 0; attempt < STALE_LOAD_RETRIES; attempt += 1) {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        return [
+          new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') }),
+        ];
+      }
+      const document = editor.document.uri.toString();
+      const loaded = await this.store.dataFor(editor.document);
+      if (vscode.window.activeTextEditor?.document.uri.toString() !== document) {
+        continue;
+      }
+      if (!loaded) {
+        // Distinguish "nothing to show for this buffer" from "the server did not answer": an
+        // unsaved buffer has no indexed path, and reporting that as an outage would be wrong.
+        return this.store.pathOf(editor.document)
+          ? [new Item('lens server offline', { icon: new vscode.ThemeIcon('cloud-offline') })]
+          : [new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') })];
+      }
+      return this.roots(loaded.path, loaded.data);
+    }
+    // The active editor changed on every attempt, so the user is still moving and every switch
+    // has queued its own refresh. Returning nothing can still blank a tree a newer request just
+    // filled, because `getChildren` has no way to decline to publish — that residual is #1022,
+    // which replaces this shape with a synchronous read over state a single pump owns.
+    return [];
+  }
+
+  protected abstract roots(path: string, data: FileData): Item[];
+}
+
+export class CloneClassesView extends FileView {
+  protected roots(path: string, data: FileData): Item[] {
+    const out: Item[] = [];
+    const unavailable = cloneGraphUnavailableReason(data.cloneGraph);
+    if (unavailable) {
+      return [
+        new Item('clone data unavailable', {
+          description: unavailable,
+          icon: new vscode.ThemeIcon('warning', new vscode.ThemeColor('editorWarning.foreground')),
+        }),
+      ];
+    }
+    if (data.cloneGraph?.stale) {
+      const built = data.cloneGraph.finished_at_ms
+        ? new Date(data.cloneGraph.finished_at_ms).toLocaleString()
+        : 'unknown';
+      out.push(
+        new Item('clone data stale', {
+          description: `graph gen ${data.cloneGraph.generation} built ${built} — recently edited files may show nothing`,
+          icon: new vscode.ThemeIcon('warning', new vscode.ThemeColor('editorWarning.foreground')),
+        }),
+      );
+    }
+    const regions = data.clones;
+    if (!regions.length) {
+      out.push(new Item('no actionable clones in this file', { icon: new vscode.ThemeIcon('check') }));
+      return out;
+    }
+    const byClass = new Map<number | null, CloneRegion[]>();
+    for (const r of regions) {
+      const list = byClass.get(r.class_id) ?? [];
+      list.push(r);
+      byClass.set(r.class_id, list);
+    }
+    for (const [gid, members] of [...byClass.entries()].sort((a, b) => (a[0] ?? 1e9) - (b[0] ?? 1e9))) {
+      const maxSim = Math.max(...members.map((m) => m.max_similarity ?? 0));
+      out.push(
+        new Item(gid != null ? `clone class ${gid}` : 'similar code', {
+          description: `${members.length} region${members.length === 1 ? '' : 's'} · best ${maxSim.toFixed(2)}`,
+          icon: new vscode.ThemeIcon(gid != null ? 'symbol-namespace' : 'symbol-misc'),
+          children: members.map((r) => regionItem(path, r)),
+        }),
+      );
+    }
+    return out;
+  }
+}
+
+export function cloneGraphUnavailableReason(meta: FileData['cloneGraph']): string | undefined {
+  if (meta && meta.eligible !== false) {
+    return undefined;
+  }
+  switch (meta?.unavailable_reason) {
+    case 'missing_generation':
+      return 'clone graph is missing; rebuild the index';
+    case 'normalizer_mismatch':
+      return 'clone graph is incompatible; rebuild the index';
+    default:
+      return meta?.unavailable_reason
+        ? `clone analysis unavailable (${meta.unavailable_reason})`
+        : 'clone graph is unavailable; rebuild the index';
+  }
+}
+
+function regionItem(path: string, r: CloneRegion): Item {
+  const siblings = r.partners.map(
+    (p) =>
+      new Item(`${p.path === path ? 'this file' : p.path}:${p.start_line ?? '?'} · ${p.symbol ?? ''}`, {
+        description: p.similarity.toFixed(2),
+        icon: new vscode.ThemeIcon('references'),
+        command: {
+          title: 'open',
+          command: 'rag-rat-lens.openLocation',
+          arguments: [{ path: p.path, line: p.start_line ?? 1 }],
+        },
+      }),
+  );
+  return new Item(`${r.symbol ?? '?'} :${r.start_line}-${r.end_line}`, {
+    description: r.refine ? `refactorability ${r.refine.refactorability.toFixed(2)}` : undefined,
+    icon: new vscode.ThemeIcon('symbol-method'),
+    tooltip: `${r.partners.length} similar regions`,
+    command: r.refine
+      ? { title: 'extract preview', command: 'rag-rat-lens.showExtract', arguments: [r] }
+      : { title: 'open', command: 'rag-rat-lens.openLocation', arguments: [{ path, line: r.start_line ?? 1 }] },
+    children: siblings.length ? siblings : undefined,
+  });
+}
+
+export class MemoriesView extends FileView {
+  protected roots(path: string, data: FileData): Item[] {
+    const memories = data.memories;
+    if (!memories.length) {
+      return [new Item('no memories bound to this file', { icon: new vscode.ThemeIcon('check') })];
+    }
+    return memories.map((m) => {
+      const diverged = m.verdict === 'diverged';
+      return new Item(m.title, {
+        description: `${m.kind}${m.line ? ` :${m.line}` : ''}${m.verdict ? ` · ${m.verdict}` : ''}`,
+        icon: new vscode.ThemeIcon(diverged ? 'warning' : 'bookmark', diverged ? new vscode.ThemeColor('errorForeground') : undefined),
+        tooltip: `${m.kind} · ${m.confidence} · ${m.anchor_status}${m.verdict_direction ? ` · ${m.verdict_direction}` : ''}`,
+        command: { title: 'show', command: 'rag-rat-lens.showMemories', arguments: [[m], path] },
+        contextValue: diverged ? 'rag-rat-memory-diverged' : 'rag-rat-memory',
+      });
+    });
+  }
+}
+
+export class PapertrailView extends FileView {
+  protected roots(_path: string, data: FileData): Item[] {
+    const { refs, decisions } = data;
+    const out: Item[] = [];
+    if (decisions.length) {
+      out.push(
+        new Item('decision records', {
+          icon: new vscode.ThemeIcon('lightbulb'),
+          children: decisions.map((d: DecisionRecord) =>
+            new Item(`#${d.item_key} ${d.title ?? ''}`, {
+              description: d.line ? `:${d.line}` : 'file-level',
+              icon: new vscode.ThemeIcon('law'),
+              command: { title: 'open', command: 'rag-rat-lens.showDecision', arguments: [d] },
+            }),
+          ),
+        }),
+      );
+    }
+    if (refs.length) {
+      const { open, closed, unknown } = groupPapertrailRefs(refs);
+      if (open.length) {
+        out.push(
+          new Item(`open (${open.length})`, {
+            icon: new vscode.ThemeIcon('issues'),
+            children: open.map((r) => refItem(r)),
+          }),
+        );
+      }
+      if (closed.length) {
+        out.push(
+          new Item(`closed/merged (${closed.length})`, {
+            icon: new vscode.ThemeIcon('issue-closed'),
+            children: closed.map((r) => refItem(r)),
+          }),
+        );
+      }
+      if (unknown.length) {
+        out.push(
+          new Item(`unknown state (${unknown.length})`, {
+            icon: new vscode.ThemeIcon('question'),
+            children: unknown.map((r) => refItem(r)),
+          }),
+        );
+      }
+    }
+    if (!out.length) {
+      return [new Item('no tracker items reference this file', { icon: new vscode.ThemeIcon('check') })];
+    }
+    return out;
+  }
+}
+
+export function groupPapertrailRefs(refs: PapertrailRef[]): {
+  open: PapertrailRef[];
+  closed: PapertrailRef[];
+  unknown: PapertrailRef[];
+} {
+  return {
+    open: refs.filter((ref) => ref.state_normalized === 'open'),
+    closed: refs.filter(
+      (ref) => ref.state_normalized === 'closed' || ref.state_normalized === 'merged',
+    ),
+    unknown: refs.filter(
+      (ref) => !['open', 'closed', 'merged'].includes(ref.state_normalized ?? ''),
+    ),
+  };
+}
+
+function refItem(r: PapertrailRef): Item {
+  const uri = externalUri(r.url);
+  return new Item(`#${r.item_key} ${r.title ?? ''}`, {
+    description: `${r.item_kind} · ${r.ref_kind}`,
+    tooltip: r.source_text.slice(0, 200),
+    icon: new vscode.ThemeIcon('link-external'),
+    command: uri ? { title: 'open', command: 'vscode.open', arguments: [uri] } : undefined,
+  });
+}
+
+function externalUri(raw: string | null): vscode.Uri | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const uri = vscode.Uri.parse(raw);
+  return uri.scheme === 'https' || uri.scheme === 'http' ? uri : undefined;
+}
+
+export function registerSidebar(
+  context: vscode.ExtensionContext,
+  store: FileStore,
+): { refresh: () => void } {
+  const clones = new CloneClassesView(store);
+  const memories = new MemoriesView(store);
+  const papertrail = new PapertrailView(store);
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider('rag-rat-lens.cloneClasses', clones),
+    vscode.window.registerTreeDataProvider('rag-rat-lens.memories', memories),
+    vscode.window.registerTreeDataProvider('rag-rat-lens.papertrail', papertrail),
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      clones.refresh();
+      memories.refresh();
+      papertrail.refresh();
+    }),
+  );
+  return {
+    refresh: () => {
+      clones.refresh();
+      memories.refresh();
+      papertrail.refresh();
+    },
+  };
+}

--- a/editors/vscode/src/store.ts
+++ b/editors/vscode/src/store.ts
@@ -1,0 +1,361 @@
+// Shared per-file data lane: one cached fetch per endpoint, consumed by the
+// CodeLens providers, sidebar views, hover, overlays, and diagnostics —
+// instead of each lane fetching its own copy of the same payload.
+import type * as vscode from 'vscode';
+import type {
+  CloneRegion,
+  CouplingPartner,
+  DecisionRecord,
+  FileMemory,
+  LensClient,
+  PapertrailRef,
+  SymbolGraph,
+} from './client';
+
+export interface CloneGraphMeta {
+  generation?: number;
+  eligible?: boolean;
+  stale?: boolean;
+  finished_at_ms?: number | null;
+  hidden_low_value_classes?: number;
+  unavailable_reason?: string;
+}
+
+export interface FileData {
+  at: number;
+  symbols: SymbolGraph[];
+  clones: CloneRegion[];
+  cloneGraph: CloneGraphMeta | null;
+  memories: FileMemory[];
+  coupling: CouplingPartner[];
+  refs: PapertrailRef[];
+  decisions: DecisionRecord[];
+}
+
+const TTL_MS = 10_000;
+
+/**
+ * Files tracked at once. An editing session across a large repository visits far more files than a
+ * reader ever looks at again, and every one of them would otherwise keep its payload — and its
+ * fallback copy — alive for the lifetime of the window.
+ */
+const MAX_TRACKED_PATHS = 256;
+
+/**
+ * How long a lane's last value may stand in for a request that failed. The fallback exists to
+ * survive a dropped request, not to keep a claim alive: memories and clone regions are anchored to
+ * line numbers, so a payload re-served over an edited file draws warnings and overlays on lines
+ * that have moved. A lane still failing after this goes empty — or, for clones, explicitly
+ * unavailable — which is the honest answer once the last real one is old.
+ */
+const FALLBACK_MAX_AGE_MS = 60_000;
+
+type Lane = 'symbols' | 'clones' | 'memories' | 'coupling' | 'papertrail';
+
+/** Everything known about one file. Kept in ONE entry so the parts cannot drift apart. */
+interface PathState {
+  /** The most recent load's payload, served until `TTL_MS` elapses or the epoch moves. */
+  fresh?: FileData;
+  /**
+   * The last payload seen for this file, kept across `invalidate` so a lane that fails on the next
+   * load falls back to it. Without it a failed memory lane would render as "this file has no
+   * memories" — clearing real diagnostics and CodeLenses over one dropped request.
+   */
+  lastGood?: FileData;
+  /** When each lane of `lastGood` last ARRIVED, bounding how long it may be carried forward. */
+  laneAt?: Partial<Record<Lane, number>>;
+  /** The last load's representative error, whether it failed wholly or in a single lane. */
+  failure?: unknown;
+  /** The last load produced NOTHING — the only case whose signals must be cleared. */
+  unusable?: boolean;
+}
+
+function laneValue<T>(lane: PromiseSettledResult<T>, fallback: T): T {
+  return lane.status === 'fulfilled' ? lane.value : fallback;
+}
+
+export class FileStore {
+  /** Least-recently-used last: `state` re-inserts on touch and the oldest entry is evicted. */
+  private paths = new Map<string, PathState>();
+  private pending = new Map<string, Promise<FileData | undefined>>();
+  /** In-flight loads, so an invalidation can stop paying for answers it has already discarded. */
+  private inflight = new Set<AbortController>();
+  /**
+   * Which server the `lastGood` payloads came from. Reuse is only sound while the SAME server is
+   * answering, and discovery can re-point silently (a restarted server, a different port), so they
+   * are dropped the moment it changes. Keying it here rather than asking callers to reset is what
+   * makes that safe: no caller has to know which of its actions can change the endpoint.
+   */
+  private lastGoodEndpoint: string | undefined;
+  private epoch = 0;
+  private online = false;
+
+  constructor(
+    private readonly client: LensClient,
+    private readonly theta: () => number,
+    private readonly minTokens: () => number,
+    private readonly documentPath: (document: vscode.TextDocument) => string | undefined,
+    /** Which server is answering right now — see [`lastGoodEndpoint`](FileStore#lastGoodEndpoint). */
+    private readonly endpoint: () => Promise<string>,
+  ) {}
+
+  /** The index moved: refetch everything, but keep each file's last payload as a fallback. */
+  invalidate(): void {
+    this.epoch += 1;
+    this.pending.clear();
+    for (const state of this.paths.values()) {
+      state.fresh = undefined;
+      state.failure = undefined;
+      state.unusable = undefined;
+    }
+    this.abortInflight();
+  }
+
+  /**
+   * The server or workspace identity may have changed. Nothing fetched before may be reused —
+   * including the per-lane fallbacks, which would otherwise show one repository's data over
+   * another's identically named file.
+   */
+  reset(): void {
+    this.invalidate();
+    this.forgetServedState();
+  }
+
+  /** The last load's error, if any — present for a partial load too, so the caller can log it. */
+  failure(path: string): unknown {
+    return this.paths.get(path)?.failure;
+  }
+
+  shouldClearSignals(path: string): boolean {
+    return !this.online || this.paths.get(path)?.unusable === true;
+  }
+
+  setOnline(online: boolean): void {
+    if (this.online !== online) {
+      this.online = online;
+      this.invalidate();
+    }
+  }
+
+  pathOf(document: vscode.TextDocument): string | undefined {
+    return this.documentPath(document);
+  }
+
+  /**
+   * Index data for a document, with the path it describes — or `undefined` when the document has
+   * no indexed path, the data is unavailable, or the document STOPPED describing that path while
+   * the request was in flight.
+   *
+   * That last case is why this exists. Every consumer runs the same three steps: resolve a path,
+   * await the data, draw. Between step two and step three the premise can expire — the user types
+   * and the buffer goes dirty, or the workspace folder is replaced — and the answer that arrives
+   * describes a file that is no longer what the editor is showing. Drawing it puts line-anchored
+   * claims back on a buffer that was deliberately cleared moments earlier.
+   *
+   * Re-asking `pathOf` after the await is the whole check, but it has to happen in EVERY
+   * consumer: overlays, diagnostics, both CodeLens providers, hovers, and the sidebar. Doing it
+   * here is what stops that from being five independent chances to forget.
+   */
+  async dataFor(
+    document: vscode.TextDocument,
+  ): Promise<{ path: string; data: FileData } | undefined> {
+    const path = this.pathOf(document);
+    if (!path) {
+      return undefined;
+    }
+    const data = await this.data(path);
+    if (!data || this.pathOf(document) !== path) {
+      return undefined;
+    }
+    return { path, data };
+  }
+
+  async data(path: string): Promise<FileData | undefined> {
+    if (!this.online) {
+      return undefined;
+    }
+    const hit = this.state(path).fresh;
+    if (hit && Date.now() - hit.at < TTL_MS) {
+      return hit;
+    }
+    const pending = this.pending.get(path);
+    if (pending) {
+      return await pending;
+    }
+    const epoch = this.epoch;
+    const request = this.load(path, epoch, 0);
+    this.pending.set(path, request);
+    try {
+      return await request;
+    } finally {
+      if (this.pending.get(path) === request) {
+        this.pending.delete(path);
+      }
+    }
+  }
+
+  private async load(path: string, epoch: number, attempt: number): Promise<FileData | undefined> {
+    const attemptControl = new AbortController();
+    this.inflight.add(attemptControl);
+    try {
+      const endpoint = await this.endpoint();
+      const signal = attemptControl.signal;
+      // The lanes settle independently. `/api/file/clones` is the slow one — it can fall back to a
+      // repository-wide scan on a linked worktree — and its timeout must not discard the graph,
+      // memory, coupling, and papertrail answers that already arrived, which would clear the
+      // file's signals and report the server as offline over a single slow lane.
+      const lanes = await Promise.allSettled([
+        this.client.fileSymbolGraph(path, signal),
+        this.client.fileClonesFull(path, this.theta(), this.minTokens(), signal),
+        this.client.fileMemories(path, signal),
+        this.client.fileCoupling(path, signal),
+        this.client.filePapertrail(path, signal),
+      ]);
+      if (!this.online || this.epoch !== epoch) {
+        return undefined;
+      }
+      // A lane that fails is retried against the replacement endpoint when discovery re-points
+      // mid-load, so this payload can span two servers — mixing one repository's memories with
+      // another's clones for an identically named file. The identity is only trustworthy when it
+      // is unchanged across the whole load.
+      //
+      // Resolving it can itself fail — the discovery file is momentarily absent while `rag-rat mcp`
+      // restarts, a hosted status probe times out — and that must not turn five successful lanes
+      // into a file-level failure that clears the editor's signals. Unconfirmed is not failed: drop
+      // the payload, record nothing, and let the next refresh ask again.
+      const settled = await this.endpoint().then(
+        (value) => value,
+        () => undefined,
+      );
+      // The identity read is another await, and an invalidation landing inside it must not be
+      // overwritten by this now-stale payload — which would then be served for a further TTL.
+      if (settled === undefined || !this.online || this.epoch !== epoch) {
+        return undefined;
+      }
+      if (settled !== endpoint) {
+        // Drop everything the previous server answered and load again, wholly against the settled
+        // one. A second re-point is left to the next refresh rather than looping here.
+        this.forgetServedState();
+        return attempt === 0 ? await this.load(path, epoch, attempt + 1) : undefined;
+      }
+      const [symbols, clones, memories, coupling, papertrail] = lanes;
+      const rejected = lanes.filter(
+        (lane): lane is PromiseRejectedResult => lane.status === 'rejected',
+      );
+      if (rejected.length === lanes.length) {
+        // Nothing arrived at all: that is a file-level failure, and the caller clears its signals.
+        return this.recordFailure(path, rejected[0].reason);
+      }
+      if (endpoint !== this.lastGoodEndpoint) {
+        for (const state of this.paths.values()) {
+          state.lastGood = undefined;
+          state.laneAt = undefined;
+        }
+        this.lastGoodEndpoint = endpoint;
+      }
+      const entry = this.state(path);
+      // A rejected lane keeps the last value that arrived for it, for a while. An empty array would
+      // be a claim — "no memories on this file" — that the caller acts on by clearing diagnostics
+      // and lenses, and a dropped request is not evidence for it. Carrying it forever is the other
+      // error: each merged payload becomes the next one's fallback, so a lane that keeps failing
+      // would re-assert line-anchored warnings over a file that has since been edited. Where there
+      // is nothing left to carry, the clone lane at least has somewhere to say so; the sidebar
+      // renders that as unavailable rather than as an empty result.
+      const now = Date.now();
+      const previous = entry.lastGood;
+      const arrivedAt = entry.laneAt ?? {};
+      const carried = <T>(lane: Lane, pick: (data: FileData) => T, empty: T): T =>
+        previous && now - (arrivedAt[lane] ?? 0) < FALLBACK_MAX_AGE_MS ? pick(previous) : empty;
+      const cloneLane = clones.status === 'fulfilled' ? clones.value : undefined;
+      const papertrailLane = papertrail.status === 'fulfilled' ? papertrail.value : undefined;
+      const data: FileData = {
+        at: now,
+        symbols: laneValue(symbols, carried('symbols', (d) => d.symbols, [])),
+        clones: cloneLane ? cloneLane.clone_regions : carried('clones', (d) => d.clones, []),
+        cloneGraph: cloneLane
+          ? cloneLane.clone_graph ?? null
+          : carried('clones', (d) => d.cloneGraph, null)
+            ?? { eligible: false, unavailable_reason: 'lens request failed' },
+        memories: laneValue(memories, carried('memories', (d) => d.memories, [])),
+        coupling: laneValue(coupling, carried('coupling', (d) => d.coupling, [])),
+        refs: papertrailLane ? papertrailLane.refs : carried('papertrail', (d) => d.refs, []),
+        decisions: papertrailLane
+          ? papertrailLane.decisions
+          : carried('papertrail', (d) => d.decisions, []),
+      };
+      entry.fresh = data;
+      entry.lastGood = data;
+      entry.laneAt = {
+        ...arrivedAt,
+        ...(symbols.status === 'fulfilled' ? { symbols: now } : {}),
+        ...(cloneLane ? { clones: now } : {}),
+        ...(memories.status === 'fulfilled' ? { memories: now } : {}),
+        ...(coupling.status === 'fulfilled' ? { coupling: now } : {}),
+        ...(papertrailLane ? { papertrail: now } : {}),
+      };
+      entry.failure = rejected.length ? rejected[0].reason : undefined;
+      entry.unusable = undefined;
+      return data;
+    } catch (error) {
+      if (!this.online || this.epoch !== epoch) {
+        return undefined;
+      }
+      return this.recordFailure(path, error);
+    } finally {
+      this.inflight.delete(attemptControl);
+    }
+  }
+
+  /** The entry for `path`, created if absent, marked most recently used, evicting the oldest. */
+  private state(path: string): PathState {
+    const existing = this.paths.get(path);
+    if (existing) {
+      this.paths.delete(path);
+      this.paths.set(path, existing);
+      return existing;
+    }
+    const created: PathState = {};
+    this.paths.set(path, created);
+    while (this.paths.size > MAX_TRACKED_PATHS) {
+      const oldest = this.paths.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.paths.delete(oldest);
+    }
+    return created;
+  }
+
+  /**
+   * Forget every payload a server answered, leaving the epoch and in-flight bookkeeping alone.
+   * Failure state stays: those files still need their signals cleared, and a server changing
+   * underneath is no evidence that they recovered.
+   */
+  private forgetServedState(): void {
+    for (const state of this.paths.values()) {
+      state.fresh = undefined;
+      state.lastGood = undefined;
+      state.laneAt = undefined;
+    }
+    this.lastGoodEndpoint = undefined;
+  }
+
+  /**
+   * Stop paying for answers already discarded. The clone lane can be a repository-wide scan, and
+   * the server frees its worker as soon as the request is aborted.
+   */
+  private abortInflight(): void {
+    for (const control of this.inflight) {
+      control.abort();
+    }
+    this.inflight.clear();
+  }
+
+  private recordFailure(path: string, error: unknown): undefined {
+    const entry = this.state(path);
+    entry.fresh = undefined;
+    entry.failure = error;
+    entry.unusable = true;
+    return undefined;
+  }
+}

--- a/editors/vscode/src/verdict.ts
+++ b/editors/vscode/src/verdict.ts
@@ -1,0 +1,10 @@
+export function verdictDirectionLabel(direction: string | null): string {
+  switch (direction) {
+    case 'code_ahead':
+      return 'the code moved ahead of this note';
+    case 'note_ahead':
+      return 'the note moved ahead of the code';
+    default:
+      return 'direction unknown';
+  }
+}

--- a/editors/vscode/src/workspace_paths.ts
+++ b/editors/vscode/src/workspace_paths.ts
@@ -1,0 +1,99 @@
+export function normalizeRelativePath(path: string): string | undefined {
+  const normalized = path.replaceAll('\\', '/');
+  if (!normalized || normalized === '.') {
+    return '';
+  }
+  if (normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)) {
+    return undefined;
+  }
+  const segments = normalized.split('/');
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+    return undefined;
+  }
+  return segments.join('/');
+}
+
+/** Resolve how the indexed root sits inside the opened workspace. */
+export function indexedRootPrefixForDiscovery(
+  indexedRoot: string,
+  workspacePathFromDiscovery: string,
+  caseInsensitive = false,
+): string | undefined {
+  const indexed = normalizeRelativePath(indexedRoot);
+  const workspace = normalizeRelativePath(workspacePathFromDiscovery);
+  if (indexed === undefined || workspace === undefined) {
+    return undefined;
+  }
+  if (!workspace) {
+    return indexed;
+  }
+  return pathsEqual(workspace, indexed, caseInsensitive) ? '' : undefined;
+}
+
+export function indexedPath(
+  workspaceRelativePath: string,
+  indexedRootPrefix: string,
+  caseInsensitive = false,
+): string | undefined {
+  const workspacePath = normalizeRelativePath(workspaceRelativePath);
+  const prefix = normalizeRelativePath(indexedRootPrefix);
+  if (workspacePath === undefined || prefix === undefined) {
+    return undefined;
+  }
+  if (!prefix) {
+    return workspacePath;
+  }
+  // Compare and split by segment, never by character offset: folding can change a string's length
+  // (`ß` folds to `ss`), so a prefix length measured before folding would cut the wrong place.
+  const prefixSegments = prefix.split('/');
+  const segments = workspacePath.split('/');
+  if (segments.length <= prefixSegments.length) {
+    return undefined;
+  }
+  const head = segments.slice(0, prefixSegments.length).join('/');
+  return pathsEqual(head, prefix, caseInsensitive)
+    ? segments.slice(prefixSegments.length).join('/')
+    : undefined;
+}
+
+export function workspacePath(
+  indexedRelativePath: string,
+  indexedRootPrefix: string,
+): string | undefined {
+  const indexed = normalizeRelativePath(indexedRelativePath);
+  const prefix = normalizeRelativePath(indexedRootPrefix);
+  if (indexed === undefined || prefix === undefined) {
+    return undefined;
+  }
+  return [prefix, indexed].filter(Boolean).join('/');
+}
+
+/**
+ * Dotless `ı` uppercases to `I` in JavaScript, but Unicode case folding — what the server uses —
+ * folds it to itself. It is the ONLY code point where the round trip below merges two names the
+ * server keeps apart, measured by folding every code point with both rules.
+ */
+const DOTLESS_I = 'ı';
+
+/**
+ * Fold a path the way the server's canonical-path lookup does: NFC first, since a decomposed
+ * `a` + U+0308 names the same file as a composed `ä` on a case-insensitive volume, then Unicode
+ * case folding per code point.
+ *
+ * JavaScript has no case-folding primitive, so the fold is a lower→upper→lower round trip: the
+ * leading lowercase is what lets `ẞ` reach `ß`'s `ss`, and the uppercase pass is what merges final
+ * sigma `ς` with `σ`. Plain lowercasing does neither. Which direction the remaining inaccuracy
+ * points is what matters: accepting a prefix the server would reject strips it and resolves the
+ * remainder against a DIFFERENT directory, while rejecting one the server would accept only costs
+ * signals for that file. Excluding [`DOTLESS_I`] leaves the relation a strict subset of the
+ * server's, so only the harmless direction remains.
+ */
+function foldPath(path: string): string {
+  return [...path.normalize('NFC')]
+    .map((char) => (char === DOTLESS_I ? char : char.toLowerCase().toUpperCase().toLowerCase()))
+    .join('');
+}
+
+function pathsEqual(left: string, right: string, caseInsensitive: boolean): boolean {
+  return caseInsensitive ? foldPath(left) === foldPath(right) : left === right;
+}

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -1559,3 +1559,40 @@ test('the memory picker routes through the revalidating open, not the captured o
   await showMemoriesQuickPick([captured], 'src/lib.rs', documents);
   assert.match(messages.at(-1), /not answering/);
 });
+
+test('open rag-rat-doc documents are withdrawn when the server they came from is gone', async () => {
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value.split(':').slice(1).join(':'), toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ThemeIcon: class {},
+    ViewColumn: { Beside: 2 },
+    window: { showTextDocument: async () => undefined },
+    workspace: {
+      openTextDocument: async (uri) => ({ uri }),
+      registerTextDocumentContentProvider: () => ({ dispose() {} }),
+    },
+    commands: { registerCommand: () => ({ dispose() {} }), executeCommand: async () => undefined },
+  };
+  const module = await loadSourceModule('lenses.ts', vscode);
+  const provider = new module.LensDocProvider();
+
+  // Stand in for a decision record or extraction preview the user opened.
+  await provider.open('Extract helper', '# Proposal\n\nlift this into a helper');
+  const uri = { path: '/0-Extract%20helper.md' };
+  assert.match(provider.provideTextDocumentContent(uri), /lift this into a helper/);
+
+  provider.withdraw();
+  const withdrawn = provider.provideTextDocumentContent(uri);
+  assert.match(withdrawn, /no longer being served/);
+  assert.doesNotMatch(withdrawn, /lift this into a helper/, "the old server's answer must be gone");
+  // Withdrawal is not deletion: an unknown key still reads as absent.
+  assert.equal(provider.provideTextDocumentContent({ path: '/never.md' }), 'not found');
+});

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -1,0 +1,1561 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const path = require('node:path');
+const test = require('node:test');
+
+const esbuild = require('esbuild');
+
+async function loadClientModule() {
+  const result = await esbuild.build({
+    entryPoints: [path.join(__dirname, '..', 'src', 'client.ts')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+  });
+  const module = { exports: {} };
+  new Function('module', 'exports', 'require', result.outputFiles[0].text)(
+    module,
+    module.exports,
+    require,
+  );
+  return module.exports;
+}
+
+async function loadClient() {
+  return (await loadClientModule()).LensClient;
+}
+
+async function loadStore() {
+  const result = await esbuild.build({
+    entryPoints: [path.join(__dirname, '..', 'src', 'store.ts')],
+    bundle: true,
+    external: ['vscode'],
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+  });
+  const module = { exports: {} };
+  new Function('module', 'exports', 'require', result.outputFiles[0].text)(
+    module,
+    module.exports,
+    (specifier) => (specifier === 'vscode' ? {} : require(specifier)),
+  );
+  return module.exports.FileStore;
+}
+
+async function loadSourceModule(file, mockVscode) {
+  const result = await esbuild.build({
+    entryPoints: [path.join(__dirname, '..', 'src', file)],
+    bundle: true,
+    external: mockVscode ? ['vscode'] : [],
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+  });
+  const module = { exports: {} };
+  new Function('module', 'exports', 'require', result.outputFiles[0].text)(
+    module,
+    module.exports,
+    (specifier) => (specifier === 'vscode' ? mockVscode : require(specifier)),
+  );
+  return module.exports;
+}
+
+/** The store keys its per-lane fallbacks by which server answered; one stable identity by default. */
+const endpoint = async () => 'http://127.0.0.1:18120 owner-token';
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test('clone payload validation tolerates nullable and unknown fields', async () => {
+  const { validateFileClones } = await loadClientModule();
+  // The Rust contract shape: nullable max_similarity, unknown refine JSON, null partner symbol.
+  const payload = {
+    clone_regions: [
+      {
+        start_line: 1,
+        end_line: 3,
+        byte_offset: 0,
+        class_id: 7,
+        class_key: 'deadbeefcafebabe',
+        symbol: 'load_user',
+        max_similarity: null,
+        partners: [
+          { path: 'src/b.rs', start_line: 1, end_line: 3, similarity: 0.91, symbol: null },
+        ],
+        refine: {
+          template: 'fn extracted() { ⟨m0⟩ }',
+          variation_points: [],
+          proposed_signature: null,
+          confidence: 'high',
+          anti_unify_coverage: 1,
+          lcs_ratio: 1,
+          refactorability: 1,
+        },
+      },
+    ],
+    clone_graph: { generation: 3, eligible: true, stale: false },
+  };
+  const validated = validateFileClones(payload);
+  assert.equal(validated.clone_regions.length, 1);
+  const region = validated.clone_regions[0];
+  assert.equal(region.max_similarity, null);
+  assert.equal(region.partners[0].symbol, null);
+  assert.equal(region.refine.refactorability, 1);
+  assert.equal(validated.clone_graph.generation, 3);
+
+  // Drift (missing/null numerics, wrong shapes) must coerce instead of crashing providers.
+  const drift = validateFileClones({ clone_regions: [{}], clone_graph: null });
+  assert.equal(drift.clone_regions.length, 1);
+  assert.equal(drift.clone_regions[0].max_similarity, null);
+  assert.deepEqual(drift.clone_regions[0].partners, []);
+  assert.equal(drift.clone_regions[0].refine, undefined);
+  assert.equal(drift.clone_graph, undefined);
+});
+
+test('client authenticates JSON and SSE requests', async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push({ url: request.url, authorization: request.headers.authorization });
+    if (request.url === '/api/health') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"status":"ok"}');
+      return;
+    }
+    if (request.url === '/api/events') {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write('event: version\r');
+      setTimeout(
+        () =>
+          response.end(
+            '\ndata: {"generation":7,"max_indexed_at_ms":11,"git_dirty":null,"revision":"r1"}\r\n\r\n',
+          ),
+        5,
+      );
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+
+  const LensClient = await loadClient();
+  const address = server.address();
+  const resolver = {
+    invalidate() {},
+    async resolve() {
+      return { baseUrl: `http://127.0.0.1:${address.port}`, token: 'secret-token' };
+    },
+  };
+  const client = new LensClient(resolver);
+  assert.deepEqual(await client.health(), { status: 'ok' });
+
+  let version;
+  await assert.rejects(
+    client.watchVersions(new AbortController().signal, (event) => {
+      version = event;
+    }),
+    /disconnected/,
+  );
+  assert.equal(version.revision, 'r1');
+  assert.deepEqual(
+    requests.map((request) => request.authorization),
+    ['Bearer secret-token', 'Bearer secret-token'],
+  );
+});
+
+test('linked abort signals fire from either side without AbortSignal.any', async () => {
+  const { eitherSignal } = await loadClientModule();
+
+  // VS Code 1.85's desktop host is Node 18, where `AbortSignal.any` does not exist.
+  const deadline = new AbortController();
+  const caller = new AbortController();
+  const linked = eitherSignal(deadline.signal, caller.signal);
+  assert.equal(linked.aborted, false);
+  caller.abort(new Error('caller went away'));
+  assert.equal(linked.aborted, true);
+  assert.match(String(linked.reason), /caller went away/);
+
+  // An already-aborted input aborts the composition immediately, and no caller means no wrapper.
+  const late = new AbortController();
+  late.abort(new Error('already gone'));
+  assert.equal(eitherSignal(late.signal, new AbortController().signal).aborted, true);
+  assert.equal(eitherSignal(late.signal), late.signal);
+});
+
+test('stalled SSE reads abort and cancel before reconnecting', async () => {
+  const { readWithTimeout } = await loadClientModule();
+  const cleanup = [];
+  const reader = {
+    read: () => new Promise(() => {}),
+    cancel: async () => {
+      cleanup.push('cancel');
+    },
+  };
+
+  await assert.rejects(
+    readWithTimeout(reader, () => cleanup.push('abort'), 5),
+    /produced no data/,
+  );
+  assert.deepEqual(cleanup, ['abort', 'cancel']);
+});
+
+test('equivalent hosted URL spellings share a token key', async () => {
+  const { normalizeServerUrl, obsoleteServerTokenSecret, serverTokenSecret } = await loadSourceModule(
+    'discovery.ts',
+    {},
+  );
+  const withSlash = 'https://lens.example/';
+  const normalized = 'https://lens.example';
+
+  assert.equal(serverTokenSecret(withSlash), serverTokenSecret(normalized));
+  assert.equal(obsoleteServerTokenSecret(withSlash, normalized), undefined);
+  assert.equal(
+    obsoleteServerTokenSecret('https://old.example', normalized),
+    serverTokenSecret('https://old.example'),
+  );
+  assert.throws(() => normalizeServerUrl('https://lens.example/rag-rat'), /must not include a path/);
+  assert.throws(() => normalizeServerUrl('https://lens.example/?repo=a'), /must not include a path/);
+  // `origin` would drop these silently, so the endpoint would not carry the credentials the user
+  // entered — the same rule the server applies to its own origin allowlist.
+  assert.throws(
+    () => normalizeServerUrl('https://user:pass@lens.example'),
+    /must not embed credentials/,
+  );
+  assert.throws(() => normalizeServerUrl('https://user@lens.example'), /must not embed credentials/);
+});
+
+test('automatic discovery accepts the full IPv4 loopback range only', async () => {
+  const { isLoopbackHost } = await loadSourceModule('discovery.ts', {});
+
+  assert.equal(isLoopbackHost('127.0.0.1'), true);
+  assert.equal(isLoopbackHost('127.0.0.2'), true);
+  assert.equal(isLoopbackHost('127.255.255.255'), true);
+  assert.equal(isLoopbackHost('localhost'), true);
+  assert.equal(isLoopbackHost('[::1]'), true);
+  assert.equal(isLoopbackHost('126.255.255.255'), false);
+  assert.equal(isLoopbackHost('127.999.0.1'), false);
+  assert.equal(isLoopbackHost('127.example'), false);
+});
+
+test('clone minimum token setting accepts integers only', () => {
+  const packageJson = require('../package.json');
+  const setting = packageJson.contributes.configuration.properties['rag-rat-lens.cloneMinTokens'];
+
+  assert.equal(setting.type, 'integer');
+});
+
+test('clone sidebar distinguishes unavailable analysis from an empty result', async () => {
+  const vscode = {
+    EventEmitter: class {},
+    ThemeColor: class {},
+    ThemeIcon: class {},
+    TreeItem: class {},
+    TreeItemCollapsibleState: { Expanded: 1, None: 0 },
+  };
+  const { cloneGraphUnavailableReason } = await loadSourceModule('sidebar.ts', vscode);
+
+  assert.equal(
+    cloneGraphUnavailableReason(null),
+    'clone graph is unavailable; rebuild the index',
+  );
+  assert.equal(
+    cloneGraphUnavailableReason({ eligible: false, unavailable_reason: 'normalizer_mismatch' }),
+    'clone graph is incompatible; rebuild the index',
+  );
+  assert.equal(cloneGraphUnavailableReason({ eligible: true }), undefined);
+});
+
+test('papertrail sidebar keeps unknown states separate from closed items', async () => {
+  const vscode = {
+    EventEmitter: class {},
+    ThemeColor: class {},
+    ThemeIcon: class {},
+    TreeItem: class {},
+    TreeItemCollapsibleState: { Expanded: 1, None: 0 },
+  };
+  const { groupPapertrailRefs } = await loadSourceModule('sidebar.ts', vscode);
+  const refs = ['open', 'closed', 'merged', null, 'draft'].map((state_normalized) => ({
+    state_normalized,
+  }));
+
+  const grouped = groupPapertrailRefs(refs);
+  assert.deepEqual(grouped.open.map((ref) => ref.state_normalized), ['open']);
+  assert.deepEqual(grouped.closed.map((ref) => ref.state_normalized), ['closed', 'merged']);
+  assert.deepEqual(grouped.unknown.map((ref) => ref.state_normalized), [null, 'draft']);
+});
+
+test('subdirectory roots map from either supported workspace opening', async () => {
+  const { indexedPath, indexedRootPrefixForDiscovery, workspacePath } = await loadSourceModule(
+    'workspace_paths.ts',
+  );
+
+  const fromWorktreeTop = indexedRootPrefixForDiscovery('crate', '');
+  assert.equal(fromWorktreeTop, 'crate');
+  assert.equal(indexedPath('crate/src/lib.rs', fromWorktreeTop), 'src/lib.rs');
+  assert.equal(workspacePath('src/lib.rs', fromWorktreeTop), 'crate/src/lib.rs');
+  assert.equal(indexedPath('README.md', fromWorktreeTop), undefined);
+
+  const fromIndexedRoot = indexedRootPrefixForDiscovery('crate', 'crate');
+  assert.equal(fromIndexedRoot, '');
+  assert.equal(indexedPath('src/lib.rs', fromIndexedRoot), 'src/lib.rs');
+  assert.equal(workspacePath('src/lib.rs', fromIndexedRoot), 'src/lib.rs');
+  assert.equal(indexedRootPrefixForDiscovery('crate', 'crate/src'), undefined);
+  assert.equal(indexedRootPrefixForDiscovery('Crate', 'crate', true), '');
+  assert.equal(indexedRootPrefixForDiscovery('Crate', 'crate', false), undefined);
+  assert.equal(indexedPath('Crate/src/lib.rs', 'crate', true), 'src/lib.rs');
+});
+
+test('case-insensitive prefixes fold like the filesystem, not like lowercasing', async () => {
+  const { indexedPath, indexedRootPrefixForDiscovery } = await loadSourceModule(
+    'workspace_paths.ts',
+  );
+
+  // Final vs medial sigma, and decomposed vs composed 'ä': one name to a case-insensitive volume,
+  // two distinct strings to `toLowerCase`. Dropping them here would never reach the server's own
+  // canonical-path lookup.
+  assert.equal(indexedPath('ς/src/lib.rs', 'σ', true), 'src/lib.rs');
+  assert.equal(indexedPath('a\u0308/src/lib.rs', '\u00e4', true), 'src/lib.rs');
+  assert.equal(indexedRootPrefixForDiscovery('σ', 'ς', true), '');
+  // Dotless `ı` uppercases to `I` in JavaScript but folds to itself on the server; accepting it
+  // would strip a prefix the server rejects and resolve the rest against another directory.
+  assert.equal(indexedPath('ı/src/lib.rs', 'I', true), undefined);
+  assert.equal(indexedPath('ı/src/lib.rs', 'i', true), undefined);
+  assert.equal(indexedPath('I/src/lib.rs', 'i', true), 'src/lib.rs');
+  // Case sensitivity is still honoured, and a different name is still a different name.
+  assert.equal(indexedPath('ς/src/lib.rs', 'σ', false), undefined);
+  assert.equal(indexedPath('τ/src/lib.rs', 'σ', true), undefined);
+  // `ß` folds to two characters; the remainder must still be cut at the segment boundary.
+  assert.equal(indexedPath('ß/src/lib.rs', 'SS', true), 'src/lib.rs');
+});
+
+test('indexed-root workspace discovers the worktree file and maps navigation', async () => {
+  const fakeUri = (uriPath) => ({
+    scheme: 'file',
+    path: uriPath,
+    toString: () => `file://${uriPath}`,
+  });
+  const folder = { uri: fakeUri('/repo/crate') };
+  const reads = [];
+  const vscode = {
+    Uri: {
+      joinPath: (base, ...segments) => fakeUri(path.posix.resolve(base.path, ...segments)),
+    },
+    workspace: {
+      workspaceFolders: [folder],
+      isTrusted: true,
+      fs: {
+        readFile: async (uri) => {
+          reads.push(uri.path);
+          if (uri.path !== '/repo/.rag-rat/sockets/lens.json') {
+            throw new Error('not found');
+          }
+          return new TextEncoder().encode(
+            JSON.stringify({
+              schema: 'rag-rat-lens-discovery',
+              version: 1,
+              url: 'http://127.0.0.1:18120',
+              indexed_root: 'crate',
+              case_insensitive_paths: false,
+              ownership_token: 'owner',
+            }),
+          );
+        },
+        stat: async (uri) => {
+          if (uri.path === '/repo/.git') {
+            return { type: 1 };
+          }
+          throw new Error('not found');
+        },
+      },
+      getWorkspaceFolder: () => folder,
+      asRelativePath: (uri) => path.posix.relative(folder.uri.path, uri.path),
+    },
+  };
+  const { LensEndpointResolver } = await loadSourceModule('discovery.ts', vscode);
+  const resolver = new LensEndpointResolver(
+    { inspect: () => ({ globalValue: '' }) },
+    { get: async () => undefined },
+  );
+
+  assert.deepEqual(await resolver.resolve(), {
+    baseUrl: 'http://127.0.0.1:18120',
+    token: 'owner',
+  });
+  assert.deepEqual(reads.slice(0, 2), [
+    '/repo/crate/.rag-rat/sockets/lens.json',
+    '/repo/.rag-rat/sockets/lens.json',
+  ]);
+  assert.equal(resolver.pathOf({ uri: fakeUri('/repo/crate/src/lib.rs') }), 'src/lib.rs');
+  assert.equal(resolver.uriOf('src/lib.rs').path, '/repo/crate/src/lib.rs');
+});
+
+test('hosted indexed-root overrides stay scoped to one workspace association', async (t) => {
+  const fakeUri = (uriPath) => ({
+    scheme: 'vscode-vfs',
+    path: uriPath,
+    toString: () => `vscode-vfs://${uriPath}`,
+  });
+  const atIndexedRoot = { uri: fakeUri('/repo-a') };
+  const atWorktreeTop = { uri: fakeUri('/repo-b') };
+  let folder = atIndexedRoot;
+  const vscode = {
+    workspace: {
+      get workspaceFolders() {
+        return [folder];
+      },
+      getWorkspaceFolder: () => folder,
+      asRelativePath: (uri) => path.posix.relative(folder.uri.path, uri.path),
+    },
+  };
+  const previousFetch = global.fetch;
+  t.after(() => {
+    global.fetch = previousFetch;
+  });
+  const requests = [];
+  global.fetch = async (url, options) => {
+    requests.push({ url: String(url), authorization: options.headers.Authorization });
+    return {
+      ok: true,
+      json: async () => ({
+        repo_id: 'repo-a',
+        worktree_id: '',
+        indexed_root: 'crate',
+        case_insensitive_paths: true,
+      }),
+    };
+  };
+  const {
+    associateHostedWorkspace,
+    hostedRepoAssociationSecret,
+    LensEndpointResolver,
+    serverTokenSecret,
+  } = await loadSourceModule('discovery.ts', vscode);
+  const baseUrl = 'https://lens.example';
+  const config = {
+    inspect: (key) => ({ globalValue: key === 'serverUrl' ? `${baseUrl}/` : undefined }),
+  };
+  const stored = new Map([[serverTokenSecret(baseUrl), 'hosted-token']]);
+  const secrets = {
+    get: async (key) => stored.get(key),
+    store: async (key, value) => {
+      stored.set(key, value);
+    },
+  };
+
+  // One workspace is opened at the indexed subdirectory and needs the override; the other is
+  // opened at its worktree top and must keep following the server's own metadata.
+  await associateHostedWorkspace(baseUrl, 'hosted-token', secrets, '.');
+  folder = atWorktreeTop;
+  await associateHostedWorkspace(baseUrl, 'hosted-token', secrets);
+  assert.deepEqual(
+    JSON.parse(stored.get(hostedRepoAssociationSecret(baseUrl, atIndexedRoot.uri.toString()))),
+    { repoId: 'repo-a', worktreeId: '', indexedRoot: '.' },
+  );
+
+  const fromTop = new LensEndpointResolver(config, secrets);
+  assert.deepEqual(await fromTop.resolve(), { baseUrl, token: 'hosted-token' });
+  assert.equal(fromTop.pathOf({ uri: fakeUri('/repo-b/Crate/src/lib.rs') }), 'src/lib.rs');
+  assert.equal(fromTop.pathOf({ uri: fakeUri('/repo-b/src/lib.rs') }), undefined);
+
+  folder = atIndexedRoot;
+  const fromIndexedRoot = new LensEndpointResolver(config, secrets);
+  assert.deepEqual(await fromIndexedRoot.resolve(), { baseUrl, token: 'hosted-token' });
+  assert.equal(fromIndexedRoot.pathOf({ uri: fakeUri('/repo-a/src/lib.rs') }), 'src/lib.rs');
+
+  await assert.rejects(
+    associateHostedWorkspace(baseUrl, 'hosted-token', secrets, '../elsewhere'),
+    /safe workspace-relative path/,
+  );
+  stored.set(
+    hostedRepoAssociationSecret(baseUrl, atIndexedRoot.uri.toString()),
+    JSON.stringify({ repoId: 'repo-b', worktreeId: '' }),
+  );
+  await assert.rejects(
+    new LensEndpointResolver(config, secrets).resolve(),
+    /no longer serves the checkout/,
+  );
+  // Linked worktrees of one repository share a `repo_id`, so the checkout half has to be checked
+  // on its own: this server answers for the bound repository from a different working tree.
+  stored.set(
+    hostedRepoAssociationSecret(baseUrl, atIndexedRoot.uri.toString()),
+    JSON.stringify({ repoId: 'repo-a', worktreeId: '/repo-a/.worktrees/branch' }),
+  );
+  await assert.rejects(
+    new LensEndpointResolver(config, secrets).resolve(),
+    /no longer serves the checkout/,
+  );
+  // A record predating the checkout binding cannot be checked, so it fails closed as absent.
+  stored.set(
+    hostedRepoAssociationSecret(baseUrl, atIndexedRoot.uri.toString()),
+    JSON.stringify({ repoId: 'repo-a' }),
+  );
+  await assert.rejects(
+    new LensEndpointResolver(config, secrets).resolve(),
+    /not associated with this workspace/,
+  );
+  stored.set(hostedRepoAssociationSecret(baseUrl, atIndexedRoot.uri.toString()), 'repo-a');
+  await assert.rejects(
+    new LensEndpointResolver(config, secrets).resolve(),
+    /not associated with this workspace/,
+  );
+  assert.ok(requests.length > 0);
+  assert.deepEqual(
+    requests.filter(
+      (request) =>
+        request.url !== `${baseUrl}/api/status` || request.authorization !== 'Bearer hosted-token',
+    ),
+    [],
+  );
+});
+
+test('diagnostics drop for documents an invalidation does not refresh', async () => {
+  const entries = new Map();
+  const vscode = {
+    languages: {
+      createDiagnosticCollection: () => ({
+        set: (uri, diagnostics) => entries.set(uri.toString(), diagnostics),
+        delete: (uri) => entries.delete(uri.toString()),
+        forEach: (visit) => {
+          for (const [key, diagnostics] of [...entries]) {
+            visit({ toString: () => key }, diagnostics);
+          }
+        },
+        clear: () => entries.clear(),
+        dispose: () => {},
+      }),
+    },
+    Range: class {},
+    Diagnostic: class {
+      constructor(range, message, severity) {
+        Object.assign(this, { range, message, severity });
+      }
+    },
+    DiagnosticSeverity: { Warning: 1, Information: 2 },
+  };
+  const { LensDiagnostics } = await loadSourceModule('diagnostics.ts', vscode);
+  const document = (uriPath) => ({
+    uri: { toString: () => uriPath },
+    lineCount: 10,
+    lineAt: () => ({ text: 'code' }),
+  });
+  const diverged = [{ title: 'Memory', line: 2, verdict: 'diverged', verdict_direction: null }];
+
+  const diagnostics = new LensDiagnostics();
+  const visible = document('/repo/src/visible.rs');
+  const hidden = document('/repo/src/hidden.rs');
+  diagnostics.apply(visible, diverged);
+  diagnostics.apply(hidden, diverged);
+  assert.deepEqual([...entries.keys()], ['/repo/src/visible.rs', '/repo/src/hidden.rs']);
+
+  // Only visible editors are re-fetched on an index change; a hidden document's entries would
+  // otherwise keep asserting a verdict from the previous index state.
+  diagnostics.retainOnly([visible.uri]);
+  assert.deepEqual([...entries.keys()], ['/repo/src/visible.rs']);
+
+  diagnostics.clear();
+  assert.deepEqual([...entries.keys()], []);
+});
+
+test('memory documents notify VS Code when cached content changes', async () => {
+  const changed = [];
+  const vscode = {
+    EventEmitter: class {
+      event = () => {};
+      fire(uri) {
+        changed.push(uri.path);
+      }
+      dispose() {}
+    },
+    Uri: {
+      parse: (raw) => ({ path: new URL(raw).pathname }),
+    },
+  };
+  const { MemoryDocProvider } = await loadSourceModule('memories.ts', vscode);
+  let memory = {
+    id: 'mem-1',
+    title: 'Title',
+    kind: 'Invariant',
+    confidence: 'high',
+    anchor_status: 'current',
+    binding_kind: 'path',
+    body: 'Before',
+    summary: null,
+    verdict: null,
+  };
+  const provider = new MemoryDocProvider({
+    data: async (path) => path === 'src/lib.rs' ? { memories: [memory] } : undefined,
+  });
+
+  const uri = provider.update(memory, 'src/lib.rs');
+  assert.match(provider.provideTextDocumentContent(uri), /Before/);
+  memory = { ...memory, body: 'After' };
+  await provider.refresh();
+  assert.match(provider.provideTextDocumentContent(uri), /After/);
+  assert.deepEqual(changed, ['/mem-1.md', '/mem-1.md']);
+});
+
+test('clone overlay ranges include the final reported line', async () => {
+  const vscode = {
+    Range: class {
+      constructor(startLine, startCharacter, endLine, endCharacter) {
+        Object.assign(this, { startLine, startCharacter, endLine, endCharacter });
+      }
+    },
+  };
+  const { inclusiveLineRange } = await loadSourceModule('overlays.ts', vscode);
+  const lines = ['one', 'two', 'three'];
+  const range = inclusiveLineRange(
+    { lineCount: lines.length, lineAt: (line) => ({ text: lines[line] }) },
+    1,
+    3,
+  );
+
+  assert.deepEqual(
+    { startLine: range.startLine, startCharacter: range.startCharacter, endLine: range.endLine, endCharacter: range.endCharacter },
+    { startLine: 0, startCharacter: 0, endLine: 2, endCharacter: 5 },
+  );
+});
+
+test('clone overlays reuse decoration types for classes with the same rendered style', async () => {
+  const created = [];
+  const vscode = {
+    MarkdownString: class {
+      appendMarkdown() {}
+    },
+    OverviewRulerLane: { Left: 1 },
+    Range: class {
+      constructor(startLine, startCharacter, endLine, endCharacter) {
+        Object.assign(this, { startLine, startCharacter, endLine, endCharacter });
+      }
+    },
+    window: {
+      visibleTextEditors: [],
+      createTextEditorDecorationType: (options) => {
+        created.push(options);
+        return { dispose() {} };
+      },
+    },
+  };
+  const { LensOverlays } = await loadSourceModule('overlays.ts', vscode);
+  const overlays = new LensOverlays();
+  const editor = {
+    document: {
+      lineCount: 1,
+      lineAt: () => ({ text: 'one' }),
+      positionAt: () => ({ line: 0 }),
+    },
+    setDecorations() {},
+  };
+  const region = (class_id) => ({
+    start_line: 1,
+    end_line: 1,
+    byte_offset: 0,
+    class_id,
+    max_similarity: 0.96,
+    partners: [],
+  });
+
+  overlays.toggle();
+  overlays.apply(editor, [region(1)], 'src/lib.rs');
+  overlays.apply(editor, [region(11)], 'src/lib.rs');
+
+  assert.equal(created.length, 1);
+});
+
+test('unknown memory verdict directions remain unknown', async () => {
+  const { verdictDirectionLabel } = await loadSourceModule('verdict.ts');
+
+  assert.equal(verdictDirectionLabel('code_ahead'), 'the code moved ahead of this note');
+  assert.equal(verdictDirectionLabel('note_ahead'), 'the note moved ahead of the code');
+  assert.equal(verdictDirectionLabel('unknown'), 'direction unknown');
+  assert.equal(verdictDirectionLabel(null), 'direction unknown');
+});
+
+test('a slow clone lane does not discard the lanes that answered', async () => {
+  const FileStore = await loadStore();
+  const client = {
+    fileSymbolGraph: async () => [{ name: 'target' }],
+    fileClonesFull: async () => {
+      throw new Error('/api/file/clones timed out');
+    },
+    fileMemories: async () => [{ title: 'Invariant', line: 3 }],
+    fileCoupling: async () => [{ path: 'src/other.rs' }],
+    filePapertrail: async () => ({ refs: [{ item_key: '5' }], decisions: [] }),
+  };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', endpoint);
+  store.setOnline(true);
+
+  const data = await store.data('src/lib.rs');
+  assert.equal(data.memories.length, 1, 'a clone timeout must not discard memories');
+  assert.equal(data.symbols.length, 1);
+  assert.equal(data.coupling.length, 1);
+  assert.equal(data.refs.length, 1);
+  // With nothing to fall back on, the failed lane reads as unavailable — not as "no clones here".
+  assert.deepEqual(data.clones, []);
+  assert.equal(data.cloneGraph.eligible, false);
+  assert.ok(data.cloneGraph.unavailable_reason);
+  // Worth logging, but the file's signals stay on screen.
+  assert.ok(store.failure('src/lib.rs'));
+  assert.equal(store.shouldClearSignals('src/lib.rs'), false);
+});
+
+test('a failed lane keeps its last value instead of reporting an empty one', async () => {
+  const FileStore = await loadStore();
+  let memoriesFail = false;
+  const client = {
+    fileSymbolGraph: async () => [],
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => {
+      if (memoriesFail) {
+        throw new Error('/api/file/memories failed');
+      }
+      return [{ title: 'Diverged memory', line: 3, verdict: 'diverged' }];
+    },
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  let answering = 'http://127.0.0.1:18120 owner-token';
+  const store = new FileStore(
+    client,
+    () => 0.9,
+    () => 100,
+    () => 'src/lib.rs',
+    async () => answering,
+  );
+  store.setOnline(true);
+  assert.equal((await store.data('src/lib.rs')).memories.length, 1);
+
+  // The index moved and the memory lane dropped its request: reporting zero memories would clear
+  // a real diverged-memory warning over one failed request.
+  memoriesFail = true;
+  store.invalidate();
+  const afterFailure = await store.data('src/lib.rs');
+  assert.equal(afterFailure.memories.length, 1, 'the last known memories survive a failed lane');
+  assert.equal(afterFailure.memories[0].verdict, 'diverged');
+
+  // Discovery can re-point silently — a restarted server mints a fresh token — and no caller
+  // announces that. The fallback is keyed by who answered, so it drops itself rather than mixing
+  // one repository's memories into another's identically named file.
+  answering = 'http://127.0.0.1:18121 other-token';
+  store.invalidate();
+  assert.deepEqual((await store.data('src/lib.rs')).memories, []);
+});
+
+test('a load that spans two servers is reloaded, not merged', async () => {
+  const FileStore = await loadStore();
+  let served = 'first';
+  const client = {
+    fileSymbolGraph: async () => [{ name: served }],
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => [{ title: 'Memory', line: 1 }],
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  // The client retries a failed lane against the replacement endpoint, so discovery re-pointing
+  // mid-load can leave one repository's lanes beside another's. Identity is read before and after
+  // the lanes: this one changes across the first attempt and is stable across the retry.
+  const answering = ['18120 first', '18121 second'];
+  let asked = 0;
+  const store = new FileStore(
+    client,
+    () => 0.9,
+    () => 100,
+    () => 'src/lib.rs',
+    async () => {
+      const identity = answering[Math.min(asked++, answering.length - 1)];
+      served = identity;
+      return identity;
+    },
+  );
+  store.setOnline(true);
+
+  const data = await store.data('src/lib.rs');
+  assert.equal(
+    data.symbols[0].name,
+    '18121 second',
+    'the retry is served wholly by the endpoint that settled, never a mixture',
+  );
+  assert.equal(
+    store.shouldClearSignals('src/lib.rs'),
+    false,
+    're-pointing is not a failure — signals are replaced, not cleared',
+  );
+});
+
+test('an unconfirmable endpoint drops the payload without failing the file', async (t) => {
+  const FileStore = await loadStore();
+  const client = {
+    fileSymbolGraph: async () => [{ name: 'target' }],
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => [{ title: 'Memory', line: 1 }],
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  // Identity is read again after the lanes, and that read can fail on its own — the discovery file
+  // is momentarily absent while `rag-rat mcp` restarts, which is the very event this survives.
+  let asked = 0;
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', async () => {
+    asked += 1;
+    if (asked === 2) {
+      throw new Error('no Lens discovery file found');
+    }
+    return 'one server';
+  });
+  store.setOnline(true);
+
+  assert.equal(await store.data('src/lib.rs'), undefined, 'an unconfirmed payload is not served');
+  assert.equal(
+    store.shouldClearSignals('src/lib.rs'),
+    false,
+    'five successful lanes must not be turned into a file-level failure that wipes the editor',
+  );
+  assert.equal(store.failure('src/lib.rs'), undefined, 'nothing failed — the answer was unusable');
+});
+
+test('an invalidation during the identity read is not overwritten', async () => {
+  const FileStore = await loadStore();
+  let loads = 0;
+  const client = {
+    fileSymbolGraph: async () => {
+      loads += 1;
+      return [{ name: `load-${loads}` }];
+    },
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => [],
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  const gate = deferred();
+  let asked = 0;
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', async () => {
+    asked += 1;
+    if (asked === 2) {
+      await gate.promise;
+    }
+    return 'one server';
+  });
+  store.setOnline(true);
+
+  const request = store.data('src/lib.rs');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  // The index moved while this load was confirming its endpoint. Committing it now would put back
+  // what the invalidation cleared, and the TTL would then serve it for another ten seconds.
+  store.invalidate();
+  gate.resolve();
+  assert.equal(await request, undefined, 'an overtaken load is not committed');
+
+  const reloaded = await store.data('src/lib.rs');
+  assert.equal(reloaded.symbols[0].name, 'load-2', 'the next read refetches instead of the stale one');
+});
+
+test('a lane that keeps failing stops being carried forward', async (t) => {
+  const FileStore = await loadStore();
+  const realNow = Date.now;
+  t.after(() => {
+    Date.now = realNow;
+  });
+  let clock = realNow();
+  Date.now = () => clock;
+  let memoriesFail = false;
+  const client = {
+    fileSymbolGraph: async () => [],
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => {
+      if (memoriesFail) {
+        throw new Error('/api/file/memories failed');
+      }
+      return [{ title: 'Memory', line: 3 }];
+    },
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', endpoint);
+  store.setOnline(true);
+  assert.equal((await store.data('src/lib.rs')).memories.length, 1);
+
+  // Each merged payload becomes the next one's fallback, so without an age bound a lane that keeps
+  // failing would re-assert its line-anchored warning forever — over a file being edited under it.
+  memoriesFail = true;
+  clock += 30_000;
+  store.invalidate();
+  assert.equal((await store.data('src/lib.rs')).memories.length, 1, 'still recent enough to carry');
+
+  clock += 40_000;
+  store.invalidate();
+  assert.deepEqual(
+    (await store.data('src/lib.rs')).memories,
+    [],
+    'past the bound the honest answer is nothing, not a minute-old claim',
+  );
+});
+
+test('an invalidation aborts the requests whose answers it discarded', async () => {
+  const FileStore = await loadStore();
+  const signals = [];
+  const hang = () => new Promise(() => {});
+  const record = (path, signal) => {
+    signals.push(signal);
+    return hang();
+  };
+  const client = {
+    fileSymbolGraph: record,
+    fileClonesFull: (path, theta, minTokens, signal) => record(path, signal),
+    fileMemories: record,
+    fileCoupling: record,
+    filePapertrail: record,
+  };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', endpoint);
+  store.setOnline(true);
+
+  void store.data('src/lib.rs');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(signals.length, 5, 'every lane carries the load signal');
+  assert.ok(signals.every((signal) => signal && !signal.aborted));
+
+  // The clone lane can be a repository-wide scan; an index change that discards its answer should
+  // stop it rather than let the server run it to completion for a reader that has gone away.
+  store.invalidate();
+  assert.ok(signals.every((signal) => signal.aborted), 'discarded requests are aborted');
+});
+
+test('tracked files are bounded so a long session cannot grow without limit', async () => {
+  const FileStore = await loadStore();
+  let memoriesFail = false;
+  const client = {
+    fileSymbolGraph: async () => [],
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => {
+      if (memoriesFail) {
+        throw new Error('/api/file/memories failed');
+      }
+      return [{ title: 'Memory', line: 1 }];
+    },
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', endpoint);
+  store.setOnline(true);
+  assert.equal((await store.data('src/first.rs')).memories.length, 1);
+
+  // Visiting far more files than the cap evicts the oldest, fallback included — otherwise every
+  // file a session ever touched would keep its payload alive for the lifetime of the window.
+  for (let i = 0; i < 300; i++) {
+    await store.data(`src/f${i}.rs`);
+  }
+  memoriesFail = true;
+  store.invalidate();
+  assert.deepEqual(
+    (await store.data('src/first.rs')).memories,
+    [],
+    'the evicted file has no fallback left to serve',
+  );
+});
+
+test('a file whose every lane fails clears its signals', async () => {
+  const FileStore = await loadStore();
+  const failing = async () => {
+    throw new Error('connection refused');
+  };
+  const client = {
+    fileSymbolGraph: failing,
+    fileClonesFull: failing,
+    fileMemories: failing,
+    fileCoupling: failing,
+    filePapertrail: failing,
+  };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', endpoint);
+  store.setOnline(true);
+
+  assert.equal(await store.data('src/lib.rs'), undefined);
+  assert.equal(store.shouldClearSignals('src/lib.rs'), true);
+  assert.ok(store.failure('src/lib.rs'));
+});
+
+test('file store stays empty while the server is unreachable and drops in-flight data', async () => {
+  const FileStore = await loadStore();
+  const pending = Array.from({ length: 5 }, deferred);
+  let loads = 0;
+  const client = {
+    fileSymbolGraph: async () => {
+      loads += 1;
+      return pending[0].promise;
+    },
+    fileClonesFull: async () => pending[1].promise,
+    fileMemories: async () => pending[2].promise,
+    fileCoupling: async () => pending[3].promise,
+    filePapertrail: async () => pending[4].promise,
+  };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', endpoint);
+
+  assert.equal(store.shouldClearSignals('src/lib.rs'), true);
+  assert.equal(await store.data('src/lib.rs'), undefined);
+  assert.equal(loads, 0, 'offline providers must not reach the HTTP client');
+
+  store.setOnline(true);
+  assert.equal(
+    store.shouldClearSignals('src/lib.rs'),
+    false,
+    'an online epoch race must not clear current signals',
+  );
+  const request = store.data('src/lib.rs');
+  store.setOnline(false);
+  assert.equal(
+    store.shouldClearSignals('src/lib.rs'),
+    true,
+    'a hidden editor selected while offline must clear stale signals',
+  );
+  pending[0].resolve([]);
+  pending[1].resolve({ clone_regions: [], clone_graph: null });
+  pending[2].resolve([]);
+  pending[3].resolve([]);
+  pending[4].resolve({ refs: [], decisions: [] });
+  assert.equal(await request, undefined, 'a disconnect invalidates an in-flight response');
+  assert.equal(await store.data('src/lib.rs'), undefined);
+  assert.equal(loads, 1, 'offline reads must not repopulate stale data');
+});
+
+test('an unsaved buffer has no indexed path, so every line-anchored surface goes quiet', async () => {
+  const fakeUri = (uriPath) => ({
+    scheme: 'file',
+    path: uriPath,
+    toString: () => `file://${uriPath}`,
+  });
+  const folder = { uri: fakeUri('/repo') };
+  const vscode = {
+    Uri: {
+      joinPath: (base, ...segments) => fakeUri(path.posix.resolve(base.path, ...segments)),
+    },
+    workspace: {
+      workspaceFolders: [folder],
+      getWorkspaceFolder: () => folder,
+      asRelativePath: (uri) => path.posix.relative(folder.uri.path, uri.path),
+    },
+  };
+  const { LensEndpointResolver } = await loadSourceModule('discovery.ts', vscode);
+  const resolver = new LensEndpointResolver(
+    { inspect: () => ({ globalValue: '' }) },
+    { get: async () => undefined },
+  );
+
+  const uri = fakeUri('/repo/src/lib.rs');
+  assert.equal(resolver.pathOf({ uri, isDirty: false }), 'src/lib.rs');
+  // Every fact the server can offer is anchored to line numbers in the SAVED file, so one
+  // inserted line puts all of them on the wrong statement.
+  assert.equal(
+    resolver.pathOf({ uri, isDirty: true }),
+    undefined,
+    'a dirty buffer must not be mapped to the indexed file',
+  );
+});
+
+test('a replaced workspace folder cannot reuse the previous folder\'s server mapping', async () => {
+  const fakeUri = (uriPath) => ({
+    scheme: 'file',
+    path: uriPath,
+    toString: () => `file://${uriPath}`,
+  });
+  const discovery = (port) =>
+    new TextEncoder().encode(
+      JSON.stringify({
+        schema: 'rag-rat-lens-discovery',
+        version: 1,
+        url: `http://127.0.0.1:${port}`,
+        indexed_root: '',
+        case_insensitive_paths: false,
+        ownership_token: `owner-${port}`,
+      }),
+    );
+  const folders = { current: { uri: fakeUri('/first') } };
+  const vscode = {
+    Uri: {
+      joinPath: (base, ...segments) => fakeUri(path.posix.resolve(base.path, ...segments)),
+    },
+    workspace: {
+      get workspaceFolders() {
+        return [folders.current];
+      },
+      isTrusted: true,
+      fs: {
+        readFile: async (uri) => {
+          if (uri.path === '/first/.rag-rat/sockets/lens.json') {
+            return discovery(18120);
+          }
+          if (uri.path === '/second/.rag-rat/sockets/lens.json') {
+            return discovery(18121);
+          }
+          throw new Error('not found');
+        },
+        stat: async (uri) => {
+          if (uri.path === '/first/.git' || uri.path === '/second/.git') {
+            return { type: 1 };
+          }
+          throw new Error('not found');
+        },
+      },
+      getWorkspaceFolder: () => folders.current,
+      asRelativePath: (uri) => path.posix.relative(folders.current.uri.path, uri.path),
+    },
+  };
+  const { LensEndpointResolver } = await loadSourceModule('discovery.ts', vscode);
+  const resolver = new LensEndpointResolver(
+    { inspect: () => ({ globalValue: '' }) },
+    { get: async () => undefined },
+  );
+
+  assert.deepEqual(await resolver.resolve(), {
+    baseUrl: 'http://127.0.0.1:18120',
+    token: 'owner-18120',
+  });
+
+  // A single-root window can replace its folder without reloading the extension host. Well inside
+  // the discovery TTL, so a cache keyed only on time (or on the server URL) would answer with the
+  // previous repository's endpoint and path mapping.
+  folders.current = { uri: fakeUri('/second') };
+  assert.deepEqual(
+    await resolver.resolve(),
+    { baseUrl: 'http://127.0.0.1:18121', token: 'owner-18121' },
+    'a resolution describes a workspace, not just a server',
+  );
+});
+
+test('a resolution that finishes after its workspace was replaced must not publish', async () => {
+  const fakeUri = (uriPath) => ({
+    scheme: 'file',
+    path: uriPath,
+    toString: () => `file://${uriPath}`,
+  });
+  const folders = { current: { uri: fakeUri('/first') } };
+  const gate = deferred();
+  const vscode = {
+    Uri: {
+      joinPath: (base, ...segments) => fakeUri(path.posix.resolve(base.path, ...segments)),
+    },
+    workspace: {
+      get workspaceFolders() {
+        return [folders.current];
+      },
+      isTrusted: true,
+      fs: {
+        readFile: async (uri) => {
+          if (uri.path !== '/first/.rag-rat/sockets/lens.json') {
+            throw new Error('not found');
+          }
+          // Hold the resolution open so the folder can be replaced mid-flight.
+          await gate.promise;
+          return new TextEncoder().encode(
+            JSON.stringify({
+              schema: 'rag-rat-lens-discovery',
+              version: 1,
+              url: 'http://127.0.0.1:18120',
+              indexed_root: 'crate',
+              case_insensitive_paths: false,
+              ownership_token: 'owner-first',
+            }),
+          );
+        },
+        stat: async (uri) => {
+          if (uri.path === '/first/.git') {
+            return { type: 1 };
+          }
+          throw new Error('not found');
+        },
+      },
+      getWorkspaceFolder: () => folders.current,
+      asRelativePath: (uri) => path.posix.relative(folders.current.uri.path, uri.path),
+    },
+  };
+  const { LensEndpointResolver } = await loadSourceModule('discovery.ts', vscode);
+  const resolver = new LensEndpointResolver(
+    { inspect: () => ({ globalValue: '' }) },
+    { get: async () => undefined },
+  );
+
+  const inFlight = resolver.resolve();
+  folders.current = { uri: fakeUri('/second') };
+  gate.resolve();
+
+  await assert.rejects(
+    inFlight,
+    /superseded/,
+    'a resolution describing the previous folder must not install its path mapping',
+  );
+  // The stale `indexed_root: 'crate'` prefix must not have landed: with it installed, a file at
+  // the new folder's root would be reported as outside the indexed tree.
+  assert.equal(resolver.pathOf({ uri: fakeUri('/second/src/lib.rs'), isDirty: false }), 'src/lib.rs');
+});
+
+test('data that arrives after its document went dirty is withheld, not drawn', async () => {
+  const FileStore = await loadStore();
+  const pending = [];
+  const client = {
+    fileSymbolGraph: () => new Promise((resolve) => pending.push(resolve)),
+    fileClonesFull: () => new Promise((resolve) => pending.push(resolve)),
+    fileMemories: () => new Promise((resolve) => pending.push(resolve)),
+    fileCoupling: () => new Promise((resolve) => pending.push(resolve)),
+    filePapertrail: () => new Promise((resolve) => pending.push(resolve)),
+  };
+  const document = { uri: { toString: () => 'file:///repo/src/lib.rs' }, isDirty: false };
+  const store = new FileStore(
+    client,
+    () => 0.9,
+    () => 100,
+    // The real resolver withholds a path for a dirty buffer; mirror that here.
+    (doc) => (doc.isDirty ? undefined : 'src/lib.rs'),
+    endpoint,
+  );
+  store.setOnline(true);
+
+  const request = store.dataFor(document);
+  // Let the store resolve its endpoint and dispatch all five lanes before disturbing anything.
+  for (let tick = 0; tick < 50 && pending.length < 5; tick += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(pending.length, 5, 'all five lanes must be in flight');
+  // The user types while they are.
+  document.isDirty = true;
+  pending[0]({ symbols: [] });
+  pending[1]({ clone_regions: [], clone_graph: null });
+  pending[2]({ memories: [] });
+  pending[3]({ coupling: [] });
+  pending[4]({ refs: [], decisions: [] });
+
+  assert.equal(
+    await request,
+    undefined,
+    'an answer for the saved file must not be drawn over the edited buffer',
+  );
+  // Saving restores it: the same cached payload is now legitimate again.
+  document.isDirty = false;
+  const loaded = await store.dataFor(document);
+  assert.equal(loaded.path, 'src/lib.rs');
+});
+
+test('a sidebar load that resolves after the active editor moved on re-aims at the new one', async () => {
+  const uriFor = (value) => ({ toString: () => value });
+  const first = { document: { uri: uriFor('file:///repo/src/first.rs') } };
+  const second = { document: { uri: uriFor('file:///repo/src/second.rs') } };
+  const active = { editor: first };
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+    },
+    ThemeColor: class {},
+    ThemeIcon: class {
+      constructor(id) {
+        this.id = id;
+      }
+    },
+    TreeItem: class {
+      constructor(label) {
+        this.label = label;
+      }
+    },
+    TreeItemCollapsibleState: { Expanded: 1, None: 0 },
+    window: {
+      get activeTextEditor() {
+        return active.editor;
+      },
+    },
+  };
+  const { CloneClassesView } = await loadSourceModule('sidebar.ts', vscode);
+  const gate = deferred();
+  const asked = [];
+  const store = {
+    async dataFor(document) {
+      const uri = document.uri.toString();
+      asked.push(uri);
+      if (uri.endsWith('first.rs')) {
+        // Hold the first load open so the user can switch editors while it is in flight.
+        await gate.promise;
+        return {
+          path: 'src/first.rs',
+          data: { clones: [{ symbol: 'from_first', partners: [] }], cloneGraph: { eligible: true } },
+        };
+      }
+      return {
+        path: 'src/second.rs',
+        data: { clones: [{ symbol: 'from_second', partners: [] }], cloneGraph: { eligible: true } },
+      };
+    },
+    pathOf: () => 'src/whatever.rs',
+  };
+  const view = new CloneClassesView(store);
+
+  const pending = view.getChildren();
+  active.editor = second;
+  gate.resolve();
+
+  const items = await pending;
+  assert.deepEqual(asked, ['file:///repo/src/first.rs', 'file:///repo/src/second.rs']);
+  // Not the stale file, and NOT empty: a load settling late must not blank the tree a newer one
+  // filled, so it answers about wherever the user actually is.
+  assert.equal(items.length, 1);
+  assert.match(JSON.stringify(items), /from_second/);
+  assert.doesNotMatch(JSON.stringify(items), /from_first/);
+});
+
+test('open memory documents are withdrawn when the server stops answering', async () => {
+  const fired = [];
+  const vscode = {
+    EventEmitter: class {
+      fire(value) {
+        fired.push(value);
+      }
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value.split(':')[1], toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ViewColumn: { Beside: 2 },
+    window: {},
+    workspace: {},
+  };
+  const { MemoryDocProvider } = await loadSourceModule('memories.ts', vscode);
+  const provider = new MemoryDocProvider({});
+  const uri = provider.update(
+    { id: 'mem-1', title: 'Bound invariant', kind: 'Invariant', body: 'The thing must hold' },
+    'src/lib.rs',
+  );
+
+  assert.match(provider.provideTextDocumentContent(uri), /Bound invariant/);
+
+  provider.withdraw();
+  const withdrawn = provider.provideTextDocumentContent(uri);
+  assert.match(withdrawn, /not answering/, 'an outage must be stated, not left showing the memory');
+  assert.doesNotMatch(withdrawn, /The thing must hold/, 'the old server\'s claim must be gone');
+  // A withdrawal is an outage, NOT a deletion: reporting "memory not found" would claim the index
+  // no longer holds it, which is what a real removal renders.
+  assert.doesNotMatch(withdrawn, /memory not found/);
+  assert.equal(
+    provider.provideTextDocumentContent({ path: '/never-existed.md' }),
+    'memory not found',
+    'a genuinely absent memory still reads as absent',
+  );
+});
+
+test('a memory refresh in flight when the server drops cannot restore the withdrawn body', async () => {
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value.split(':')[1], toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ViewColumn: { Beside: 2 },
+    window: {},
+    workspace: {},
+  };
+  const { MemoryDocProvider } = await loadSourceModule('memories.ts', vscode);
+  const gate = deferred();
+  const store = {
+    async data() {
+      await gate.promise;
+      return { memories: [{ id: 'mem-1', title: 'Bound invariant', kind: 'Invariant', body: 'body' }] };
+    },
+  };
+  const provider = new MemoryDocProvider(store);
+  const uri = provider.update(
+    { id: 'mem-1', title: 'Bound invariant', kind: 'Invariant', body: 'body' },
+    'src/lib.rs',
+  );
+
+  const refreshing = provider.refresh();
+  // The server drops out while that refresh is awaiting its answer.
+  provider.withdraw();
+  gate.resolve();
+  await refreshing;
+
+  assert.match(
+    provider.provideTextDocumentContent(uri),
+    /not answering/,
+    'a pre-withdrawal refresh must not republish the unreachable server\'s memory',
+  );
+});
+
+test('a command captured before an outage cannot restore a withdrawn memory', async () => {
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value.split(':')[1], toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ViewColumn: { Beside: 2 },
+    window: {},
+    workspace: {},
+  };
+  const { MemoryDocProvider } = await loadSourceModule('memories.ts', vscode);
+  const answers = { data: undefined };
+  const provider = new MemoryDocProvider({ async data() { return answers.data; } });
+  const memory = { id: 'mem-1', title: 'Bound invariant', kind: 'Invariant', body: 'the claim' };
+  const uri = provider.update(memory, 'src/lib.rs');
+  assert.match(provider.provideTextDocumentContent(uri), /the claim/);
+
+  provider.withdraw();
+  // A QuickPick opened before the outage still holds this `FileMemory` and renders it on pick.
+  provider.update(memory, 'src/lib.rs');
+  assert.match(
+    provider.provideTextDocumentContent(uri),
+    /not answering/,
+    'rendering from a pre-outage capture must not put the old body back',
+  );
+
+  // Reachability is what lifts the withdrawal — not a refresh, which iterates nothing when no
+  // memory documents are open and would leave the flag stuck forever.
+  provider.restore();
+  answers.data = { memories: [memory] };
+  await provider.refresh();
+  assert.match(provider.provideTextDocumentContent(uri), /the claim/);
+});
+
+test('a withdrawal made with no documents open does not outlive the outage', async () => {
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value.split(':')[1], toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ViewColumn: { Beside: 2 },
+    window: {},
+    workspace: {},
+  };
+  const { MemoryDocProvider } = await loadSourceModule('memories.ts', vscode);
+  const provider = new MemoryDocProvider({ async data() { return { memories: [] }; } });
+
+  // The server drops while nothing is open, so there is no source path for a refresh to walk.
+  provider.withdraw();
+  await provider.refresh();
+  provider.restore();
+
+  const uri = provider.update(
+    { id: 'mem-1', title: 'Bound invariant', kind: 'Invariant', body: 'the claim' },
+    'src/lib.rs',
+  );
+  assert.match(
+    provider.provideTextDocumentContent(uri),
+    /the claim/,
+    'a memory opened after the server returned must render, not report an outage',
+  );
+});
+
+test('a memory picked after the index moved is re-read, never rendered from the captured copy', async () => {
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value.split(':')[1], toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ViewColumn: { Beside: 2 },
+    window: {},
+    workspace: {},
+  };
+  const { MemoryDocProvider } = await loadSourceModule('memories.ts', vscode);
+  const answers = { data: undefined };
+  const provider = new MemoryDocProvider({ async data() { return answers.data; } });
+  const captured = { id: 'mem-1', title: 'Bound invariant', kind: 'Invariant', body: 'OLD body' };
+
+  // The index moved while the picker sat open: same memory, revised body.
+  answers.data = { memories: [{ ...captured, body: 'NEW body' }] };
+  const ready = await provider.openPicked(captured.id, 'src/lib.rs');
+  assert.equal(ready.kind, 'ready');
+  const rendered = provider.provideTextDocumentContent(ready.uri);
+  assert.match(rendered, /NEW body/);
+  assert.doesNotMatch(rendered, /OLD body/, 'the captured copy must not be what gets rendered');
+
+  // The memory was deleted while the picker sat open: rendering the capture would resurrect it.
+  answers.data = { memories: [] };
+  // "absent", not "deleted": a failed memory lane also produces an empty list, so the payload
+  // cannot distinguish the two and neither may the message.
+  assert.deepEqual(await provider.openPicked(captured.id, 'src/lib.rs'), { kind: 'absent' });
+
+  // The server stopped answering: an outage is not a deletion.
+  answers.data = undefined;
+  assert.deepEqual(await provider.openPicked(captured.id, 'src/lib.rs'), { kind: 'unavailable' });
+});
+
+test('the memory picker routes through the revalidating open, not the captured object', async () => {
+  const shown = [];
+  const messages = [];
+  const vscode = {
+    EventEmitter: class {
+      fire() {}
+      get event() {
+        return () => ({ dispose() {} });
+      }
+      dispose() {}
+    },
+    Uri: { parse: (value) => ({ path: value, toString: () => value }) },
+    Range: class {},
+    CodeLens: class {},
+    ViewColumn: { Beside: 2 },
+    window: {
+      showQuickPick: async (items) => items[0],
+      showTextDocument: async (doc) => shown.push(doc),
+      showInformationMessage: async (message) => messages.push(message),
+    },
+    workspace: { openTextDocument: async (uri) => ({ uri }) },
+  };
+  const { showMemoriesQuickPick } = await loadSourceModule('memories.ts', vscode);
+  const captured = { id: 'mem-1', title: 'T', kind: 'Invariant', body: 'OLD', confidence: 'high' };
+
+  const calls = { openPicked: [], update: [] };
+  const documents = {
+    async openPicked(id, path) {
+      calls.openPicked.push([id, path]);
+      return { kind: 'ready', uri: 'rag-rat-memory:/mem-1.md' };
+    },
+    update(memory, path) {
+      calls.update.push([memory, path]);
+      return 'rag-rat-memory:/mem-1.md';
+    },
+  };
+
+  await showMemoriesQuickPick([captured], 'src/lib.rs', documents);
+  assert.deepEqual(calls.openPicked, [['mem-1', 'src/lib.rs']], 'the pick must be re-read by id');
+  assert.deepEqual(calls.update, [], 'the captured object must never be rendered directly');
+  assert.equal(shown.length, 1);
+
+  // A memory deleted while the picker was open is reported, not opened.
+  shown.length = 0;
+  documents.openPicked = async () => ({ kind: 'absent' });
+  await showMemoriesQuickPick([captured], 'src/lib.rs', documents);
+  assert.equal(shown.length, 0, 'nothing to show for a memory that is gone');
+  assert.match(messages.at(-1), /may have been removed, or the lookup for this file failed/);
+  assert.doesNotMatch(messages.at(-1), /no longer in the index/, 'deletion must not be asserted');
+
+  // An outage says so, rather than claiming the memory was deleted.
+  documents.openPicked = async () => ({ kind: 'unavailable' });
+  await showMemoriesQuickPick([captured], 'src/lib.rs', documents);
+  assert.match(messages.at(-1), /not answering/);
+});

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "WebWorker"],
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- add a loopback-only Axum Lens API available through standalone `rag-rat serve` and elected embedded MCP hosting
- expose authenticated file graph, clone, memory, coupling, papertrail, status, event, and treemap data for editor clients
- add a web-compatible VS Code extension with overlays, diagnostics, hovers, CodeLens, and sidebar views
- keep Lens freshness checks O(1) with a per-repository enrichment revision and disconnect clients when the index becomes unavailable
- harden bearer-token discovery against tracked credentials, tracked runtime files, symlinked paths, ignore-rule negation, linked-worktree ambiguity, and repository dirtiness

## Correctness

- scope API reads and freshness revisions to the active repository and worktree
- serve linked-worktree clone and chunk data through scope-correct source roots, including subdirectory-rooted indexes
- preserve sibling checkout isolation while invalidating clients after linked-worktree materialization
- canonicalize CLI and environment browser origins, accept the full IPv4 loopback range, normalize hosted token identities, and reject path/query/fragment URL components that cannot be preserved
- bind hosted endpoints to the opened workspace through an authenticated `repo_id` association stored outside repository settings
- resolve case aliases to indexed path spellings before exact file queries, including workspaces whose root name contains no letters
- cap interactive memory payloads, prioritize file-specific bindings, and batch dream-state reads so one file cannot exhaust the request budget
- preserve symbol-less file callers and render unavailable or unknown editor states without claiming empty or terminal results
- refresh open memory detail documents after SSE invalidation, including when their source editor is hidden
- transition the extension offline on event-stream failure, clear stale signals when documents leave the indexed root, and prevent in-flight responses from repopulating state
- coalesce synchronized SSE version-cache misses into one bounded database read
- include complete inclusive clone ranges and bound decoration resources by reusable rendered styles rather than unbounded class IDs

## Verification

- `cargo nextest run --workspace` (4,091 passed before the bounded Lens follow-ups)
- `cargo nextest run -p rag-rat-core -p rag-rat-mcp` (1,715 passed, 2 skipped before the final runtime-file guard)
- `cargo nextest run -p rag-rat-mcp` (95 passed after the latest SSE and memory-document follow-up)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p rag-rat-core -p rag-rat-mcp --all-targets -- -D warnings`
- `cargo clippy -p rag-rat-mcp --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `npm run package`
- `npm test` (16 passed)
- `npm audit --omit=dev` (0 vulnerabilities)

Refs #216. This PR establishes the serving and editor-extension foundation but intentionally does not close the issue. The hotspot treemap UI, branch-review mode, and optional bundled web-VS-Code appliance remain follow-up scope. Related: #214, #215, #217, #960.