### PR TITLE
feat(plugin): add Cursor and VS Code hook adapters

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "rag-rat",
+  "owner": {
+    "name": "Kristaps Karlsons"
+  },
+  "metadata": {
+    "description": "rag-rat local repo-intelligence plugins for coding agents."
+  },
+  "plugins": [
+    {
+      "name": "rag-rat",
+      "source": "plugin",
+      "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
+      "version": "0.21.1",
+      "homepage": "https://github.com/cq27-dev/rag-rat",
+      "repository": "https://github.com/cq27-dev/rag-rat",
+      "license": "MIT",
+      "keywords": ["mcp", "code-intelligence", "semantic-search", "code-graph", "repo-memory"],
+      "author": { "name": "Kristaps Karlsons" }
+    }
+  ]
+}

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - "plugin/**"
+      - ".cursor-plugin/**"
       - ".github/workflows/plugin-test.yml"
   workflow_dispatch:
     inputs:

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -1,18 +1,13 @@
-//! `rag-rat agent-hook`: the coding-agent hook client (PreToolUse + PostToolUse + SessionStart).
-//! Harness-neutral — Claude Code, Codex, and Cursor all use the same `hook_event_name` /
-//! `tool_name` / `tool_input` input and the same `hookSpecificOutput.additionalContext` output, so
-//! one entrypoint serves all.
+//! `rag-rat agent-hook`: coding-agent hook adapters for Claude/Codex, Cursor, and VS Code.
 //!
 //! Reads the hook JSON from stdin and branches on `hook_event_name`:
 //! - `"SessionStart"`: injects a read-only repo orientation digest into the model context.
-//! - `"PostToolUse"`: after an edit tool completes, triggers a scoped reindex of the edited path(s)
-//!   in a DETACHED child (`edit_reindex`), watcher-aware — see [`posttooluse`]. Scoped to Claude
-//!   Code, whose PostToolUse carries the edited `file_path` (Codex's `apply_patch` PostToolUse
-//!   fires before the write lands, and Cursor's payload is unpinned, so neither is wired — #661).
-//! - PreToolUse (anything else, or absent): grep-augmentation on `Grep`/`Bash` (asks the elected
-//!   listener or falls back to a direct read-only query), and the write-time clone check on the
-//!   edit tools — `Write`/`Edit`/`MultiEdit` (Claude) and `apply_patch` (Codex/Cursor, whose V4A
-//!   diff is parsed for added lines). Prints `additionalContext` JSON.
+//! - successful edit events trigger a scoped reindex in a DETACHED child (`edit_reindex`),
+//!   watcher-aware — see [`posttooluse`].
+//! - tool events run grep/read augmentation or a write-time clone check after harness-specific tool
+//!   names and camel/snake-case fields have been normalized.
+//! - context is serialized only through the selected harness's documented output field; raw stdin
+//!   is never copied into output.
 //!
 //! Exit 0 on every path — the hook must never block a tool call or session start.
 
@@ -30,6 +25,8 @@ use rag_rat_core::query::orientation::Orientation;
 use rag_rat_core::query::{grep_augment, read_augment};
 use rag_rat_db::storage::IndexConnection;
 use serde::Deserialize;
+
+use crate::cli::AgentHookHarnessArg;
 
 pub(crate) mod edit_reindex;
 
@@ -72,6 +69,308 @@ pub struct HookInput {
     /// Present on PreToolUse only.
     #[serde(default)]
     pub tool_input: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Harness {
+    Native,
+    Cursor,
+    Vscode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Dispatch {
+    SessionStart,
+    PreToolUse,
+    PostToolUse,
+    CursorPostToolUse,
+    Ignore,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputEvent {
+    SessionStart,
+    PreToolUse,
+    CursorBeforeShell,
+    CursorPostToolUse,
+    None,
+}
+
+struct NormalizedHook {
+    harness: Harness,
+    input: HookInput,
+    dispatch: Dispatch,
+    output_event: OutputEvent,
+}
+
+fn normalize_hook(raw: &str, requested: AgentHookHarnessArg) -> Option<NormalizedHook> {
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let harness = match requested {
+        AgentHookHarnessArg::Cursor => Harness::Cursor,
+        AgentHookHarnessArg::Vscode => Harness::Vscode,
+        AgentHookHarnessArg::Auto => detect_harness(&value),
+    };
+    match harness {
+        Harness::Native => normalize_native(value),
+        Harness::Cursor => normalize_cursor(&value),
+        Harness::Vscode => normalize_vscode(&value),
+    }
+}
+
+fn detect_harness(value: &serde_json::Value) -> Harness {
+    let event = value.get("hook_event_name").and_then(|field| field.as_str()).unwrap_or_default();
+    if value.get("cursor_version").is_some() || event.chars().next().is_some_and(char::is_lowercase)
+    {
+        return Harness::Cursor;
+    }
+    let tool = value.get("tool_name").and_then(|field| field.as_str()).unwrap_or_default();
+    if value.get("source").and_then(|field| field.as_str()) == Some("new") || is_vscode_tool(tool) {
+        return Harness::Vscode;
+    }
+    Harness::Native
+}
+
+fn normalize_native(value: serde_json::Value) -> Option<NormalizedHook> {
+    let input: HookInput = serde_json::from_value(value).ok()?;
+    let (dispatch, output_event) = match input.hook_event_name.as_deref() {
+        Some("SessionStart") => (Dispatch::SessionStart, OutputEvent::SessionStart),
+        Some("PostToolUse") => (Dispatch::PostToolUse, OutputEvent::None),
+        Some("PreToolUse") | None => (Dispatch::PreToolUse, OutputEvent::PreToolUse),
+        _ => (Dispatch::Ignore, OutputEvent::None),
+    };
+    Some(NormalizedHook { harness: Harness::Native, input, dispatch, output_event })
+}
+
+fn normalize_cursor(value: &serde_json::Value) -> Option<NormalizedHook> {
+    let event = value.get("hook_event_name").and_then(|field| field.as_str())?;
+    let cwd = cursor_hook_cwd(value);
+    let session_id = value
+        .get("session_id")
+        .or_else(|| value.get("conversation_id"))
+        .and_then(|field| field.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let mut input = HookInput { session_id, cwd, ..Default::default() };
+    let (dispatch, output_event) = match event {
+        "sessionStart" => {
+            input.hook_event_name = Some("SessionStart".to_string());
+            input.source = Some("startup".to_string());
+            (Dispatch::SessionStart, OutputEvent::SessionStart)
+        },
+        "beforeShellExecution" => {
+            input.hook_event_name = Some("PreToolUse".to_string());
+            input.tool_name = "Bash".to_string();
+            input.tool_input = normalize_tool_input("Bash", value);
+            (Dispatch::PreToolUse, OutputEvent::CursorBeforeShell)
+        },
+        "beforeReadFile" => {
+            input.hook_event_name = Some("PreToolUse".to_string());
+            input.tool_name = "Read".to_string();
+            input.tool_input = normalize_tool_input("Read", value);
+            // Cursor documents no model-context field for beforeReadFile. The native manifest uses
+            // postToolUse for read augmentation; an explicitly invoked beforeReadFile stays quiet.
+            (Dispatch::PreToolUse, OutputEvent::None)
+        },
+        "afterFileEdit" => {
+            input.hook_event_name = Some("PostToolUse".to_string());
+            input.tool_name = "Edit".to_string();
+            input.tool_input = normalize_tool_input("Edit", value);
+            (Dispatch::PostToolUse, OutputEvent::None)
+        },
+        "postToolUse" => {
+            let raw_tool =
+                value.get("tool_name").and_then(|field| field.as_str()).unwrap_or_default();
+            let tool_input = value.get("tool_input").unwrap_or(&serde_json::Value::Null);
+            let Some(tool_name) = normalize_tool_name(raw_tool, tool_input) else {
+                return Some(NormalizedHook {
+                    harness: Harness::Cursor,
+                    input,
+                    dispatch: Dispatch::Ignore,
+                    output_event: OutputEvent::None,
+                });
+            };
+            input.hook_event_name = Some("PostToolUse".to_string());
+            input.tool_input = normalize_tool_input(&tool_name, tool_input);
+            input.tool_name = tool_name;
+            (Dispatch::CursorPostToolUse, OutputEvent::CursorPostToolUse)
+        },
+        // MCP hooks and every unsupported lifecycle event are intentionally inert.
+        _ => (Dispatch::Ignore, OutputEvent::None),
+    };
+    Some(NormalizedHook { harness: Harness::Cursor, input, dispatch, output_event })
+}
+
+fn normalize_vscode(value: &serde_json::Value) -> Option<NormalizedHook> {
+    let event = value.get("hook_event_name").and_then(|field| field.as_str())?;
+    let mut input = HookInput {
+        session_id: value
+            .get("session_id")
+            .and_then(|field| field.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        cwd: hook_cwd(value),
+        hook_event_name: Some(event.to_string()),
+        ..Default::default()
+    };
+    let (dispatch, output_event) = match event {
+        "SessionStart" => {
+            input.source = Some("startup".to_string());
+            (Dispatch::SessionStart, OutputEvent::SessionStart)
+        },
+        "PreToolUse" | "PostToolUse" => {
+            let raw_tool =
+                value.get("tool_name").and_then(|field| field.as_str()).unwrap_or_default();
+            let tool_input = value.get("tool_input").unwrap_or(&serde_json::Value::Null);
+            let Some(tool_name) = normalize_tool_name(raw_tool, tool_input) else {
+                return Some(NormalizedHook {
+                    harness: Harness::Vscode,
+                    input,
+                    dispatch: Dispatch::Ignore,
+                    output_event: OutputEvent::None,
+                });
+            };
+            input.tool_input = normalize_tool_input(&tool_name, tool_input);
+            input.tool_name = tool_name;
+            if event == "PreToolUse" {
+                (Dispatch::PreToolUse, OutputEvent::PreToolUse)
+            } else {
+                (Dispatch::PostToolUse, OutputEvent::None)
+            }
+        },
+        _ => (Dispatch::Ignore, OutputEvent::None),
+    };
+    Some(NormalizedHook { harness: Harness::Vscode, input, dispatch, output_event })
+}
+
+fn hook_cwd(value: &serde_json::Value) -> String {
+    value
+        .get("cwd")
+        .and_then(|field| field.as_str())
+        .or_else(|| {
+            value
+                .get("workspace_roots")
+                .and_then(|field| field.as_array())
+                .and_then(|roots| roots.first())
+                .and_then(|root| root.as_str())
+        })
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn cursor_hook_cwd(value: &serde_json::Value) -> String {
+    if let Some(cwd) = value.get("cwd").and_then(|field| field.as_str()) {
+        return cwd.to_string();
+    }
+    let event_path = string_field(value, &["file_path", "filePath", "path"]).or_else(|| {
+        value
+            .get("tool_input")
+            .and_then(|tool_input| string_field(tool_input, &["file_path", "filePath", "path"]))
+    });
+    let roots = value.get("workspace_roots").and_then(|field| field.as_array());
+    if let (Some(event_path), Some(roots)) = (event_path, roots) {
+        let event_path = Path::new(event_path);
+        if let Some(root) = roots
+            .iter()
+            .filter_map(|root| root.as_str())
+            .filter(|root| event_path.starts_with(root))
+            .max_by_key(|root| Path::new(root).components().count())
+        {
+            return root.to_string();
+        }
+    }
+    hook_cwd(value)
+}
+
+fn is_vscode_tool(tool: &str) -> bool {
+    matches!(
+        tool,
+        "run_in_terminal"
+            | "runTerminalCommand"
+            | "read_file"
+            | "readFile"
+            | "create_file"
+            | "createFile"
+            | "replace_string_in_file"
+            | "replaceStringInFile"
+            | "multi_replace_string_in_file"
+            | "multiReplaceStringInFile"
+            | "editFiles"
+    )
+}
+
+fn normalize_tool_name(raw_tool: &str, tool_input: &serde_json::Value) -> Option<String> {
+    let normalized = match raw_tool {
+        "Shell" | "Bash" | "run_in_terminal" | "runTerminalCommand" | "run_terminal_command" =>
+            "Bash",
+        "Grep" | "grep_search" | "grepSearch" => "Grep",
+        "Read" | "read_file" | "readFile" => "Read",
+        "create_file" | "createFile" => "Write",
+        "replace_string_in_file" | "replaceStringInFile" => "Edit",
+        "multi_replace_string_in_file" | "multiReplaceStringInFile" | "editFiles" => "MultiEdit",
+        "apply_patch" => "apply_patch",
+        "Write" => {
+            if tool_input.get("edits").is_some() || tool_input.get("replacements").is_some() {
+                "MultiEdit"
+            } else if tool_input.get("new_string").is_some()
+                || tool_input.get("newString").is_some()
+            {
+                "Edit"
+            } else {
+                "Write"
+            }
+        },
+        "Edit" | "MultiEdit" => raw_tool,
+        _ => return None,
+    };
+    Some(normalized.to_string())
+}
+
+fn normalize_tool_input(tool_name: &str, value: &serde_json::Value) -> serde_json::Value {
+    let mut out = serde_json::Map::new();
+    if let Some(command) = string_field(value, &["command", "commandLine"]) {
+        out.insert("command".to_string(), command.into());
+    }
+    if let Some(pattern) = string_field(value, &["pattern", "query"]) {
+        out.insert("pattern".to_string(), pattern.into());
+    }
+    if let Some(path) = string_field(value, &["file_path", "filePath", "path"]) {
+        let key = if tool_name == "Grep" { "path" } else { "file_path" };
+        out.insert(key.to_string(), path.into());
+    }
+    if let Some(content) = string_field(value, &["content"]) {
+        out.insert("content".to_string(), content.into());
+    }
+    if let Some(new_string) = string_field(value, &["new_string", "newString", "replacement"]) {
+        out.insert("new_string".to_string(), new_string.into());
+    }
+    if let Some(edits) = value.get("edits").or_else(|| value.get("replacements"))
+        && let Some(edits) = edits.as_array()
+    {
+        let normalized = edits
+            .iter()
+            .filter_map(|edit| {
+                let new_string = string_field(edit, &["new_string", "newString", "replacement"])?;
+                Some(serde_json::json!({ "new_string": new_string }))
+            })
+            .collect::<Vec<_>>();
+        out.insert("edits".to_string(), normalized.into());
+    }
+    if let Some(files) = value.get("files").and_then(|field| field.as_array()) {
+        let paths = files
+            .iter()
+            .filter_map(|file| {
+                file.as_str().map(str::to_string).or_else(|| {
+                    string_field(file, &["file_path", "filePath", "path"]).map(str::to_string)
+                })
+            })
+            .collect::<Vec<_>>();
+        out.insert("files".to_string(), serde_json::json!(paths));
+    }
+    serde_json::Value::Object(out)
+}
+
+fn string_field<'a>(value: &'a serde_json::Value, names: &[&str]) -> Option<&'a str> {
+    names.iter().find_map(|name| value.get(name).and_then(|field| field.as_str()))
 }
 
 pub struct Search {
@@ -287,38 +586,44 @@ fn shell_tokens(segment: &str) -> Option<Vec<String>> {
     Some(tokens)
 }
 
-/// Entry point for `rag-rat agent-hook`. Every failure path prints nothing and returns
-/// Ok(()) — the hook must never block a grep (spec: error posture).
-pub fn run() -> anyhow::Result<()> {
-    let _ = run_inner(); // swallow: silence is the contract
+/// Entry point for `rag-rat agent-hook`. Every failure path prints nothing and returns `Ok(())`.
+pub fn run(requested: AgentHookHarnessArg) -> anyhow::Result<()> {
+    let _ = run_inner(requested); // swallow: silence is the contract
     Ok(())
 }
 
-fn run_inner() -> anyhow::Result<()> {
+fn run_inner(requested: AgentHookHarnessArg) -> anyhow::Result<()> {
     let mut raw = String::new();
     std::io::stdin().read_to_string(&mut raw)?;
-    // Tolerant parse: missing fields use Default so both PreToolUse and SessionStart succeed.
-    let input: HookInput = serde_json::from_str(&raw).unwrap_or_default();
-    match input.hook_event_name.as_deref() {
-        Some("SessionStart") => session_start(&input),
-        Some("PostToolUse") => posttooluse(&input),
-        _ => pretooluse(&input),
+    let Some(normalized) = normalize_hook(&raw, requested) else { return Ok(()) };
+    let context = match normalized.dispatch {
+        Dispatch::SessionStart => session_start(&normalized.input)?,
+        Dispatch::PreToolUse => pretooluse(&normalized.input)?,
+        Dispatch::PostToolUse => {
+            posttooluse(&normalized.input)?;
+            None
+        },
+        Dispatch::CursorPostToolUse => cursor_posttooluse(&normalized.input)?,
+        Dispatch::Ignore => None,
+    };
+    if let Some(context) = context {
+        print_context(normalized.harness, normalized.output_event, &context);
     }
+    Ok(())
 }
 
 /// SessionStart path: inject a read-only repo orientation digest as plain stdout.
 /// Every error path prints nothing and returns Ok — never block session start.
-fn session_start(input: &HookInput) -> anyhow::Result<()> {
+fn session_start(input: &HookInput) -> anyhow::Result<Option<String>> {
     // Allowlist: only fire for meaningful session triggers, not resume.
     match input.source.as_deref() {
         Some("startup") | Some("clear") | Some("compact") => {},
-        _ => return Ok(()),
+        _ => return Ok(None),
     }
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
-    // If the DB file does not exist, print a minimal nudge and exit — do NOT open/create it.
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
+    // Do not open/create an absent database. Hooks are inert until the first index exists.
     if !config.database.is_file() {
-        print!("{}", db_absent_notice());
-        return Ok(());
+        return Ok(None);
     }
     // Open read-only; compose the orientation; print the digest.
     // Any error (locked, corrupt, etc.) propagates via `?` to run_inner, which run() swallows
@@ -331,8 +636,7 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
     // schema message already carries the remedy (and the non-Linux no-hot-upgrade caveat).
     let schema = rag_rat_db::schema::status(conn.connection())?;
     if schema.state == rag_rat_db::schema::SchemaState::Newer {
-        print!("{}", newer_schema_notice(&schema.message));
-        return Ok(());
+        return Ok(Some(newer_schema_notice(&schema.message)));
     }
     // Scope orientation to the session's worktree: `config.root` (anchored to the main worktree) is
     // the base index, `input.cwd` is where the session is — a linked worktree gets its branch
@@ -346,11 +650,11 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
         config.repo_id_override.as_deref(),
     )?;
     let (live, enabled) = watcher_state(&config);
-    print!("{}", format_digest(&o, live, enabled));
+    let mut context = format_digest(&o, live, enabled);
     if let Some(line) = version_check_line(&config) {
-        print!("{line}");
+        context.push_str(&line);
     }
-    Ok(())
+    Ok(Some(context))
 }
 
 /// The session-start notice replacing the digest when the index schema is NEWER than this binary
@@ -394,44 +698,38 @@ fn version_line(status: &rag_rat_core::version_check::VersionStatus) -> Option<S
 
 /// PreToolUse path: the write-time clone check (#287) on the edit tools, read augmentation on
 /// `Read` (#756), grep augmentation on a code search otherwise.
-fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
+fn pretooluse(input: &HookInput) -> anyhow::Result<Option<String>> {
     if matches!(input.tool_name.as_str(), "Write" | "Edit" | "MultiEdit" | "apply_patch") {
         return clone_check(input);
     }
     if input.tool_name == "Read" {
         return read_augment_hook(input);
     }
-    let Some(search) = extract_search(input) else { return Ok(()) };
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+    let Some(search) = extract_search(input) else { return Ok(None) };
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
 
     // Pass the session cwd through both paths so the grep-augmentation is scoped to the worktree
     // the session is in (a linked worktree gets its branch overlay), not just the base index
     // (#219).
     let context = ask_listener(&config, &input.session_id, &input.cwd, &search)
         .unwrap_or_else(|| fallback_compose(&config, &input.cwd, &search));
-    if let Some(context) = context {
-        print_additional_context(&context);
-    }
-    Ok(())
+    Ok(context)
 }
 
 /// Read-augmentation path (#756): when the agent opens a file, inject the repo memories bound to it
 /// (+ its directory) and the load-bearing symbols defined in it. Silent no-op unless the file is a
 /// tracked, root-relative path with something to say. Prefers the warm listener (per-session
 /// dedup); falls back to a direct read-only compose.
-fn read_augment_hook(input: &HookInput) -> anyhow::Result<()> {
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+fn read_augment_hook(input: &HookInput) -> anyhow::Result<Option<String>> {
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
     let Some(file_path) = input.tool_input.get("file_path").and_then(|v| v.as_str()) else {
-        return Ok(());
+        return Ok(None);
     };
     let indexed_root = session_indexed_root(&config, &input.cwd);
-    let Some(rel_path) = worktree_rel_path(file_path, &indexed_root) else { return Ok(()) };
+    let Some(rel_path) = worktree_rel_path(file_path, &indexed_root) else { return Ok(None) };
     let context = ask_listener_read(&config, &input.session_id, &input.cwd, &rel_path)
         .unwrap_or_else(|| fallback_compose_read(&config, &input.cwd, &rel_path));
-    if let Some(context) = context {
-        print_additional_context(&context);
-    }
-    Ok(())
+    Ok(context)
 }
 
 /// The absolute directory that indexed `files.path` are relative to, IN THE SESSION'S checkout.
@@ -490,16 +788,53 @@ fn worktree_rel_path(file_path: &str, worktree_root: &Path) -> Option<String> {
 /// Emit an `additionalContext` block for a PreToolUse hook. PreToolUse contract: additionalContext
 /// only — no `permissionDecision` (Codex rejects the "allow" value, and we only inject context,
 /// never gate the tool). Plain stdout is debug-only.
-fn print_additional_context(context: &str) {
-    println!(
-        "{}",
-        serde_json::json!({
+fn print_context(harness: Harness, event: OutputEvent, context: &str) {
+    if let Some(output) = format_context_output(harness, event, context) {
+        print!("{output}");
+        if harness != Harness::Native || event != OutputEvent::SessionStart {
+            println!();
+        }
+    }
+}
+
+fn format_context_output(harness: Harness, event: OutputEvent, context: &str) -> Option<String> {
+    let output = match (harness, event) {
+        (Harness::Native, OutputEvent::SessionStart) => return Some(context.to_string()),
+        (Harness::Vscode, OutputEvent::SessionStart) => serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": context,
+            }
+        }),
+        (Harness::Native | Harness::Vscode, OutputEvent::PreToolUse) => serde_json::json!({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "additionalContext": context,
             }
-        })
-    );
+        }),
+        (Harness::Cursor, OutputEvent::SessionStart | OutputEvent::CursorPostToolUse) => {
+            serde_json::json!({ "additional_context": context })
+        },
+        (Harness::Cursor, OutputEvent::CursorBeforeShell) => {
+            serde_json::json!({ "agent_message": context })
+        },
+        (_, OutputEvent::None) | (Harness::Cursor, OutputEvent::PreToolUse) => return None,
+        (
+            Harness::Native | Harness::Vscode,
+            OutputEvent::CursorBeforeShell | OutputEvent::CursorPostToolUse,
+        ) => return None,
+    };
+    Some(output.to_string())
+}
+
+/// Cursor's generic postToolUse is the only documented context channel shared by reads and write
+/// results. Reads reuse PreToolUse composition; edits run a clone check only when the normalized
+/// payload contains actual replacement text. The dedicated afterFileEdit event owns reindexing.
+fn cursor_posttooluse(input: &HookInput) -> anyhow::Result<Option<String>> {
+    if matches!(input.tool_name.as_str(), "Write" | "Edit" | "MultiEdit" | "apply_patch") {
+        return clone_check(input);
+    }
+    pretooluse(input)
 }
 
 /// PostToolUse path (#661): after an edit tool completes, trigger a scoped reindex of the edited
@@ -531,21 +866,39 @@ fn posttooluse(input: &HookInput) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The edited absolute path(s) to reindex, from a PostToolUse edit-tool payload. `Write` / `Edit` /
-/// `MultiEdit` (Claude Code) all carry a single `tool_input.file_path` (MultiEdit batches edits to
-/// ONE file). Any other tool — including `apply_patch`, whose Codex PostToolUse fires before the
-/// write lands — yields nothing, so the trigger stays scoped to the harness that delivers a usable
-/// post-edit event (#661).
+/// The edited absolute path(s) to reindex from a successful post-edit event. Relative paths are
+/// resolved against the event cwd; all further root/scope validation remains owned by
+/// `edit-reindex`. Codex does not register PostToolUse, so accepting an `apply_patch` here is safe
+/// for harnesses that explicitly guarantee the post event fires after the write lands.
 fn extract_edited_paths(input: &HookInput) -> Vec<PathBuf> {
-    match input.tool_name.as_str() {
-        "Write" | "Edit" | "MultiEdit" => input
+    let paths = match input.tool_name.as_str() {
+        "Write" | "Edit" | "MultiEdit" => {
+            let mut paths = input
+                .tool_input
+                .get("file_path")
+                .and_then(|value| value.as_str())
+                .map(|path| vec![path.to_string()])
+                .unwrap_or_default();
+            if let Some(files) = input.tool_input.get("files").and_then(|value| value.as_array()) {
+                paths.extend(files.iter().filter_map(|path| path.as_str().map(str::to_string)));
+            }
+            paths
+        },
+        "apply_patch" => input
             .tool_input
-            .get("file_path")
+            .get("command")
             .and_then(|value| value.as_str())
-            .map(|path| vec![PathBuf::from(path)])
+            .map(parse_v4a_paths)
             .unwrap_or_default(),
         _ => Vec::new(),
-    }
+    };
+    paths
+        .into_iter()
+        .map(|path| {
+            let path = PathBuf::from(path);
+            if path.is_absolute() { path } else { Path::new(&input.cwd).join(path) }
+        })
+        .collect()
 }
 
 /// Which of the edited paths this hook must reindex, given whether a watcher is live. No watcher ⇒
@@ -632,40 +985,27 @@ fn clone_check_skipped_for_size(indexed: bool, function_count: u64) -> bool {
 /// existing indexed code. Best-effort + READ-ONLY — every "not ready" path (no config, DB absent,
 /// index owes a heal/migrate, index too large, no parseable functions) is a SILENT no-op, so it
 /// never blocks or perceptibly delays a write.
-fn clone_check(input: &HookInput) -> anyhow::Result<()> {
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+fn clone_check(input: &HookInput) -> anyhow::Result<Option<String>> {
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
     if !config.database.is_file() {
-        return Ok(()); // index not built yet
+        return Ok(None); // index not built yet
     }
     // `try_open_config_read_only` returns None when the index still owes a heal/migrate (NOT
     // ready), so this is the no-op-when-not-ready guard — the same gate the MCP read tools use.
-    let Some(db) = IndexDatabase::try_open_config_read_only(&config)? else { return Ok(()) };
+    let Some(db) = IndexDatabase::try_open_config_read_only(&config)? else { return Ok(None) };
     // The size guard bounds ONLY the RAM fallback. When a live postings generation is eligible the
     // check is a bounded indexed lookup (#296 phase 4), so run it regardless of corpus size; only
     // the fallback no-ops above the cap.
     let indexed = db.clone_check_indexed_generation().unwrap_or(None).is_some();
     if clone_check_skipped_for_size(indexed, db.clone_check_function_count().unwrap_or(u64::MAX)) {
-        return Ok(());
+        return Ok(None);
     }
     let inputs = extract_clone_inputs(input, &config.root);
     if inputs.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     let matches = db.clones_of_texts(&inputs, HOOK_NEAR_THRESHOLD)?;
-    if let Some(context) = format_clone_warning(&matches) {
-        // PreToolUse contract: additionalContext only — a warning, not a block (no
-        // permissionDecision).
-        println!(
-            "{}",
-            serde_json::json!({
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "additionalContext": context,
-                }
-            })
-        );
-    }
-    Ok(())
+    Ok(format_clone_warning(&matches))
 }
 
 /// Pull the (relative-path, text) inputs to clone-check from an edit tool call:
@@ -770,6 +1110,22 @@ fn parse_v4a_added_lines(patch: &str) -> Vec<(String, String)> {
     out
 }
 
+/// Extract every path affected by a V4A patch, including deletion-only sections that intentionally
+/// have no added text and therefore cannot appear in [`parse_v4a_added_lines`].
+fn parse_v4a_paths(patch: &str) -> Vec<String> {
+    patch
+        .lines()
+        .filter_map(|line| {
+            ["*** Add File: ", "*** Update File: ", "*** Delete File: ", "*** Move to: "]
+                .into_iter()
+                .find_map(|prefix| line.strip_prefix(prefix))
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
 /// Render clone-check findings as the `additionalContext` injected back to the agent, or `None`
 /// when there are none (stay silent).
 fn format_clone_warning(matches: &[TextCloneMatch]) -> Option<String> {
@@ -798,12 +1154,6 @@ fn format_clone_warning(matches: &[TextCloneMatch]) -> Option<String> {
          symbol_lookup to inspect them.\n",
     );
     Some(out)
-}
-
-/// One-liner shown when the DB file is absent (no config directory walk — `find_config` already
-/// succeeded, so we know we're in a rag-rat repo; the DB just hasn't been built yet).
-fn db_absent_notice() -> String {
-    format!("{}\nindex not built — run 'rag-rat index'\n", ATTRIBUTION_HEADER.trim_end())
 }
 
 /// Probe whether the per-worktree watcher election lock is currently held (i.e. a watcher is live).

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -631,7 +631,7 @@ fn session_start(input: &HookInput) -> anyhow::Result<Option<String>> {
         Some("startup") | Some("clear") | Some("compact") => {},
         _ => return Ok(None),
     }
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
+    let Some(config) = find_governing_config(Path::new(&input.cwd)) else { return Ok(None) };
     // Do not open/create an absent database. Hooks are inert until the first index exists.
     if !config.database.is_file() {
         return Ok(None);
@@ -717,7 +717,7 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<Option<String>> {
         return read_augment_hook(input);
     }
     let Some(search) = extract_search(input) else { return Ok(None) };
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
+    let Some(config) = find_governing_config(Path::new(&input.cwd)) else { return Ok(None) };
 
     // Pass the session cwd through both paths so the grep-augmentation is scoped to the worktree
     // the session is in (a linked worktree gets its branch overlay), not just the base index
@@ -732,7 +732,7 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<Option<String>> {
 /// tracked, root-relative path with something to say. Prefers the warm listener (per-session
 /// dedup); falls back to a direct read-only compose.
 fn read_augment_hook(input: &HookInput) -> anyhow::Result<Option<String>> {
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
+    let Some(config) = find_governing_config(Path::new(&input.cwd)) else { return Ok(None) };
     let Some(file_path) = input.tool_input.get("file_path").and_then(|v| v.as_str()) else {
         return Ok(None);
     };
@@ -1309,24 +1309,12 @@ pub fn format_digest(o: &Orientation, live: bool, enabled: bool) -> String {
     out
 }
 
-/// Walk up from the hook's cwd to the nearest rag-rat.toml and load it. `None` ⇒ not a rag-rat repo
-/// ⇒ silent no-op (what makes `--global` install safe). Shares the upward-walk primitive with
-/// `Config::load`'s discovery seam ([`rag_rat_base::config::nearest_config_at_or_above`]). Used by
-/// the READ paths (SessionStart / grep/read augmentation): cheaper than governing discovery,
-/// and a linked worktree with no branch-local config merely loses context there (not an incorrect
-/// index). The edit-reindex path instead uses [`find_governing_config`].
-fn find_config(start: &Path) -> Option<Config> {
-    rag_rat_base::config::nearest_config_at_or_above(start)
-        .and_then(|path| Config::load(&path).ok())
-}
-
-/// Resolve the GOVERNING config for the edit hook's cwd and load it, falling back to the MAIN
+/// Resolve the GOVERNING config for the hook's cwd and load it, falling back to the MAIN
 /// worktree's config for a linked worktree with no branch-local `rag-rat.toml` (the documented
-/// main-governed setup) — the same governing discovery the CLI's own entry uses. Unlike
-/// [`find_config`], the edit-reindex path MUST resolve this: bare `nearest_config_at_or_above`
-/// stops at the linked worktree root and returns `None` there, so the hook would exit before
-/// reindexing a linked-checkout edit and leave that worktree stale. `Config::load`'s seam then
-/// re-anchors root to main and `reindex_paths` routes the edit through the overlay.
+/// main-governed setup) — the same governing discovery the CLI's own entry uses. Bare
+/// `nearest_config_at_or_above` stops at the linked worktree root and returns `None` there, which
+/// would silently disable session, augmentation, clone-check, and reindex hooks. `Config::load`'s
+/// seam then re-anchors root to main; each operation separately selects the active overlay.
 /// `discover_config_path` returns a path even when none exists; `Config::load` then fails → `None`,
 /// preserving the no-config no-op.
 fn find_governing_config(start: &Path) -> Option<Config> {

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -1002,13 +1002,14 @@ fn clone_check_skipped_for_size(indexed: bool, function_count: u64) -> bool {
 /// index owes a heal/migrate, index too large, no parseable functions) is a SILENT no-op, so it
 /// never blocks or perceptibly delays a write.
 fn clone_check(input: &HookInput) -> anyhow::Result<Option<String>> {
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(None) };
+    let Some(config) = find_governing_config(Path::new(&input.cwd)) else { return Ok(None) };
     if !config.database.is_file() {
         return Ok(None); // index not built yet
     }
     // `try_open_config_read_only` returns None when the index still owes a heal/migrate (NOT
     // ready), so this is the no-op-when-not-ready guard — the same gate the MCP read tools use.
-    let Some(db) = IndexDatabase::try_open_config_read_only(&config)? else { return Ok(None) };
+    let Some(mut db) = IndexDatabase::try_open_config_read_only(&config)? else { return Ok(None) };
+    db.use_worktree_scope(&config.root, Some(Path::new(&input.cwd)))?;
     // The size guard bounds ONLY the RAM fallback. When a live postings generation is eligible the
     // check is a bounded indexed lookup (#296 phase 4), so run it regardless of corpus size; only
     // the fallback no-ops above the cap.
@@ -1016,7 +1017,7 @@ fn clone_check(input: &HookInput) -> anyhow::Result<Option<String>> {
     if clone_check_skipped_for_size(indexed, db.clone_check_function_count().unwrap_or(u64::MAX)) {
         return Ok(None);
     }
-    let inputs = extract_clone_inputs(input, &config.root);
+    let inputs = extract_clone_inputs(input, &session_indexed_root(&config, &input.cwd));
     if inputs.is_empty() {
         return Ok(None);
     }
@@ -1034,37 +1035,40 @@ fn extract_clone_inputs(input: &HookInput, root: &Path) -> Vec<CloneCheckInput> 
         return extract_apply_patch_inputs(&input.tool_input, root);
     }
     let ti = &input.tool_input;
-    let Some(file_path) = ti.get("file_path").and_then(|v| v.as_str()) else { return Vec::new() };
-    let abs = Path::new(file_path);
-    let Some(language) = Language::from_path(abs) else { return Vec::new() };
-    // The indexed refs are root-relative, so relativize for the parse + the self-file exclusion.
-    let rel = abs.strip_prefix(root).unwrap_or(abs).to_path_buf();
-    let texts: Vec<String> = match input.tool_name.as_str() {
-        "Write" => ti
-            .get("content")
-            .and_then(|v| v.as_str())
-            .map(|s| vec![s.to_string()])
-            .unwrap_or_default(),
-        "Edit" => ti
-            .get("new_string")
-            .and_then(|v| v.as_str())
-            .map(|s| vec![s.to_string()])
-            .unwrap_or_default(),
+    let default_path = ti.get("file_path").and_then(|value| value.as_str());
+    match input.tool_name.as_str() {
+        "Write" => default_path
+            .zip(ti.get("content").and_then(|value| value.as_str()))
+            .and_then(|(path, text)| clone_input(path, text, root))
+            .into_iter()
+            .collect(),
+        "Edit" => default_path
+            .zip(ti.get("new_string").and_then(|value| value.as_str()))
+            .and_then(|(path, text)| clone_input(path, text, root))
+            .into_iter()
+            .collect(),
         "MultiEdit" => ti
             .get("edits")
-            .and_then(|v| v.as_array())
-            .map(|edits| {
-                edits
-                    .iter()
-                    .filter_map(|e| {
-                        e.get("new_string").and_then(|v| v.as_str()).map(str::to_string)
-                    })
-                    .collect()
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|edit| {
+                let path =
+                    edit.get("file_path").and_then(|value| value.as_str()).or(default_path)?;
+                let text = edit.get("new_string").and_then(|value| value.as_str())?;
+                clone_input(path, text, root)
             })
-            .unwrap_or_default(),
+            .collect(),
         _ => Vec::new(),
-    };
-    texts.into_iter().map(|text| CloneCheckInput { text, language, path: rel.clone() }).collect()
+    }
+}
+
+fn clone_input(file_path: &str, text: &str, root: &Path) -> Option<CloneCheckInput> {
+    let abs = Path::new(file_path);
+    let language = Language::from_path(abs)?;
+    // Indexed refs are root-relative, so relativize for parsing and self-file exclusion.
+    let path = abs.strip_prefix(root).unwrap_or(abs).to_path_buf();
+    Some(CloneCheckInput { text: text.to_string(), language, path })
 }
 
 /// Extract clone-check inputs from a Codex / Cursor `apply_patch` V4A envelope
@@ -1308,7 +1312,7 @@ pub fn format_digest(o: &Orientation, live: bool, enabled: bool) -> String {
 /// Walk up from the hook's cwd to the nearest rag-rat.toml and load it. `None` ⇒ not a rag-rat repo
 /// ⇒ silent no-op (what makes `--global` install safe). Shares the upward-walk primitive with
 /// `Config::load`'s discovery seam ([`rag_rat_base::config::nearest_config_at_or_above`]). Used by
-/// the READ paths (SessionStart / grep-augment / clone-check): cheaper than governing discovery,
+/// the READ paths (SessionStart / grep/read augmentation): cheaper than governing discovery,
 /// and a linked worktree with no branch-local config merely loses context there (not an incorrect
 /// index). The edit-reindex path instead uses [`find_governing_config`].
 fn find_config(start: &Path) -> Option<Config> {

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -214,7 +214,10 @@ fn normalize_vscode(value: &serde_json::Value) -> Option<NormalizedHook> {
     };
     let (dispatch, output_event) = match event {
         "SessionStart" => {
-            input.source = Some("startup".to_string());
+            input.source = value
+                .get("source")
+                .and_then(|field| field.as_str())
+                .map(|source| if source == "new" { "startup" } else { source }.to_string());
             (Dispatch::SessionStart, OutputEvent::SessionStart)
         },
         "PreToolUse" | "PostToolUse" => {
@@ -349,8 +352,16 @@ fn normalize_tool_input(tool_name: &str, value: &serde_json::Value) -> serde_jso
         let normalized = edits
             .iter()
             .filter_map(|edit| {
-                let new_string = string_field(edit, &["new_string", "newString", "replacement"])?;
-                Some(serde_json::json!({ "new_string": new_string }))
+                let mut normalized = serde_json::Map::new();
+                if let Some(path) = string_field(edit, &["file_path", "filePath", "path"]) {
+                    normalized.insert("file_path".to_string(), path.into());
+                }
+                if let Some(new_string) =
+                    string_field(edit, &["new_string", "newString", "replacement"])
+                {
+                    normalized.insert("new_string".to_string(), new_string.into());
+                }
+                (!normalized.is_empty()).then_some(serde_json::Value::Object(normalized))
             })
             .collect::<Vec<_>>();
         out.insert("edits".to_string(), normalized.into());
@@ -881,6 +892,11 @@ fn extract_edited_paths(input: &HookInput) -> Vec<PathBuf> {
                 .unwrap_or_default();
             if let Some(files) = input.tool_input.get("files").and_then(|value| value.as_array()) {
                 paths.extend(files.iter().filter_map(|path| path.as_str().map(str::to_string)));
+            }
+            if let Some(edits) = input.tool_input.get("edits").and_then(|value| value.as_array()) {
+                paths.extend(edits.iter().filter_map(|edit| {
+                    string_field(edit, &["file_path", "filePath", "path"]).map(str::to_string)
+                }));
             }
             paths
         },

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -179,6 +179,44 @@ fn vscode_tool_names_and_camel_case_inputs_normalize() {
 }
 
 #[test]
+fn vscode_multi_replacements_preserve_each_edited_path() {
+    let value = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "cwd": "/repo",
+        "tool_name": "multi_replace_string_in_file",
+        "tool_input": {
+            "replacements": [
+                {"filePath": "src/a.rs", "newString": "fn a() {}"},
+                {"filePath": "/other/b.rs", "newString": "fn b() {}"},
+            ]
+        },
+    });
+    let normalized = normalize_hook(&value.to_string(), AgentHookHarnessArg::Vscode).unwrap();
+    assert_eq!(normalized.input.tool_name, "MultiEdit");
+    assert_eq!(normalized.input.tool_input["edits"][0]["file_path"], "src/a.rs");
+    assert_eq!(normalized.input.tool_input["edits"][1]["file_path"], "/other/b.rs");
+    assert_eq!(extract_edited_paths(&normalized.input), vec![
+        PathBuf::from("/repo/src/a.rs"),
+        PathBuf::from("/other/b.rs"),
+    ]);
+}
+
+#[test]
+fn vscode_session_start_maps_only_new_to_startup() {
+    for (source, expected) in
+        [("new", "startup"), ("resume", "resume"), ("clear", "clear"), ("compact", "compact")]
+    {
+        let value = serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "cwd": "/repo",
+            "source": source,
+        });
+        let normalized = normalize_hook(&value.to_string(), AgentHookHarnessArg::Vscode).unwrap();
+        assert_eq!(normalized.input.source.as_deref(), Some(expected), "source={source}");
+    }
+}
+
+#[test]
 fn snake_case_and_camel_case_paths_normalize_identically() {
     for field in ["file_path", "filePath"] {
         let value = serde_json::json!({
@@ -247,21 +285,25 @@ fn context_output_contains_only_intentional_context() {
 
 #[test]
 fn hook_manifests_register_one_dispatcher_per_event() {
-    for manifest in [
-        include_str!("../../../../plugin/hooks/hooks.json"),
-        include_str!("../../../../plugin/hooks.vscode.json"),
-    ] {
-        let value: serde_json::Value = serde_json::from_str(manifest).unwrap();
-        for event in ["SessionStart", "PreToolUse", "PostToolUse"] {
-            let entries = value["hooks"][event].as_array().expect("event array");
-            assert_eq!(entries.len(), 1, "{event} must have one dispatcher");
-            assert!(entries[0].get("matcher").is_none(), "{event} must not rely on matchers");
-        }
+    let claude: serde_json::Value =
+        serde_json::from_str(include_str!("../../../../plugin/hooks/hooks.json")).unwrap();
+    for event in ["SessionStart", "PreToolUse", "PostToolUse"] {
+        let entries = claude["hooks"][event].as_array().expect("event array");
+        assert_eq!(entries.len(), 1, "Claude {event} must have one dispatcher");
     }
+    assert!(claude["hooks"]["SessionStart"][0].get("matcher").is_none());
+    assert_eq!(
+        claude["hooks"]["PreToolUse"][0]["matcher"],
+        "^(Grep|Read|Bash|Write|Edit|MultiEdit)$"
+    );
+    assert_eq!(claude["hooks"]["PostToolUse"][0]["matcher"], "^(Write|Edit|MultiEdit)$");
 
     let vscode: serde_json::Value =
         serde_json::from_str(include_str!("../../../../plugin/hooks.vscode.json")).unwrap();
     for event in ["SessionStart", "PreToolUse", "PostToolUse"] {
+        let entries = vscode["hooks"][event].as_array().expect("event array");
+        assert_eq!(entries.len(), 1, "VS Code {event} must have one dispatcher");
+        assert!(entries[0].get("matcher").is_none(), "VS Code ignores matchers");
         let command = vscode["hooks"][event][0]["command"].as_str().unwrap();
         assert!(command.contains("${PLUGIN_ROOT}/scripts/launch.js"));
         assert!(command.ends_with("agent-hook vscode"));

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -195,6 +195,15 @@ fn vscode_multi_replacements_preserve_each_edited_path() {
     assert_eq!(normalized.input.tool_name, "MultiEdit");
     assert_eq!(normalized.input.tool_input["edits"][0]["file_path"], "src/a.rs");
     assert_eq!(normalized.input.tool_input["edits"][1]["file_path"], "/other/b.rs");
+    let clone_inputs = extract_clone_inputs(&normalized.input, Path::new("/repo"));
+    assert_eq!(clone_inputs.iter().map(|input| input.path.as_path()).collect::<Vec<_>>(), vec![
+        Path::new("src/a.rs"),
+        Path::new("/other/b.rs"),
+    ]);
+    assert_eq!(clone_inputs.iter().map(|input| input.text.as_str()).collect::<Vec<_>>(), vec![
+        "fn a() {}",
+        "fn b() {}",
+    ]);
     assert_eq!(extract_edited_paths(&normalized.input), vec![
         PathBuf::from("/repo/src/a.rs"),
         PathBuf::from("/other/b.rs"),
@@ -958,6 +967,23 @@ fn extract_clone_inputs_write_edit_multiedit() {
         "fn a() {}",
         "fn b() {}"
     ]);
+
+    let per_file = write_event(
+        "MultiEdit",
+        serde_json::json!({
+            "edits": [
+                {"file_path": "/repo/src/a.rs", "new_string": "fn a() {}"},
+                {"file_path": "/repo/src/b.py", "new_string": "def b(): pass"},
+            ]
+        }),
+    );
+    let per_file = super::extract_clone_inputs(&per_file, root);
+    assert_eq!(per_file.iter().map(|input| input.path.as_path()).collect::<Vec<_>>(), vec![
+        Path::new("src/a.rs"),
+        Path::new("src/b.py"),
+    ]);
+    assert_eq!(per_file[0].language, Language::Rust);
+    assert_eq!(per_file[1].language, Language::Python);
 }
 
 #[test]

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -62,6 +62,224 @@ fn session_start_json_without_tool_fields_deserializes() {
 }
 
 #[test]
+fn cursor_events_normalize_to_internal_actions() {
+    let session = normalize_hook(
+        r#"{"hook_event_name":"sessionStart","conversation_id":"c1","workspace_roots":["/repo"]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(session.harness, Harness::Cursor);
+    assert_eq!(session.dispatch, Dispatch::SessionStart);
+    assert_eq!(session.input.cwd, "/repo");
+    assert_eq!(session.input.session_id, "c1");
+
+    let shell = normalize_hook(
+        r#"{"hook_event_name":"beforeShellExecution","command":"rg needle src","cwd":"/repo"}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(shell.dispatch, Dispatch::PreToolUse);
+    assert_eq!(shell.output_event, OutputEvent::CursorBeforeShell);
+    assert_eq!(shell.input.tool_name, "Bash");
+    assert_eq!(shell.input.tool_input["command"], "rg needle src");
+
+    let edit = normalize_hook(
+        r#"{"hook_event_name":"afterFileEdit","file_path":"/repo/src/lib.rs","edits":[{"old_string":"a","new_string":"b"}],"workspace_roots":["/repo"]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(edit.dispatch, Dispatch::PostToolUse);
+    assert_eq!(edit.input.tool_input["file_path"], "/repo/src/lib.rs");
+    assert_eq!(edit.input.tool_input["edits"][0]["new_string"], "b");
+}
+
+#[test]
+fn cursor_multi_root_events_use_the_root_containing_the_file() {
+    let edit = normalize_hook(
+        r#"{"hook_event_name":"afterFileEdit","workspace_roots":["/repo-a","/repo-b"],"file_path":"/repo-b/src/lib.rs","edits":[]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(edit.input.cwd, "/repo-b");
+
+    let read = normalize_hook(
+        r#"{"hook_event_name":"postToolUse","workspace_roots":["/repo-a","/repo-b"],"tool_name":"Read","tool_input":{"file_path":"/repo-b/src/lib.rs"}}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(read.input.cwd, "/repo-b");
+}
+
+#[test]
+fn cursor_read_uses_posttool_context_channel_only() {
+    let before = normalize_hook(
+        r#"{"hook_event_name":"beforeReadFile","file_path":"/repo/src/lib.rs","workspace_roots":["/repo"]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(before.input.tool_name, "Read");
+    assert_eq!(before.output_event, OutputEvent::None);
+
+    let after = normalize_hook(
+        r#"{"hook_event_name":"postToolUse","tool_name":"Read","tool_input":{"file_path":"/repo/src/lib.rs"},"workspace_roots":["/repo"]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(after.dispatch, Dispatch::CursorPostToolUse);
+    assert_eq!(after.output_event, OutputEvent::CursorPostToolUse);
+}
+
+#[test]
+fn cursor_clone_check_requires_generic_posttool_edit_text() {
+    let dedicated = normalize_hook(
+        r#"{"hook_event_name":"afterFileEdit","file_path":"/repo/src/lib.rs","edits":[{"new_string":"fn added() {}"}],"workspace_roots":["/repo"]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(dedicated.dispatch, Dispatch::PostToolUse);
+    assert_eq!(dedicated.output_event, OutputEvent::None);
+
+    let generic = normalize_hook(
+        r#"{"hook_event_name":"postToolUse","tool_name":"Write","tool_input":{"file_path":"/repo/src/lib.rs","edits":[{"new_string":"fn added() {}"}]},"workspace_roots":["/repo"]}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    assert_eq!(generic.dispatch, Dispatch::CursorPostToolUse);
+    assert_eq!(generic.input.tool_name, "MultiEdit");
+    assert_eq!(generic.input.tool_input["edits"][0]["new_string"], "fn added() {}");
+    assert_eq!(generic.output_event, OutputEvent::CursorPostToolUse);
+}
+
+#[test]
+fn vscode_tool_names_and_camel_case_inputs_normalize() {
+    let cases = [
+        ("run_in_terminal", serde_json::json!({"command": "rg foo"}), "Bash"),
+        ("read_file", serde_json::json!({"filePath": "/repo/a.rs"}), "Read"),
+        (
+            "create_file",
+            serde_json::json!({"filePath": "/repo/a.rs", "content": "fn a() {}"}),
+            "Write",
+        ),
+        (
+            "replace_string_in_file",
+            serde_json::json!({"filePath": "/repo/a.rs", "newString": "fn b() {}"}),
+            "Edit",
+        ),
+    ];
+    for (tool, tool_input, expected) in cases {
+        let value = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/repo",
+            "tool_name": tool,
+            "tool_input": tool_input,
+        });
+        let normalized = normalize_hook(&value.to_string(), AgentHookHarnessArg::Vscode).unwrap();
+        assert_eq!(normalized.input.tool_name, expected, "{tool}");
+    }
+}
+
+#[test]
+fn snake_case_and_camel_case_paths_normalize_identically() {
+    for field in ["file_path", "filePath"] {
+        let value = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": "/repo",
+            "tool_name": "read_file",
+            "tool_input": { (field): "/repo/src/lib.rs" },
+        });
+        let normalized = normalize_hook(&value.to_string(), AgentHookHarnessArg::Vscode).unwrap();
+        assert_eq!(normalized.input.tool_input["file_path"], "/repo/src/lib.rs");
+    }
+}
+
+#[test]
+fn cursor_and_vscode_shell_commands_feed_the_existing_parser() {
+    let cursor = normalize_hook(
+        r#"{"hook_event_name":"beforeShellExecution","command":"rg -n needle src","cwd":"/repo"}"#,
+        AgentHookHarnessArg::Cursor,
+    )
+    .unwrap();
+    let vscode = normalize_hook(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"runTerminalCommand","tool_input":{"commandLine":"rg -n needle src"},"cwd":"/repo"}"#,
+        AgentHookHarnessArg::Vscode,
+    )
+    .unwrap();
+    for normalized in [cursor, vscode] {
+        let search = extract_search(&normalized.input).unwrap();
+        assert_eq!(search.pattern, "needle");
+        assert_eq!(search.search_path.as_deref(), Some("src"));
+    }
+}
+
+#[test]
+fn irrelevant_tools_and_malformed_input_are_silent() {
+    let irrelevant = normalize_hook(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"fetch_webpage","tool_input":{"secret":"RAW-PAYLOAD-SENTINEL"}}"#,
+        AgentHookHarnessArg::Vscode,
+    )
+    .unwrap();
+    assert_eq!(irrelevant.dispatch, Dispatch::Ignore);
+    assert_eq!(irrelevant.output_event, OutputEvent::None);
+    assert!(normalize_hook("not json", AgentHookHarnessArg::Cursor).is_none());
+}
+
+#[test]
+fn context_output_contains_only_intentional_context() {
+    let cursor = format_context_output(
+        Harness::Cursor,
+        OutputEvent::CursorPostToolUse,
+        "bounded augmentation",
+    )
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&cursor).unwrap(),
+        serde_json::json!({"additional_context": "bounded augmentation"})
+    );
+    assert!(!cursor.contains("RAW-PAYLOAD-SENTINEL"));
+
+    let vscode =
+        format_context_output(Harness::Vscode, OutputEvent::PreToolUse, "bounded augmentation")
+            .unwrap();
+    let value: serde_json::Value = serde_json::from_str(&vscode).unwrap();
+    assert_eq!(value["hookSpecificOutput"]["additionalContext"], "bounded augmentation");
+    assert!(format_context_output(Harness::Cursor, OutputEvent::None, "ignored").is_none());
+}
+
+#[test]
+fn hook_manifests_register_one_dispatcher_per_event() {
+    for manifest in [
+        include_str!("../../../../plugin/hooks/hooks.json"),
+        include_str!("../../../../plugin/hooks.vscode.json"),
+    ] {
+        let value: serde_json::Value = serde_json::from_str(manifest).unwrap();
+        for event in ["SessionStart", "PreToolUse", "PostToolUse"] {
+            let entries = value["hooks"][event].as_array().expect("event array");
+            assert_eq!(entries.len(), 1, "{event} must have one dispatcher");
+            assert!(entries[0].get("matcher").is_none(), "{event} must not rely on matchers");
+        }
+    }
+
+    let vscode: serde_json::Value =
+        serde_json::from_str(include_str!("../../../../plugin/hooks.vscode.json")).unwrap();
+    for event in ["SessionStart", "PreToolUse", "PostToolUse"] {
+        let command = vscode["hooks"][event][0]["command"].as_str().unwrap();
+        assert!(command.contains("${PLUGIN_ROOT}/scripts/launch.js"));
+        assert!(command.ends_with("agent-hook vscode"));
+    }
+
+    let cursor: serde_json::Value =
+        serde_json::from_str(include_str!("../../../../plugin/hooks.cursor.json")).unwrap();
+    for event in ["sessionStart", "beforeShellExecution", "postToolUse", "afterFileEdit"] {
+        let entries = cursor["hooks"][event].as_array().expect("Cursor event array");
+        assert_eq!(entries.len(), 1, "Cursor {event} must have one dispatcher");
+        assert!(
+            entries[0]["command"].as_str().unwrap().ends_with("agent-hook cursor"),
+            "Cursor {event} must select the Cursor adapter"
+        );
+    }
+}
+
+#[test]
 fn parses_grep_tool_input() {
     let json = r#"{"session_id":"s1","cwd":"/repo","hook_event_name":"PreToolUse",
             "tool_name":"Grep","tool_input":{"pattern":"watcher_main","path":"crates"}}"#;
@@ -213,8 +431,8 @@ fn extract_edited_paths_pulls_file_path_from_the_edit_tools() {
 
 #[test]
 fn extract_edited_paths_ignores_non_edit_tools_and_missing_paths() {
-    // A non-edit tool yields nothing — including `apply_patch`, deliberately unscoped (#661).
-    for tool in ["Read", "Grep", "Bash", "apply_patch"] {
+    // A non-edit tool yields nothing.
+    for tool in ["Read", "Grep", "Bash"] {
         let json = format!(
             r#"{{"hook_event_name":"PostToolUse","tool_name":"{tool}",
                 "tool_input":{{"file_path":"/repo/x.rs"}}}}"#,
@@ -226,6 +444,34 @@ fn extract_edited_paths_ignores_non_edit_tools_and_missing_paths() {
     let json = r#"{"hook_event_name":"PostToolUse","tool_name":"Write","tool_input":{}}"#;
     let input: HookInput = serde_json::from_str(json).unwrap();
     assert!(extract_edited_paths(&input).is_empty());
+}
+
+#[test]
+fn extract_edited_paths_resolves_relative_files_and_apply_patch() {
+    let multi = HookInput {
+        cwd: "/repo".to_string(),
+        tool_name: "MultiEdit".to_string(),
+        tool_input: serde_json::json!({"files": ["src/a.rs", "/other/b.rs"]}),
+        ..Default::default()
+    };
+    assert_eq!(extract_edited_paths(&multi), vec![
+        PathBuf::from("/repo/src/a.rs"),
+        PathBuf::from("/other/b.rs"),
+    ]);
+
+    let patch = HookInput {
+        cwd: "/repo".to_string(),
+        tool_name: "apply_patch".to_string(),
+        tool_input: serde_json::json!({
+            "command": "*** Begin Patch\n*** Update File: src/lib.rs\n*** Move to: src/moved.rs\n+fn added() {}\n*** Delete File: src/gone.rs\n*** End Patch\n"
+        }),
+        ..Default::default()
+    };
+    assert_eq!(extract_edited_paths(&patch), vec![
+        PathBuf::from("/repo/src/lib.rs"),
+        PathBuf::from("/repo/src/moved.rs"),
+        PathBuf::from("/repo/src/gone.rs"),
+    ]);
 }
 
 #[test]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -38,10 +38,9 @@ pub(crate) enum Command {
     /// Scan the repository and write a starter rag-rat.toml (interactive).
     Init(InitArgs),
 
-    /// Internal: coding-agent hook entrypoint (reads a JSON hook event on stdin; Claude Code,
-    /// Codex, Cursor).
+    /// Internal: coding-agent hook entrypoint (reads a JSON hook event on stdin).
     #[command(hide = true)]
-    AgentHook,
+    AgentHook(AgentHookArgs),
 
     /// Internal: the detached edit-driven reindex runner (#661), spawned by the PostToolUse edit
     /// hook. Coalesces a burst of edits via the single-flight and runs one scoped structural
@@ -169,6 +168,22 @@ pub(crate) struct RmArgs {
     /// Preview what would be deleted (per-table row counts) and exit without changing anything.
     #[arg(long)]
     pub dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AgentHookArgs {
+    /// Input/output contract to normalize. Auto preserves the shared Claude/Codex plugin
+    /// entrypoint and detects Cursor's lower-camel lifecycle names.
+    #[arg(value_enum, default_value_t = AgentHookHarnessArg::Auto)]
+    pub harness: AgentHookHarnessArg,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum AgentHookHarnessArg {
+    #[default]
+    Auto,
+    Cursor,
+    Vscode,
 }
 
 #[derive(Debug, Args)]
@@ -917,6 +932,21 @@ mod tests {
                 assert_eq!(args.action, HookAction::Install);
             },
             other => panic!("expected hooks, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_hook_harness_parses_and_defaults_to_auto() {
+        let cli = Cli::try_parse_from(["rag-rat", "agent-hook", "cursor"]).expect("parse");
+        match cli.command {
+            Command::AgentHook(args) => assert_eq!(args.harness, AgentHookHarnessArg::Cursor),
+            other => panic!("expected agent-hook, got {other:?}"),
+        }
+
+        let cli = Cli::try_parse_from(["rag-rat", "agent-hook"]).expect("parse default");
+        match cli.command {
+            Command::AgentHook(args) => assert_eq!(args.harness, AgentHookHarnessArg::Auto),
+            other => panic!("expected agent-hook, got {other:?}"),
         }
     }
 

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> anyhow::Result<()> {
     // there isn't one.
     match &cli.command {
         Cmd::Init(args) => return init::run(args, cli.config.as_deref().unwrap_or("rag-rat.toml")),
-        Cmd::AgentHook => return agent_hook::run(),
+        Cmd::AgentHook(args) => return agent_hook::run(args.harness),
         // The detached edit-reindex runner discovers its own config from the hook's cwd (a
         // not-a-rag-rat-repo cwd is a silent no-op), so it tolerates config absence like
         // agent-hook.
@@ -118,7 +118,7 @@ fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Cmd::Init(_)
-        | Cmd::AgentHook
+        | Cmd::AgentHook(_)
         | Cmd::EditReindex(_)
         | Cmd::Mcp
         | Cmd::Doctor(_)

--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -54,6 +54,15 @@ fn run_hook_for(
     (String::from_utf8_lossy(&out.stdout).into_owned(), out.status)
 }
 
+#[cfg(unix)]
+fn clone_candidate(name: &str) -> String {
+    format!(
+        "pub fn {name}(x: i64, y: i64) -> i64 {{\n    let a = x + y;\n    let b = a * 2;\n    let \
+         c = b - x;\n    let d = c + y;\n    let e = d * 3;\n    let f = e - a;\n    let g = f + \
+         b;\n    let h = g - c;\n    h + d + e + f + g\n}}\n"
+    )
+}
+
 #[test]
 fn no_rag_rat_toml_means_silent_exit_zero() {
     let dir = unique_dir("hook-noindex");
@@ -337,6 +346,14 @@ impl LinkedTestRepo {
         assert!(!linked.join("rag-rat.toml").exists());
         assert!(symbol_indexed_in_checkout(&config, &main, "main_checkout_xyz"));
         Self { main, linked, config }
+    }
+
+    fn add_clone_candidate(&self) {
+        let path = self.linked.join("src/branch_clone.rs");
+        fs::write(&path, clone_candidate("branch_clone_xyz")).unwrap();
+        rag_rat_core::watch::reindex_paths(&self.config, &[path], |_| {}).unwrap();
+        assert!(symbol_indexed_in_checkout(&self.config, &self.linked, "branch_clone_xyz"));
+        assert!(!symbol_indexed_in_checkout(&self.config, &self.main, "branch_clone_xyz"));
     }
 }
 
@@ -668,6 +685,53 @@ fn cursor_and_vscode_reindex_only_the_active_linked_worktree() {
     assert!(!symbol_indexed_in_checkout(&repo.config, &repo.linked, "cursor_linked_xyz"));
     assert!(symbol_indexed_in_checkout(&repo.config, &repo.main, "main_checkout_xyz"));
     assert!(!symbol_indexed_in_checkout(&repo.config, &repo.main, "vscode_linked_xyz"));
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_and_vscode_clone_checks_use_the_active_linked_worktree() {
+    let repo = LinkedTestRepo::indexed();
+    repo.add_clone_candidate();
+
+    let cursor_path = repo.linked.join("src/cursor_new.rs");
+    let cursor_content = clone_candidate("cursor_new_xyz");
+    fs::write(&cursor_path, &cursor_content).unwrap();
+    let cursor = serde_json::json!({
+        "hook_event_name": "postToolUse",
+        "conversation_id": "cursor-linked-clone",
+        "workspace_roots": [repo.main.as_path(), repo.linked.as_path()],
+        "tool_name": "Write",
+        "tool_input": {"file_path": &cursor_path, "content": cursor_content},
+    });
+    let (stdout, status) = run_hook_for(Some("cursor"), &cursor.to_string(), &repo.linked);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(
+        output["additional_context"].as_str().unwrap().contains("branch_clone_xyz"),
+        "Cursor clone check must read the linked overlay: {stdout}"
+    );
+
+    let vscode_path = repo.linked.join("src/vscode_new.rs");
+    let vscode_content = clone_candidate("vscode_new_xyz");
+    let vscode = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "vscode-linked-clone",
+        "cwd": repo.linked.as_path(),
+        "tool_name": "multi_replace_string_in_file",
+        "tool_input": {
+            "replacements": [{"filePath": &vscode_path, "newString": vscode_content}],
+        },
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &vscode.to_string(), &repo.linked);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(
+        output["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap()
+            .contains("branch_clone_xyz"),
+        "VS Code multi-file clone check must read the linked overlay: {stdout}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -14,9 +14,9 @@ use std::{
 
 mod common;
 
-#[cfg(unix)]
-use common::ScratchRoot;
 use common::unique_dir;
+#[cfg(unix)]
+use common::{ScratchRoot, git, git_commit};
 #[cfg(unix)]
 use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
 
@@ -303,6 +303,44 @@ impl TestRepo {
 }
 
 #[cfg(unix)]
+struct LinkedTestRepo {
+    main: ScratchRoot,
+    linked: ScratchRoot,
+    config: rag_rat_base::config::Config,
+}
+
+#[cfg(unix)]
+impl LinkedTestRepo {
+    fn indexed() -> Self {
+        let main = unique_dir("hook-linked-main");
+        fs::create_dir_all(main.join("src")).unwrap();
+        fs::write(main.join("src/lib.rs"), "pub fn main_checkout_xyz() {}\n").unwrap();
+        fs::write(main.join(".gitignore"), ".rag-rat/\nrag-rat.toml\n").unwrap();
+        git(&main, &["init", "-q", "-b", "main"]);
+        git(&main, &["config", "user.email", "t@example.com"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git_commit(&main, &["-q", "-m", "base"]);
+
+        let config_path = main.join("rag-rat.toml");
+        fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\ndatabase = \
+             \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let config = rag_rat_base::config::Config::load(&config_path).unwrap();
+        rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+
+        let linked = unique_dir("hook-linked-worktree");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+        assert!(!linked.join("rag-rat.toml").exists());
+        assert!(symbol_indexed_in_checkout(&config, &main, "main_checkout_xyz"));
+        Self { main, linked, config }
+    }
+}
+
+#[cfg(unix)]
 struct McpServer {
     child: Child,
     _stdin: std::process::ChildStdin,
@@ -530,6 +568,16 @@ fn cursor_and_vscode_session_start_wrap_the_orientation_digest() {
             .unwrap()
             .contains("rag-rat repo intelligence")
     );
+
+    let resumed = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "vscode-resume",
+        "cwd": repo.root.as_path(),
+        "source": "resume",
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &resumed.to_string(), &repo.root);
+    assert!(status.success());
+    assert!(stdout.is_empty(), "resumed sessions must not receive another orientation digest");
 }
 
 #[cfg(unix)]
@@ -567,6 +615,87 @@ fn vscode_post_edit_backgrounds_a_scoped_reindex() {
     assert!(status.success());
     assert!(stdout.is_empty(), "edit reindex must not add AI context: {stdout}");
     wait_for_symbol(&repo.config, "vscode_edit_xyz", Duration::from_secs(30));
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_and_vscode_reindex_only_the_active_linked_worktree() {
+    let repo = LinkedTestRepo::indexed();
+    let linked_file = repo.linked.join("src/lib.rs");
+
+    fs::write(&linked_file, "pub fn cursor_linked_xyz() {}\n").unwrap();
+    let cursor = serde_json::json!({
+        "hook_event_name": "afterFileEdit",
+        "conversation_id": "cursor-linked-edit",
+        "workspace_roots": [repo.main.as_path(), repo.linked.as_path()],
+        "file_path": &linked_file,
+        "edits": [{"new_string": "pub fn cursor_linked_xyz() {}"}],
+    });
+    let (stdout, status) = run_hook_for(Some("cursor"), &cursor.to_string(), &repo.linked);
+    assert!(status.success());
+    assert!(stdout.is_empty());
+    wait_for_checkout_symbol(
+        &repo.config,
+        &repo.linked,
+        "cursor_linked_xyz",
+        Duration::from_secs(30),
+    );
+    assert!(symbol_indexed_in_checkout(&repo.config, &repo.main, "main_checkout_xyz"));
+    assert!(!symbol_indexed_in_checkout(&repo.config, &repo.main, "cursor_linked_xyz"));
+
+    fs::write(&linked_file, "pub fn vscode_linked_xyz() {}\n").unwrap();
+    let vscode = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": "vscode-linked-edit",
+        "cwd": repo.linked.as_path(),
+        "tool_name": "multi_replace_string_in_file",
+        "tool_input": {
+            "replacements": [{
+                "filePath": &linked_file,
+                "newString": "pub fn vscode_linked_xyz() {}",
+            }],
+        },
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &vscode.to_string(), &repo.linked);
+    assert!(status.success());
+    assert!(stdout.is_empty());
+    wait_for_checkout_symbol(
+        &repo.config,
+        &repo.linked,
+        "vscode_linked_xyz",
+        Duration::from_secs(30),
+    );
+    assert!(!symbol_indexed_in_checkout(&repo.config, &repo.linked, "cursor_linked_xyz"));
+    assert!(symbol_indexed_in_checkout(&repo.config, &repo.main, "main_checkout_xyz"));
+    assert!(!symbol_indexed_in_checkout(&repo.config, &repo.main, "vscode_linked_xyz"));
+}
+
+#[cfg(unix)]
+fn symbol_indexed_in_checkout(
+    config: &rag_rat_base::config::Config,
+    checkout: &Path,
+    symbol: &str,
+) -> bool {
+    let mut db = rag_rat_core::IndexDatabase::open_config(config).unwrap();
+    db.use_worktree_scope(&config.root, Some(checkout)).unwrap();
+    db.symbols(symbol, None, 10).unwrap().iter().any(|candidate| candidate.name == symbol)
+}
+
+#[cfg(unix)]
+fn wait_for_checkout_symbol(
+    config: &rag_rat_base::config::Config,
+    checkout: &Path,
+    symbol: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if symbol_indexed_in_checkout(config, checkout, symbol) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("edited symbol `{symbol}` not indexed for {} within {timeout:?}", checkout.display());
 }
 
 #[cfg(unix)]

--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -17,10 +17,21 @@ mod common;
 #[cfg(unix)]
 use common::ScratchRoot;
 use common::unique_dir;
+#[cfg(unix)]
+use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
 
 fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::ExitStatus) {
+    run_hook_for(None, stdin_body, cwd)
+}
+
+fn run_hook_for(
+    harness: Option<&str>,
+    stdin_body: &str,
+    cwd: &std::path::Path,
+) -> (String, std::process::ExitStatus) {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
         .arg("agent-hook")
+        .args(harness)
         .current_dir(cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -63,6 +74,29 @@ fn garbage_stdin_means_silent_exit_zero() {
     let (stdout, status) = run_hook("this is not json", &dir);
     assert!(status.success());
     assert!(stdout.is_empty());
+}
+
+#[test]
+fn cursor_and_vscode_missing_state_are_silent() {
+    let dir = unique_dir("hook-adapter-noindex");
+    std::fs::create_dir_all(&dir).unwrap();
+    let cursor = serde_json::json!({
+        "hook_event_name": "sessionStart",
+        "conversation_id": "cursor-session",
+        "workspace_roots": [dir.as_path()],
+    });
+    let vscode = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "vscode-session",
+        "cwd": dir.as_path(),
+        "tool_name": "run_in_terminal",
+        "tool_input": {"command": "rg anything"},
+    });
+    for (harness, input) in [("cursor", cursor), ("vscode", vscode)] {
+        let (stdout, status) = run_hook_for(Some(harness), &input.to_string(), &dir);
+        assert!(status.success(), "{harness} must fail open");
+        assert!(stdout.is_empty(), "{harness} must be silent without rag-rat state: {stdout}");
+    }
 }
 
 #[test]
@@ -191,6 +225,26 @@ impl TestRepo {
     /// Same client computation as the CLI: the deterministic socket path for this config.
     fn socket_path(&self) -> PathBuf {
         rag_rat_base::locks::hook_socket_path_for(&self.config)
+    }
+
+    fn add_file_memory(&self, marker: &str) {
+        rag_rat_core::IndexDatabase::open_config(&self.config)
+            .unwrap()
+            .memory_create(RepoMemoryCreate {
+                kind: "Invariant".to_string(),
+                title: marker.to_string(),
+                body: "The read hook must surface this memory title.".to_string(),
+                confidence: "high".to_string(),
+                created_by: Some("agent-hook-e2e".to_string()),
+                source: Some("agent".to_string()),
+                tags: Vec::new(),
+                payload_json: None,
+                bind: RepoMemoryBindTarget {
+                    path: Some("src/lib.rs".to_string()),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
     }
 
     /// Spawn `rag-rat mcp` and drive `initialize` so the server is fully up and `run_stdio_unix`
@@ -366,6 +420,153 @@ fn posttooluse_backgrounds_a_scoped_reindex() {
     assert!(stdout.is_empty(), "PostToolUse prints nothing, got: {stdout}");
     // The reindex runs in a detached child; poll until the edit lands.
     wait_for_symbol(&repo.config, "added_via_hook_tuv", Duration::from_secs(30));
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_and_vscode_payloads_emit_only_documented_context() {
+    let repo = TestRepo::indexed_with_symbol();
+    let cursor = serde_json::json!({
+        "hook_event_name": "postToolUse",
+        "conversation_id": "cursor-e2e",
+        "cursor_version": "1.7.2",
+        "workspace_roots": [repo.root.as_path()],
+        "tool_name": "Shell",
+        "tool_input": {"command": "rg frobnicate_xyz", "private": "RAW-PAYLOAD-SENTINEL"},
+        "tool_output": "PRIVATE TOOL OUTPUT",
+    });
+    let (cursor_stdout, cursor_status) =
+        run_hook_for(Some("cursor"), &cursor.to_string(), &repo.root);
+    assert!(cursor_status.success());
+    let cursor_output: serde_json::Value = serde_json::from_str(cursor_stdout.trim()).unwrap();
+    assert!(cursor_output["additional_context"].as_str().unwrap().contains("frobnicate_xyz"));
+    assert!(!cursor_stdout.contains("RAW-PAYLOAD-SENTINEL"));
+    assert!(!cursor_stdout.contains("PRIVATE TOOL OUTPUT"));
+
+    let vscode = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "vscode-e2e",
+        "cwd": repo.root.as_path(),
+        "tool_name": "run_in_terminal",
+        "tool_input": {"command": "rg frobnicate_xyz", "private": "RAW-PAYLOAD-SENTINEL"},
+        "transcript_path": "/private/transcript.jsonl",
+    });
+    let (vscode_stdout, vscode_status) =
+        run_hook_for(Some("vscode"), &vscode.to_string(), &repo.root);
+    assert!(vscode_status.success());
+    let vscode_output: serde_json::Value = serde_json::from_str(vscode_stdout.trim()).unwrap();
+    assert!(
+        vscode_output["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap()
+            .contains("frobnicate_xyz")
+    );
+    assert!(!vscode_stdout.contains("RAW-PAYLOAD-SENTINEL"));
+    assert!(!vscode_stdout.contains("transcript.jsonl"));
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_and_vscode_read_payloads_emit_bounded_augmentation() {
+    let repo = TestRepo::indexed_with_symbol();
+    repo.add_file_memory("READ-AUGMENT-MARKER");
+    let cursor = serde_json::json!({
+        "hook_event_name": "postToolUse",
+        "conversation_id": "cursor-read",
+        "workspace_roots": [repo.root.as_path()],
+        "tool_name": "Read",
+        "tool_input": {"file_path": repo.root.join("src/lib.rs")},
+    });
+    let (stdout, status) = run_hook_for(Some("cursor"), &cursor.to_string(), &repo.root);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(output["additional_context"].as_str().unwrap().contains("READ-AUGMENT-MARKER"));
+
+    let vscode = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "vscode-read",
+        "cwd": repo.root.as_path(),
+        "tool_name": "read_file",
+        "tool_input": {"filePath": repo.root.join("src/lib.rs")},
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &vscode.to_string(), &repo.root);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(
+        output["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap()
+            .contains("READ-AUGMENT-MARKER")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_and_vscode_session_start_wrap_the_orientation_digest() {
+    let repo = TestRepo::indexed_with_symbol();
+    let cursor = serde_json::json!({
+        "hook_event_name": "sessionStart",
+        "conversation_id": "cursor-start",
+        "workspace_roots": [repo.root.as_path()],
+        "composer_mode": "agent",
+    });
+    let (stdout, status) = run_hook_for(Some("cursor"), &cursor.to_string(), &repo.root);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(output["additional_context"].as_str().unwrap().contains("rag-rat repo intelligence"));
+
+    let vscode = serde_json::json!({
+        "hook_event_name": "SessionStart",
+        "session_id": "vscode-start",
+        "cwd": repo.root.as_path(),
+        "source": "new",
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &vscode.to_string(), &repo.root);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(
+        output["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap()
+            .contains("rag-rat repo intelligence")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_after_file_edit_backgrounds_a_scoped_reindex() {
+    let repo = TestRepo::indexed_with_symbol();
+    fs::write(repo.root.join("src/lib.rs"), "pub fn cursor_edit_xyz() {}\n").unwrap();
+    let input = serde_json::json!({
+        "hook_event_name": "afterFileEdit",
+        "conversation_id": "cursor-edit",
+        "workspace_roots": ["/unrelated-workspace", repo.root.as_path()],
+        "file_path": repo.root.join("src/lib.rs"),
+        "edits": [{"old_string": "frobnicate_xyz", "new_string": "cursor_edit_xyz"}],
+    });
+    let (stdout, status) = run_hook_for(Some("cursor"), &input.to_string(), &repo.root);
+    assert!(status.success());
+    assert!(stdout.is_empty(), "edit reindex must not add AI context: {stdout}");
+    wait_for_symbol(&repo.config, "cursor_edit_xyz", Duration::from_secs(30));
+}
+
+#[cfg(unix)]
+#[test]
+fn vscode_post_edit_backgrounds_a_scoped_reindex() {
+    let repo = TestRepo::indexed_with_symbol();
+    fs::write(repo.root.join("src/lib.rs"), "pub fn vscode_edit_xyz() {}\n").unwrap();
+    let input = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": "vscode-edit",
+        "cwd": repo.root.as_path(),
+        "tool_name": "replace_string_in_file",
+        "tool_input": {"filePath": repo.root.join("src/lib.rs")},
+        "tool_response": "File edited successfully",
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &input.to_string(), &repo.root);
+    assert!(status.success());
+    assert!(stdout.is_empty(), "edit reindex must not add AI context: {stdout}");
+    wait_for_symbol(&repo.config, "vscode_edit_xyz", Duration::from_secs(30));
 }
 
 #[cfg(unix)]

--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -237,23 +237,7 @@ impl TestRepo {
     }
 
     fn add_file_memory(&self, marker: &str) {
-        rag_rat_core::IndexDatabase::open_config(&self.config)
-            .unwrap()
-            .memory_create(RepoMemoryCreate {
-                kind: "Invariant".to_string(),
-                title: marker.to_string(),
-                body: "The read hook must surface this memory title.".to_string(),
-                confidence: "high".to_string(),
-                created_by: Some("agent-hook-e2e".to_string()),
-                source: Some("agent".to_string()),
-                tags: Vec::new(),
-                payload_json: None,
-                bind: RepoMemoryBindTarget {
-                    path: Some("src/lib.rs".to_string()),
-                    ..Default::default()
-                },
-            })
-            .unwrap();
+        add_file_memory(&self.config, marker);
     }
 
     /// Spawn `rag-rat mcp` and drive `initialize` so the server is fully up and `run_stdio_unix`
@@ -299,7 +283,7 @@ impl TestRepo {
     }
 
     /// Run the hook client with a Grep `tool_input` for the indexed symbol under the given session,
-    /// cwd = repo root (so `find_config` walks up to our `rag-rat.toml`).
+    /// cwd = repo root (so governing config discovery reaches our `rag-rat.toml`).
     fn run_hook_session(&self, session_id: &str) -> String {
         let input = serde_json::json!({
             "session_id": session_id, "cwd": self.root.as_path(), "hook_event_name": "PreToolUse",
@@ -355,6 +339,31 @@ impl LinkedTestRepo {
         assert!(symbol_indexed_in_checkout(&self.config, &self.linked, "branch_clone_xyz"));
         assert!(!symbol_indexed_in_checkout(&self.config, &self.main, "branch_clone_xyz"));
     }
+
+    fn add_file_memory(&self, marker: &str) {
+        add_file_memory(&self.config, marker);
+    }
+}
+
+#[cfg(unix)]
+fn add_file_memory(config: &rag_rat_base::config::Config, marker: &str) {
+    rag_rat_core::IndexDatabase::open_config(config)
+        .unwrap()
+        .memory_create(RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: marker.to_string(),
+            body: "The read hook must surface this memory title.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("agent-hook-e2e".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
 }
 
 #[cfg(unix)]
@@ -552,6 +561,43 @@ fn cursor_and_vscode_read_payloads_emit_bounded_augmentation() {
             .as_str()
             .unwrap()
             .contains("READ-AUGMENT-MARKER")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cursor_and_vscode_reads_resolve_main_governed_linked_worktrees() {
+    let repo = LinkedTestRepo::indexed();
+    repo.add_file_memory("LINKED-READ-AUGMENT-MARKER");
+    let linked_file = repo.linked.join("src/lib.rs");
+
+    let cursor = serde_json::json!({
+        "hook_event_name": "postToolUse",
+        "conversation_id": "cursor-linked-read",
+        "workspace_roots": [repo.main.as_path(), repo.linked.as_path()],
+        "tool_name": "Read",
+        "tool_input": {"file_path": &linked_file},
+    });
+    let (stdout, status) = run_hook_for(Some("cursor"), &cursor.to_string(), &repo.linked);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(output["additional_context"].as_str().unwrap().contains("LINKED-READ-AUGMENT-MARKER"));
+
+    let vscode = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "vscode-linked-read",
+        "cwd": repo.linked.as_path(),
+        "tool_name": "read_file",
+        "tool_input": {"filePath": &linked_file},
+    });
+    let (stdout, status) = run_hook_for(Some("vscode"), &vscode.to_string(), &repo.linked);
+    assert!(status.success());
+    let output: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(
+        output["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap()
+            .contains("LINKED-READ-AUGMENT-MARKER")
     );
 }
 

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "rag-rat",
+  "version": "0.21.1",
+  "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
+  "author": { "name": "Kristaps Karlsons" },
+  "homepage": "https://github.com/cq27-dev/rag-rat",
+  "repository": "https://github.com/cq27-dev/rag-rat",
+  "license": "MIT",
+  "keywords": ["mcp", "code-intelligence", "semantic-search", "code-graph", "repo-memory"],
+  "skills": "skills/",
+  "hooks": "hooks.cursor.json",
+  "mcpServers": ".mcp.json"
+}

--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "rag-rat",
+  "version": "0.21.1",
+  "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
+  "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
+  "homepage": "https://github.com/cq27-dev/rag-rat",
+  "repository": "https://github.com/cq27-dev/rag-rat",
+  "license": "MIT",
+  "skills": "skills/",
+  "hooks": "hooks.vscode.json",
+  "mcpServers": ".mcp.json"
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,31 +1,36 @@
 # rag-rat plugin (prototype)
 
-A coding-agent plugin — for **Claude Code, Codex, and opencode** (and any other harness with the
-same plugin shape) — that bundles rag-rat's MCP server, skills, and hooks, and **installs a
+A coding-agent plugin for **Claude Code, Codex, Cursor, VS Code, and opencode** that bundles
+rag-rat's MCP server, skills, and hooks, and **installs a
 version-matched rag-rat binary on first run**. Installing the plugin is one step: the user does
 not need to `cargo install` / `brew install` / put `rag-rat` on `PATH` first.
 
 ## Layout (single source, shared across harnesses)
 
 ```
-plugin/                          plugin root (CLAUDE_PLUGIN_ROOT / CODEX_PLUGIN_ROOT)
+.claude-plugin/marketplace.json  Claude marketplace → plugin/
+.cursor-plugin/marketplace.json  Cursor marketplace → plugin/
+plugin/                          plugin root (harness root token or plugin working directory)
   scripts/launch.js                the all-OS hook launcher (resolves the binary; never installs)
   skills/                          curated public skills (four rag-rat workflows)
   hooks/hooks.json                 Claude hooks (auto-discovered)
+  .cursor-plugin/plugin.json       Cursor plugin manifest
+  hooks.cursor.json                Cursor-native hooks
+  .plugin/plugin.json              VS Code/OpenPlugin manifest
+  hooks.vscode.json                VS Code hooks (one dispatcher per lifecycle event)
   .mcp.json                        Codex MCP config (root) → npx @rag-rat/bin mcp
   .claude-plugin/plugin.json       Claude: mcpServers → npx @rag-rat/bin mcp
-  .claude-plugin/marketplace.json
   .codex-plugin/plugin.json        Codex manifest: mcpServers → ./.mcp.json, skills → ./skills/
   .codex-plugin/hooks/hooks.json   Codex hooks
   opencode/rag-rat.ts              opencode plugin (TS module; MCP self-registration + hooks)
 ```
 
-Both harnesses treat `plugin/` as the plugin root, so `scripts/`, `skills/`, and the launcher are
-shared — no per-harness duplication.
+The harness manifests treat `plugin/` as the plugin root, so `scripts/`, `skills/`, and the launcher
+are shared without per-harness runtime duplication.
 
 ## MCP server & hook launcher
 
-**MCP server** — both manifests launch it as `npx -y @rag-rat/bin@latest mcp`. npx runs in the
+**MCP server** — the manifests launch it through the pinned `@rag-rat/bin` package. npx runs in the
 agent's project working directory (so the server resolves that repo's `rag-rat.toml`) and installs the
 version-matched binary from the `@rag-rat/bin` npm package on first use — no `cargo install` / `brew`
 / `PATH` setup first.
@@ -58,22 +63,64 @@ all of `.agents/skills`: contributor-only guidance such as `rust-modern-style` s
 
 ## Hooks
 
-The hook command routes through the launcher: `node <launcher> --no-install agent-hook`, so it
-resolves the same version-matched binary and never blocks on install. The handler
-(`rag-rat agent-hook`) is harness-neutral: Claude Code, Codex, and Cursor share the same
-`hook_event_name` / `tool_name` / `tool_input` input and the same `hookSpecificOutput.additionalContext`
-output.
+Hook commands route through the launcher in resolve-only mode, so they never install or access the
+network during a tool call. The stable adapter entrypoints are `rag-rat agent-hook cursor` and
+`rag-rat agent-hook vscode`; no argument (or `auto`) preserves Claude/Codex behavior and recognizes
+Cursor's lower-camel lifecycle names when Claude settings are explicitly imported into Cursor.
+
+The adapters consume the complete stdin event locally but never echo it. Only a bounded orientation
+digest, grep/read augmentation, or clone warning can enter model context. Commands, file contents,
+transcripts, tool output, and raw payloads are never copied into hook output. Reindex events emit no
+model context. Every adapter exits successfully and silently when input is malformed or rag-rat is
+unconfigured, unindexed, unavailable, or not yet present in the launcher's cache.
 
 **Claude** (`hooks/hooks.json`, auto-discovered):
 - `SessionStart` (`startup|clear|compact`, 5s) → repo orientation digest.
 - `PreToolUse` on `Grep`/`Bash` (10s) → grep-augmentation.
 - `PreToolUse` on `Write`/`Edit`/`MultiEdit` (10s) → write-time clone check.
+- `PostToolUse` on successful edits → detached, watcher-aware scoped reindex.
+- The manifest has one dispatcher per lifecycle event. Irrelevant tools are filtered inside the
+  adapter rather than by matcher-only registration.
 
 **Codex** (`.codex-plugin/hooks/hooks.json`, `{"hooks":{…}}` wrapper):
 - `SessionStart` → repo orientation digest.
 - `PreToolUse` on `^Bash$` → grep-augmentation.
 - `PreToolUse` on `^apply_patch$` → write-time clone check. The handler parses the V4A diff in
-  `tool_input.command` for added lines (Codex/Cursor edit via `apply_patch`, not `Write`/`Edit`).
+  `tool_input.command` for added lines.
+
+**Cursor** (`.cursor-plugin/plugin.json` → `hooks.cursor.json`):
+- Cursor lifecycle names, workspace roots, tool names, and flat output fields are normalized by the
+  Cursor adapter; Cursor does not share Claude's payload contract.
+- `sessionStart` → bounded orientation through Cursor's `additional_context` field.
+- `beforeShellExecution` → grep augmentation through Cursor's `agent_message` field, only for
+  supported `grep`/`rg`/`ag` commands.
+- File-read augmentation uses generic successful `postToolUse`, whose documented
+  `additional_context` field can safely inject context. `beforeReadFile` is deliberately not used
+  for augmentation because it has no documented model-context output field.
+- `afterFileEdit` triggers watcher-aware scoped reindexing and emits no context.
+- Clone checking runs only when generic write-tool input contains verified `content`, `new_string`,
+  or `edits[].new_string` data. Although native `afterFileEdit` includes old/new edit strings, that
+  event has no documented context output, so rag-rat does not emit a clone warning from it.
+- `beforeMCPExecution` and `afterMCPExecution` are ignored.
+
+Cursor discovers the bundled native manifest and hooks when the plugin is installed from its
+marketplace. For a project-native `.cursor/hooks.json`, invoke a locally installed binary as
+`rag-rat agent-hook cursor`; project hooks run from the project root. Cursor hook failures are
+fail-open by default, and rag-rat does not set `failClosed`.
+
+**VS Code Preview** (`.plugin/plugin.json` → `hooks.vscode.json`):
+- Exactly one matcher-free dispatcher is registered for each of `SessionStart`, `PreToolUse`, and
+  `PostToolUse`. This is required because VS Code currently parses Claude matcher syntax but ignores
+  matcher values.
+- The adapter recognizes VS Code terminal/read/edit names including `run_in_terminal`, `read_file`,
+  `create_file`, and `replace_string_in_file`, and normalizes camelCase fields such as `filePath`,
+  `newString`, and `commandLine`.
+- Session, grep/read, and clone context uses the documented
+  `hookSpecificOutput.additionalContext` channel. Successful edits trigger a silent detached scoped
+  reindex.
+- The OpenPlugin manifest is detected before the bundled Claude manifest, preventing duplicate
+  matcher-induced registrations. Workspace-only setups can place the same three dispatcher entries
+  under `.github/hooks/*.json` and invoke `rag-rat agent-hook vscode`.
 
 **opencode** (`opencode/rag-rat.ts`, a TS plugin module — no hooks manifest exists there):
 - `config` hook → self-registers the `rag-rat` MCP server (`npx -y @rag-rat/bin@<version> mcp`)
@@ -119,15 +166,16 @@ Three options:
 The Codex wiring is built from OpenAI's published hook docs (input field names, PreToolUse tool-name
 regex matching, `hookSpecificOutput.additionalContext` output) but hasn't been exercised against a
 live Codex. Confirm: the plugin `hooks.json` path/schema is read as expected, `^Bash$`/`^apply_patch$`
-matchers actually fire, and the digest/clone-check output is injected. Cursor mirrors the same shape.
+matchers actually fire, and the digest/clone-check output is injected. Cursor and VS Code use their
+dedicated adapters and do not rely on Codex/Claude payload equivalence.
 
 ## Installation for non-Claude agents
 
 Two layers:
 - **Universal (any MCP agent):** register `node <launcher> mcp` in the agent's MCP config — the
   launcher is harness-agnostic and self-installs the binary. This covers every MCP-capable agent.
-- **Native plugin UX:** Claude + Codex manifests are bundled here. Cursor / Windsurf / others follow
-  the same two files (a `plugin.json` + a `hooks.json`) pointed at the shared launcher.
+- **Native plugin UX:** Claude, Codex, Cursor, VS Code OpenPlugin, and opencode manifests are bundled
+  here.
 
 ## Testing
 
@@ -141,7 +189,15 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 
 # SessionStart hook through the launcher:
 printf '%s\n' '{"hook_event_name":"SessionStart","source":"startup"}' \
-  | RAG_RAT_BIN="$(command -v rag-rat)" node scripts/launch.js --no-install agent-hook
+  | RAG_RAT_BIN="$(command -v rag-rat)" node scripts/launch.js --no-install agent-hook auto
+
+# Cursor native event:
+printf '%s\n' '{"hook_event_name":"sessionStart","workspace_roots":["."]}' \
+  | RAG_RAT_BIN="$(command -v rag-rat)" node scripts/launch.js --no-install agent-hook cursor
+
+# VS Code Preview event:
+printf '%s\n' '{"hook_event_name":"SessionStart","source":"new","cwd":"."}' \
+  | RAG_RAT_BIN="$(command -v rag-rat)" node scripts/launch.js --no-install agent-hook vscode
 ```
 
 Verified: launcher syntax; `$RAG_RAT_BIN` override; `PATH` version-match; `--no-install` cold-cache
@@ -167,7 +223,7 @@ Remaining:
 - **Plugin version tracks the release (automated).** The launcher fetches
   `releases/download/v<plugin-version>`, so the manifests' `version` must match the released crate
   version. `.github/workflows/release-plz.yml` runs `tools/sync-plugin-version.mjs` on the Release PR
-  to bump all three manifests in lockstep with `Cargo.toml` — no manual step (proves out on the next
+  to bump every manifest in lockstep with `Cargo.toml` — no manual step (proves out on the next
   release). Aside: a release binary that carries a `+g<hash>` version suffix won't satisfy the strict
   PATH `--version` match, so the launcher downloads rather than reusing an on-PATH release build
   (correct, just not optimal).

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -79,8 +79,8 @@ unconfigured, unindexed, unavailable, or not yet present in the launcher's cache
 - `PreToolUse` on `Grep`/`Bash` (10s) → grep-augmentation.
 - `PreToolUse` on `Write`/`Edit`/`MultiEdit` (10s) → write-time clone check.
 - `PostToolUse` on successful edits → detached, watcher-aware scoped reindex.
-- The manifest has one dispatcher per lifecycle event. Irrelevant tools are filtered inside the
-  adapter rather than by matcher-only registration.
+- The manifest has one dispatcher per lifecycle event, with combined matchers preventing unrelated
+  tool calls from launching the hook process. The adapter still validates every payload it receives.
 
 **Codex** (`.codex-plugin/hooks/hooks.json`, `{"hooks":{…}}` wrapper):
 - `SessionStart` → repo orientation digest.

--- a/plugin/hooks.cursor.json
+++ b/plugin/hooks.cursor.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "node \"./scripts/launch.js\" --no-install agent-hook cursor",
+        "timeout": 5
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "node \"./scripts/launch.js\" --no-install agent-hook cursor",
+        "timeout": 10
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "node \"./scripts/launch.js\" --no-install agent-hook cursor",
+        "matcher": "Read|Write",
+        "timeout": 10
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "node \"./scripts/launch.js\" --no-install agent-hook cursor",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/plugin/hooks.vscode.json
+++ b/plugin/hooks.vscode.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "node \"${PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook vscode",
+        "timeout": 5
+      }
+    ],
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "node \"${PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook vscode",
+        "timeout": 10
+      }
+    ],
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "node \"${PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook vscode",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -9,6 +9,7 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "^(Grep|Read|Bash|Write|Edit|MultiEdit)$",
         "hooks": [
           { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook auto", "timeout": 10 }
         ]
@@ -16,6 +17,7 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [
           { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook auto", "timeout": 10 }
         ]

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,68 +1,23 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook auto", "timeout": 5 }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
-        "matcher": "Grep",
         "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
-        ]
-      },
-      {
-        "matcher": "Read",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
-        ]
-      },
-      {
-        "matcher": "Edit",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
-        ]
-      },
-      {
-        "matcher": "MultiEdit",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook auto", "timeout": 10 }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Write",
         "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
-        ]
-      },
-      {
-        "matcher": "Edit",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
-        ]
-      },
-      {
-        "matcher": "MultiEdit",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "startup|clear|compact",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook auto", "timeout": 10 }
         ]
       }
     ]

--- a/plugin/scripts/launch.js
+++ b/plugin/scripts/launch.js
@@ -89,7 +89,13 @@ if (process.env.RAG_RAT_BIN) {
 
 // ---- version = the plugin's declared version (single source of truth) -----------------------------
 function readVersion() {
-  for (const c of [path.join(pluginRoot, ".claude-plugin", "plugin.json"), path.join(pluginRoot, "plugin.json")]) {
+  for (const c of [
+    path.join(pluginRoot, ".claude-plugin", "plugin.json"),
+    path.join(pluginRoot, ".cursor-plugin", "plugin.json"),
+    path.join(pluginRoot, ".plugin", "plugin.json"),
+    path.join(pluginRoot, ".codex-plugin", "plugin.json"),
+    path.join(pluginRoot, "plugin.json"),
+  ]) {
     if (fs.existsSync(c)) {
       try {
         const v = JSON.parse(fs.readFileSync(c, "utf8")).version;

--- a/plugin/test/verify-launcher.sh
+++ b/plugin/test/verify-launcher.sh
@@ -26,11 +26,13 @@ pass "launcher syntax"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 printf '{"version":"0.0.0-none"}\n' > "$TMP/plugin.json"
-if env -u RAG_RAT_BIN PLUGIN_ROOT="$TMP" node "$LAUNCH" --no-install agent-hook </dev/null >/dev/null 2>&1; then
-  pass "--no-install no-op exits 0 (cold cache)"
-else
-  fail "--no-install did not exit 0 on a cold cache"
-fi
+for harness in auto cursor vscode; do
+  if env -u RAG_RAT_BIN PLUGIN_ROOT="$TMP" node "$LAUNCH" --no-install agent-hook "$harness" </dev/null >/dev/null 2>&1; then
+    pass "--no-install $harness hook exits 0 (cold cache)"
+  else
+    fail "--no-install $harness hook did not exit 0 on a cold cache"
+  fi
+done
 
 do_handshake=0
 [ -n "${RAG_RAT_BIN:-}" ] && do_handshake=1

--- a/tools/sync-plugin-version.mjs
+++ b/tools/sync-plugin-version.mjs
@@ -36,8 +36,11 @@ let changed = 0;
 // Require the exact count so a schema change cannot silently leave one stale.
 const VERSION_FILES = [
   [".claude-plugin/marketplace.json", 1],
+  [".cursor-plugin/marketplace.json", 1],
   ["plugin/.claude-plugin/plugin.json", 1],
   ["plugin/.codex-plugin/plugin.json", 1],
+  ["plugin/.cursor-plugin/plugin.json", 1],
+  ["plugin/.plugin/plugin.json", 1],
   ["plugin/opencode/package.json", 1],
   ["server.json", 2],
 ];


### PR DESCRIPTION
## Summary

- add explicit `cursor` and `vscode` agent-hook adapters while preserving existing Claude and Codex auto-detection
- normalize native hook payloads, emit bounded privacy-safe context, and scope edit-triggered reindexing to affected paths
- ship native Cursor and VS Code plugin manifests, cached launcher support, documentation, and version synchronization
- cover orientation, augmentation, privacy, malformed input, duplicate prevention, and edit reindex behavior with unit and end-to-end tests

## Verification

- `cargo nextest run -p rag-rat`
- `cargo clippy -p rag-rat --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `node tools/sync-plugin-version.mjs`
- `sh plugin/test/verify-launcher.sh`
- `git diff --check origin/main...HEAD`

Closes #986
Closes #987