### PR TITLE
fix(oracle): finish live LSP lifecycle

### DIFF
--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -30,7 +30,6 @@ use crate::index::{IndexDatabase, papertrail_autosync as autosync};
 pub(crate) const FLEET_DEBOUNCE: Duration = Duration::from_millis(500);
 pub(crate) const FLEET_MAX_LATENCY: Duration = Duration::from_millis(2000);
 pub(crate) const IDLE_WAIT: Duration = Duration::from_millis(500);
-pub(crate) const LIVE_ORACLE_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 
 /// A running watcher. Dropping it signals the thread to stop and joins it.
 #[derive(Debug)]
@@ -224,7 +223,7 @@ fn watcher_main(
                     Some(&mut live_oracle),
                 ),
             };
-            live_oracle.retry_needed()
+            live_oracle.next_wake_in(&config, Instant::now())
         }
     }) else {
         return;
@@ -254,7 +253,6 @@ fn watcher_main(
         scheduler: &mut scheduler,
         papertrail_tx: papertrail_tx.as_ref(),
         papertrail_interval,
-        live_oracle_retry_interval: LIVE_ORACLE_RETRY_INTERVAL,
         stop,
         fleet_trigger: &mut fire_fleet_trigger,
     }
@@ -351,8 +349,6 @@ pub(crate) struct EventLoop<'a, W: notify::Watcher> {
     /// `None` disables the papertrail trigger (no tracker bindings, or no worker thread).
     pub(crate) papertrail_tx: Option<&'a Sender<AutosyncRequest>>,
     pub(crate) papertrail_interval: Option<Duration>,
-    /// Delay before retrying a live-oracle backlog without waiting for another filesystem event.
-    pub(crate) live_oracle_retry_interval: Duration,
     pub(crate) stop: &'a AtomicBool,
     /// Injected so tests can observe the fleet firing; production wires [`fleet::trigger`].
     pub(crate) fleet_trigger: &'a mut (dyn FnMut(&Path) + Send),
@@ -387,7 +383,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
         let mut papertrail_clock =
             PapertrailClock::new(self.papertrail_tx.and(self.papertrail_interval), Instant::now());
         let mut papertrail_scheduler = PapertrailScheduler::new();
-        let mut live_oracle_retry_at: Option<Instant> = None;
+        let mut live_oracle_wake_at: Option<Instant> = None;
         // The overlay scope accumulated while the debounce is armed (#577): every firing event
         // merges its contribution, and the union rides the next dispatched pass. Cleared ONLY on
         // dispatch, like the debounce itself — mid-pass events keep accumulating for the
@@ -428,7 +424,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     fleet_debounce.due_in(now),
                     sweep.due_in(now),
                     papertrail_clock.due_in(now),
-                    live_oracle_retry_at.map(|at| at.saturating_duration_since(now)),
+                    live_oracle_wake_at.map(|at| at.saturating_duration_since(now)),
                 ]
                 .into_iter()
                 .flatten()
@@ -497,11 +493,11 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     }
                 },
                 Ok(LoopMsg::Fs(Err(_))) => {},
-                Ok(LoopMsg::PassDone { live_oracle_retry }) => {
+                Ok(LoopMsg::PassDone { live_oracle_wake_in }) => {
                     self.scheduler.on_done();
                     let done_at = Instant::now();
-                    live_oracle_retry_at =
-                        live_oracle_retry.then(|| done_at + self.live_oracle_retry_interval);
+                    live_oracle_wake_at =
+                        live_oracle_wake_in.and_then(|delay| done_at.checked_add(delay));
                     sweep.on_pass_done(done_at);
                     // The cooldown counts from pass COMPLETION (#823) — the armed debounce below
                     // is typically long-elapsed by now, and without this the next iteration
@@ -550,12 +546,12 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                 }
             }
             let periodic_due = sweep.due(now);
-            let live_oracle_retry_due = live_oracle_retry_at.is_some_and(|at| now >= at);
+            let live_oracle_wake_due = live_oracle_wake_at.is_some_and(|at| now >= at);
             // The cooldown (#823) holds back only the DEBOUNCE-driven dispatch; a due periodic
             // sweep dispatches regardless — the missed-event backstop is never starved by the
             // cooldown.
             if periodic_due
-                || live_oracle_retry_due
+                || live_oracle_wake_due
                 || (debounce.should_fire(now) && cooldown.ready(now))
             {
                 // The periodic sweep is the missed-event backstop, so it refreshes every overlay;
@@ -577,9 +573,9 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                         sweep.on_dispatch(matches!(overlay_scope, OverlayScope::All));
                     }
                     let _ = self.pass_tx.send(request);
-                    // Every pass retries the resident backlog. Its completion re-arms this only
-                    // when unfinished work remains.
-                    live_oracle_retry_at = None;
+                    // Every pass services the resident tail. Its completion re-arms the next
+                    // backlog retry or idle-shutdown deadline when needed.
+                    live_oracle_wake_at = None;
                     // Reset ONLY on dispatch: while a pass is in flight the armed debounce (and
                     // the scope accumulated with it) is the record that a follow-up is owed, and
                     // it fires as soon as `PassDone` lands.

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -10,10 +10,11 @@
 //!
 //! Everything here is best-effort: a missing `rust-analyzer`, a failed spawn, a warming server,
 //! or a dead server mid-pass never fails the maintenance pass — the worklist rides to the next
-//! pass via the backlog, and an aborted session is dropped so a later pass respawns. Bounded
-//! respawn backoff remains in #535.
+//! pass via the backlog, and an aborted session is dropped so a later pass respawns with bounded
+//! backoff. The tail reports its next backlog-retry or idle-shutdown deadline to the event loop.
 
 use std::collections::{BTreeSet, HashSet};
+use std::time::{Duration, Instant};
 
 use rag_rat_base::config::Config;
 use rag_rat_base::language::Language;
@@ -22,6 +23,89 @@ use rag_rat_oracle::LiveOracleSession;
 
 use crate::index::IndexDatabase;
 
+const LIVE_ORACLE_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+const RESPAWN_BACKOFF_MAX: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Default)]
+struct RespawnBackoff {
+    failures: u32,
+    retry_at: Option<Instant>,
+}
+
+impl RespawnBackoff {
+    fn ready(&self, now: Instant) -> bool {
+        self.retry_at.is_none_or(|retry_at| now >= retry_at)
+    }
+
+    fn record_failure(&mut self, now: Instant) {
+        self.failures = self.failures.saturating_add(1);
+        let exponent = self.failures.saturating_sub(1).min(4);
+        let delay =
+            LIVE_ORACLE_RETRY_INTERVAL.saturating_mul(1 << exponent).min(RESPAWN_BACKOFF_MAX);
+        self.retry_at = now.checked_add(delay);
+    }
+
+    fn remaining(&self, now: Instant) -> Option<Duration> {
+        self.retry_at.map(|retry_at| retry_at.saturating_duration_since(now))
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+#[derive(Default)]
+struct LiveOracleLifecycle {
+    session_last_used_at: Option<Instant>,
+    respawn_backoff: RespawnBackoff,
+}
+
+impl LiveOracleLifecycle {
+    fn next_wake_in(&self, has_backlog: bool, idle: Duration, now: Instant) -> Option<Duration> {
+        if has_backlog {
+            return self
+                .respawn_backoff
+                .remaining(now)
+                .filter(|remaining| !remaining.is_zero())
+                .or(Some(LIVE_ORACLE_RETRY_INTERVAL));
+        }
+        self.session_last_used_at
+            .map(|last_used_at| scheduled_idle_wake_in(last_used_at, now, idle))
+    }
+
+    fn can_respawn(&self, now: Instant) -> bool {
+        self.respawn_backoff.ready(now)
+    }
+
+    fn on_spawned(&mut self, now: Instant) {
+        self.session_last_used_at = Some(now);
+    }
+
+    fn on_session_used(&mut self, now: Instant) {
+        debug_assert!(self.session_last_used_at.is_some());
+        self.session_last_used_at = Some(now);
+    }
+
+    fn idle_shutdown_due(&self, has_pending_work: bool, idle: Duration, now: Instant) -> bool {
+        self.session_last_used_at.is_some_and(|last_used_at| {
+            should_idle_shutdown(has_pending_work, last_used_at, now, idle)
+        })
+    }
+
+    fn on_session_ended(&mut self) {
+        self.session_last_used_at = None;
+    }
+
+    fn on_failure(&mut self, now: Instant) {
+        self.on_session_ended();
+        self.respawn_backoff.record_failure(now);
+    }
+
+    fn on_stable_batch(&mut self) {
+        self.respawn_backoff.reset();
+    }
+}
+
 /// Resident live-oracle state for one watcher: the LSP session + the deferred-path backlog.
 /// Owned by the pass-worker closure (it must outlive individual passes); the hook/CLI
 /// `maintenance_pass*` entry points pass no state, so the live stage only ever runs from the
@@ -29,21 +113,29 @@ use crate::index::IndexDatabase;
 pub(crate) struct LiveOracleTail {
     session: Option<LiveOracleSession>,
     backlog: Vec<String>,
+    lifecycle: LiveOracleLifecycle,
 }
 
 impl LiveOracleTail {
     pub(crate) fn new() -> Self {
-        Self { session: None, backlog: Vec::new() }
+        Self { session: None, backlog: Vec::new(), lifecycle: LiveOracleLifecycle::default() }
     }
 
-    /// Whether the watcher must schedule another pass even if no filesystem event arrives.
-    pub(crate) fn retry_needed(&self) -> bool {
-        !self.backlog.is_empty()
+    /// Delay until the watcher should run another pass without waiting for a filesystem event.
+    /// A backlog takes priority; otherwise a resident session schedules its own idle shutdown.
+    pub(crate) fn next_wake_in(&self, config: &Config, now: Instant) -> Option<Duration> {
+        if !config.oracle.live.enabled {
+            return None;
+        }
+        self.lifecycle.next_wake_in(
+            !self.backlog.is_empty(),
+            Duration::from_secs(config.oracle.live.idle_shutdown_secs),
+            now,
+        )
     }
 
-    /// One pass's live stage: the idle-shutdown sweep, then (when enabled and there is work)
-    /// resolve the changed Rust files through the resident client. Never returns an error — a
-    /// failure is logged and the work rides the next pass.
+    /// One pass's live stage: resolve pending work, or shut an otherwise-workless session down
+    /// once idle. Never returns an error — a failure is logged and the work rides the next pass.
     pub(crate) fn on_pass(
         &mut self,
         db: &IndexDatabase,
@@ -54,22 +146,26 @@ impl LiveOracleTail {
         if !live_cfg.enabled {
             return;
         }
-        let now = now_ms();
-        // Idle-shutdown sweep: an idle server shouldn't hold rust-analyzer's resident memory.
-        // Runs even on a workless (quiet) pass — that is exactly when idleness accrues.
-        if self.session.as_ref().is_some_and(|session| {
-            session.idle_for(now, live_cfg.idle_shutdown_secs.saturating_mul(1000))
-        }) && let Some(session) = self.session.take()
-        {
-            tracing::debug!(target: "rag_rat_core::watch", "live oracle: idle shutdown");
-            session.shutdown();
-        }
+        let now = Instant::now();
+        let started_at_ms = now_ms();
 
         // The worklist: backlog first (older edits wait longest), then this pass's changed Rust
         // paths, deduped. `changed_paths` is `None` on a heal/bootstrap — no reliable superset,
         // so only the backlog rides.
         let worklist = assemble_worklist(std::mem::take(&mut self.backlog), changed_paths);
+        let idle_shutdown_due = self.lifecycle.idle_shutdown_due(
+            !worklist.is_empty(),
+            Duration::from_secs(live_cfg.idle_shutdown_secs),
+            now,
+        );
         if worklist.is_empty() {
+            // Pending work always wins over idle shutdown: a short idle timeout must not kill a
+            // warming server immediately before its retained backlog retries.
+            if idle_shutdown_due && let Some(session) = self.session.take() {
+                tracing::debug!(target: "rag_rat_core::watch", "live oracle: idle shutdown");
+                self.lifecycle.on_session_ended();
+                session.shutdown();
+            }
             return;
         }
         // Rust must be an indexed language of this checkout (ra-lsp's language).
@@ -81,14 +177,31 @@ impl LiveOracleTail {
         // unw spawnable) leaves the work in the backlog for a later pass — the same
         // degrade-quietly UX as a missing embedding model.
         if self.session.is_none() {
-            self.session = LiveOracleSession::spawn(&config.root, now);
+            if !self.lifecycle.can_respawn(now) {
+                self.backlog = worklist;
+                return;
+            }
+            self.session = LiveOracleSession::spawn(&config.root);
+            if self.session.is_some() {
+                self.lifecycle.on_spawned(now);
+            }
         }
         let Some(session) = &mut self.session else {
             self.backlog = worklist;
+            self.lifecycle.on_failure(Instant::now());
             return;
         };
 
-        match db.run_live_oracle_pass(session, &worklist, live_cfg.max_requests_per_pass, now) {
+        let result = db.run_live_oracle_pass(
+            session,
+            &worklist,
+            live_cfg.max_requests_per_pass,
+            started_at_ms,
+        );
+        // Count idleness from completion: a request batch longer than the idle window must not
+        // force an immediate shutdown and cold respawn.
+        self.lifecycle.on_session_used(Instant::now());
+        match result {
             Ok(report) => {
                 self.backlog = report.unfinished_paths.clone();
                 // An aborted pass means the server died or wedged mid-resolution: drop the
@@ -102,8 +215,13 @@ impl LiveOracleTail {
                     tracing::warn!(
                         target: "rag_rat_core::watch",
                         status = %report.status,
-                        "live oracle: server aborted; session dropped, respawn on next pass"
+                        "live oracle: server aborted; session dropped, respawn after backoff"
                     );
+                    self.lifecycle.on_failure(Instant::now());
+                } else if report.status != "Warming" {
+                    // A completed request batch proves the replacement session is stable enough
+                    // to end an earlier crash/spawn-failure streak. Warm-up alone does not.
+                    self.lifecycle.on_stable_batch();
                 }
                 if report.rows_written > 0 || !report.unfinished_paths.is_empty() {
                     tracing::info!(
@@ -127,6 +245,7 @@ impl LiveOracleTail {
                     session.shutdown();
                 }
                 self.backlog = worklist;
+                self.lifecycle.on_failure(Instant::now());
                 tracing::warn!(
                     target: "rag_rat_core::watch",
                     error = %err,
@@ -135,6 +254,26 @@ impl LiveOracleTail {
             },
         }
     }
+}
+
+fn idle_wake_in(last_used_at: Instant, now: Instant, idle: Duration) -> Duration {
+    idle.saturating_sub(now.saturating_duration_since(last_used_at))
+}
+
+fn scheduled_idle_wake_in(last_used_at: Instant, now: Instant, idle: Duration) -> Duration {
+    let remaining = idle_wake_in(last_used_at, now, idle);
+    // If a pass failed before reaching the tail, do not redispatch an overdue deadline in a tight
+    // loop. A serviced idle wake removes the session and therefore returns no next wake.
+    if remaining.is_zero() { LIVE_ORACLE_RETRY_INTERVAL } else { remaining }
+}
+
+fn should_idle_shutdown(
+    has_pending_work: bool,
+    last_used_at: Instant,
+    now: Instant,
+    idle: Duration,
+) -> bool {
+    !has_pending_work && now.saturating_duration_since(last_used_at) >= idle
 }
 
 /// The pass's worklist: backlog paths first (oldest edits wait longest), then the changed
@@ -184,5 +323,83 @@ mod tests {
         // A heal/bootstrap pass (None) contributes no paths.
         assert_eq!(assemble_worklist(backlog, None), vec!["src/a.rs"]);
         assert!(assemble_worklist(Vec::new(), None).is_empty());
+    }
+
+    #[test]
+    fn respawn_backoff_doubles_and_caps_without_allowing_early_retries() {
+        let mut backoff = RespawnBackoff::default();
+        let mut now = Instant::now();
+        for expected in [30, 60, 120, 240, 300, 300] {
+            backoff.record_failure(now);
+            assert!(!backoff.ready(now));
+            assert_eq!(backoff.remaining(now), Some(Duration::from_secs(expected)));
+            now += Duration::from_secs(expected);
+            assert!(backoff.ready(now));
+        }
+        backoff.reset();
+        assert!(backoff.ready(now));
+        assert_eq!(backoff.remaining(now), None);
+    }
+
+    #[test]
+    fn idle_wake_counts_from_last_session_use() {
+        let last_used = Instant::now();
+        assert_eq!(
+            idle_wake_in(last_used, last_used + Duration::from_secs(3), Duration::from_secs(10)),
+            Duration::from_secs(7),
+        );
+        assert_eq!(
+            idle_wake_in(last_used, last_used + Duration::from_secs(10), Duration::from_secs(10)),
+            Duration::ZERO,
+        );
+        assert_eq!(
+            scheduled_idle_wake_in(
+                last_used,
+                last_used + Duration::from_secs(10),
+                Duration::from_secs(10),
+            ),
+            LIVE_ORACLE_RETRY_INTERVAL,
+            "an unserviced overdue deadline must not spin the maintenance loop",
+        );
+        assert!(should_idle_shutdown(
+            false,
+            last_used,
+            last_used + Duration::from_secs(10),
+            Duration::from_secs(10),
+        ));
+        assert!(
+            !should_idle_shutdown(
+                true,
+                last_used,
+                last_used + Duration::from_secs(60),
+                Duration::from_secs(10),
+            ),
+            "pending warming work must win even when the session is otherwise idle",
+        );
+    }
+
+    #[test]
+    fn lifecycle_prioritizes_pending_work_and_rearms_unserviced_idle_wakes() {
+        let mut lifecycle = LiveOracleLifecycle::default();
+        let started = Instant::now();
+        let idle = Duration::from_secs(10);
+        lifecycle.on_spawned(started);
+        assert_eq!(lifecycle.next_wake_in(false, idle, started), Some(idle));
+
+        let overdue = started + Duration::from_secs(60);
+        assert!(!lifecycle.idle_shutdown_due(true, idle, overdue));
+        assert!(lifecycle.idle_shutdown_due(false, idle, overdue));
+        assert_eq!(
+            lifecycle.next_wake_in(false, idle, overdue),
+            Some(LIVE_ORACLE_RETRY_INTERVAL),
+            "a pass that did not service the overdue wake must not spin",
+        );
+
+        lifecycle.on_session_ended();
+        assert_eq!(lifecycle.next_wake_in(false, idle, overdue), None);
+
+        lifecycle.on_failure(overdue);
+        assert!(!lifecycle.can_respawn(overdue));
+        assert_eq!(lifecycle.next_wake_in(true, idle, overdue), Some(LIVE_ORACLE_RETRY_INTERVAL),);
     }
 }

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -190,7 +190,7 @@ pub(crate) enum PassRequest {
 #[derive(Debug)]
 pub(crate) enum LoopMsg {
     Fs(notify::Result<Event>),
-    PassDone { live_oracle_retry: bool },
+    PassDone { live_oracle_wake_in: Option<Duration> },
     PapertrailDone,
     Wake,
 }
@@ -246,20 +246,20 @@ impl PassScheduler {
 /// each pass still takes the write lock itself, so concurrent writers (git-hook `maintenance`,
 /// other servers' elected watchers, the CLI) serialize exactly as before; the single worker
 /// thread is what keeps THIS watcher to one pass at a time. Each request is answered with
-/// [`LoopMsg::PassDone`] so the loop can refresh worktree watch state, schedule any live-oracle
-/// backlog retry, and dispatch a coalesced follow-up; the worker exits when the request channel
-/// closes.
+/// [`LoopMsg::PassDone`] so the loop can refresh worktree watch state, schedule the live oracle's
+/// next backlog-retry or idle-shutdown wake, and dispatch a coalesced follow-up; the worker exits
+/// when the request channel closes.
 pub(crate) fn spawn_pass_worker(
     pass_rx: Receiver<PassRequest>,
     done_tx: Sender<LoopMsg>,
-    mut run_pass_request: impl FnMut(&PassRequest) -> bool + Send + 'static,
+    mut run_pass_request: impl FnMut(&PassRequest) -> Option<Duration> + Send + 'static,
 ) -> Option<JoinHandle<()>> {
     std::thread::Builder::new()
         .name("rag-rat-watch-pass".to_string())
         .spawn(move || {
             while let Ok(request) = pass_rx.recv() {
-                let live_oracle_retry = run_pass_request(&request);
-                if done_tx.send(LoopMsg::PassDone { live_oracle_retry }).is_err() {
+                let live_oracle_wake_in = run_pass_request(&request);
+                if done_tx.send(LoopMsg::PassDone { live_oracle_wake_in }).is_err() {
                     return;
                 }
             }

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -523,7 +523,6 @@ fn the_event_loop_drain_persists_a_placement_failure_while_running() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2686,7 +2685,7 @@ fn pass_worker_runs_requests_in_order_and_reports_completion() {
         let ran = Arc::clone(&ran);
         move |request: &PassRequest| {
             ran.lock().unwrap().push(request.clone());
-            false
+            None
         }
     })
     .expect("worker thread spawns");
@@ -2696,7 +2695,7 @@ fn pass_worker_runs_requests_in_order_and_reports_completion() {
         .unwrap();
     for _ in 0..2 {
         match done_rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(LoopMsg::PassDone { live_oracle_retry: false }) => {},
+            Ok(LoopMsg::PassDone { live_oracle_wake_in: None }) => {},
             other => panic!("expected PassDone, got {other:?}"),
         }
     }
@@ -2757,7 +2756,6 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2793,7 +2791,7 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         );
 
         // Completing the pass dispatches the coalesced follow-up.
-        tx.send(LoopMsg::PassDone { live_oracle_retry: false }).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_wake_in: None }).unwrap();
         assert_eq!(
             pass_rx.recv_timeout(Duration::from_secs(5)),
             Ok(PassRequest::Maintenance {
@@ -2854,7 +2852,6 @@ fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2878,7 +2875,7 @@ fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
         // debounce is already past due and the loop's own PassDone iteration is where the
         // back-to-back redispatch used to happen.
         std::thread::sleep(Duration::from_millis(100));
-        tx.send(LoopMsg::PassDone { live_oracle_retry: false }).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_wake_in: None }).unwrap();
 
         // The pre-#823 behavior was an immediate redispatch here. The follow-up must instead
         // wait out the cooldown (2 s; the 700 ms probe leaves ample CI-jitter margin)...
@@ -2950,7 +2947,6 @@ fn a_due_periodic_sweep_overrides_the_pass_cooldown() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2962,7 +2958,7 @@ fn a_due_periodic_sweep_overrides_the_pass_cooldown() {
             pass_rx.recv_timeout(Duration::from_secs(5)),
             Ok(PassRequest::Maintenance { run_gc: false, overlay_scope: OverlayScope::All }),
         );
-        tx.send(LoopMsg::PassDone { live_oracle_retry: false }).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_wake_in: None }).unwrap();
 
         // The next sweep falls due one second later — deep inside the cooldown — and must
         // dispatch anyway: the backstop bypasses the cooldown.
@@ -3764,7 +3760,6 @@ fn event_loop_ignores_fs_errors_and_exits_on_disconnect() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -3818,7 +3813,6 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -3842,7 +3836,7 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
 }
 
 #[test]
-fn live_oracle_backlog_retries_without_events_or_periodic_sweeps() {
+fn live_oracle_deadline_dispatches_without_events_or_periodic_sweeps() {
     let tmp = tempfile::TempDir::new().unwrap();
     let root = tmp.path();
     std::fs::create_dir_all(root.join("src")).unwrap();
@@ -3878,21 +3872,21 @@ fn live_oracle_backlog_retries_without_events_or_periodic_sweeps() {
         scheduler: &mut scheduler,
         papertrail_tx: None,
         papertrail_interval: None,
-        live_oracle_retry_interval: Duration::from_millis(25),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
 
     std::thread::scope(|scope| {
         let handle = scope.spawn(move || event_loop.run());
-        tx.send(LoopMsg::PassDone { live_oracle_retry: true }).unwrap();
+        tx.send(LoopMsg::PassDone { live_oracle_wake_in: Some(Duration::from_millis(25)) })
+            .unwrap();
         assert_eq!(
             pass_rx.recv_timeout(Duration::from_secs(5)),
             Ok(PassRequest::Maintenance {
                 run_gc: false,
                 overlay_scope: OverlayScope::Linked(BTreeSet::new())
             }),
-            "the resident backlog must provide its own retry source",
+            "backlog retries and idle shutdown must share an independent wake source",
         );
 
         stop.store(true, Ordering::Relaxed);
@@ -4035,7 +4029,6 @@ fn idle_watcher_enqueues_papertrail_evaluation_without_filesystem_activity() {
         scheduler: &mut scheduler,
         papertrail_tx: Some(&papertrail_tx),
         papertrail_interval: Some(Duration::from_millis(50)),
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -4093,7 +4086,6 @@ fn papertrail_deadline_fires_during_an_in_flight_pass_and_ticks_coalesce() {
         scheduler: &mut scheduler,
         papertrail_tx: Some(&papertrail_tx),
         papertrail_interval: Some(Duration::from_millis(100)),
-        live_oracle_retry_interval: Duration::from_secs(30),
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -34,9 +34,9 @@
 //!   — the live analog of the batch join's index-vs-disk content gate. Anything else is skipped,
 //!   never mis-joined.
 //!
-//! Out of scope: watcher-level respawn backoff and independent idle scheduling (#535), non-Rust
-//! backends (#536), and `resolved-external` verdicts (a live definition outside the checkout has
-//! no batch-interchangeable SCIP symbol string, so it is skipped, not written).
+//! Out of scope: non-Rust backends (#536) and `resolved-external` verdicts (a live definition
+//! outside the checkout has no batch-interchangeable SCIP symbol string, so it is skipped, not
+//! written).
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -61,7 +61,6 @@ pub struct LiveOracleSession {
     client: LspClient,
     tool_version: String,
     root_uri: String,
-    last_used_ms: i64,
 }
 
 impl LiveOracleSession {
@@ -70,7 +69,7 @@ impl LiveOracleSession {
     /// as a missing embedding model or batch tool (never an error, never a failed pass). The
     /// version is RE-probed at every spawn so `tool_version` always names the binary this
     /// session's verdicts came from.
-    pub fn spawn(checkout_root: &Path, now_ms: i64) -> Option<Self> {
+    pub fn spawn(checkout_root: &Path) -> Option<Self> {
         let manifest = ToolManifest::for_tool(OracleTool::RaLsp);
         let ToolAvailability::Available { version, .. } = manifest.probe_in(checkout_root) else {
             return None;
@@ -78,7 +77,7 @@ impl LiveOracleSession {
         let root_uri = root_uri_for(checkout_root)?;
         let mut client = LspClient::spawn(manifest.program, &[], checkout_root).ok()?;
         client.initialize(&root_uri).ok()?;
-        Some(Self { client, tool_version: version, root_uri, last_used_ms: now_ms })
+        Some(Self { client, tool_version: version, root_uri })
     }
 
     /// Test seam: a session over an injected (fake-server) client transport. Runs the
@@ -102,26 +101,11 @@ impl LiveOracleSession {
 
     #[cfg(test)]
     fn from_initialized_client(client: LspClient, tool_version: &str, root_uri: &str) -> Self {
-        Self {
-            client,
-            tool_version: tool_version.to_string(),
-            root_uri: root_uri.to_string(),
-            last_used_ms: 0,
-        }
+        Self { client, tool_version: tool_version.to_string(), root_uri: root_uri.to_string() }
     }
 
     pub fn tool_version(&self) -> &str {
         &self.tool_version
-    }
-
-    pub fn last_used_ms(&self) -> i64 {
-        self.last_used_ms
-    }
-
-    /// Whether the session has gone `idle_ms` without a pass — the watcher's cue to shut it
-    /// down (an idle server shouldn't hold rust-analyzer's resident memory).
-    pub fn idle_for(&self, now_ms: i64, idle_ms: u64) -> bool {
-        now_ms.saturating_sub(self.last_used_ms) > idle_ms as i64
     }
 
     /// Graceful LSP teardown (`shutdown` + `exit`); the client's Drop hard-kills as the
@@ -129,10 +113,6 @@ impl LiveOracleSession {
     pub fn shutdown(self) {
         let mut this = self;
         let _ = this.client.shutdown();
-    }
-
-    fn touch(&mut self, now_ms: i64) {
-        self.last_used_ms = now_ms;
     }
 
     fn readiness_checkpoint(&mut self) -> std::io::Result<Option<u64>> {
@@ -215,13 +195,11 @@ pub fn live_oracle_pass(
         Ok(None) => {
             report.unfinished_paths = input.worklist.to_vec();
             report.status = "Warming".to_string();
-            session.touch(rag_rat_base::time::now_ms());
             return Ok(report);
         },
         Err(err) => {
             report.unfinished_paths = input.worklist.to_vec();
             report.status = format!("Aborted: {err}");
-            session.touch(rag_rat_base::time::now_ms());
             return Ok(report);
         },
     }
@@ -284,7 +262,6 @@ pub fn live_oracle_pass(
                 report.unfinished_paths = input.worklist.to_vec();
                 report.status = "VersionMigrationBlocked".to_string();
                 tx.commit()?;
-                session.touch(rag_rat_base::time::now_ms());
                 return Ok(report);
             },
         }
@@ -636,9 +613,6 @@ pub fn live_oracle_pass(
         };
     }
     tx.commit()?;
-    // Stamp usage at COMPLETION, not the pass's start: a pass longer than the idle window must
-    // not read as idle on the next pass (that would force a needless respawn + warm-up).
-    session.touch(rag_rat_base::time::now_ms());
     Ok(report)
 }
 


### PR DESCRIPTION
## Summary

- back off failed rust-analyzer respawns exponentially from 30 seconds to a five-minute cap, including edit-triggered passes
- schedule resident-session idle shutdown independently of filesystem events and periodic sweeps
- keep pending warming work ahead of idle shutdown and use monotonic lifecycle timing
- prevent overdue lifecycle deadlines from spinning maintenance passes when an earlier stage fails

Closes #535.

## Verification

- `cargo nextest run -p rag-rat-oracle` (216 passed)
- `cargo nextest run -p rag-rat-core live_oracle` (6 passed)
- `cargo clippy -p rag-rat-oracle -p rag-rat-core --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`