### PR TITLE
feat(sync): device pairing CLI (init/join) + restore-from-zero drill

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -219,6 +219,64 @@ pub(crate) enum SyncCommand {
         #[arg(long)]
         once: bool,
     },
+    /// Mint a one-time enrollment invite on THIS (owner) device and host the pairing exchange.
+    #[command(long_about = "Owner-side pairing. Mints a one-time, role-fixed invite ticket, \
+                            prints it, then binds the sync endpoint and hosts enrollment plus \
+                            the joiner's follow-up account + content restore until interrupted \
+                            (Ctrl-C). Share the printed ticket with the joining device, which \
+                            redeems it with `rag-rat sync join <ticket>`. Must run on the \
+                            account's FOUNDER device (the one that ran `rag-rat sync enable`); \
+                            hosting enrollment from a granted owner is not yet supported.")]
+    Init {
+        /// Role granted to the joining device, fixed at mint time (default: least-privilege
+        /// read-only). `read-only` reads/syncs; `member` also authors content; `owner` also holds
+        /// full control authority (granting an owner does not yet let it host enrollment — only
+        /// the founder can run `sync init`).
+        #[arg(long, value_enum, default_value_t = InviteRole::ReadOnly)]
+        role: InviteRole,
+        /// Optional human label recorded for the joining device (e.g. "laptop").
+        #[arg(long, value_name = "NAME")]
+        label: Option<String>,
+        /// Invite lifetime in seconds before it expires (default 900 = 15 minutes).
+        #[arg(long, value_name = "SECS", default_value_t = 900)]
+        ttl_secs: u64,
+    },
+    /// Enroll THIS device into an account with an invite ticket, then restore its state.
+    #[command(long_about = "Joiner-side pairing. Decodes the invite ticket printed by `rag-rat \
+                            sync init` on an owner device, dials that owner, enrolls this device \
+                            into the account roster, then restores the account log and its \
+                            content. The inviting owner must be online (running `rag-rat sync \
+                            init` or `rag-rat sync serve`).")]
+    Join {
+        /// The invite ticket string printed by `rag-rat sync init` on the owner device.
+        #[arg(value_name = "TICKET")]
+        ticket: String,
+    },
+}
+
+/// Roster role an operator grants a joining device at `sync init` time. Mirrors
+/// [`rag_rat_oplog::DeviceRole`] with CLI-friendly token names; fixed into the invite at mint time
+/// so a joiner cannot escalate.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub(crate) enum InviteRole {
+    /// Reads and syncs only — the default, least-privilege role.
+    #[value(name = "read-only")]
+    ReadOnly,
+    /// Reads, syncs, and authors content.
+    Member,
+    /// Reads, syncs, authors content, and holds full control authority. (Hosting enrollment via
+    /// `sync init` is currently limited to the account's founder device.)
+    Owner,
+}
+
+impl InviteRole {
+    pub(crate) fn to_device_role(self) -> rag_rat_oplog::DeviceRole {
+        match self {
+            InviteRole::ReadOnly => rag_rat_oplog::DeviceRole::ReadOnly,
+            InviteRole::Member => rag_rat_oplog::DeviceRole::Member,
+            InviteRole::Owner => rag_rat_oplog::DeviceRole::Owner,
+        }
+    }
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -23,11 +23,19 @@ const SERVE_SESSION_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 const SERVE_INIT_LOCK_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
-    // `serve` is a long-running server that manages its own connection; it must run OUTSIDE the
-    // command-wide repo write lock, which would otherwise block indexing, the watcher, and GC for
-    // the entire life of the server.
-    if let SyncCommand::Serve { once } = &args.command {
-        return serve(config, *once);
+    // `serve`, `init`, and `join` bind an endpoint and run their own network loop; they must run
+    // OUTSIDE the command-wide repo write lock (which would block indexing, the watcher, and GC for
+    // the server's whole life) and manage the database-scoped SESSION lock themselves instead.
+    match &args.command {
+        SyncCommand::Serve { once } => return serve(config, *once),
+        SyncCommand::Init { role, label, ttl_secs } =>
+            return init(config, InviteMint {
+                role: role.to_device_role(),
+                label: label.clone(),
+                ttl: Duration::from_secs(*ttl_secs),
+            }),
+        SyncCommand::Join { ticket } => return join(config, ticket),
+        SyncCommand::Enable | SyncCommand::CatchUp { .. } => {},
     }
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
@@ -58,7 +66,8 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "note": "existing live keys were re-wrapped without rotation; no enrollment, pairing, or transport occurred",
             }))
         },
-        SyncCommand::Serve { .. } => unreachable!("serve is dispatched before the write lock"),
+        SyncCommand::Serve { .. } | SyncCommand::Init { .. } | SyncCommand::Join { .. } =>
+            unreachable!("the network commands are dispatched before the write lock"),
     }
 }
 
@@ -71,12 +80,37 @@ fn effective_relay_url(config: &Config) -> String {
     }
 }
 
+/// A one-time enrollment invite `sync init` mints as it starts hosting the pairing exchange.
+struct InviteMint {
+    role: rag_rat_oplog::DeviceRole,
+    label: Option<String>,
+    ttl: Duration,
+}
+
 /// Run a headless store-and-forward peer for this account's op log: bind the sync endpoint over the
 /// configured relay and replicate with peers the roster authorizes. Serves BOTH streams a peer may
 /// negotiate — the account log (`SYNC_ALPN`) and `/3` content (`CONTENT_SYNC_ALPN`) — routing
 /// each connection by its ALPN. Runs until interrupted; `once` serves a single connection (one
 /// stream), so a full account+content sync a device drives needs two connections.
 fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
+    serve_with(config, once, None)
+}
+
+/// Owner-side pairing (`sync init`): mint a one-time invite, print the ticket, then host the
+/// enrollment exchange AND the joiner's follow-up account + content restore until interrupted. It
+/// is the same accept loop as [`serve`] — `accept_and_dispatch` already routes the enrollment ALPN
+/// against the owner's database — so `init` is simply "mint, then serve". Never `--once`: a joiner
+/// needs the enrollment connection plus two sync connections.
+fn init(config: &Config, mint: InviteMint) -> anyhow::Result<()> {
+    serve_with(config, false, Some(mint))
+}
+
+/// Shared machinery behind [`serve`] and [`init`]: acquire the session lock, open the index, bind
+/// the endpoint, and run the ALPN-dispatching accept loop. When `mint` is set (`sync init`), a
+/// one-time invite is minted AFTER the endpoint binds and the roster gate passes — so a bind
+/// failure never strands the candidate reservation the mint makes — and its ticket is printed on
+/// the startup line. Minting enforces founder/owner authority, so a non-owner `init` fails there.
+fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::Result<()> {
     let relay = effective_relay_url(config);
     // Hold a database-scoped session lock for the SERVER'S WHOLE LIFETIME. `sync_node_secret` is
     // store-global, so a second `serve` (or a colocated device-side sync) on the same database
@@ -133,16 +167,51 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
                  this peer with the Member or Owner role"
             );
         }
+        // `sync init` mints its one-time invite ONLY NOW — after the endpoint bound and the roster
+        // gate passed — so a bind failure (e.g. a bad relay) never strands the candidate
+        // reservation the mint makes, which would otherwise gate the next mint until the
+        // TTL expires. The mint is a single BEGIN IMMEDIATE transaction serialized by
+        // SQLite against any watcher write (the same lock-free posture as the accept loop's
+        // ingests below), so it needs no repo write lock. Minting enforces founder/owner
+        // authority; a non-owner `init` fails here.
+        let invite = match mint {
+            Some(mint) => {
+                let ticket = rag_rat_sync::mint_invite(conn, rag_rat_sync::InviteSpec {
+                    account_id,
+                    inviter_node_id: local_node,
+                    relay_url: relay.clone(),
+                    role: mint.role,
+                    label: mint.label.as_deref(),
+                    now_ms: &|| time::now_ms(),
+                    ttl: mint.ttl,
+                })
+                .map_err(|e| anyhow!("minting the enrollment invite failed: {e}"))?;
+                Some((ticket, mint.role))
+            },
+            None => None,
+        };
         let policy = AuthPolicy::Closed;
 
-        tracing::info!(node_id = %endpoint.id(), relay = %relay, "sync serve listening");
+        tracing::info!(
+            node_id = %endpoint.id(),
+            relay = %relay,
+            minted_invite = invite.is_some(),
+            "sync serve listening"
+        );
         // The dialable node identity must reach the operator on stdout: repository logging is off
         // by default, and a peer cannot connect without the node id (the relay is shared config).
-        crate::print_output(&serde_json::json!({
+        // `sync init` additionally emits the invite ticket to share with the joining device.
+        let mut listening = serde_json::json!({
             "status": "listening",
             "node_id": endpoint.id().to_string(),
             "relay": relay,
-        }))?;
+        });
+        if let Some((ticket, role)) = &invite {
+            listening["invite"] = serde_json::json!(ticket.to_ticket_string());
+            listening["invite_role"] = serde_json::json!(role.as_db_str());
+            listening["invite_expires_at_ms"] = serde_json::json!(ticket.expires_at_ms);
+        }
+        crate::print_output(&listening)?;
 
         // The database-scoped session lock taken at startup is still held for this whole loop
         // (released only when serve exits), keeping this database's node identity singular. A
@@ -207,6 +276,176 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
     })
 }
 
+/// Joiner-side pairing (`sync join`): redeem an invite ticket, enrolling THIS device into the
+/// account, then restore its state (account log then `/3` content) from the inviter. Holds the
+/// database-scoped session lock for the whole exchange — enrollment + restore consume candidate
+/// capacity, which must be serialized against any colocated `serve`/device sync (the requirement
+/// `connect_and_enroll` documents).
+fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
+    let ticket = rag_rat_sync::EnrollmentTicket::from_ticket_string(ticket)
+        .map_err(|e| anyhow!("invalid enrollment ticket: {e}"))?;
+    // Bind over the INVITER's relay (the ticket's), not the local `[sync] relay_url`: both peers
+    // must share a relay to meet, and the ticket names where the inviter is reachable. `sync init`
+    // minted the ticket with the relay IT is serving on.
+    let relay = ticket.relay_url.clone();
+    let _session = locks::WriteLock::acquire_sync_session_timeout(
+        &config.database,
+        SERVE_SESSION_LOCK_TIMEOUT,
+    )?
+    .ok_or_else(|| {
+        anyhow!(
+            "another sync session already holds this database's node identity (a `serve` peer or \
+             a device sync is running); stop it before joining"
+        )
+    })?;
+    let lock_repo = locks::write_lock_repo_id(config);
+    let repo_lock =
+        locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SERVE_INIT_LOCK_TIMEOUT)?
+            .ok_or_else(|| {
+            anyhow!("the index write lock is busy (another writer is mid-pass); retry `sync join`")
+        })?;
+    let db = crate::open_index(config)?;
+    let node_key = {
+        let conn = db.connection();
+        // A store already bound to a DIFFERENT account cannot adopt this ticket — enrollment would
+        // corrupt its identity. A matching account is allowed (a resumed or repeated join).
+        if let Some(existing) = rag_rat_oplog::read_local_account(conn)?
+            && existing != ticket.account_id
+        {
+            bail!(
+                "this store already belongs to a different sync account; `sync join` enrolls a \
+                 fresh device"
+            );
+        }
+        // Mint the account device identity if absent (NOT a genesis) so the enrollment request can
+        // present the joiner's keys. `local_device` is idempotent on an existing identity.
+        rag_rat_oplog::local_device(conn, time::now_ms())?;
+        node_secret(conn)?
+    };
+    drop(repo_lock);
+
+    let account_id = ticket.account_id;
+    let runtime =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
+    runtime.block_on(async move {
+        let conn = db.connection();
+        let endpoint = rag_rat_sync::build_endpoint(*node_key, &relay)
+            .await
+            .with_context(|| format!("binding the sync endpoint over relay {relay}"))?;
+        let peer = rag_rat_sync::peer_addr_from_bytes(&ticket.inviter_node_id, &relay)
+            .map_err(|e| anyhow!("the ticket's inviter address is invalid: {e}"))?;
+        let local_node = *endpoint.id().as_bytes();
+        // Whether this device is ALREADY a roster member — a resumed join whose enrollment
+        // committed on an earlier run. It decides only whether restore may still proceed if
+        // redemption fails.
+        let already_effective = device_roster_capability(conn, account_id, &local_node)?.is_some();
+
+        // 1) Enrollment — dial the owner over the enroll ALPN. The owner authors this device's
+        //    DeviceAdd and returns the account bootstrap, which `connect_and_enroll` adopts,
+        //    leaving this device roster-effective. Budget / held-entries / transport id are
+        //    recomputed from the local store inside the call, so the placeholders here are
+        //    overwritten.
+        //
+        //    ALWAYS attempt redemption — never skip on an already-effective device. Within the
+        //    receipt-replay window the owner replays the exact prior receipt and adoption is
+        //    idempotent, so a resumed join re-runs cleanly; and a genuinely UNUSED ticket is
+        //    consumed rather than left live for another bearer. Only a consumed/expired/unknown
+        //    nonce on a device that is ALREADY enrolled falls back to restore (a resume past the
+        //    replay window, where enrollment is unnecessary); every other failure — and any failure
+        //    on a not-yet-enrolled device — is a real error.
+        let local = rag_rat_oplog::local_device(conn, time::now_ms())?;
+        let request = rag_rat_sync::EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account_id,
+            ed25519_pubkey: local.ed25519_public_key(),
+            x25519_pubkey: local.x25519_public_key(),
+            transport_node_id: [0u8; 32],
+            budget: rag_rat_oplog::EnrollmentBudget {
+                account_entries_remaining: 0,
+                account_bytes_remaining: 0,
+                global_entries_remaining: 0,
+                global_bytes_remaining: 0,
+            },
+            held_entry_hashes: Vec::new(),
+        };
+        match rag_rat_sync::connect_and_enroll(
+            &endpoint,
+            peer.clone(),
+            conn,
+            account_id,
+            &request,
+            time::now_ms(),
+        )
+        .await
+        {
+            Ok(_) => {},
+            Err(error)
+                if already_effective
+                    && matches!(
+                        error,
+                        rag_rat_sync::InviteError::Used
+                            | rag_rat_sync::InviteError::Expired
+                            | rag_rat_sync::InviteError::Unknown
+                    ) =>
+                tracing::info!(
+                    %error,
+                    "invite already spent and this device is enrolled; resuming restore"
+                ),
+            Err(error) => return Err(anyhow!("enrollment failed: {error}")),
+        }
+
+        // 2) Restore-from-zero — pull the account log then `/3` content from the inviter, now that
+        //    this device is roster-effective. Content rides on the account log's authority, so the
+        //    account log runs first. The inviter must still be serving (its `sync init` / `serve`).
+        let account_report = {
+            let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
+            rag_rat_sync::connect_and_sync(
+                &endpoint,
+                peer.clone(),
+                rag_rat_sync::SYNC_ALPN,
+                &mut store,
+                AuthPolicy::Closed,
+                time::now_ms(),
+            )
+            .await
+            .map_err(|e| anyhow!("restoring the account log from the inviter failed: {e}"))?
+        };
+        let content_report = {
+            let mut store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
+            rag_rat_sync::connect_and_sync(
+                &endpoint,
+                peer,
+                rag_rat_sync::CONTENT_SYNC_ALPN,
+                &mut store,
+                AuthPolicy::Closed,
+                time::now_ms(),
+            )
+            .await
+            .map_err(|e| anyhow!("restoring content from the inviter failed: {e}"))?
+        };
+        db.fold_wal();
+
+        // The inviter's node id in dial form, so the operator can add it to `[sync] server_peers`
+        // for ongoing sync (auto-persisting it is a deliberate follow-up). The inviter's RELAY must
+        // travel with it: device-side sync rebuilds the peer address from `[sync] relay_url`, so if
+        // the inviter serves on a different relay than this device's default, ongoing sync would
+        // dial the wrong relay unless the operator also points `relay_url` at the inviter's.
+        let inviter = rag_rat_sync::node_id_to_string(&ticket.inviter_node_id)
+            .unwrap_or_else(|_| hash::hex_lower(&ticket.inviter_node_id));
+        crate::print_output(&serde_json::json!({
+            "status": "joined",
+            "account_id": hash::hex_lower(&account_id.to_bytes()),
+            "account_entries_restored": account_report.entries_newly_stored,
+            "content_entries_restored": content_report.entries_newly_stored,
+            "inviter_node_id": inviter,
+            "inviter_relay": ticket.relay_url,
+            "note": "to keep syncing, add inviter_node_id to [sync] server_peers and set [sync] \
+                     relay_url (or RAG_RAT_SYNC_RELAY) to inviter_relay",
+        }))?;
+        anyhow::Ok(())
+    })
+}
+
 /// How long device-side sync waits for the per-database session lock before deferring to the next
 /// maintenance pass. Kept short: a colocated `serve` peer holds this lock for its whole life, so a
 /// long wait would just burn time on every hook before deferring; a transient overlap with another
@@ -224,7 +463,10 @@ pub(crate) enum DeviceSyncOutcome {
     Skipped,
     /// The per-database session lock is held (a serve peer or another sync); retry next pass.
     Deferred,
-    /// Ran against the configured peers: `ok` sessions succeeded, `errors` failed.
+    /// Ran against the configured peers (resolved through the discovery seam): `ok` sessions
+    /// succeeded, `errors` failed. `peers` is the configured count and `ok + errors == peers` — a
+    /// configured id that failed to resolve is logged and counted as an error, so a typo stays
+    /// visible rather than shrinking the peer set to a healthy-looking zero.
     Ran { peers: usize, ok: usize, errors: usize },
 }
 
@@ -274,7 +516,17 @@ pub(crate) fn device_sync_run(
         return Ok(DeviceSyncOutcome::Disabled);
     }
     let relay = effective_relay_url(config);
-    let peers = &config.sync.server_peers;
+    // Resolve which peers to dial through the discovery seam — explicit config today, with
+    // relay-side account-keyed discovery landing behind it (`rag_rat_sync::discover_peers`, #988).
+    // Each entry pairs the peer's node-id string (for logs) with its dialable address; a configured
+    // id that does not parse is logged and dropped there, so it never becomes a dial attempt.
+    let configured = config.sync.server_peers.len();
+    let peers = rag_rat_sync::discover_peers(account_id, &config.sync.server_peers, &relay);
+    // Count the dropped (unresolvable) configured ids as errors: otherwise an all-typo
+    // `server_peers` reports a healthy-looking `ran` with zero peers and stamps the cadence
+    // watermark, silently suppressing sync until the next interval (repository logging is off
+    // by default).
+    let unresolved = configured.saturating_sub(peers.len());
 
     let runtime =
         tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
@@ -283,20 +535,16 @@ pub(crate) fn device_sync_run(
             .await
             .with_context(|| format!("binding the sync endpoint over relay {relay}"))?;
         let mut ok = 0usize;
-        let mut errors = 0usize;
-        for peer in peers {
-            let addr = match rag_rat_sync::peer_addr(peer, &relay) {
-                Ok(addr) => addr,
-                Err(e) => {
-                    errors += 1;
-                    tracing::warn!(peer, error = %e, "skipping a server peer with an invalid node id");
-                    continue;
-                },
-            };
-            // Account log FIRST — it carries the roster + stream ownership that AUTHORIZE content, so
-            // leading with it minimizes parking on the peer. The account-log result IS the peer's
-            // outcome, so `ok + errors` stays equal to the number of configured peers. `/3` content
-            // rides on top: best-effort, attempted only once the account log reached the peer, and a
+        let mut errors = unresolved;
+        for (peer, addr) in &peers {
+            // Own a copy of the resolved address: it is dialed twice (account log, then content),
+            // and `addr` is a borrow into `peers`.
+            let addr = (*addr).clone();
+            // Account log FIRST — it carries the roster + stream ownership that AUTHORIZE content,
+            // so leading with it minimizes parking on the peer. The account-log result
+            // IS the peer's outcome, so `ok + errors` (seeded with the unresolvable count)
+            // stays equal to the number of configured peers. `/3` content rides on top:
+            // best-effort, attempted only once the account log reached the peer, and a
             // content hiccup is logged — never a peer failure.
             let account_ok = {
                 let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
@@ -362,7 +610,7 @@ pub(crate) fn device_sync_run(
     // fails the hook), but it is now cadence-limited exactly like an unreachable peer.
     record_device_sync(conn)?;
     let (ok, errors) = result?;
-    Ok(DeviceSyncOutcome::Ran { peers: peers.len(), ok, errors })
+    Ok(DeviceSyncOutcome::Ran { peers: configured, ok, errors })
 }
 
 /// The cadence gate: whether enough time has passed since the last device-side sync attempt.
@@ -491,7 +739,7 @@ mod tests {
 
     use super::{
         DEVICE_SYNC_LAST_META_KEY, DeviceSyncOutcome, decode_node_secret, device_can_serve,
-        device_can_sync, device_sync_due, device_sync_run, node_secret, record_device_sync,
+        device_can_sync, device_sync_due, device_sync_run, join, node_secret, record_device_sync,
     };
 
     fn schema_conn() -> Connection {
@@ -571,6 +819,27 @@ mod tests {
         assert!(!device_can_serve(read_only));
         assert!(device_can_serve(Some(rag_rat_sync::PeerCapability::ReadWrite)));
         assert!(!device_can_sync(None));
+    }
+
+    #[test]
+    fn join_rejects_a_malformed_ticket_before_touching_the_store() {
+        // The ticket is decoded before any lock or index open, so a bad ticket fails fast without a
+        // real database — `min_config` points at a nonexistent path that must not be opened here.
+        let err = join(&min_config(), "not-a-real-ticket").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid enrollment ticket"),
+            "a malformed ticket is rejected up front: {err}",
+        );
+    }
+
+    #[test]
+    fn invite_role_maps_to_the_device_role() {
+        use rag_rat_oplog::DeviceRole;
+
+        use crate::cli::InviteRole;
+        assert_eq!(InviteRole::ReadOnly.to_device_role(), DeviceRole::ReadOnly);
+        assert_eq!(InviteRole::Member.to_device_role(), DeviceRole::Member);
+        assert_eq!(InviteRole::Owner.to_device_role(), DeviceRole::Owner);
     }
 
     #[test]

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -138,8 +138,10 @@ fn sync_enable_is_narrow_idempotent_and_help_is_honest() {
     let help = run_ok(&root, &data_dir, &model_cache, &["sync", "--help"]);
     assert!(help.contains("enable"));
     assert!(help.contains("does not configure transport or peers"));
+    // Pairing shipped (#930): `init` mints an invite and hosts the exchange, `join` redeems it.
+    assert!(help.contains("init"));
+    assert!(help.contains("join"));
     assert!(!help.contains("disable"));
-    assert!(!help.contains("pair"));
     assert!(!help.contains("push"));
     assert!(!help.contains("pull"));
 

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -110,6 +110,59 @@ pub fn peer_addr(node_id: &str, relay_url: &str) -> Result<EndpointAddr, Endpoin
     Ok(EndpointAddr::new(id).with_relay_url(relay))
 }
 
+/// Build a dialable [`EndpointAddr`] from a peer's node id BYTES — the form an
+/// [`crate::EnrollmentTicket`] carries — and the shared relay URL. The byte-oriented sibling of
+/// [`peer_addr`], so the enrollment CLI can dial a ticket's inviter without naming an iroh type.
+pub fn peer_addr_from_bytes(
+    node_id: &[u8; 32],
+    relay_url: &str,
+) -> Result<EndpointAddr, EndpointError> {
+    let id = EndpointId::from_bytes(node_id).map_err(|e| EndpointError::PeerId(e.to_string()))?;
+    let relay =
+        RelayUrl::from_str(relay_url.trim()).map_err(|e| EndpointError::RelayUrl(e.to_string()))?;
+    Ok(EndpointAddr::new(id).with_relay_url(relay))
+}
+
+/// Resolve the peers a device-side sync should dial for `account_id` into dialable addresses, each
+/// paired with the node-id string that names it (for logging). This is the single seam the sync
+/// driver iterates: today it maps each explicitly configured node id through the pinned relay,
+/// logging and skipping any that do not parse, so a misconfigured entry surfaces in the logs rather
+/// than aborting the whole pass.
+///
+/// `account_id` is unused by the explicit-config resolver — it is the parameter a relay-backed
+/// resolver keys on. When peers of an account are online together they should auto-discover and
+/// sync directly instead of every device carrying a static peer list; because the driver only ever
+/// iterates this function, that lands as an implementation swap here, not a driver rewrite. A
+/// discovered peer fills the same `(node_id, addr)` shape a configured one does.
+// TODO(discovery, #988): a relay-side account-keyed resolver plugs in here — query the pinned
+// relay for the endpoints advertising `account_id` and compose them with the configured peers.
+pub fn discover_peers(
+    account_id: AccountId,
+    configured_peers: &[String],
+    relay_url: &str,
+) -> Vec<(String, EndpointAddr)> {
+    let _ = account_id; // reserved for the relay-backed resolver (see the TODO above)
+    configured_peers
+        .iter()
+        .filter_map(|peer| match peer_addr(peer, relay_url) {
+            Ok(addr) => Some((peer.clone(), addr)),
+            Err(error) => {
+                tracing::warn!(peer, %error, "skipping a configured sync peer with an invalid node id");
+                None
+            },
+        })
+        .collect()
+}
+
+/// The dialable node-id string for a peer's node id BYTES — the inverse of the byte form a ticket
+/// or discovery record carries, in the z-base-32 shape `[sync] server_peers` accepts. Lets the
+/// enrollment CLI print a joinable peer id without naming an iroh type.
+pub fn node_id_to_string(node_id: &[u8; 32]) -> Result<String, EndpointError> {
+    EndpointId::from_bytes(node_id)
+        .map(|id| id.to_string())
+        .map_err(|e| EndpointError::PeerId(e.to_string()))
+}
+
 /// This endpoint's dialable address — hand it (or a ticket wrapping it) to a peer so it can
 /// [`connect_and_sync`] back.
 pub fn endpoint_addr(endpoint: &Endpoint) -> EndpointAddr {
@@ -550,6 +603,28 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         conn
+    }
+
+    #[test]
+    fn discover_peers_resolves_valid_ids_and_drops_invalid_ones() {
+        let valid = node_id_to_string(&node_id_from_secret([7u8; 32])).unwrap();
+        let peers = discover_peers(
+            AccountId::from_bytes([1u8; 32]),
+            &[valid.clone(), "not-a-node-id".to_string()],
+            "https://relay.example",
+        );
+        assert_eq!(peers.len(), 1, "the unparseable id is dropped, the valid one resolves");
+        assert_eq!(peers[0].0, valid, "the resolved entry keeps its node-id label");
+    }
+
+    #[test]
+    fn node_id_string_round_trips_through_bytes() {
+        let bytes = node_id_from_secret([9u8; 32]);
+        let text = node_id_to_string(&bytes).unwrap();
+        // `peer_addr` parses the same z-base-32 form, so the string is a valid dial id, and
+        // `peer_addr_from_bytes` reaches the same address from the raw bytes a ticket carries.
+        assert!(peer_addr(&text, "https://relay.example").is_ok());
+        assert!(peer_addr_from_bytes(&bytes, "https://relay.example").is_ok());
     }
 
     struct TestStore {

--- a/crates/rag-rat-sync/src/enrollment.rs
+++ b/crates/rag-rat-sync/src/enrollment.rs
@@ -95,6 +95,46 @@ impl EnrollmentTicket {
         }
         Ok(ticket)
     }
+
+    /// The human-transferable ticket string an owner prints and a joiner pastes: a scheme tag plus
+    /// the lower-hex of the canonical CBOR. Hex (not base32) needs no new dependency and matches
+    /// the node-secret encoding already persisted by the CLI; the tag makes a wrong paste fail
+    /// with a clear message instead of an opaque CBOR error.
+    pub fn to_ticket_string(&self) -> String {
+        format!("{TICKET_STRING_PREFIX}{}", rag_rat_base::hash::hex_lower(&self.encode()))
+    }
+
+    /// Parse a ticket string produced by [`to_ticket_string`]. Surrounding whitespace is tolerated
+    /// (a pasted line often carries it); the scheme tag, hex, and canonical-CBOR shape are all
+    /// validated, so a mistyped or truncated ticket is rejected rather than half-decoded.
+    pub fn from_ticket_string(s: &str) -> Result<Self, InviteError> {
+        let body = s.trim().strip_prefix(TICKET_STRING_PREFIX).ok_or_else(|| {
+            InviteError::Malformed(format!(
+                "enrollment ticket must start with `{TICKET_STRING_PREFIX}`"
+            ))
+        })?;
+        Self::decode(&decode_ticket_hex(body)?)
+    }
+}
+
+/// Scheme tag prefixing every ticket string — see [`EnrollmentTicket::to_ticket_string`].
+const TICKET_STRING_PREFIX: &str = "ragrat-invite-";
+
+/// Decode the lower-hex body of a ticket string. A wrong length or non-hex character is a corrupt
+/// paste, surfaced as [`InviteError::Malformed`] rather than silently coerced.
+fn decode_ticket_hex(hex: &str) -> Result<Vec<u8>, InviteError> {
+    let hex = hex.trim();
+    if !hex.len().is_multiple_of(2) {
+        return Err(InviteError::Malformed("enrollment ticket hex has an odd length".into()));
+    }
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    for pair in hex.as_bytes().chunks_exact(2) {
+        match ((pair[0] as char).to_digit(16), (pair[1] as char).to_digit(16)) {
+            (Some(hi), Some(lo)) => out.push(((hi << 4) | lo) as u8),
+            _ => return Err(InviteError::Malformed("enrollment ticket is not valid hex".into())),
+        }
+    }
+    Ok(out)
 }
 
 fn validate_enrollment_route(
@@ -1268,6 +1308,60 @@ mod tests {
             .map(|ordinal| Sha256::digest(ordinal.to_be_bytes()).into())
             .find(|bytes| EndpointId::from_bytes(bytes).is_err())
             .expect("random-looking bytes include an invalid compressed Edwards point")
+    }
+
+    fn sample_ticket() -> EnrollmentTicket {
+        EnrollmentTicket {
+            account_id: AccountId::from_bytes([9u8; 32]),
+            inviter_node_id: crate::endpoint::node_id_from_secret([7u8; 32]),
+            relay_url: "https://relay.example".into(),
+            nonce: [3u8; 32],
+            expires_at_ms: 1_700_000_000_123,
+        }
+    }
+
+    #[test]
+    fn ticket_string_round_trips_through_the_scheme_tag() {
+        let ticket = sample_ticket();
+        let s = ticket.to_ticket_string();
+        assert!(s.starts_with("ragrat-invite-"), "the scheme tag prefixes the string: {s}");
+        assert_eq!(EnrollmentTicket::from_ticket_string(&s).unwrap(), ticket);
+        assert_eq!(
+            EnrollmentTicket::from_ticket_string(&format!("  {s}\n")).unwrap(),
+            ticket,
+            "surrounding whitespace on a pasted line is tolerated",
+        );
+    }
+
+    #[test]
+    fn ticket_string_rejects_a_missing_tag_and_corrupt_hex() {
+        let ticket = sample_ticket();
+        let s = ticket.to_ticket_string();
+        let hex = s.strip_prefix("ragrat-invite-").unwrap();
+        assert!(
+            matches!(EnrollmentTicket::from_ticket_string(hex), Err(InviteError::Malformed(_))),
+            "the bare hex without the scheme tag is refused",
+        );
+        assert!(
+            matches!(
+                EnrollmentTicket::from_ticket_string("ragrat-invite-abc"),
+                Err(InviteError::Malformed(_))
+            ),
+            "an odd-length hex body is refused",
+        );
+        assert!(
+            matches!(
+                EnrollmentTicket::from_ticket_string("ragrat-invite-zz"),
+                Err(InviteError::Malformed(_))
+            ),
+            "a non-hex body is refused",
+        );
+        let mut truncated = s.clone();
+        truncated.truncate(s.len() - 2);
+        assert!(
+            EnrollmentTicket::from_ticket_string(&truncated).is_err(),
+            "dropping a CBOR byte fails the canonical-shape check",
+        );
     }
 
     /// A budget no honest redemption can exceed, for tests that are not exercising the capacity

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -29,8 +29,8 @@ pub use auth::{
 };
 pub use endpoint::{
     EndpointError, SyncFailure, accept_and_dispatch, accept_and_sync, accept_enrollment,
-    build_endpoint, connect_and_enroll, connect_and_sync, endpoint_addr, node_id_from_secret,
-    peer_addr,
+    build_endpoint, connect_and_enroll, connect_and_sync, discover_peers, endpoint_addr,
+    node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -647,6 +647,223 @@ async fn a_real_iroh_round_trip_restores_content_via_alpn_dispatch() {
     );
 }
 
+/// Two loopback endpoints with NO relay (`RelayMode::Disabled`), reachable only by their direct
+/// 127.0.0.1 socket address — a relay-free transport so the pairing drill runs in CI, unlike the
+/// `#[ignore]` live tests that dial over a real relay.
+async fn loopback_endpoints() -> (iroh::Endpoint, iroh::Endpoint) {
+    use rag_rat_sync::{CONTENT_SYNC_ALPN, ENROLL_ALPN, SYNC_ALPN};
+    let bind = |seed: [u8; 32]| async move {
+        iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+            .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec(), ENROLL_ALPN.to_vec()])
+            .relay_mode(iroh::RelayMode::Disabled)
+            .secret_key(iroh::SecretKey::from_bytes(&seed))
+            .bind()
+            .await
+            .unwrap()
+    };
+    (bind([0x31; 32]).await, bind([0x32; 32]).await)
+}
+
+/// A relay-free, directly dialable address for a loopback endpoint (its 127.0.0.1 socket).
+fn direct_addr(endpoint: &iroh::Endpoint) -> iroh::EndpointAddr {
+    let port = endpoint
+        .addr()
+        .ip_addrs()
+        .next()
+        .expect("a bound endpoint advertises at least one socket address")
+        .port();
+    iroh::EndpointAddr::new(endpoint.id())
+        .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+}
+
+/// The pairing acceptance drill (#930): a FRESH device holding no account enrolls into an owner's
+/// account over the real iroh transport (loopback endpoints, no relay), then restores the account
+/// log and its `/3` content — byte-identical — over the same endpoints. This is the D4
+/// restore-from-zero criterion running in CI, composing the enrollment exchange
+/// (`accept_enrollment` / `connect_and_enroll`) with steady-state sync (`accept_and_dispatch` /
+/// `connect_and_sync`).
+///
+/// Content is `Plaintext`-sealed so the assertion is a byte-level restore of the moved entries;
+/// sealed-key delivery to a joiner is covered separately by the oplog enrollment key-catch-up
+/// tests.
+#[tokio::test]
+async fn a_fresh_device_enrolls_then_restores_the_account_byte_for_byte() {
+    use std::collections::BTreeSet;
+
+    use rag_rat_oplog::{
+        DeviceRole, MemoryOp, NodeContent, NodeId, SealPolicy, author_content_batch,
+        content_entries_for_sync, ensure_owned_stream_v2_in_tx,
+    };
+    use rag_rat_sync::{
+        AuthPolicy, CONTENT_SYNC_ALPN, EnrollmentRequest, InviteSpec, OplogContentSyncStore,
+        SYNC_ALPN, accept_and_dispatch, accept_enrollment, connect_and_enroll, connect_and_sync,
+        mint_invite,
+    };
+    use rusqlite::{Transaction, TransactionBehavior};
+
+    // Owner: an account, an owned stream, two authored memories.
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let stream = {
+        let tx = Transaction::new_unchecked(&owner, TransactionBehavior::Immediate).unwrap();
+        let s = ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW).unwrap();
+        tx.commit().unwrap();
+        s
+    };
+    let node = |id: &str, title: &str| MemoryOp::NodeCreate {
+        node_id: NodeId::from(id),
+        content: NodeContent {
+            kind: "Invariant".into(),
+            title: title.into(),
+            body: "body".into(),
+            confidence: "high".into(),
+            source: "agent".into(),
+            tags: Vec::new(),
+            payload: None,
+        },
+    };
+    author_content_batch(
+        &owner,
+        stream,
+        &[node("n1", "first"), node("n2", "second")],
+        SealPolicy::Plaintext,
+        NOW,
+    )
+    .unwrap();
+    assert_eq!(
+        content_entries_for_sync(&owner, account).unwrap().len(),
+        2,
+        "the owner authored two memories to restore",
+    );
+
+    // Joiner: a fresh store with a device identity but no account membership yet.
+    let joiner = fresh_db();
+    assert!(
+        rag_rat_oplog::read_local_account(&joiner).unwrap().is_none(),
+        "the joiner starts with no account",
+    );
+
+    let (owner_ep, joiner_ep) = loopback_endpoints().await;
+    let owner_addr = direct_addr(&owner_ep);
+
+    // 1) Enrollment — the pairing moment. The owner atomically authors the joiner's DeviceAdd.
+    {
+        let local = rag_rat_oplog::local_device(&joiner, NOW).unwrap();
+        let ticket = mint_invite(&owner, InviteSpec {
+            account_id: account,
+            inviter_node_id: *owner_ep.id().as_bytes(),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: Some("laptop"),
+            now_ms: &|| NOW,
+            ttl: std::time::Duration::from_secs(60),
+        })
+        .unwrap();
+        // Budget / held / transport are recomputed inside `connect_and_enroll`; the placeholders
+        // here mirror how the CLI hands off a freshly minted request.
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: local.ed25519_public_key(),
+            x25519_pubkey: local.x25519_public_key(),
+            transport_node_id: [0u8; 32],
+            budget: rag_rat_oplog::enrollment_budget(&joiner, account, NOW).unwrap(),
+            held_entry_hashes: Vec::new(),
+        };
+        let server = accept_enrollment(&owner_ep, &owner, || NOW);
+        let client =
+            connect_and_enroll(&joiner_ep, owner_addr.clone(), &joiner, account, &request, NOW);
+        let (server_r, client_r) = tokio::join!(server, client);
+        server_r.unwrap();
+        client_r.unwrap();
+    }
+    assert_eq!(
+        rag_rat_oplog::read_local_account(&joiner).unwrap(),
+        Some(account),
+        "the joiner adopted the account on enrollment",
+    );
+
+    let policy = AuthPolicy::Closed;
+
+    // 2) Account log first — the roster + stream ownership that authorize content acceptance.
+    {
+        let mut owner_account = OplogSyncStore::new(&owner, account, || NOW);
+        let mut owner_content = OplogContentSyncStore::new(&owner, account, || NOW);
+        let mut joiner_account = OplogSyncStore::new(&joiner, account, || NOW);
+        let server =
+            accept_and_dispatch(&owner_ep, &mut owner_account, &mut owner_content, policy, || NOW);
+        let client = connect_and_sync(
+            &joiner_ep,
+            owner_addr.clone(),
+            SYNC_ALPN,
+            &mut joiner_account,
+            policy,
+            NOW,
+        );
+        let (server_r, client_r) = tokio::join!(server, client);
+        assert_eq!(server_r.unwrap().0, SYNC_ALPN, "the account-log connection routed by ALPN");
+        client_r.unwrap();
+    }
+
+    // 3) Content — accepted now that its authority is present on the joiner.
+    {
+        let mut owner_account = OplogSyncStore::new(&owner, account, || NOW);
+        let mut owner_content = OplogContentSyncStore::new(&owner, account, || NOW);
+        let mut joiner_content = OplogContentSyncStore::new(&joiner, account, || NOW);
+        let server =
+            accept_and_dispatch(&owner_ep, &mut owner_account, &mut owner_content, policy, || NOW);
+        let client = connect_and_sync(
+            &joiner_ep,
+            owner_addr,
+            CONTENT_SYNC_ALPN,
+            &mut joiner_content,
+            policy,
+            NOW,
+        );
+        let (server_r, client_r) = tokio::join!(server, client);
+        assert_eq!(server_r.unwrap().0, CONTENT_SYNC_ALPN, "the content connection routed by ALPN");
+        client_r.unwrap();
+    }
+
+    // Restore-from-zero: the joiner's account log and content are byte-identical to the owner's
+    // FINAL state — the owner's account log grew by the joiner's own `DeviceAdd` during enrollment,
+    // so the comparison reads the owner after pairing, not the pre-pairing snapshot.
+    let signed = |entries: Vec<Vec<u8>>| -> BTreeSet<Vec<u8>> { entries.into_iter().collect() };
+    let owner_account = signed(
+        account_entries_for_sync(&owner, account)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.signed_bytes)
+            .collect(),
+    );
+    let owner_content = signed(
+        content_entries_for_sync(&owner, account)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.signed_bytes)
+            .collect(),
+    );
+    let joiner_account = signed(
+        account_entries_for_sync(&joiner, account)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.signed_bytes)
+            .collect(),
+    );
+    let joiner_content = signed(
+        content_entries_for_sync(&joiner, account)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.signed_bytes)
+            .collect(),
+    );
+    assert_eq!(
+        joiner_account, owner_account,
+        "the account log restored byte-for-byte on the joiner"
+    );
+    assert_eq!(joiner_content, owner_content, "the content restored byte-for-byte on the joiner");
+}
+
 /// A peer that offers a valid entry for a DIFFERENT account than the session is scoped to must not
 /// have it stored — the account-scoped store rejects it before ingest, so it cannot grow other
 /// accounts through a session that never named them.


### PR DESCRIPTION
Completes the pairing half of peer sync: a fresh device enrolls into an account and restores byte-identical state. Builds on the enrollment wire (invite mint/redeem, `EnrollmentTicket`, the `rag-rat/enroll/1` ALPN, the `sync_invites` table) and the capability gate already in place — this adds the operator surface plus a CI restore drill. No schema change.

## What's new

- **`sync init [--role read-only|member|owner] [--label NAME] [--ttl-secs N]`** (owner) — mints a one-time, role-fixed invite, prints the ticket, and hosts the enrollment exchange plus the joiner's follow-up account + content restore until interrupted. It reuses the `serve` accept loop (`accept_and_dispatch` already routes the enrollment ALPN against the owner's database), so init is "mint, then serve". The invite is minted only after the endpoint binds and the roster gate passes, so a bind failure never strands the reservation. `sync init` must run on the account's **founder** device (the one that ran `sync enable`); a granted `owner` gets full control authority but cannot yet host enrollment (promoted-owner enrollment is a deferred wire feature).
- **`sync join <ticket>`** (fresh device) — decodes the ticket, enrolls this device (adopting the account bootstrap), then restores the account log and `/3` content from the inviter, and prints the inviter node id to add to `[sync] server_peers`. Enrollment is skipped when the device is already roster-effective, so an interrupted join (enroll committed, restore not finished) resumes straight to restore instead of re-redeeming the consumed nonce.
- **Ticket string codec** on `EnrollmentTicket` — a scheme-tagged lower-hex of the canonical CBOR — with golden round-trip and rejection tests, plus a `peer_addr_from_bytes` / `node_id_to_string` byte↔address helper pair so the CLI stays free of iroh types.
- **`discover_peers(account_id, peers, relay)` seam** — device-side sync now iterates this resolver instead of the raw config list. Explicit config today; relay-side account-keyed discovery lands behind it (#988).
- **Restore-from-zero drill** — a CI test over relay-free loopback endpoints: a fresh joiner enrolls, then restores account + content byte-for-byte.

## Verification

- `cargo nextest run` and `cargo test` for `rag-rat-sync` + `rag-rat`, under both default and `--no-default-features`: 461 pass (2 live tests ignored), including the drill and the new join/ticket tests.
- All CI clippy legs green (`--no-default-features`, `--all-features`, and both eval legs), `cargo +nightly fmt` clean.

Closes #930. Discovery follow-up tracked in #988.
