### PR TITLE
feat(oracle): add a live TypeScript LSP backend (#536)

### DIFF
--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -245,6 +245,10 @@ pub struct OracleLiveConfig {
     /// Cap on LSP requests a single pass may issue (default 200) — the budget that keeps a
     /// big change set from monopolizing the maintenance pass. Unfinished files ride the next
     /// pass via the watcher's backlog. Must be positive; zero is rejected at config load.
+    ///
+    /// SHARED across live backends, not per backend: the pass holds the repository write lock
+    /// while it runs, so this is a lock-hold bound, and a mixed-language checkout must not spend
+    /// one allowance per language. The backends draw from it in a rotating order so none starves.
     pub max_requests_per_pass: u64,
 }
 

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -684,10 +684,14 @@ pub(crate) enum OracleToolArg {
     ScipTypescript,
     #[value(name = "scip-java")]
     ScipJava,
-    /// The live watcher oracle (#534). Selectable for `oracle status`; `oracle run --tool
-    /// ra-lsp` degrades to the documented `Blocked` hint (live tools never produce a `.scip`).
+    /// The live watcher oracle for Rust (#534). Selectable for `oracle status`; `oracle run
+    /// --tool ra-lsp` degrades to the documented `Blocked` hint (live tools never produce a
+    /// `.scip`).
     #[value(name = "ra-lsp")]
     RaLsp,
+    /// The live watcher oracle for TypeScript (#536). Same status/run semantics as `ra-lsp`.
+    #[value(name = "ts-lsp")]
+    TsLsp,
 }
 
 impl OracleToolArg {
@@ -699,6 +703,7 @@ impl OracleToolArg {
             OracleToolArg::ScipTypescript => rag_rat_oracle::OracleTool::ScipTypescript,
             OracleToolArg::ScipJava => rag_rat_oracle::OracleTool::ScipJava,
             OracleToolArg::RaLsp => rag_rat_oracle::OracleTool::RaLsp,
+            OracleToolArg::TsLsp => rag_rat_oracle::OracleTool::TsLsp,
         }
     }
 }
@@ -1139,16 +1144,46 @@ mod tests {
     }
 
     #[test]
-    fn oracle_status_accepts_the_live_tool_selector() {
-        // `oracle status --tool ra-lsp` must parse (#534): the status selector includes the
-        // live backend; `oracle run --tool ra-lsp` is gated to Blocked downstream instead.
-        let cli = Cli::try_parse_from(["rag-rat", "oracle", "status", "--tool", "ra-lsp"])
-            .expect("parse");
-        match cli.command {
-            Command::Oracle(OracleArgs { command: OracleCommand::Status(args) }) => {
-                assert_eq!(args.tool, Some(OracleToolArg::RaLsp));
-            },
-            other => panic!("expected oracle status, got {other:?}"),
+    fn oracle_status_accepts_every_live_tool_selector() {
+        // `oracle status --tool <live>` must parse: the status selector includes the live
+        // backends; `oracle run --tool <live>` is gated to Blocked downstream instead.
+        for tool in rag_rat_oracle::OracleTool::ALL.iter().filter(|tool| !tool.batch_capable()) {
+            let cli =
+                Cli::try_parse_from(["rag-rat", "oracle", "status", "--tool", tool.as_db_str()])
+                    .unwrap_or_else(|err| panic!("{} must parse: {err}", tool.as_db_str()));
+            match cli.command {
+                Command::Oracle(OracleArgs { command: OracleCommand::Status(args) }) => {
+                    assert_eq!(args.tool.map(OracleToolArg::core), Some(*tool));
+                },
+                other => panic!("expected oracle status, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn the_tool_selector_covers_every_registered_oracle_tool() {
+        // The CLI selector and the tool registry drift silently otherwise: a new backend would be
+        // indexed and surfaced but unselectable from `oracle status`/`oracle run`, and its
+        // `--tool` name could disagree with the id its rows are persisted under.
+        use clap::ValueEnum as _;
+        let selectable: Vec<rag_rat_oracle::OracleTool> =
+            OracleToolArg::value_variants().iter().map(|arg| arg.core()).collect();
+        assert_eq!(
+            selectable,
+            rag_rat_oracle::OracleTool::ALL.to_vec(),
+            "OracleToolArg must mirror OracleTool::ALL, in order",
+        );
+        for arg in OracleToolArg::value_variants() {
+            let name = arg
+                .to_possible_value()
+                .expect("every selector variant is selectable")
+                .get_name()
+                .to_string();
+            assert_eq!(
+                name,
+                arg.core().as_db_str(),
+                "the --tool name must match the persisted tool id",
+            );
         }
     }
 

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -262,13 +262,21 @@ impl IndexDatabase {
         self.run_oracle(tool, tool_version, scip_bytes, OracleShaSnapshots::default())
     }
 
-    /// Probe whether an oracle tool is installed, for `oracle status`. Config-backed opens probe
-    /// from the checkout root so rustup directory overrides select the same rust-analyzer as the
-    /// watcher. A `Blocked` probe is informational (the tool isn't installed), never an error.
+    /// Probe whether an oracle tool can actually run here, for `oracle status`. Config-backed
+    /// opens probe from the checkout root so rustup directory overrides select the same
+    /// rust-analyzer as the watcher. A `Blocked` probe is informational, never an error.
+    ///
+    /// "Installed" is not the same question as "can run": every backend also has checkout
+    /// prerequisites (`scip-clang` needs a compile_commands.json, `scip-java` a Gradle build, the
+    /// live TypeScript client a tsconfig project). Reporting a tool as available while its
+    /// prerequisite is unmet is the worst answer — it says nothing is wrong when the backend can
+    /// never produce a verdict — so an unmet prerequisite is folded in here as `Blocked` carrying
+    /// its hint. This is the only probe seam with a checkout root to check against.
     pub fn probe_oracle_tool(&self, tool: OracleTool) -> rag_rat_oracle::ToolAvailability {
         let manifest = ToolManifest::for_tool(tool);
         match &self.config {
-            Some(config) => manifest.probe_in(&config.root),
+            Some(config) => manifest.probe_runnable_in(&config.root),
+            // No checkout root to evaluate prerequisites against; report installedness only.
             None => manifest.probe(),
         }
     }

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -177,6 +177,9 @@ struct LiveBackendTail {
     session: Option<LiveOracleSession>,
     backlog: Vec<String>,
     lifecycle: LiveOracleLifecycle,
+    /// Whether this backend's unmet checkout prerequisite has already been reported. The block is
+    /// permanent until the checkout changes, so it is worth saying — once, not on every retry.
+    prerequisite_reported: bool,
 }
 
 impl LiveBackendTail {
@@ -186,6 +189,7 @@ impl LiveBackendTail {
             session: None,
             backlog: Vec::new(),
             lifecycle: LiveOracleLifecycle::default(),
+            prerequisite_reported: false,
         }
     }
 
@@ -241,17 +245,33 @@ impl LiveBackendTail {
             return;
         }
 
-        // Spawn the session lazily on the first eligible pass. `None` (the server is absent, a
-        // checkout prerequisite is unmet, or the spawn failed) leaves the work in the backlog for
-        // a later pass — the same degrade-quietly UX as a missing embedding model.
+        // Spawn the session lazily on the first eligible pass. A decline leaves the work in the
+        // backlog for a later pass — the same degrade-quietly UX as a missing embedding model.
         if self.session.is_none() {
             if !self.lifecycle.can_respawn(now) {
                 self.backlog = worklist;
                 return;
             }
-            self.session = LiveOracleSession::spawn(self.backend.tool, &config.root);
-            if self.session.is_some() {
-                self.lifecycle.on_spawned(now);
+            match LiveOracleSession::spawn(self.backend.tool, &config.root) {
+                Ok(session) => {
+                    self.session = Some(session);
+                    self.lifecycle.on_spawned(now);
+                },
+                // A prerequisite block is PERMANENT until the checkout changes, so retrying it
+                // silently would leave an operator with a live oracle that never runs and no
+                // reason why. Say it once, then fall through to the ordinary backoff (which is
+                // the right cadence for something that cannot fix itself).
+                Err(rag_rat_oracle::LiveSpawnBlocked::Prerequisite(hint)) => {
+                    if !self.prerequisite_reported {
+                        self.prerequisite_reported = true;
+                        tracing::warn!(
+                            target: "rag_rat_core::watch",
+                            tool = self.backend.tool.as_db_str(),
+                            "live oracle blocked: {hint}"
+                        );
+                    }
+                },
+                Err(rag_rat_oracle::LiveSpawnBlocked::Unavailable) => {},
             }
         }
         let Some(session) = &mut self.session else {
@@ -259,6 +279,8 @@ impl LiveBackendTail {
             self.lifecycle.on_failure(Instant::now());
             return;
         };
+        // A session exists, so whatever blocked earlier is resolved; report it again if it returns.
+        self.prerequisite_reported = false;
 
         let result = db.run_live_oracle_pass(session, &worklist, *budget, started_at_ms);
         // Count idleness from completion: a request batch longer than the idle window must not

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -180,7 +180,21 @@ struct LiveBackendTail {
     /// Whether this backend's unmet checkout prerequisite has already been reported. The block is
     /// permanent until the checkout changes, so it is worth saying — once, not on every retry.
     prerequisite_reported: bool,
+    /// Consecutive passes this backend has spent warming without ever resolving anything, and
+    /// whether that has been reported. See [`WARMING_PASSES_BEFORE_REPORT`].
+    warming_passes: u32,
+    warming_reported: bool,
 }
+
+/// How many consecutive warming passes go by before the watcher says so. A cold language server
+/// legitimately warms for a pass or two; a server that never becomes ready is a real problem the
+/// operator cannot otherwise see, because the safe behaviour — never ask a warming server — is
+/// also a SILENT one.
+///
+/// The causes are open-ended (a language server that cannot resolve a compiler for the project, a
+/// broken toolchain install, a project too large to load inside the retry window), so this reports
+/// the observed state rather than trying to predict any particular cause.
+const WARMING_PASSES_BEFORE_REPORT: u32 = 5;
 
 impl LiveBackendTail {
     fn new(backend: LiveBackend) -> Self {
@@ -190,6 +204,8 @@ impl LiveBackendTail {
             backlog: Vec::new(),
             lifecycle: LiveOracleLifecycle::default(),
             prerequisite_reported: false,
+            warming_passes: 0,
+            warming_reported: false,
         }
     }
 
@@ -197,6 +213,31 @@ impl LiveBackendTail {
     /// resident session schedules its own idle shutdown.
     fn next_wake_in(&self, idle: Duration, now: Instant) -> Option<Duration> {
         self.lifecycle.next_wake_in(!self.backlog.is_empty(), idle, now)
+    }
+
+    /// Track consecutive warming passes and report a server that never becomes ready.
+    ///
+    /// Refusing to ask a warming server is the correct behaviour, but on its own it is
+    /// indistinguishable from working: the backlog just rides forever. Say so once, and reset as
+    /// soon as the backend gets anywhere, so a normally-warming server stays quiet.
+    fn note_warming(&mut self, status: &str) {
+        if status != "Warming" {
+            self.warming_passes = 0;
+            self.warming_reported = false;
+            return;
+        }
+        self.warming_passes = self.warming_passes.saturating_add(1);
+        if self.warming_passes >= WARMING_PASSES_BEFORE_REPORT && !self.warming_reported {
+            self.warming_reported = true;
+            tracing::warn!(
+                target: "rag_rat_core::watch",
+                tool = self.backend.tool.as_db_str(),
+                passes = self.warming_passes,
+                "live oracle: the language server has not reported a completed project load — \
+                 it resolves nothing until it does. Check that it can load this project (for \
+                 TypeScript, that a `typescript` package resolves for the tsconfig project)."
+            );
+        }
     }
 
     /// This backend's share of one pass: resolve pending work, or shut an otherwise-workless
@@ -311,6 +352,7 @@ impl LiveBackendTail {
                     // to end an earlier crash/spawn-failure streak. Warm-up alone does not.
                     self.lifecycle.on_stable_batch();
                 }
+                self.note_warming(&report.status);
                 if report.rows_written > 0 || !report.unfinished_paths.is_empty() {
                     tracing::info!(
                         target: "rag_rat_core::watch",
@@ -488,6 +530,28 @@ mod tests {
         // A wrapped counter must not panic or skip anyone.
         assert_eq!(claim_order(2, usize::MAX).collect::<Vec<_>>(), vec![1, 0]);
         assert_eq!(claim_order(0, 5).count(), 0, "no backends is not a division by zero");
+    }
+
+    #[test]
+    fn a_server_that_never_warms_is_reported_once_then_stays_quiet() {
+        // Refusing to ask a warming server is correct but SILENT — on its own it is
+        // indistinguishable from the backend working, and the backlog just rides forever. The
+        // watcher has to say so, once, and stop as soon as the backend gets anywhere.
+        let mut tail =
+            LiveBackendTail::new(LiveBackend::for_tool(rag_rat_oracle::OracleTool::TsLsp).unwrap());
+        for _ in 0..WARMING_PASSES_BEFORE_REPORT - 1 {
+            tail.note_warming("Warming");
+            assert!(!tail.warming_reported, "a normally-warming server must stay quiet");
+        }
+        tail.note_warming("Warming");
+        assert!(tail.warming_reported, "a server that never warms must be reported");
+        tail.note_warming("Warming");
+        assert!(tail.warming_reported, "reported ONCE, not on every later pass");
+
+        // Any progress at all clears the streak, so a later cold start reports afresh.
+        tail.note_warming("Completed");
+        assert_eq!(tail.warming_passes, 0);
+        assert!(!tail.warming_reported);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -1,14 +1,21 @@
 //! The live oracle's maintenance-pass tail (#74 slice 2 / #534): the watcher-owned state that
-//! drives [`rag_rat_oracle::live_oracle_pass`] — the resident LSP session (lazily spawned,
-//! idle-shutdown) and the backlog of changed paths a prior pass's request budget didn't reach.
+//! drives [`rag_rat_oracle::live_oracle_pass`] — a resident LSP session per live backend (lazily
+//! spawned, idle-shutdown) and the backlog of changed paths a prior pass's request budget didn't
+//! reach.
 //!
 //! Gating (all cheap, in order): `[oracle.live] enabled` (standalone — it does NOT imply or
-//! require `[oracle] auto_run`), Rust among the checkout's indexed languages, and a non-empty
-//! worklist (backlog ∪ this pass's changed `.rs` paths). A pass with no reliable changed set
-//! (a heal/bootstrap leaves `clone_delta_hint = None`) contributes no paths: live's scope is
-//! exactly "files the pass reindexed", and a whole-checkout sweep is the BATCH pass's job.
+//! require `[oracle] auto_run`), the backend's language among the checkout's indexed languages,
+//! and a non-empty worklist (backlog ∪ this pass's changed paths in that language). A pass with
+//! no reliable changed set (a heal/bootstrap leaves `clone_delta_hint = None`) contributes no
+//! paths: live's scope is exactly "files the pass reindexed", and a whole-checkout sweep is the
+//! BATCH pass's job.
 //!
-//! Everything here is best-effort: a missing `rust-analyzer`, a failed spawn, a warming server,
+//! Backends are INDEPENDENT: each keeps its own session, backlog, and respawn backoff, so a
+//! wedged `rust-analyzer` never stalls TypeScript resolution (and vice versa), and each spends
+//! its own request budget. A mixed-language repo therefore runs several resident servers when it
+//! has several live-capable languages indexed.
+//!
+//! Everything here is best-effort: a missing language server, a failed spawn, a warming server,
 //! or a dead server mid-pass never fails the maintenance pass — the worklist rides to the next
 //! pass via the backlog, and an aborted session is dropped so a later pass respawns with bounded
 //! backoff. The tail reports its next backlog-retry or idle-shutdown deadline to the event loop.
@@ -17,9 +24,8 @@ use std::collections::{BTreeSet, HashSet};
 use std::time::{Duration, Instant};
 
 use rag_rat_base::config::Config;
-use rag_rat_base::language::Language;
 use rag_rat_base::time::now_ms;
-use rag_rat_oracle::LiveOracleSession;
+use rag_rat_oracle::{LiveBackend, LiveOracleSession};
 
 use crate::index::IndexDatabase;
 
@@ -106,53 +112,108 @@ impl LiveOracleLifecycle {
     }
 }
 
-/// Resident live-oracle state for one watcher: the LSP session + the deferred-path backlog.
-/// Owned by the pass-worker closure (it must outlive individual passes); the hook/CLI
-/// `maintenance_pass*` entry points pass no state, so the live stage only ever runs from the
-/// resident watcher — a one-shot CLI pass must not spawn a minutes-warming language server.
+/// Resident live-oracle state for one watcher: one [`LiveBackendTail`] per live backend. Owned by
+/// the pass-worker closure (it must outlive individual passes); the hook/CLI `maintenance_pass*`
+/// entry points pass no state, so the live stage only ever runs from the resident watcher — a
+/// one-shot CLI pass must not spawn a minutes-warming language server.
 pub(crate) struct LiveOracleTail {
-    session: Option<LiveOracleSession>,
-    backlog: Vec<String>,
-    lifecycle: LiveOracleLifecycle,
+    backends: Vec<LiveBackendTail>,
+    /// Which backend claims the shared request budget first on the next pass. Rotated every pass
+    /// so a language with a constantly-large change set cannot starve the others (see
+    /// [`Self::on_pass`]).
+    first_claim: usize,
 }
 
 impl LiveOracleTail {
     pub(crate) fn new() -> Self {
-        Self { session: None, backlog: Vec::new(), lifecycle: LiveOracleLifecycle::default() }
+        Self { backends: LiveBackend::all().map(LiveBackendTail::new).collect(), first_claim: 0 }
     }
 
-    /// Delay until the watcher should run another pass without waiting for a filesystem event.
-    /// A backlog takes priority; otherwise a resident session schedules its own idle shutdown.
+    /// Delay until the watcher should run another pass without waiting for a filesystem event —
+    /// the EARLIEST any backend needs one, since a single pass services them all.
     pub(crate) fn next_wake_in(&self, config: &Config, now: Instant) -> Option<Duration> {
         if !config.oracle.live.enabled {
             return None;
         }
-        self.lifecycle.next_wake_in(
-            !self.backlog.is_empty(),
-            Duration::from_secs(config.oracle.live.idle_shutdown_secs),
-            now,
-        )
+        let idle = Duration::from_secs(config.oracle.live.idle_shutdown_secs);
+        self.backends.iter().filter_map(|backend| backend.next_wake_in(idle, now)).min()
     }
 
-    /// One pass's live stage: resolve pending work, or shut an otherwise-workless session down
-    /// once idle. Never returns an error — a failure is logged and the work rides the next pass.
+    /// One pass's live stage, for every backend in turn.
+    ///
+    /// `max_requests_per_pass` bounds the whole MAINTENANCE PASS, not each backend: the pass holds
+    /// the repository write lock while it runs, so the cap is a lock-hold guarantee and giving
+    /// every backend its own copy would multiply the real bound by the number of live languages.
+    /// The backends therefore draw from ONE budget, and the order rotates each pass so a language
+    /// with a perpetually-large change set cannot starve the rest (whatever a backend does not
+    /// reach stays in its own backlog).
     pub(crate) fn on_pass(
         &mut self,
         db: &IndexDatabase,
         config: &Config,
         changed_paths: Option<&BTreeSet<String>>,
     ) {
-        let live_cfg = &config.oracle.live;
-        if !live_cfg.enabled {
+        if !config.oracle.live.enabled {
             return;
         }
+        let mut budget = config.oracle.live.max_requests_per_pass;
+        for index in claim_order(self.backends.len(), self.first_claim) {
+            self.backends[index].on_pass(db, config, changed_paths, &mut budget);
+        }
+        self.first_claim = self.first_claim.wrapping_add(1);
+    }
+}
+
+/// Backend indices for one pass, starting at `first` and wrapping — the rotation that keeps the
+/// shared request budget fair across passes.
+fn claim_order(count: usize, first: usize) -> impl Iterator<Item = usize> {
+    (0..count).map(move |offset| (first.wrapping_add(offset)) % count.max(1))
+}
+
+/// One live backend's resident state: its LSP session, deferred-path backlog, and respawn/idle
+/// lifecycle. Independent of every other backend's.
+struct LiveBackendTail {
+    backend: LiveBackend,
+    session: Option<LiveOracleSession>,
+    backlog: Vec<String>,
+    lifecycle: LiveOracleLifecycle,
+}
+
+impl LiveBackendTail {
+    fn new(backend: LiveBackend) -> Self {
+        Self {
+            backend,
+            session: None,
+            backlog: Vec::new(),
+            lifecycle: LiveOracleLifecycle::default(),
+        }
+    }
+
+    /// Delay until this backend needs another pass. A backlog takes priority; otherwise a
+    /// resident session schedules its own idle shutdown.
+    fn next_wake_in(&self, idle: Duration, now: Instant) -> Option<Duration> {
+        self.lifecycle.next_wake_in(!self.backlog.is_empty(), idle, now)
+    }
+
+    /// This backend's share of one pass: resolve pending work, or shut an otherwise-workless
+    /// session down once idle. Never returns an error — a failure is logged and the work rides
+    /// the next pass.
+    fn on_pass(
+        &mut self,
+        db: &IndexDatabase,
+        config: &Config,
+        changed_paths: Option<&BTreeSet<String>>,
+        budget: &mut u64,
+    ) {
+        let live_cfg = &config.oracle.live;
         let now = Instant::now();
         let started_at_ms = now_ms();
 
-        // The worklist: backlog first (older edits wait longest), then this pass's changed Rust
-        // paths, deduped. `changed_paths` is `None` on a heal/bootstrap — no reliable superset,
-        // so only the backlog rides.
-        let worklist = assemble_worklist(std::mem::take(&mut self.backlog), changed_paths);
+        // The worklist: backlog first (older edits wait longest), then this pass's changed paths
+        // in this backend's language, deduped. `changed_paths` is `None` on a heal/bootstrap — no
+        // reliable superset, so only the backlog rides.
+        let worklist =
+            assemble_worklist(std::mem::take(&mut self.backlog), changed_paths, &self.backend);
         let idle_shutdown_due = self.lifecycle.idle_shutdown_due(
             !worklist.is_empty(),
             Duration::from_secs(live_cfg.idle_shutdown_secs),
@@ -168,20 +229,27 @@ impl LiveOracleTail {
             }
             return;
         }
-        // Rust must be an indexed language of this checkout (ra-lsp's language).
-        if !config.targets.iter().any(|target| target.language == Language::Rust) {
+        // An earlier backend spent the pass's whole request allowance. Keep this backend's work
+        // (a spawn + a zero-budget pass would only defer it again, after paying a language-server
+        // warm-up) and let the rotation give it first claim on a later pass.
+        if *budget == 0 {
+            self.backlog = worklist;
+            return;
+        }
+        // This backend's language must be an indexed language of the checkout.
+        if !config.targets.iter().any(|target| target.language == self.backend.language) {
             return;
         }
 
-        // Spawn the session lazily on the first eligible pass. `None` (rust-analyzer absent /
-        // unw spawnable) leaves the work in the backlog for a later pass — the same
-        // degrade-quietly UX as a missing embedding model.
+        // Spawn the session lazily on the first eligible pass. `None` (the server is absent, a
+        // checkout prerequisite is unmet, or the spawn failed) leaves the work in the backlog for
+        // a later pass — the same degrade-quietly UX as a missing embedding model.
         if self.session.is_none() {
             if !self.lifecycle.can_respawn(now) {
                 self.backlog = worklist;
                 return;
             }
-            self.session = LiveOracleSession::spawn(&config.root);
+            self.session = LiveOracleSession::spawn(self.backend.tool, &config.root);
             if self.session.is_some() {
                 self.lifecycle.on_spawned(now);
             }
@@ -192,17 +260,15 @@ impl LiveOracleTail {
             return;
         };
 
-        let result = db.run_live_oracle_pass(
-            session,
-            &worklist,
-            live_cfg.max_requests_per_pass,
-            started_at_ms,
-        );
+        let result = db.run_live_oracle_pass(session, &worklist, *budget, started_at_ms);
         // Count idleness from completion: a request batch longer than the idle window must not
         // force an immediate shutdown and cold respawn.
         self.lifecycle.on_session_used(Instant::now());
         match result {
             Ok(report) => {
+                // Charge what was actually spent against the pass-wide allowance, so the
+                // backends that run after this one see a real remainder.
+                *budget = budget.saturating_sub(report.requests_used);
                 self.backlog = report.unfinished_paths.clone();
                 // An aborted pass means the server died or wedged mid-resolution: drop the
                 // session so the next pass respawns a clean one instead of reusing a broken
@@ -276,12 +342,17 @@ fn should_idle_shutdown(
     !has_pending_work && now.saturating_duration_since(last_used_at) >= idle
 }
 
-/// The pass's worklist: backlog paths first (oldest edits wait longest), then the changed
-/// `.rs` paths (ra-lsp's language), deduped, order-preserving. `None` changed paths (a
-/// heal/bootstrap pass) contributes nothing — only the backlog rides.
+/// The pass's worklist for one backend: backlog paths first (oldest edits wait longest), then the
+/// changed paths this backend's language claims, deduped, order-preserving. `None` changed paths
+/// (a heal/bootstrap pass) contributes nothing — only the backlog rides.
+///
+/// The language filter is what keeps backends disjoint: a changed `.ts` file must never reach the
+/// Rust session, which would open it under the wrong `languageId` and spend budget on a file its
+/// server cannot resolve.
 fn assemble_worklist(
     backlog: Vec<String>,
     changed_paths: Option<&BTreeSet<String>>,
+    backend: &LiveBackend,
 ) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut worklist = Vec::new();
@@ -291,7 +362,7 @@ fn assemble_worklist(
         }
     }
     if let Some(paths) = changed_paths {
-        for path in paths.iter().filter(|p| p.ends_with(".rs")) {
+        for path in paths.iter().filter(|path| backend.claims_path(path)) {
             if seen.insert(path.clone()) {
                 worklist.push(path.clone());
             }
@@ -304,25 +375,108 @@ fn assemble_worklist(
 mod tests {
     use super::*;
 
+    fn backend(tool: rag_rat_oracle::OracleTool) -> LiveBackend {
+        LiveBackend::for_tool(tool).expect("a live backend")
+    }
+
     #[test]
-    fn worklist_dedupes_backlog_against_changed_and_filters_non_rust() {
+    fn worklist_dedupes_backlog_against_changed_and_filters_other_languages() {
+        let rust = backend(rag_rat_oracle::OracleTool::RaLsp);
         let backlog = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
         let changed = BTreeSet::from([
             "src/b.rs".to_string(),
             "src/c.rs".to_string(),
             "Cargo.toml".to_string(),
         ]);
-        let worklist = assemble_worklist(backlog, Some(&changed));
+        let worklist = assemble_worklist(backlog, Some(&changed), &rust);
         // Backlog order first, then new changed paths; duplicates collapse; non-Rust dropped.
         assert_eq!(worklist, vec!["src/a.rs", "src/b.rs", "src/c.rs"]);
     }
 
     #[test]
     fn worklist_without_changed_set_rides_backlog_only() {
+        let rust = backend(rag_rat_oracle::OracleTool::RaLsp);
         let backlog = vec!["src/a.rs".to_string()];
         // A heal/bootstrap pass (None) contributes no paths.
-        assert_eq!(assemble_worklist(backlog, None), vec!["src/a.rs"]);
-        assert!(assemble_worklist(Vec::new(), None).is_empty());
+        assert_eq!(assemble_worklist(backlog, None, &rust), vec!["src/a.rs"]);
+        assert!(assemble_worklist(Vec::new(), None, &rust).is_empty());
+    }
+
+    #[test]
+    fn each_backend_claims_only_its_own_languages_changed_paths() {
+        // One changed set, several backends: a `.ts` file reaching the Rust session would be
+        // opened under the wrong languageId and burn budget on a file that server cannot
+        // resolve, and vice versa.
+        let changed = BTreeSet::from([
+            "src/a.rs".to_string(),
+            "src/b.ts".to_string(),
+            "src/c.tsx".to_string(),
+            "README.md".to_string(),
+        ]);
+        assert_eq!(
+            assemble_worklist(
+                Vec::new(),
+                Some(&changed),
+                &backend(rag_rat_oracle::OracleTool::RaLsp)
+            ),
+            vec!["src/a.rs"],
+        );
+        assert_eq!(
+            assemble_worklist(
+                Vec::new(),
+                Some(&changed),
+                &backend(rag_rat_oracle::OracleTool::TsLsp)
+            ),
+            vec!["src/b.ts", "src/c.tsx"],
+        );
+    }
+
+    #[test]
+    fn the_tail_wakes_for_the_earliest_backend_that_needs_one() {
+        // A single pass services every backend, so the tail's deadline is the minimum across
+        // them — a backend with a backlog must not wait for another backend's longer idle timer.
+        let mut tail = LiveOracleTail::new();
+        assert!(tail.backends.len() >= 2, "the multi-backend case must actually be exercised");
+        let now = Instant::now();
+        let idle = Duration::from_secs(600);
+        // One backend holds a backlog (retry cadence); another holds an idle session.
+        tail.backends[0].backlog.push("src/a.rs".to_string());
+        tail.backends[1].lifecycle.on_spawned(now);
+        let earliest = tail
+            .backends
+            .iter()
+            .filter_map(|backend| backend.next_wake_in(idle, now))
+            .min()
+            .expect("at least one backend schedules a wake");
+        assert_eq!(earliest, LIVE_ORACLE_RETRY_INTERVAL, "the backlog's retry wins over idle");
+    }
+
+    #[test]
+    fn the_claim_order_rotates_so_no_backend_starves_the_shared_budget() {
+        // `max_requests_per_pass` bounds the whole pass, so the backends share one allowance. If
+        // the order were fixed, a language whose change set always exhausts it would keep every
+        // other language's backlog permanently unserviced.
+        let order = |first| claim_order(3, first).collect::<Vec<_>>();
+        assert_eq!(order(0), vec![0, 1, 2]);
+        assert_eq!(order(1), vec![1, 2, 0]);
+        assert_eq!(order(2), vec![2, 0, 1]);
+        // Every backend is still visited exactly once per pass, whatever the rotation.
+        assert_eq!(order(7).len(), 3);
+        assert_eq!(order(7).iter().collect::<HashSet<_>>().len(), 3);
+        // A wrapped counter must not panic or skip anyone.
+        assert_eq!(claim_order(2, usize::MAX).collect::<Vec<_>>(), vec![1, 0]);
+        assert_eq!(claim_order(0, 5).count(), 0, "no backends is not a division by zero");
+    }
+
+    #[test]
+    fn one_backends_failure_does_not_disturb_another() {
+        // Backends are independent: a crash streak on one must not gate the other's respawn, or
+        // a wedged rust-analyzer would silently stop TypeScript resolution.
+        let mut tail = LiveOracleTail::new();
+        let now = Instant::now();
+        tail.backends[0].lifecycle.on_failure(now);
+        assert!(!tail.backends[0].lifecycle.can_respawn(now));
+        assert!(tail.backends[1].lifecycle.can_respawn(now), "sibling backoff must be separate");
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/backend.rs
+++ b/crates/rag-rat-oracle/src/backend.rs
@@ -135,9 +135,17 @@ fn is_searchable_dir(name: &str) -> bool {
     name != "node_modules" && !name.starts_with('.')
 }
 
-/// The directory of the nearest `tsconfig.json` at or above `path`, stopping at `root` — how
-/// tsserver decides which project a file belongs to. `None` means the file would open as an
-/// inferred project, which loads SILENTLY (no progress cycle).
+/// The directory of the nearest `tsconfig.json` at or above `path`, stopping at `root`. `None`
+/// means no config governs the file at all, and opening it produces NO project-load progress.
+///
+/// ANCESTRY IS THE WHOLE TEST — deliberately. A config's `files`/`include`/`exclude` decide
+/// membership, so an ancestor config does not prove the file is *in* that project; the tempting
+/// "fix" is to evaluate those globs here. Measured against the real server, that would be wasted
+/// complexity: opening a file whose ancestor config EXCLUDES it (root `"include": ["src"]`,
+/// opening `scripts/main.ts`) still emits a full `$/progress` begin/end cycle, because tsserver
+/// loads the config project in order to decide the file isn't in it. The load is observable either
+/// way. Only a file with no ancestor config at all loads silently. Do not reimplement tsconfig
+/// glob semantics here — it would add a second, subtler source of truth for no gain.
 fn enclosing_tsconfig_dir(root: &Path, path: &Path) -> Option<PathBuf> {
     let mut dir = path.parent()?;
     loop {

--- a/crates/rag-rat-oracle/src/backend.rs
+++ b/crates/rag-rat-oracle/src/backend.rs
@@ -1,0 +1,341 @@
+//! The LIVE backend registry: what distinguishes one resident language server from another once
+//! the shared client substrate is in place.
+//!
+//! [`crate::manifest::ToolManifest`] answers "which binary, with what argv, and can it run here?"
+//! for every backend, batch and live alike. This module answers the questions only a *live* driver
+//! asks: which language's files belong on its worklist, what `languageId` to open them under, and
+//! which readiness signal the server actually emits. Adding a backend is one entry here plus one
+//! manifest entry — not new protocol code.
+
+use std::path::{Path, PathBuf};
+
+use rag_rat_base::language::Language;
+
+use super::OracleTool;
+use super::lsp::readiness::ReadinessPolicy;
+
+/// The static registry entry for one live oracle backend.
+#[derive(Debug, Clone, Copy)]
+pub struct LiveBackend {
+    /// The persisted tool id its verdicts are written under. Always a non-`batch_capable` tool.
+    pub tool: OracleTool,
+    /// The language whose files this backend resolves. Drives the watcher's worklist filter, so a
+    /// backend never sees a path it cannot open.
+    pub language: Language,
+    /// How this server announces that it is ready to answer definitions.
+    pub(crate) readiness: ReadinessPolicy,
+    /// LSP `languageId` per file extension, first match wins; the last entry is the fallback for
+    /// any extension the language claims but this table doesn't name.
+    language_ids: &'static [(&'static str, &'static str)],
+}
+
+impl LiveBackend {
+    /// The live backend for `tool`, or `None` for a batch tool. Total over the non-batch variants:
+    /// [`OracleTool::batch_capable`] is `false` exactly when this returns `Some`.
+    pub fn for_tool(tool: OracleTool) -> Option<Self> {
+        match tool {
+            OracleTool::RaLsp => Some(Self {
+                tool,
+                language: Language::Rust,
+                // rust-analyzer reports load/index quiescence explicitly, for any checkout.
+                readiness: ReadinessPolicy::ServerStatus,
+                language_ids: &[("rs", "rust")],
+            }),
+            OracleTool::TsLsp => Some(Self {
+                tool,
+                language: Language::TypeScript,
+                // typescript-language-server has no quiescence notification. The only warm-up
+                // signal it emits is the work-done progress cycle bracketing a project load —
+                // which is why the manifest blocks this backend on a checkout with no
+                // tsconfig.json, where no such cycle is ever emitted.
+                readiness: ReadinessPolicy::WorkDoneProgress,
+                language_ids: &[("tsx", "typescriptreact"), ("ts", "typescript")],
+            }),
+            OracleTool::RustAnalyzer
+            | OracleTool::ScipClang
+            | OracleTool::ScipPython
+            | OracleTool::ScipTypescript
+            | OracleTool::ScipJava => None,
+        }
+    }
+
+    /// Every live backend, in [`OracleTool::ALL`] order — the watcher's enumeration seam.
+    pub fn all() -> impl Iterator<Item = Self> {
+        OracleTool::ALL.iter().copied().filter_map(Self::for_tool)
+    }
+
+    /// The LSP `languageId` to open `path` under. A mis-declared id makes a server reject or
+    /// mis-parse the document (tsserver warns and rewrites, other servers simply refuse), so the
+    /// extension decides rather than a per-backend constant.
+    pub(crate) fn language_id_for(&self, path: &str) -> &'static str {
+        let extension = path.rsplit('.').next().unwrap_or_default();
+        self.language_ids
+            .iter()
+            .find_map(|(ext, id)| (*ext == extension).then_some(*id))
+            .unwrap_or_else(|| self.language_ids.last().expect("a backend declares one id").1)
+    }
+
+    /// Whether this backend's language claims `path` — the worklist filter. Reuses the language
+    /// registry's extension set so a backend and the indexer never disagree about which files
+    /// exist in that language.
+    pub fn claims_path(&self, path: &str) -> bool {
+        self.language.claims_path(std::path::Path::new(path))
+    }
+
+    /// Whether opening `path` (repo-relative, under `root`) would produce an observable readiness
+    /// signal — i.e. whether it is a useful warm-up document.
+    ///
+    /// `ServerStatus` backends report session-level quiescence regardless of what is open, so any
+    /// file will do. `typescript-language-server` only brackets a TSCONFIG PROJECT's load in a
+    /// progress cycle: opening a file that belongs to no project creates an inferred project
+    /// SILENTLY (measured: no `$/progress` at all), so warming on one teaches the session nothing
+    /// and it stays `Warming` while a file that IS in a project would have warmed it.
+    pub(crate) fn open_signals_readiness(&self, root: &Path, path: &str) -> bool {
+        match self.readiness {
+            ReadinessPolicy::ServerStatus => true,
+            ReadinessPolicy::WorkDoneProgress =>
+                enclosing_tsconfig_dir(root, &root.join(path)).is_some(),
+        }
+    }
+
+    /// Any document in the checkout whose `didOpen` would produce an observable readiness signal,
+    /// found by search rather than taken from the worklist.
+    ///
+    /// This is what makes the backend usable on a checkout whose CHANGED files all sit outside a
+    /// project: the expensive warm-up is per SERVER, not per project, so loading one real project
+    /// makes the session ready — after which even project-less files resolve correctly (measured).
+    /// Without it, a worklist of only project-less files would re-open an ineffective document
+    /// every pass and never warm.
+    ///
+    /// `None` means the checkout contains no project this backend could ever warm on, which is
+    /// also what makes its `prerequisite_blocked` gate fire — the two answer the same question, so
+    /// they cannot disagree.
+    pub(crate) fn warmup_document(&self, root: &Path) -> Option<PathBuf> {
+        match self.readiness {
+            // Session-level quiescence needs no document.
+            ReadinessPolicy::ServerStatus => None,
+            ReadinessPolicy::WorkDoneProgress =>
+                find_document_in_project(root, self.language, false),
+        }
+    }
+
+    /// Whether this checkout can ever produce a readiness signal for this backend. Backs the
+    /// manifest's prerequisite gate.
+    pub fn checkout_can_signal_readiness(&self, root: &Path) -> bool {
+        match self.readiness {
+            ReadinessPolicy::ServerStatus => true,
+            ReadinessPolicy::WorkDoneProgress => self.warmup_document(root).is_some(),
+        }
+    }
+}
+
+/// Directories that never hold a project this checkout owns: `node_modules` vendors thousands of
+/// dependency tsconfigs, and dot-directories are VCS/tooling state.
+fn is_searchable_dir(name: &str) -> bool {
+    name != "node_modules" && !name.starts_with('.')
+}
+
+/// The directory of the nearest `tsconfig.json` at or above `path`, stopping at `root` — how
+/// tsserver decides which project a file belongs to. `None` means the file would open as an
+/// inferred project, which loads SILENTLY (no progress cycle).
+fn enclosing_tsconfig_dir(root: &Path, path: &Path) -> Option<PathBuf> {
+    let mut dir = path.parent()?;
+    loop {
+        if dir.join("tsconfig.json").exists() {
+            return Some(dir.to_path_buf());
+        }
+        if dir == root {
+            return None;
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// The first file `language` claims that lies inside a tsconfig project at or below `dir`.
+///
+/// Deliberately UNBOUNDED in depth (it only skips vendored/VCS directories): a project can sit
+/// arbitrarily deep in a monorepo — `services/teams/foo/web/tsconfig.json` is an ordinary layout —
+/// and a fixed depth limit would silently disable those checkouts. The walk early-exits on the
+/// first hit, so the only full traversal is the case that ends in a `Blocked` verdict, which the
+/// watcher then backs off to five-minute retries.
+fn find_document_in_project(
+    dir: &Path,
+    language: Language,
+    inside_project: bool,
+) -> Option<PathBuf> {
+    let inside_project = inside_project || dir.join("tsconfig.json").exists();
+    let mut subdirectories = Vec::new();
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let name = entry.file_name();
+        if !is_searchable_dir(&name.to_string_lossy()) {
+            continue;
+        }
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_dir() {
+            subdirectories.push(entry.path());
+        } else if inside_project && language.claims_path(&entry.path()) {
+            return Some(entry.path());
+        }
+    }
+    subdirectories
+        .into_iter()
+        .find_map(|sub| find_document_in_project(&sub, language, inside_project))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_backends_are_exactly_the_non_batch_tools() {
+        // The two must stay in lockstep: a live tool with no backend entry would be enumerated by
+        // the watcher and spawn nothing, and a backend for a batch tool would double-write edges
+        // the batch pass already owns authoritatively.
+        for &tool in OracleTool::ALL {
+            assert_eq!(
+                LiveBackend::for_tool(tool).is_some(),
+                !tool.batch_capable(),
+                "{} disagrees about being a live backend",
+                tool.as_db_str()
+            );
+        }
+    }
+
+    #[test]
+    fn every_live_backend_copies_monikers_from_a_batch_tool_for_its_own_language() {
+        // A live verdict's `scip_symbol` is its batch counterpart's moniker verbatim. If the two
+        // resolved different languages the copy would be meaningless, so the pairing is asserted
+        // rather than assumed.
+        for backend in LiveBackend::all() {
+            let source = backend
+                .tool
+                .batch_moniker_source()
+                .unwrap_or_else(|| panic!("{} has no moniker source", backend.tool.as_db_str()));
+            assert!(source.batch_capable(), "a moniker source must be a batch tool");
+            let batch_languages = crate::ToolManifest::for_tool(source).languages;
+            assert!(
+                batch_languages.contains(&backend.language.as_str()),
+                "{} resolves {} but copies monikers from {}, which indexes {batch_languages:?}",
+                backend.tool.as_db_str(),
+                backend.language,
+                source.as_db_str(),
+            );
+        }
+    }
+
+    #[test]
+    fn every_live_backend_declares_ids_for_the_extensions_its_language_claims() {
+        // `claims_path` admits a file to the worklist and `language_id_for` decides how it is
+        // opened; a gap between them means a file gets resolved under a fallback id.
+        for backend in LiveBackend::all() {
+            for extension in backend.language.target_extensions() {
+                let path = format!("src/file.{extension}");
+                assert!(backend.claims_path(&path), "{path} must be claimed");
+                assert!(
+                    backend.language_ids.iter().any(|(ext, _)| ext == extension),
+                    "{} claims .{extension} but declares no languageId for it",
+                    backend.tool.as_db_str(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn typescript_opens_tsx_as_typescriptreact() {
+        let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
+        assert_eq!(ts.language_id_for("src/main.ts"), "typescript");
+        assert_eq!(ts.language_id_for("src/App.tsx"), "typescriptreact");
+        // An extension the table doesn't name still opens under the backend's fallback rather
+        // than an empty id the server would reject.
+        assert_eq!(ts.language_id_for("src/no-extension"), "typescript");
+        assert!(!ts.claims_path("src/lib.rs"), "another language's file never enters the worklist");
+    }
+
+    /// A TypeScript project at `relative_dir` holding one `main.ts`.
+    fn write_project(root: &Path, relative_dir: &str) {
+        let dir = root.join(relative_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
+        std::fs::write(dir.join("main.ts"), "export function greet() {}\n").unwrap();
+    }
+
+    #[test]
+    fn enclosing_tsconfig_walks_up_to_the_nearest_project_and_stops_at_the_root() {
+        // This is how tsserver assigns a file to a project, and it decides whether opening the
+        // file produces an observable load. A file under no project opens as an inferred project
+        // SILENTLY, so warming on it teaches the session nothing.
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-enclosing");
+        std::fs::create_dir_all(dir.join("packages/app/src")).unwrap();
+        std::fs::create_dir_all(dir.join("scripts")).unwrap();
+        std::fs::write(dir.join("packages/app/tsconfig.json"), "{}").unwrap();
+
+        assert_eq!(
+            enclosing_tsconfig_dir(&dir, &dir.join("packages/app/src/main.ts")),
+            Some(dir.join("packages/app")),
+            "the nearest enclosing project wins",
+        );
+        assert_eq!(
+            enclosing_tsconfig_dir(&dir, &dir.join("scripts/tool.ts")),
+            None,
+            "a file under no project has none",
+        );
+    }
+
+    #[test]
+    fn a_warmup_document_is_found_at_any_depth_and_only_inside_a_project() {
+        // A project can sit arbitrarily deep in a monorepo; a depth limit would silently disable
+        // those checkouts entirely, which is worse than the walk it saves.
+        let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-warmup-doc");
+        std::fs::create_dir_all(dir.join("scripts")).unwrap();
+        std::fs::write(dir.join("scripts/tool.ts"), "export function x() {}\n").unwrap();
+        assert_eq!(
+            ts.warmup_document(&dir),
+            None,
+            "a TypeScript file outside every project is not a warm-up document",
+        );
+        assert!(!ts.checkout_can_signal_readiness(&dir));
+
+        write_project(&dir, "services/teams/foo/web");
+        assert_eq!(
+            ts.warmup_document(&dir),
+            Some(dir.join("services/teams/foo/web/main.ts")),
+            "a deeply nested project is still found",
+        );
+        assert!(ts.checkout_can_signal_readiness(&dir));
+    }
+
+    #[test]
+    fn the_warmup_search_ignores_vendored_and_vcs_directories() {
+        // `node_modules` ships thousands of tsconfigs describing DEPENDENCIES. Warming on one
+        // would report the checkout usable while none of ITS files ever resolve.
+        let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-vendored-warmup");
+        write_project(&dir, "node_modules/some-dep");
+        write_project(&dir, ".cache/tooling");
+        assert_eq!(ts.warmup_document(&dir), None);
+        assert!(!ts.checkout_can_signal_readiness(&dir));
+    }
+
+    #[test]
+    fn a_server_status_backend_needs_no_warmup_document_and_is_never_blocked_on_one() {
+        // rust-analyzer reports quiescence for any checkout, so the whole notion is TS-specific
+        // and must not leak into the other backend's gating.
+        let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ra-lsp-warmup-doc");
+        assert_eq!(rust.warmup_document(&dir), None);
+        assert!(rust.checkout_can_signal_readiness(&dir), "an empty checkout still signals");
+        assert!(rust.open_signals_readiness(&dir, "src/lib.rs"), "any document will do");
+    }
+
+    #[test]
+    fn rust_claims_only_rust_paths() {
+        let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
+        assert_eq!(rust.language_id_for("src/lib.rs"), "rust");
+        assert!(rust.claims_path("src/lib.rs"));
+        assert!(!rust.claims_path("src/main.ts"));
+        assert!(!rust.claims_path("Cargo.toml"));
+    }
+}

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -19,6 +19,7 @@
 //! - `store.rs` — `oracle_runs` / `edge_oracle` read + write helpers.
 
 mod auto_run;
+mod backend;
 mod corpus;
 mod join;
 mod library_usage;
@@ -38,6 +39,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 pub use auto_run::{AutoRunDecision, AutoRunInputs, auto_run_decision};
+pub use backend::LiveBackend;
 pub use corpus::{
     HealthViolation, check_corpus_health, corpora_for_tier, corpus_by_id, load_corpora,
 };
@@ -725,13 +727,19 @@ pub enum OracleTool {
     /// stopping the whole-checkout batch pass. Never batch-capable — see
     /// [`Self::batch_capable`].
     RaLsp,
+    /// The LIVE `typescript-language-server` client (#536) — the TypeScript sibling of
+    /// [`Self::RaLsp`], resolving callees in just-changed `.ts` / `.tsx` files at watcher cadence.
+    /// A DISTINCT tool id from [`Self::ScipTypescript`] for the same reason `RaLsp` is distinct
+    /// from `RustAnalyzer` (live run rows would otherwise wedge the batch staleness gate). Never
+    /// batch-capable.
+    TsLsp,
 }
 
 impl OracleTool {
     /// Every known oracle tool, for "report on all tools" surfaces (`oracle status` with no
     /// `--tool`). Later language backends extend this alongside the enum. Includes the LIVE tools
-    /// (`RaLsp`) — read surfaces merge across every writer with a run; batch-only DRIVERS must
-    /// filter through [`Self::batch_capable`].
+    /// (`RaLsp`, `TsLsp`) — read surfaces merge across every writer with a run; batch-only DRIVERS
+    /// must filter through [`Self::batch_capable`].
     pub const ALL: &[OracleTool] = &[
         Self::RustAnalyzer,
         Self::ScipClang,
@@ -739,6 +747,7 @@ impl OracleTool {
         Self::ScipTypescript,
         Self::ScipJava,
         Self::RaLsp,
+        Self::TsLsp,
     ];
 
     pub fn as_db_str(self) -> &'static str {
@@ -751,20 +760,25 @@ impl OracleTool {
 
     /// Whether this tool produces/consumes whole-checkout `.scip` indexes — the batch paths:
     /// `oracle run`, the background auto-run loop, the init-wizard tool listing, and
-    /// [`produce_scip_with_tool`]. `false` ONLY for the live LSP tools (`RaLsp`), which write
-    /// per-pass verdicts from the watcher and have no `scip_command`; every batch driver must skip
-    /// them rather than try to invoke them as indexers.
+    /// [`produce_scip_with_tool`]. `false` ONLY for the live LSP tools, which write per-pass
+    /// verdicts from the watcher and have no `scip_command`; every batch driver must skip them
+    /// rather than try to invoke them as indexers.
     pub fn batch_capable(self) -> bool {
-        !matches!(self, Self::RaLsp)
+        !matches!(self, Self::RaLsp | Self::TsLsp)
     }
 
     /// The batch tool whose `logical_symbol_monikers` rows a LIVE tool copies into its own
     /// `edge_oracle.scip_symbol` values, so live verdicts are byte-identical to what the batch
     /// pass would write (clone-collapse + memory anchoring treat them as one evidence set, #534).
     /// `None` for a batch tool (it mints monikers itself).
+    ///
+    /// The copy is safe even where the batch tool's monikers are rewritten on the way in
+    /// (`stabilize_moniker_version` is non-identity for `ScipTypescript`): the source is the
+    /// STORED `logical_symbol_monikers` row, which the batch pass already wrote in its final form.
     pub fn batch_moniker_source(self) -> Option<OracleTool> {
         match self {
             Self::RaLsp => Some(Self::RustAnalyzer),
+            Self::TsLsp => Some(Self::ScipTypescript),
             _ => None,
         }
     }
@@ -796,9 +810,9 @@ impl OracleTool {
             // UTF-16 count). Reading them as the UTF-32 fallback mis-converts past astral chars.
             Self::ScipTypescript | Self::ScipJava =>
                 PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
-            // RaLsp never parses a `.scip` (the live client negotiates its own LSP encoding);
-            // the arm exists only for exhaustiveness.
-            Self::RustAnalyzer | Self::ScipClang | Self::ScipPython | Self::RaLsp =>
+            // The live tools never parse a `.scip` (the live client negotiates its own LSP
+            // encoding per session); their arms exist only for exhaustiveness.
+            Self::RustAnalyzer | Self::ScipClang | Self::ScipPython | Self::RaLsp | Self::TsLsp =>
                 PositionEncoding::UnspecifiedPositionEncoding,
         }
     }

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -48,7 +48,9 @@ pub use library_usage::{
     LibraryUsageCallSite, LibraryUsageEntry, LibraryUsageOptions, LibraryUsageReport,
     LibraryUsageStatus, check_library_usage,
 };
-pub use live::{LiveOracleSession, LivePassInput, LivePassReport, live_oracle_pass};
+pub use live::{
+    LiveOracleSession, LivePassInput, LivePassReport, LiveSpawnBlocked, live_oracle_pass,
+};
 // LSP position conversion (line/char <-> byte under an encoding) — consumed by the engine's
 // corpus fixtures; the rest of `lsp` stays private.
 pub use lsp::position::{LineIndex, LspEncoding, LspPosition};

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -1,18 +1,19 @@
 //! The live oracle pass: wire the resident LSP client to the watcher's maintenance pass and WRITE
-//! its per-callee verdicts into the `edge_oracle` seam under the distinct
-//! [`OracleTool::RaLsp`] tool id.
+//! its per-callee verdicts into the `edge_oracle` seam under the live backend's distinct tool id
+//! (`ra-lsp`, `ts-lsp`, …). The pass is backend-agnostic: which server it drives, which files it
+//! accepts, and how it knows the server is ready all come from the session's `LiveBackend`.
 //!
 //! Invariants this module upholds (settled on #74):
 //!
-//! - **Tool identity.** Live rows carry `ra-lsp` + the session's probed `rust-analyzer --version`
-//!   (re-probed at every spawn). Reusing the batch `rust-analyzer` id is rejected: a live
-//!   `oracle_runs` row under the batch id would make `auto_run_decision` see the index as
-//!   always-fresh and silently stop the whole-checkout batch pass.
+//! - **Tool identity.** Live rows carry the LIVE tool id + the session's probed `--version`
+//!   (re-probed at every spawn). Reusing the batch tool's id is rejected: a live `oracle_runs` row
+//!   under the batch id would make `auto_run_decision` see the index as always-fresh and silently
+//!   stop the whole-checkout batch pass.
 //! - **Moniker source.** A live verdict's `scip_symbol` is the resolved target's BATCH moniker from
 //!   `logical_symbol_monikers` — byte-identical to what the batch pass writes, so clone-collapse
 //!   (#275) and moniker-anchored memory relocation treat live and batch rows as one evidence set
 //!   with zero consumer changes. When the target has no batch moniker (batch never ran, or the def
-//!   is outside its definitions) the fallback is a `local ra-lsp-<hash>` SCIP-local sentinel:
+//!   is outside its definitions) the fallback is a `local <tool>-<hash>` SCIP-local sentinel:
 //!   `is_local_symbol` skips it before the conflict logic, so it can never poison a batch moniker,
 //!   while the row's `resolved_symbol_id` still upgrades the edge tier. The sentinel's hash is
 //!   content-derived (callsite path + callee span), so it is STABLE across reindexes — a no-op
@@ -34,9 +35,13 @@
 //!   — the live analog of the batch join's index-vs-disk content gate. Anything else is skipped,
 //!   never mis-joined.
 //!
-//! Out of scope: non-Rust backends (#536) and `resolved-external` verdicts (a live definition
-//! outside the checkout has no batch-interchangeable SCIP symbol string, so it is skipped, not
-//! written).
+//! - **Readiness.** A warming server is never asked for a definition, and a batch that straddled a
+//!   reload is discarded rather than interpreted. This is a correctness rule, not a latency one: a
+//!   not-yet-loaded server does not reliably answer `null`, it can answer WRONG (see
+//!   `lsp::readiness`), and a wrong answer would be persisted as a real verdict.
+//!
+//! Out of scope: `resolved-external` verdicts (a live definition outside the checkout has no
+//! batch-interchangeable SCIP symbol string, so it is skipped, not written).
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -48,60 +53,92 @@ use rusqlite::Connection;
 use serde::Serialize;
 use url::Url;
 
+use super::backend::LiveBackend;
 use super::lsp::client::LspClient;
 use super::lsp::position::LineIndex;
 use super::store::{self, EdgeOracleRow};
 use super::{OracleResolutionKind, OracleTool, ToolAvailability, ToolManifest, join};
 
-/// A resident live-oracle language-server session: the spawned client, the `tool_version` its
-/// rows are stamped with, and the checkout root URI documents are opened under. Owned by the
-/// watcher's pass worker across passes; spawned lazily on the first eligible pass and shut down
-/// after an idle window (both driven by the watcher).
+/// A resident live-oracle language-server session: the spawned client, the backend it drives, the
+/// `tool_version` its rows are stamped with, and the checkout root URI documents are opened
+/// under. Owned by the watcher's pass worker across passes; spawned lazily on the first eligible
+/// pass and shut down after an idle window (both driven by the watcher).
 pub struct LiveOracleSession {
+    backend: LiveBackend,
     client: LspClient,
     tool_version: String,
     root_uri: String,
 }
 
 impl LiveOracleSession {
-    /// Probe `rust-analyzer` and spawn the resident client for `checkout_root`, or `None` when
-    /// the tool is unavailable / the session can't be established — the same degrade-quietly UX
-    /// as a missing embedding model or batch tool (never an error, never a failed pass). The
-    /// version is RE-probed at every spawn so `tool_version` always names the binary this
-    /// session's verdicts came from.
-    pub fn spawn(checkout_root: &Path) -> Option<Self> {
-        let manifest = ToolManifest::for_tool(OracleTool::RaLsp);
+    /// Probe `backend`'s language server and spawn the resident client for `checkout_root`, or
+    /// `None` when the tool is unavailable / a checkout prerequisite is unmet / the session can't
+    /// be established — the same degrade-quietly UX as a missing embedding model or batch tool
+    /// (never an error, never a failed pass). The version is RE-probed at every spawn so
+    /// `tool_version` always names the binary this session's verdicts came from.
+    pub fn spawn(tool: OracleTool, checkout_root: &Path) -> Option<Self> {
+        let backend = LiveBackend::for_tool(tool)?;
+        let manifest = ToolManifest::for_tool(tool);
+        // The prerequisite gate is not cosmetic for every backend: the live TypeScript client
+        // needs a tsconfig.json because that is what makes the server emit the project-load
+        // signal it has no other way to report. Spawning without it would resolve definitions
+        // during a warm-up window that answers WRONG rather than null.
+        if manifest.prerequisite_blocked(checkout_root).is_some() {
+            return None;
+        }
         let ToolAvailability::Available { version, .. } = manifest.probe_in(checkout_root) else {
             return None;
         };
         let root_uri = root_uri_for(checkout_root)?;
-        let mut client = LspClient::spawn(manifest.program, &[], checkout_root).ok()?;
+        let mut client = LspClient::spawn(
+            manifest.program,
+            manifest.live_args,
+            checkout_root,
+            backend.readiness,
+        )
+        .ok()?;
         client.initialize(&root_uri).ok()?;
-        Some(Self { client, tool_version: version, root_uri })
+        Some(Self { backend, client, tool_version: version, root_uri })
     }
 
     /// Test seam: a session over an injected (fake-server) client transport. Runs the
     /// `initialize` handshake exactly like [`Self::spawn`] so the negotiated encoding is real.
     #[cfg(test)]
-    pub(crate) fn from_client(mut client: LspClient, tool_version: &str, root_uri: &str) -> Self {
-        client.initialize(root_uri).expect("test server completes the handshake");
-        client.assume_ready();
-        Self::from_initialized_client(client, tool_version, root_uri)
+    pub(crate) fn from_client(client: LspClient, tool_version: &str, root_uri: &str) -> Self {
+        let mut session = Self::from_warming_client(client, tool_version, root_uri);
+        session.client.assume_ready();
+        session
     }
 
     #[cfg(test)]
     pub(crate) fn from_warming_client(
+        client: LspClient,
+        tool_version: &str,
+        root_uri: &str,
+    ) -> Self {
+        Self::from_warming_client_for(OracleTool::RaLsp, client, tool_version, root_uri)
+    }
+
+    /// The tool-parameterized warm session seam: drives the pass through a specific backend's
+    /// language ids, sentinel namespace, and moniker source.
+    #[cfg(test)]
+    pub(crate) fn from_warming_client_for(
+        tool: OracleTool,
         mut client: LspClient,
         tool_version: &str,
         root_uri: &str,
     ) -> Self {
         client.initialize(root_uri).expect("test server completes the handshake");
-        Self::from_initialized_client(client, tool_version, root_uri)
+        Self {
+            backend: LiveBackend::for_tool(tool).expect("a live backend"),
+            client,
+            tool_version: tool_version.to_string(),
+            root_uri: root_uri.to_string(),
+        }
     }
 
-    #[cfg(test)]
-    fn from_initialized_client(client: LspClient, tool_version: &str, root_uri: &str) -> Self {
-        Self { client, tool_version: tool_version.to_string(), root_uri: root_uri.to_string() }
+    pub fn tool(&self) -> OracleTool {
+        self.backend.tool
     }
 
     pub fn tool_version(&self) -> &str {
@@ -117,6 +154,58 @@ impl LiveOracleSession {
 
     fn readiness_checkpoint(&mut self) -> std::io::Result<Option<u64>> {
         self.client.readiness_checkpoint()
+    }
+
+    /// Nudge a backend whose readiness signal only appears in response to an open document
+    /// (`typescript-language-server` starts its project load on the first `didOpen`, not at
+    /// `initialize`): send one `didOpen`/`didClose` pair for a worklist file that can actually
+    /// produce the signal, then return.
+    ///
+    /// The file CHOICE matters, it is not just "the first one on disk": a document belonging to no
+    /// tsconfig project opens as an inferred project silently, emitting no progress cycle, so
+    /// warming on it leaves the session exactly as un-warmed as before. A worklist of only such
+    /// files would re-open an ineffective document every pass and never warm — so when none of
+    /// them qualifies the backend supplies one by SEARCHING the checkout. That is worth doing
+    /// because the expensive warm-up is per server, not per project: once any real project has
+    /// loaded, even the project-less files resolve correctly.
+    ///
+    /// Deliberately fire-and-forget. The pass runs under the repository write lock, so blocking
+    /// here for a project load — seconds on a real project — would stall every writer. The
+    /// notifications are enough: the server loads in the background, its progress cycle latches
+    /// the session ready, and the NEXT pass resolves the deferred worklist normally. Closing the
+    /// document immediately does not cancel the load.
+    fn trigger_warmup_open(&mut self, checkout_root: &Path, worklist: &[String]) {
+        let open_document = |absolute: &Path| {
+            let text = std::fs::read_to_string(absolute).ok()?;
+            let uri: String = Url::from_file_path(absolute).ok()?.into();
+            let language_id = self.backend.language_id_for(&absolute.to_string_lossy());
+            Some((language_id, uri, text))
+        };
+        let opened = worklist
+            .iter()
+            .filter(|path| self.backend.open_signals_readiness(checkout_root, path))
+            .find_map(|path| open_document(&checkout_root.join(path)))
+            .or_else(|| {
+                self.backend.warmup_document(checkout_root).as_deref().and_then(open_document)
+            });
+        let Some((language_id, uri, text)) = opened else {
+            return;
+        };
+        if self.client.did_open(&uri, language_id, &text).is_ok() {
+            let _ = self.client.did_close(&uri);
+        }
+    }
+
+    fn needs_warmup_open(&self) -> bool {
+        self.client.needs_warmup_open()
+    }
+
+    /// Test barrier: one synchronous round trip. The transport is FIFO, so a returned response
+    /// proves the server has processed every fire-and-forget notification sent before it —
+    /// without this, a test asserting on the warm-up `didOpen` races the server thread.
+    #[cfg(test)]
+    pub(crate) fn barrier(&mut self) {
+        let _ = self.client.request("$/barrier", serde_json::Value::Null);
     }
 }
 
@@ -193,6 +282,11 @@ pub fn live_oracle_pass(
     match session.readiness_checkpoint() {
         Ok(Some(_)) => {},
         Ok(None) => {
+            // A backend whose readiness signal only fires for an open document can never report
+            // ready while the pass declines to open one. Break that deadlock without blocking.
+            if session.needs_warmup_open() {
+                session.trigger_warmup_open(input.checkout_root, input.worklist);
+            }
             report.unfinished_paths = input.worklist.to_vec();
             report.status = "Warming".to_string();
             return Ok(report);
@@ -203,9 +297,9 @@ pub fn live_oracle_pass(
             return Ok(report);
         },
     }
-    let tool = OracleTool::RaLsp;
-    // The batch tool whose monikers live copies (rust-analyzer for ra-lsp) — always `Some` for a
-    // live tool; the join is vacuous without it.
+    let tool = session.tool();
+    // The batch tool whose monikers live copies (rust-analyzer for ra-lsp, scip-typescript for
+    // ts-lsp) — always `Some` for a live tool; the join is vacuous without it.
     let Some(moniker_source) = tool.batch_moniker_source() else {
         anyhow::bail!("live_oracle_pass requires a live (non-batch) tool");
     };
@@ -369,7 +463,8 @@ pub fn live_oracle_pass(
         let starts: Vec<usize> =
             to_resolve.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
         report.requests_used += starts.len() as u64;
-        let resolved = match session.client.resolve_definitions(&uri, "rust", &text, &starts) {
+        let language_id = session.backend.language_id_for(path);
+        let resolved = match session.client.resolve_definitions(&uri, language_id, &text, &starts) {
             Ok(resolved) => resolved,
             Err(err) => {
                 // A dead/wedged server: keep what earlier files produced, REQUEUE this file and
@@ -519,7 +614,7 @@ pub fn live_oracle_pass(
             let scip_symbol = moniker_cache
                 .get(&symbol_id)
                 .and_then(Clone::clone)
-                .unwrap_or_else(|| live_local_sentinel(&candidate.source_path, candidate));
+                .unwrap_or_else(|| live_local_sentinel(tool, &candidate.source_path, candidate));
 
             let row = EdgeOracleRow {
                 source_path: &candidate.source_path,
@@ -628,16 +723,24 @@ fn defer_candidate_paths_from(
 }
 
 /// The content-stable SCIP-local sentinel a live verdict carries when the resolved symbol has no
-/// batch moniker: `local ra-lsp-<hash>` keyed by the callsite (path + callee span), so a no-op
+/// batch moniker: `local <tool>-<hash>` keyed by the callsite (path + callee span), so a no-op
 /// re-pass reproduces the SAME string (a same-value upsert — no refine-cache churn). Parses as a
 /// SCIP local symbol, so `is_local_symbol` drops it before `current_callee_monikers`' conflict
 /// logic and it can never poison a batch moniker.
-fn live_local_sentinel(source_path: &str, candidate: &store::EdgeJoinCandidate) -> String {
+///
+/// The tool id namespaces the sentinel so two live backends can never mint the same string for
+/// different evidence; the HASH input deliberately stays callsite-only, so `ra-lsp` rows written
+/// before a second backend existed keep reproducing byte-identically.
+fn live_local_sentinel(
+    tool: OracleTool,
+    source_path: &str,
+    candidate: &store::EdgeJoinCandidate,
+) -> String {
     let hash = hex_sha256(
         format!("{}:{}:{}", source_path, candidate.callee_start_byte, candidate.callee_end_byte)
             .as_bytes(),
     );
-    format!("local ra-lsp-{}", &hash[..16])
+    format!("local {}-{}", tool.as_db_str(), &hash[..16])
 }
 
 /// The canonical `file://` URL of a checkout directory. `url` handles native disk,
@@ -749,12 +852,42 @@ mod tests {
             edge_kind: "calls_name".to_string(),
             to_symbol_id: None,
         };
-        let a = live_local_sentinel("src/lib.rs", &candidate);
-        let b = live_local_sentinel("src/lib.rs", &candidate);
+        let a = live_local_sentinel(OracleTool::RaLsp, "src/lib.rs", &candidate);
+        let b = live_local_sentinel(OracleTool::RaLsp, "src/lib.rs", &candidate);
         assert_eq!(a, b, "same callsite reproduces the same sentinel (no refine churn)");
         assert!(super::super::scip::is_local_symbol(&a), "parses as a SCIP local: {a}");
+        // Pinned: rows written before a second live backend existed must keep reproducing this
+        // exact string, or every ra-lsp verdict churns the refine cache on the next pass.
         assert!(a.starts_with("local ra-lsp-"));
         let other = store::EdgeJoinCandidate { callee_start_byte: 5, ..candidate };
-        assert_ne!(a, live_local_sentinel("src/lib.rs", &other), "span-keyed");
+        assert_ne!(a, live_local_sentinel(OracleTool::RaLsp, "src/lib.rs", &other), "span-keyed");
+    }
+
+    #[test]
+    fn every_live_backend_mints_a_distinct_parseable_sentinel() {
+        // Two backends must never mint the same sentinel for the same callsite (that would make
+        // one backend's evidence indistinguishable from the other's), and every sentinel must
+        // still parse as a SCIP local so it is dropped before the moniker-conflict logic.
+        let candidate = store::EdgeJoinCandidate {
+            edge_id: 1,
+            source_path: "src/lib".to_string(),
+            file_sha: "sha".to_string(),
+            source_start_byte: 0,
+            source_end_byte: 10,
+            callee_start_byte: 4,
+            callee_end_byte: 9,
+            confidence: "NameOnly".to_string(),
+            edge_kind: "calls_name".to_string(),
+            to_symbol_id: None,
+        };
+        let mut seen = std::collections::HashSet::new();
+        for &tool in OracleTool::ALL.iter().filter(|tool| !tool.batch_capable()) {
+            let sentinel = live_local_sentinel(tool, "src/lib", &candidate);
+            assert!(
+                super::super::scip::is_local_symbol(&sentinel),
+                "{sentinel} must parse as a SCIP local"
+            );
+            assert!(seen.insert(sentinel.clone()), "{sentinel} collides across backends");
+        }
     }
 }

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -70,35 +70,54 @@ pub struct LiveOracleSession {
     root_uri: String,
 }
 
+/// Why a live session could not be established. The distinction is operational, not cosmetic: a
+/// `Prerequisite` block is a PERMANENT property of the checkout that a human has to act on, while
+/// `Unavailable` is the ordinary missing-tool degradation the watcher just keeps retrying.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiveSpawnBlocked {
+    /// A checkout prerequisite this backend needs is unmet, with the operator-facing hint. Retrying
+    /// cannot fix it — only a change to the checkout can — so the caller must SURFACE the hint
+    /// rather than fold it into a spawn-failure retry loop.
+    Prerequisite(String),
+    /// The language server is absent, unrunnable, or the session could not be established.
+    Unavailable,
+}
+
 impl LiveOracleSession {
-    /// Probe `backend`'s language server and spawn the resident client for `checkout_root`, or
-    /// `None` when the tool is unavailable / a checkout prerequisite is unmet / the session can't
-    /// be established — the same degrade-quietly UX as a missing embedding model or batch tool
-    /// (never an error, never a failed pass). The version is RE-probed at every spawn so
-    /// `tool_version` always names the binary this session's verdicts came from.
-    pub fn spawn(tool: OracleTool, checkout_root: &Path) -> Option<Self> {
-        let backend = LiveBackend::for_tool(tool)?;
+    /// Probe `tool`'s language server and spawn the resident client for `checkout_root`.
+    ///
+    /// Never an error and never a failed pass — the same degrade-quietly UX as a missing embedding
+    /// model or batch tool — but the two ways it can decline are reported separately so a
+    /// permanent configuration problem does not masquerade as a transient one. The version is
+    /// RE-probed at every spawn so `tool_version` always names the binary this session's verdicts
+    /// came from.
+    pub fn spawn(tool: OracleTool, checkout_root: &Path) -> Result<Self, LiveSpawnBlocked> {
+        let Some(backend) = LiveBackend::for_tool(tool) else {
+            return Err(LiveSpawnBlocked::Unavailable);
+        };
         let manifest = ToolManifest::for_tool(tool);
         // The prerequisite gate is not cosmetic for every backend: the live TypeScript client
-        // needs a tsconfig.json because that is what makes the server emit the project-load
+        // needs a tsconfig project because that is what makes the server emit the project-load
         // signal it has no other way to report. Spawning without it would resolve definitions
         // during a warm-up window that answers WRONG rather than null.
-        if manifest.prerequisite_blocked(checkout_root).is_some() {
-            return None;
+        if let Some(hint) = manifest.prerequisite_blocked(checkout_root) {
+            return Err(LiveSpawnBlocked::Prerequisite(hint));
         }
         let ToolAvailability::Available { version, .. } = manifest.probe_in(checkout_root) else {
-            return None;
+            return Err(LiveSpawnBlocked::Unavailable);
         };
-        let root_uri = root_uri_for(checkout_root)?;
+        let Some(root_uri) = root_uri_for(checkout_root) else {
+            return Err(LiveSpawnBlocked::Unavailable);
+        };
         let mut client = LspClient::spawn(
             manifest.program,
             manifest.live_args,
             checkout_root,
             backend.readiness,
         )
-        .ok()?;
-        client.initialize(&root_uri).ok()?;
-        Some(Self { backend, client, tool_version: version, root_uri })
+        .map_err(|_| LiveSpawnBlocked::Unavailable)?;
+        client.initialize(&root_uri).map_err(|_| LiveSpawnBlocked::Unavailable)?;
+        Ok(Self { backend, client, tool_version: version, root_uri })
     }
 
     /// Test seam: a session over an injected (fake-server) client transport. Runs the

--- a/crates/rag-rat-oracle/src/lsp/client.rs
+++ b/crates/rag-rat-oracle/src/lsp/client.rs
@@ -14,7 +14,6 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -23,6 +22,7 @@ use serde_json::{Value, json};
 
 use super::position::LspEncoding;
 use super::protocol;
+use super::readiness::{ReadinessPolicy, ReadinessState, ReadinessTracker};
 
 /// The JSON-RPC `MethodNotFound` code — a server's answer for a method it doesn't implement (an
 /// optional request like `textDocument/moniker`), and the code we reply with to a server→client
@@ -37,10 +37,6 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// readiness is coalesced separately. Bounding the remainder prevents an idle server from growing
 /// the client's heap without limit.
 const INCOMING_QUEUE_CAPACITY: usize = 64;
-
-/// The low bit of `readiness_state` is current readiness; the remaining bits count non-ready
-/// transitions. Keeping both in one atomic makes a checkpoint an indivisible snapshot.
-const SERVER_READY_BIT: u64 = 1;
 
 type IncomingMessage = io::Result<Option<Value>>;
 
@@ -64,7 +60,8 @@ pub(crate) struct LspClient {
     next_id: i64,
     encoding: LspEncoding,
     request_timeout: Duration,
-    readiness_state: Arc<AtomicU64>,
+    readiness_policy: ReadinessPolicy,
+    readiness_state: Arc<ReadinessState>,
     /// The child process for a spawned server; `None` for an injected (test) transport. Present so
     /// [`Drop`] can hard-kill it.
     child: Option<Child>,
@@ -74,8 +71,14 @@ impl LspClient {
     /// Spawn `program args…` from `cwd` as a language server, piping stdio into the JSON-RPC
     /// transport. stderr is discarded (server diagnostics are not part of the protocol). The
     /// session starts at the LSP default encoding (UTF-16) until
-    /// [`initialize`](Self::initialize) negotiates one.
-    pub(crate) fn spawn(program: &str, args: &[&str], cwd: &Path) -> io::Result<Self> {
+    /// [`initialize`](Self::initialize) negotiates one, and interprets readiness under `readiness`
+    /// — the signal this backend actually emits.
+    pub(crate) fn spawn(
+        program: &str,
+        args: &[&str],
+        cwd: &Path,
+        readiness: ReadinessPolicy,
+    ) -> io::Result<Self> {
         let mut child = Command::new(program)
             .args(args)
             .current_dir(cwd)
@@ -87,16 +90,17 @@ impl LspClient {
             child.stdin.take().ok_or_else(|| io::Error::other("child stdin unavailable"))?;
         let stdout =
             child.stdout.take().ok_or_else(|| io::Error::other("child stdout unavailable"))?;
-        let readiness_state = Arc::new(AtomicU64::new(0));
+        let readiness_state = Arc::new(ReadinessState::default());
         Ok(Self {
             outgoing: spawn_writer_pump(Box::new(stdin)),
             incoming: spawn_reader_pump(
                 Box::new(BufReader::new(stdout)),
-                Arc::clone(&readiness_state),
+                ReadinessTracker::new(readiness, Arc::clone(&readiness_state)),
             ),
             next_id: 1,
             encoding: LspEncoding::Utf16,
             request_timeout: REQUEST_TIMEOUT,
+            readiness_policy: readiness,
             readiness_state,
             child: Some(child),
         })
@@ -112,16 +116,37 @@ impl LspClient {
         writer: Box<dyn Write + Send>,
         request_timeout: Duration,
     ) -> Self {
-        let readiness_state = Arc::new(AtomicU64::new(0));
+        Self::from_transport_with(reader, writer, request_timeout, ReadinessPolicy::ServerStatus)
+    }
+
+    fn from_transport_with(
+        reader: Box<dyn BufRead + Send>,
+        writer: Box<dyn Write + Send>,
+        request_timeout: Duration,
+        readiness: ReadinessPolicy,
+    ) -> Self {
+        let readiness_state = Arc::new(ReadinessState::default());
         Self {
             outgoing: spawn_writer_pump(writer),
-            incoming: spawn_reader_pump(reader, Arc::clone(&readiness_state)),
+            incoming: spawn_reader_pump(
+                reader,
+                ReadinessTracker::new(readiness, Arc::clone(&readiness_state)),
+            ),
             next_id: 1,
             encoding: LspEncoding::Utf16,
             request_timeout,
+            readiness_policy: readiness,
             readiness_state,
             child: None,
         }
+    }
+
+    /// Whether this session still needs a warm-up `didOpen` before its backend can report ready.
+    /// See [`ReadinessPolicy::needs_warmup_open`]: a `WorkDoneProgress` server only starts (and
+    /// therefore only reports) its project load once a document is opened, so a pass that waits
+    /// for readiness without opening one would wait forever.
+    pub(crate) fn needs_warmup_open(&self) -> bool {
+        self.readiness_policy.needs_warmup_open() && self.readiness_state.checkpoint().is_none()
     }
 
     /// The position encoding negotiated during [`initialize`](Self::initialize) (UTF-16 until
@@ -130,11 +155,11 @@ impl LspClient {
         self.encoding
     }
 
-    /// Drain pending server messages and return a checkpoint only when rust-analyzer is ready.
-    /// Comparing checkpoints around a definition batch detects even a non-ready→ready cycle that
-    /// the latest boolean state alone would hide. Unknown status is deliberately not ready:
-    /// sending definitions before the first status can turn warm-up `null`s into permanently
-    /// missing evidence.
+    /// Drain pending server messages and return a checkpoint only when the server is ready under
+    /// its backend's [`ReadinessPolicy`]. Comparing checkpoints around a definition batch detects
+    /// even a non-ready→ready cycle that the latest boolean state alone would hide. An unobserved
+    /// signal is deliberately not ready: a warming server answers a definition with a warm-up
+    /// artifact, which the write path would persist as a real verdict.
     pub(crate) fn readiness_checkpoint(&mut self) -> io::Result<Option<u64>> {
         let deadline = Instant::now() + self.request_timeout;
         loop {
@@ -146,10 +171,7 @@ impl LspClient {
                     let message = message?.ok_or_else(server_closed_error)?;
                     self.handle_server_message(&message, deadline)?;
                 },
-                Err(TryRecvError::Empty) => {
-                    let state = self.readiness_state.load(Ordering::SeqCst);
-                    return Ok((state & SERVER_READY_BIT != 0).then_some(state >> 1));
-                },
+                Err(TryRecvError::Empty) => return Ok(self.readiness_state.checkpoint()),
                 Err(TryRecvError::Disconnected) => return Err(server_closed_error()),
             }
         }
@@ -157,7 +179,7 @@ impl LspClient {
 
     #[cfg(test)]
     pub(crate) fn assume_ready(&mut self) {
-        self.readiness_state.fetch_or(SERVER_READY_BIT, Ordering::SeqCst);
+        self.readiness_state.assume_ready();
     }
 
     /// Send a request and return its `result`, mapping a JSON-RPC `error` response to an `Err`.
@@ -260,7 +282,21 @@ impl LspClient {
                 "textDocument": {
                     "definition": { "dynamicRegistration": false, "linkSupport": true },
                 },
-                "experimental": { "serverStatusNotification": true },
+                // A readiness signal must be ASKED for, and ONLY the one this session reads:
+                // a server emits server-initiated work-done progress only when the client
+                // advertises `window.workDoneProgress`, and rust-analyzer emits
+                // `experimental/serverStatus` only under its experimental capability. Advertising
+                // a signal we then discard invites the server to open progress tokens whose
+                // `window/workDoneProgress/create` requests occupy the bounded incoming queue
+                // between passes for no benefit.
+                "window": {
+                    "workDoneProgress":
+                        self.readiness_policy == ReadinessPolicy::WorkDoneProgress,
+                },
+                "experimental": {
+                    "serverStatusNotification":
+                        self.readiness_policy == ReadinessPolicy::ServerStatus,
+                },
             },
         });
         let result = self.request("initialize", params)?;
@@ -362,31 +398,22 @@ fn spawn_writer_pump(mut writer: Box<dyn Write + Send>) -> SyncSender<OutgoingMe
 
 fn spawn_reader_pump(
     mut reader: Box<dyn BufRead + Send>,
-    readiness_state: Arc<AtomicU64>,
+    mut readiness: ReadinessTracker,
 ) -> Receiver<IncomingMessage> {
     let (sender, receiver) = mpsc::sync_channel(INCOMING_QUEUE_CAPACITY);
     thread::spawn(move || {
         loop {
             let message = protocol::read_message(&mut reader);
             match message {
-                Ok(Some(message)) if is_server_status(&message) => {
-                    let ready = status_is_ready(&message);
-                    if ready {
-                        readiness_state.fetch_or(SERVER_READY_BIT, Ordering::SeqCst);
-                    } else {
-                        let _ = readiness_state.fetch_update(
-                            Ordering::SeqCst,
-                            Ordering::SeqCst,
-                            |state| Some(state.wrapping_add(2) & !SERVER_READY_BIT),
-                        );
-                    }
-                },
+                // Readiness signals are coalesced into the shared state, never queued: a
+                // long-running server emits many of them and they carry no reply obligation.
+                Ok(Some(message)) if readiness.observe(&message) => {},
                 Ok(Some(message)) if should_queue_incoming(&message) => {
                     if sender.send(Ok(Some(message))).is_err() {
                         return;
                     }
                 },
-                // Diagnostics, logs, and progress are irrelevant to this client.
+                // Diagnostics, logs, and the other backend's progress chatter are irrelevant.
                 Ok(Some(_)) => {},
                 terminal => {
                     let _ = sender.send(terminal);
@@ -398,20 +425,10 @@ fn spawn_reader_pump(
     receiver
 }
 
-fn is_server_status(message: &Value) -> bool {
-    message.get("method").and_then(Value::as_str) == Some("experimental/serverStatus")
-}
-
 fn should_queue_incoming(message: &Value) -> bool {
     // Responses and server requests have ids. Ordinary notifications do not and would otherwise
     // accumulate while the watcher is idle.
     message.get("id").is_some()
-}
-
-fn status_is_ready(message: &Value) -> bool {
-    let params = &message["params"];
-    params.get("quiescent").and_then(Value::as_bool) == Some(true)
-        && params.get("health").and_then(Value::as_str) != Some("error")
 }
 
 fn server_closed_error() -> io::Error {
@@ -449,7 +466,7 @@ pub(crate) mod test_support {
 
     use serde_json::Value;
 
-    use super::{LspClient, protocol};
+    use super::{LspClient, ReadinessPolicy, protocol};
 
     /// Wire an [`LspClient`] to an in-process fake server run on a thread over two
     /// `std::io::pipe`s. `handler(request)` returns `Some(messages_to_emit)` (notifications can
@@ -464,7 +481,27 @@ pub(crate) mod test_support {
         client_with_server_timeout(handler, super::REQUEST_TIMEOUT)
     }
 
+    /// A fake-server client that interprets readiness under `policy` — the seam for exercising a
+    /// backend whose signal is not rust-analyzer's `experimental/serverStatus`.
+    pub(crate) fn client_with_server_policy<H>(handler: H, policy: ReadinessPolicy) -> LspClient
+    where
+        H: FnMut(&Value) -> Option<Vec<Value>> + Send + 'static,
+    {
+        client_with_server_inner(handler, super::REQUEST_TIMEOUT, policy)
+    }
+
     pub(crate) fn client_with_server_timeout<H>(handler: H, timeout: Duration) -> LspClient
+    where
+        H: FnMut(&Value) -> Option<Vec<Value>> + Send + 'static,
+    {
+        client_with_server_inner(handler, timeout, ReadinessPolicy::ServerStatus)
+    }
+
+    fn client_with_server_inner<H>(
+        handler: H,
+        timeout: Duration,
+        policy: ReadinessPolicy,
+    ) -> LspClient
     where
         H: FnMut(&Value) -> Option<Vec<Value>> + Send + 'static,
     {
@@ -485,10 +522,11 @@ pub(crate) mod test_support {
                 }
             }
         });
-        LspClient::from_transport_with_timeout(
+        LspClient::from_transport_with(
             Box::new(BufReader::new(from_server_read)),
             Box::new(to_server_write),
             timeout,
+            policy,
         )
     }
 }
@@ -528,6 +566,44 @@ mod tests {
             init["params"]["capabilities"]["experimental"]["serverStatusNotification"].as_bool(),
             Some(true),
         );
+    }
+
+    #[test]
+    fn initialize_asks_only_for_the_readiness_signal_this_session_reads() {
+        // Advertising a signal the session then discards invites the server to open progress
+        // tokens whose `window/workDoneProgress/create` requests occupy the bounded incoming
+        // queue between passes, for a signal nothing consumes.
+        for (policy, work_done, server_status) in [
+            (ReadinessPolicy::ServerStatus, false, true),
+            (ReadinessPolicy::WorkDoneProgress, true, false),
+        ] {
+            let captured = Arc::new(Mutex::new(Vec::new()));
+            let capture = Arc::clone(&captured);
+            let mut client = test_support::client_with_server_policy(
+                move |msg: &Value| {
+                    capture.lock().unwrap().push(msg.clone());
+                    respond(msg, Some("utf-16"))
+                },
+                policy,
+            );
+            client.initialize("file:///repo").unwrap();
+            let requests = captured.lock().unwrap();
+            let capabilities = requests
+                .iter()
+                .find(|m| m.get("method").and_then(Value::as_str) == Some("initialize"))
+                .expect("an initialize request was sent")["params"]["capabilities"]
+                .clone();
+            assert_eq!(
+                capabilities["window"]["workDoneProgress"].as_bool(),
+                Some(work_done),
+                "{policy:?}",
+            );
+            assert_eq!(
+                capabilities["experimental"]["serverStatusNotification"].as_bool(),
+                Some(server_status),
+                "{policy:?}",
+            );
+        }
     }
 
     /// Build an `initialize` response echoing `encoding` (or none when `encoding` is `None`), and a
@@ -725,10 +801,12 @@ mod tests {
         )
         .unwrap();
 
-        let readiness_state = Arc::new(AtomicU64::new(0));
         let incoming = spawn_reader_pump(
             Box::new(BufReader::new(std::io::Cursor::new(framed))),
-            readiness_state,
+            ReadinessTracker::new(
+                ReadinessPolicy::ServerStatus,
+                Arc::new(ReadinessState::default()),
+            ),
         );
         assert_eq!(
             incoming.recv_timeout(Duration::from_secs(1)).unwrap().unwrap(),
@@ -752,14 +830,28 @@ mod tests {
 
     #[test]
     fn spawn_of_a_missing_program_errors() {
-        assert!(LspClient::spawn("rag-rat-no-such-lsp-xyzzy", &[], Path::new(".")).is_err());
+        assert!(
+            LspClient::spawn(
+                "rag-rat-no-such-lsp-xyzzy",
+                &[],
+                Path::new("."),
+                ReadinessPolicy::ServerStatus,
+            )
+            .is_err()
+        );
     }
 
     #[test]
     fn spawn_applies_the_checkout_cwd() {
         let root = rag_rat_base::test_scratch::ScratchDir::new("lsp-spawn-cwd");
         assert!(
-            LspClient::spawn("cargo", &["--version"], &root.path().join("missing")).is_err(),
+            LspClient::spawn(
+                "cargo",
+                &["--version"],
+                &root.path().join("missing"),
+                ReadinessPolicy::ServerStatus,
+            )
+            .is_err(),
             "a missing cwd must prevent spawn"
         );
     }

--- a/crates/rag-rat-oracle/src/lsp/mod.rs
+++ b/crates/rag-rat-oracle/src/lsp/mod.rs
@@ -17,9 +17,13 @@
 //!   position encoding. The batch analog is `scip::LineColumnToByte`; LSP defaults to UTF-16 and
 //!   negotiates via `initialize`, and unlike SCIP we need BOTH directions (byte → position to ASK
 //!   for a definition, position → byte to READ one back).
+//! - `readiness.rs` — the per-backend "is it safe to ask yet?" signal. Servers disagree on how they
+//!   announce that a project has finished loading, and a warming server does not reliably answer
+//!   `null` — it can answer WRONG — so this is a correctness seam, not a latency one.
 #![allow(dead_code)] // `resolve_callees`'s moniker fan-out is unused until a consumer needs it.
 
 pub(crate) mod client;
 pub(crate) mod position;
 mod protocol;
+pub(crate) mod readiness;
 pub(crate) mod resolve;

--- a/crates/rag-rat-oracle/src/lsp/readiness.rs
+++ b/crates/rag-rat-oracle/src/lsp/readiness.rs
@@ -92,7 +92,19 @@ pub(crate) struct ReadinessTracker {
     /// Work-done progress tokens the server has begun and not yet ended. Every `$/progress` we
     /// see is server-created work-done progress: partial-result progress only flows for a
     /// `partialResultToken` the client supplied, and this client never sends one.
-    in_flight: HashSet<String>,
+    ///
+    /// Keyed by the token's JSON value, not its rendering: LSP allows a `ProgressToken` to be an
+    /// integer OR a string, so flattening both to text would let `7` and `"7"` share a slot —
+    /// ending either would empty the set and report ready while the other load is still running.
+    in_flight: HashSet<ProgressToken>,
+}
+
+/// An LSP `ProgressToken`, which the protocol defines as `integer | string`. Kept as a typed value
+/// so two tokens are equal only when the server meant them to be.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ProgressToken {
+    Number(String),
+    Text(String),
 }
 
 impl ReadinessTracker {
@@ -148,12 +160,12 @@ impl ReadinessTracker {
     }
 }
 
-/// A progress token, which LSP allows to be either a string or an integer. Normalized to a string
-/// so both forms key the same in-flight set.
-fn progress_token(params: &Value) -> Option<String> {
+/// The `token` of a `$/progress` notification, preserving whether the server sent it as a number
+/// or a string (see [`ProgressToken`]).
+fn progress_token(params: &Value) -> Option<ProgressToken> {
     match params.get("token")? {
-        Value::String(token) => Some(token.clone()),
-        Value::Number(token) => Some(token.to_string()),
+        Value::String(token) => Some(ProgressToken::Text(token.clone())),
+        Value::Number(token) => Some(ProgressToken::Number(token.to_string())),
         _ => None,
     }
 }
@@ -275,8 +287,6 @@ mod tests {
 
     #[test]
     fn integer_progress_tokens_pair_with_their_own_end() {
-        // LSP allows an integer ProgressToken; normalizing to a string must not make two distinct
-        // tokens collide or a matching pair miss each other.
         let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
         tracker.observe(&json!({
             "method": "$/progress", "params": {"token": 7, "value": {"kind": "begin"}}
@@ -285,6 +295,28 @@ mod tests {
             "method": "$/progress", "params": {"token": 7, "value": {"kind": "end"}}
         }));
         assert!(state.checkpoint().is_some());
+    }
+
+    #[test]
+    fn an_integer_token_never_shares_a_slot_with_the_same_digits_as_a_string() {
+        // LSP's ProgressToken is `integer | string`, so `7` and `"7"` are DIFFERENT tokens. If
+        // both keyed one slot, ending either would empty the set and report ready while the other
+        // load was still running — persisting a warming server's answers, the exact failure this
+        // whole policy exists to prevent.
+        let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        for token in [json!(7), json!("7")] {
+            tracker.observe(&json!({
+                "method": "$/progress", "params": {"token": token, "value": {"kind": "begin"}}
+            }));
+        }
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": 7, "value": {"kind": "end"}}
+        }));
+        assert_eq!(state.checkpoint(), None, "the string token's load is still in flight");
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": "7", "value": {"kind": "end"}}
+        }));
+        assert!(state.checkpoint().is_some(), "ready only once BOTH loads drained");
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/lsp/readiness.rs
+++ b/crates/rag-rat-oracle/src/lsp/readiness.rs
@@ -1,0 +1,313 @@
+//! Backend-specific readiness: how a live language server tells the client that asking for a
+//! definition will produce a real answer rather than a warm-up artifact.
+//!
+//! Readiness is not a nicety. A server that has not finished loading its project does not
+//! reliably answer `null` — `typescript-language-server` answers an imported callee with the
+//! IMPORT STATEMENT in the calling file, a plausible non-null that the write path would persist as
+//! a real `Upgrade`/`Contradict` verdict and (under the covered-skip budget) never revisit until
+//! the file's bytes change. So each backend declares the signal it actually emits, and the pass
+//! refuses to interpret a batch that straddled a non-ready window.
+//!
+//! Two signals cover the live backends:
+//!
+//! - [`ReadinessPolicy::ServerStatus`] — `rust-analyzer`'s `experimental/serverStatus`
+//!   notification, an explicit session-level quiescence flag.
+//! - [`ReadinessPolicy::WorkDoneProgress`] — the LSP-standard `$/progress` work-done cycle, which
+//!   `typescript-language-server` emits around each project load. Readiness LATCHES: the session
+//!   becomes ready when its first cycle drains, and a later load flips it back and bumps the
+//!   checkpoint so an in-flight batch is discarded.
+//!
+//! Both encode into one [`ReadinessState`] atomic whose snapshot ([`ReadinessState::checkpoint`])
+//! is indivisible, so comparing checkpoints around a batch detects even a
+//! non-ready→ready cycle that the latest boolean alone would hide.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::Value;
+
+/// The low bit is current readiness; the remaining bits count non-ready transitions.
+const SERVER_READY_BIT: u64 = 1;
+
+/// How a backend signals that it is ready to answer definition requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReadinessPolicy {
+    /// `rust-analyzer`: `experimental/serverStatus` with `quiescent: true` and a non-error health.
+    /// Advertised through the `experimental.serverStatusNotification` client capability.
+    ServerStatus,
+    /// LSP-standard work-done progress (`$/progress` begin/end). The session is ready once it has
+    /// COMPLETED at least one cycle: `typescript-language-server` starts its project load on the
+    /// first `textDocument/didOpen`, not at `initialize`, so an un-warmed session has no cycle yet
+    /// and must not be asked for definitions.
+    WorkDoneProgress,
+}
+
+impl ReadinessPolicy {
+    /// Whether a session under this policy needs a warm-up `didOpen` before it can ever report
+    /// ready. `WorkDoneProgress` does: its signal is emitted in response to opening a document,
+    /// so waiting for readiness without opening one waits forever.
+    pub(crate) fn needs_warmup_open(self) -> bool {
+        matches!(self, Self::WorkDoneProgress)
+    }
+}
+
+/// The readiness bits shared between the reader pump (which writes them) and the client (which
+/// snapshots them).
+#[derive(Debug, Default)]
+pub(crate) struct ReadinessState {
+    bits: AtomicU64,
+}
+
+impl ReadinessState {
+    /// A checkpoint when the server is ready, `None` otherwise. The value is the non-ready
+    /// transition count, so two equal checkpoints prove no reload happened in between.
+    pub(crate) fn checkpoint(&self) -> Option<u64> {
+        let bits = self.bits.load(Ordering::SeqCst);
+        (bits & SERVER_READY_BIT != 0).then_some(bits >> 1)
+    }
+
+    fn mark_ready(&self) {
+        self.bits.fetch_or(SERVER_READY_BIT, Ordering::SeqCst);
+    }
+
+    fn mark_not_ready(&self) {
+        let _ = self.bits.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |bits| {
+            Some(bits.wrapping_add(2) & !SERVER_READY_BIT)
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn assume_ready(&self) {
+        self.mark_ready();
+    }
+}
+
+/// The reader pump's readiness bookkeeping: interprets the server's notifications under the
+/// backend's policy and folds them into the shared [`ReadinessState`]. Owned by the single reader
+/// thread, so the in-flight token set needs no synchronization.
+pub(crate) struct ReadinessTracker {
+    policy: ReadinessPolicy,
+    state: Arc<ReadinessState>,
+    /// Work-done progress tokens the server has begun and not yet ended. Every `$/progress` we
+    /// see is server-created work-done progress: partial-result progress only flows for a
+    /// `partialResultToken` the client supplied, and this client never sends one.
+    in_flight: HashSet<String>,
+}
+
+impl ReadinessTracker {
+    pub(crate) fn new(policy: ReadinessPolicy, state: Arc<ReadinessState>) -> Self {
+        Self { policy, state, in_flight: HashSet::new() }
+    }
+
+    /// Fold a server message into the readiness state. Returns whether the message WAS a readiness
+    /// signal — the caller drops those instead of queueing them, so an idle server's progress
+    /// chatter cannot occupy the bounded response queue.
+    pub(crate) fn observe(&mut self, message: &Value) -> bool {
+        let Some(method) = message.get("method").and_then(Value::as_str) else {
+            return false;
+        };
+        match (self.policy, method) {
+            (ReadinessPolicy::ServerStatus, "experimental/serverStatus") => {
+                if server_status_is_ready(&message["params"]) {
+                    self.state.mark_ready();
+                } else {
+                    self.state.mark_not_ready();
+                }
+                true
+            },
+            (ReadinessPolicy::WorkDoneProgress, "$/progress") => {
+                self.observe_progress(&message["params"]);
+                true
+            },
+            _ => false,
+        }
+    }
+
+    fn observe_progress(&mut self, params: &Value) {
+        let Some(token) = progress_token(params) else {
+            return;
+        };
+        match params["value"].get("kind").and_then(Value::as_str) {
+            Some("begin") => {
+                self.in_flight.insert(token);
+                self.state.mark_not_ready();
+            },
+            Some("end") => {
+                // Only a token we saw BEGIN can end. A stray `end` must not fabricate readiness
+                // for a session that has never completed a cycle — that is exactly the warm-up
+                // window whose answers are wrong.
+                let ended_a_tracked_cycle = self.in_flight.remove(&token);
+                if ended_a_tracked_cycle && self.in_flight.is_empty() {
+                    self.state.mark_ready();
+                }
+            },
+            // `report` carries percentage/message updates only.
+            _ => {},
+        }
+    }
+}
+
+/// A progress token, which LSP allows to be either a string or an integer. Normalized to a string
+/// so both forms key the same in-flight set.
+fn progress_token(params: &Value) -> Option<String> {
+    match params.get("token")? {
+        Value::String(token) => Some(token.clone()),
+        Value::Number(token) => Some(token.to_string()),
+        _ => None,
+    }
+}
+
+/// rust-analyzer is ready when it reports itself quiescent and not in an error health state.
+fn server_status_is_ready(params: &Value) -> bool {
+    params.get("quiescent").and_then(Value::as_bool) == Some(true)
+        && params.get("health").and_then(Value::as_str) != Some("error")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn tracker(policy: ReadinessPolicy) -> (ReadinessTracker, Arc<ReadinessState>) {
+        let state = Arc::new(ReadinessState::default());
+        (ReadinessTracker::new(policy, Arc::clone(&state)), state)
+    }
+
+    #[test]
+    fn a_session_starts_not_ready_under_every_policy() {
+        // Unknown status is deliberately not ready: asking before the first signal turns warm-up
+        // answers into permanent evidence.
+        for policy in [ReadinessPolicy::ServerStatus, ReadinessPolicy::WorkDoneProgress] {
+            let (_tracker, state) = tracker(policy);
+            assert_eq!(state.checkpoint(), None, "{policy:?} must start not ready");
+        }
+    }
+
+    #[test]
+    fn server_status_tracks_quiescent_non_error_readiness() {
+        let (mut tracker, state) = tracker(ReadinessPolicy::ServerStatus);
+        assert!(tracker.observe(&json!({
+            "method": "experimental/serverStatus",
+            "params": {"health": "ok", "quiescent": true}
+        })));
+        assert!(state.checkpoint().is_some());
+        tracker.observe(&json!({
+            "method": "experimental/serverStatus",
+            "params": {"health": "ok", "quiescent": false}
+        }));
+        assert_eq!(state.checkpoint(), None, "a reload drops readiness");
+        tracker.observe(&json!({
+            "method": "experimental/serverStatus",
+            "params": {"health": "error", "quiescent": true}
+        }));
+        assert_eq!(state.checkpoint(), None, "error health is never ready");
+    }
+
+    #[test]
+    fn work_done_progress_becomes_ready_only_after_a_full_cycle() {
+        let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        assert!(tracker.observe(&json!({
+            "method": "$/progress",
+            "params": {"token": "t1", "value": {"kind": "begin", "title": "loading"}}
+        })));
+        assert_eq!(state.checkpoint(), None, "a load in flight is not ready");
+        tracker.observe(&json!({
+            "method": "$/progress",
+            "params": {"token": "t1", "value": {"kind": "report", "percentage": 50}}
+        }));
+        assert_eq!(state.checkpoint(), None, "a report is not an end");
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": "t1", "value": {"kind": "end"}}
+        }));
+        assert!(state.checkpoint().is_some(), "the drained cycle latches ready");
+    }
+
+    #[test]
+    fn a_later_load_bumps_the_checkpoint_so_a_straddling_batch_is_discarded() {
+        // A second project loading mid-pass must invalidate the batch, not merely be invisible:
+        // the checkpoint the pass captured before the batch must no longer compare equal.
+        let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        for kind in ["begin", "end"] {
+            tracker.observe(&json!({
+                "method": "$/progress", "params": {"token": "t1", "value": {"kind": kind}}
+            }));
+        }
+        let before = state.checkpoint().expect("ready after the first cycle");
+        for kind in ["begin", "end"] {
+            tracker.observe(&json!({
+                "method": "$/progress", "params": {"token": "t2", "value": {"kind": kind}}
+            }));
+        }
+        let after = state.checkpoint().expect("ready again after the second cycle");
+        assert_ne!(before, after, "a completed reload must not look like no reload at all");
+    }
+
+    #[test]
+    fn concurrent_progress_cycles_stay_not_ready_until_the_last_one_drains() {
+        let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        for token in ["a", "b"] {
+            tracker.observe(&json!({
+                "method": "$/progress", "params": {"token": token, "value": {"kind": "begin"}}
+            }));
+        }
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": "a", "value": {"kind": "end"}}
+        }));
+        assert_eq!(state.checkpoint(), None, "one outstanding load still blocks");
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": "b", "value": {"kind": "end"}}
+        }));
+        assert!(state.checkpoint().is_some());
+    }
+
+    #[test]
+    fn a_stray_end_cannot_fabricate_readiness() {
+        // Without a matching begin there was no observed cycle, so the session is still in the
+        // warm-up window whose answers are wrong.
+        let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": "ghost", "value": {"kind": "end"}}
+        }));
+        assert_eq!(state.checkpoint(), None);
+    }
+
+    #[test]
+    fn integer_progress_tokens_pair_with_their_own_end() {
+        // LSP allows an integer ProgressToken; normalizing to a string must not make two distinct
+        // tokens collide or a matching pair miss each other.
+        let (mut tracker, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": 7, "value": {"kind": "begin"}}
+        }));
+        tracker.observe(&json!({
+            "method": "$/progress", "params": {"token": 7, "value": {"kind": "end"}}
+        }));
+        assert!(state.checkpoint().is_some());
+    }
+
+    #[test]
+    fn each_policy_ignores_the_other_backends_signal() {
+        // A tracker must not consume (or act on) a signal from a policy it isn't running: leaving
+        // it unconsumed is what keeps the message-routing honest.
+        let (mut server_status, state) = tracker(ReadinessPolicy::ServerStatus);
+        assert!(!server_status.observe(&json!({
+            "method": "$/progress", "params": {"token": "t", "value": {"kind": "end"}}
+        })));
+        assert_eq!(state.checkpoint(), None);
+
+        let (mut progress, state) = tracker(ReadinessPolicy::WorkDoneProgress);
+        assert!(!progress.observe(&json!({
+            "method": "experimental/serverStatus",
+            "params": {"health": "ok", "quiescent": true}
+        })));
+        assert_eq!(state.checkpoint(), None);
+    }
+
+    #[test]
+    fn only_the_progress_policy_needs_a_warmup_open() {
+        assert!(!ReadinessPolicy::ServerStatus.needs_warmup_open());
+        assert!(ReadinessPolicy::WorkDoneProgress.needs_warmup_open());
+    }
+}

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -169,13 +169,20 @@ impl ToolManifest {
     /// hint, and a prerequisite is moot until the tool exists.
     pub fn probe_runnable_in(&self, root: &Path) -> ToolAvailability {
         let availability = self.probe_in(root);
-        match (&availability, self.prerequisite_blocked(root)) {
-            (ToolAvailability::Available { .. }, Some(hint)) => ToolAvailability::Blocked {
+        if !availability.is_available() {
+            // Already blocked, and the prerequisite is not evaluated at all — checking it would
+            // only be discarded, and for the live TypeScript backend it is a whole-checkout
+            // project search. `oracle status` with no `--tool` probes every backend, so an
+            // eagerly-evaluated prerequisite would walk a large checkout once per absent tool.
+            return availability;
+        }
+        match self.prerequisite_blocked(root) {
+            Some(hint) => ToolAvailability::Blocked {
                 tool: self.tool.as_db_str().to_string(),
                 program: self.program.to_string(),
                 hint,
             },
-            _ => availability,
+            None => availability,
         }
     }
 

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -22,6 +22,12 @@ pub struct ToolManifest {
     pub tool: OracleTool,
     /// The executable to invoke (looked up on `PATH`).
     pub program: &'static str,
+    /// Arguments the LIVE backends spawn the program with. Language servers disagree on how the
+    /// stdio transport is selected — `rust-analyzer` speaks LSP on stdio by default, while
+    /// `typescript-language-server` prints usage and exits without `--stdio` — so the argv belongs
+    /// to the registry entry, not the client. Empty for batch tools, which build their whole
+    /// invocation in [`ToolManifest::scip_command`].
+    pub live_args: &'static [&'static str],
     /// Languages this backend resolves, for status/diagnostics.
     pub languages: &'static [&'static str],
     /// A one-line install hint surfaced when the tool is absent (the `Blocked` UX).
@@ -52,6 +58,7 @@ impl ToolManifest {
             OracleTool::RustAnalyzer => ToolManifest {
                 tool,
                 program: "rust-analyzer",
+                live_args: &[],
                 languages: &["rust"],
                 install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
                                component add rust-analyzer`) or pass a pre-built index with \
@@ -60,6 +67,7 @@ impl ToolManifest {
             OracleTool::ScipClang => ToolManifest {
                 tool,
                 program: "scip-clang",
+                live_args: &[],
                 languages: &["c", "cpp"],
                 install_hint: "scip-clang not found on PATH. Install it from \
                                github.com/sourcegraph/scip-clang and generate a \
@@ -71,6 +79,7 @@ impl ToolManifest {
             OracleTool::ScipPython => ToolManifest {
                 tool,
                 program: "scip-python",
+                live_args: &[],
                 languages: &["python"],
                 install_hint: "scip-python not found on PATH. Install it (e.g. `npm install -g \
                                @sourcegraph/scip-python`) AND install the project's dependencies \
@@ -80,6 +89,7 @@ impl ToolManifest {
             OracleTool::ScipTypescript => ToolManifest {
                 tool,
                 program: "scip-typescript",
+                live_args: &[],
                 languages: &["typescript"],
                 install_hint: "scip-typescript not found on PATH. Install it (e.g. `npm install \
                                -g @sourcegraph/scip-typescript`) AND install the project's \
@@ -92,6 +102,7 @@ impl ToolManifest {
             OracleTool::ScipJava => ToolManifest {
                 tool,
                 program: "scip-java",
+                live_args: &[],
                 languages: &["kotlin"],
                 install_hint: "scip-java not found on PATH. Install it (e.g. `cs install \
                                --contrib scip-java`, needs a JVM) — it indexes Kotlin through the \
@@ -104,10 +115,24 @@ impl ToolManifest {
             OracleTool::RaLsp => ToolManifest {
                 tool,
                 program: "rust-analyzer",
+                live_args: &[],
                 languages: &["rust"],
                 install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
                                component add rust-analyzer`) so the live oracle (`[oracle.live] \
                                enabled`) can spawn it as a language server.",
+            },
+            // The live typescript-language-server client (#536). `--stdio` is REQUIRED: without a
+            // transport flag the program prints usage and exits, so the spawn would fail with an
+            // opaque EOF instead of a session.
+            OracleTool::TsLsp => ToolManifest {
+                tool,
+                program: "typescript-language-server",
+                live_args: &["--stdio"],
+                languages: &["typescript"],
+                install_hint: "typescript-language-server not found on PATH. Install it (e.g. \
+                               `npm install -g typescript-language-server typescript`) so the \
+                               live oracle (`[oracle.live] enabled`) can spawn it as a language \
+                               server.",
             },
         }
     }
@@ -168,9 +193,10 @@ impl ToolManifest {
                     .arg("--help")
                     .output()
                     .is_ok_and(|output| output.status.success()),
-            // The live client drives rust-analyzer as an LSP server (no `scip` subcommand needed);
-            // a successful `--version` (already detected by `probe`) is the capability signal.
-            OracleTool::RaLsp => true,
+            // The live clients drive their program as an LSP server (no `.scip` subcommand
+            // needed); a successful `--version` (already detected by `probe`) is the capability
+            // signal.
+            OracleTool::RaLsp | OracleTool::TsLsp => true,
         }
     }
 
@@ -228,8 +254,36 @@ impl ToolManifest {
                     root.display()
                 )
             }),
-            // The live client has no checkout prerequisite beyond the binary itself.
+            // The live rust-analyzer client has no checkout prerequisite beyond the binary itself:
+            // `experimental/serverStatus` reports quiescence for any checkout.
             OracleTool::RaLsp => None,
+            // The live TS client needs a tsconfig project SOMEWHERE in the checkout, for a
+            // different reason than the batch backend's root-level requirement (which is about
+            // `--infer-tsconfig` writing a tsconfig into the source tree).
+            //
+            // typescript-language-server has no quiescence notification. The only warm-up signal
+            // it emits is the work-done progress cycle bracketing a TSCONFIG PROJECT's load;
+            // opening a file that belongs to no project creates an inferred project silently, with
+            // no progress at all. So a checkout with no tsconfig anywhere can never report ready
+            // and the backend would sit in `Warming` forever — correct (the readiness policy still
+            // refuses to ask), but silent. Block with a reason instead.
+            //
+            // The config does NOT have to be at the root: a monorepo whose projects live at
+            // `packages/*/tsconfig.json` warms fine, because the FIRST project load is what the
+            // cycle reports. Requiring a root config would wrongly disable those checkouts.
+            OracleTool::TsLsp => (!super::backend::LiveBackend::for_tool(self.tool)
+                .is_some_and(|backend| backend.checkout_can_signal_readiness(root)))
+            .then(|| {
+                format!(
+                    "the live TypeScript oracle found no tsconfig.json under {} — \
+                     typescript-language-server only reports project-load progress for a real \
+                     tsconfig project, and that signal is what tells the oracle its answers are \
+                     trustworthy (asked mid-load it resolves an imported callee to the import \
+                     statement instead of the definition). Add a tsconfig.json for the project \
+                     (most TypeScript projects ship one) to enable it.",
+                    root.display()
+                )
+            }),
         }
     }
 
@@ -316,9 +370,10 @@ impl ToolManifest {
             // Unreachable: every batch driver gates live-only tools out BEFORE building a command
             // (`produce_scip_with_tool` returns `Blocked`, the auto-run loop and the wizard filter
             // on `batch_capable`). A live tool has no whole-checkout index invocation.
-            OracleTool::RaLsp => unreachable!(
-                "ra-lsp is a live oracle backend with no scip_command — the caller must gate on \
-                 OracleTool::batch_capable()"
+            tool @ (OracleTool::RaLsp | OracleTool::TsLsp) => unreachable!(
+                "{} is a live oracle backend with no scip_command — the caller must gate on \
+                 OracleTool::batch_capable()",
+                tool.as_db_str()
             ),
         }
     }
@@ -363,212 +418,54 @@ mod tests {
     use super::*;
 
     #[test]
-    fn every_tool_has_a_manifest_entry() {
-        // Exhaustive over the OracleTool registry: each variant must resolve to a manifest with a
-        // non-empty program + hint, so `oracle run`/`status` can always describe it. (The `match`
-        // in `for_tool` is the exhaustiveness guard a new variant trips.)
-        for &tool in OracleTool::ALL {
-            let manifest = ToolManifest::for_tool(tool);
-            assert_eq!(manifest.tool, tool);
-            assert!(!manifest.program.is_empty());
-            assert!(!manifest.install_hint.is_empty());
-            assert!(!manifest.languages.is_empty());
+    fn live_backends_declare_their_stdio_argv_and_batch_tools_declare_none() {
+        // A live backend is spawned as `program live_args…`; batch tools build their whole
+        // invocation in `scip_command`, so a stray `live_args` there would be silently ignored
+        // and mislead the next reader.
+        let ts = ToolManifest::for_tool(OracleTool::TsLsp);
+        assert_eq!(ts.program, "typescript-language-server");
+        assert_eq!(
+            ts.live_args,
+            ["--stdio"],
+            "without a transport flag the program prints usage and exits, so the spawn fails with \
+             an opaque EOF instead of a session"
+        );
+        // rust-analyzer speaks LSP on stdio with no flag — the two backends genuinely differ.
+        assert!(ToolManifest::for_tool(OracleTool::RaLsp).live_args.is_empty());
+        for tool in OracleTool::ALL.iter().filter(|tool| tool.batch_capable()) {
+            assert!(
+                ToolManifest::for_tool(*tool).live_args.is_empty(),
+                "{} is batch-only and must declare no live argv",
+                tool.as_db_str()
+            );
         }
     }
 
     #[test]
-    fn absent_program_probes_blocked_with_hint() {
-        // A program that cannot exist on PATH yields Blocked (never an error), carrying the hint —
-        // the missing-tool UX the `oracle run` command turns into exit 0.
-        let manifest = ToolManifest {
-            tool: OracleTool::RustAnalyzer,
-            program: "rag-rat-no-such-tool-xyzzy",
-            languages: &["rust"],
-            install_hint: "install hint here",
-        };
-        let availability = manifest.probe();
-        assert!(!availability.is_available());
-        match availability {
-            ToolAvailability::Blocked { hint, program, .. } => {
-                assert_eq!(program, "rag-rat-no-such-tool-xyzzy");
-                assert_eq!(hint, "install hint here");
-            },
-            other => panic!("expected Blocked, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn detect_version_reads_a_known_program() {
-        // `cargo --version` is reliably present in the test environment (we're building with it).
-        // Proves the version-detection path returns a non-empty line for a real program.
-        let version = detect_version_in("cargo", None);
-        assert!(version.is_some_and(|v| v.starts_with("cargo")));
-    }
-
-    #[test]
-    fn detect_version_in_applies_the_checkout_cwd() {
-        let root = rag_rat_base::test_scratch::ScratchDir::new("oracle-probe-cwd");
-        assert!(detect_version_in("cargo", Some(root.path())).is_some());
-        assert!(
-            detect_version_in("cargo", Some(&root.path().join("missing"))).is_none(),
-            "a missing cwd must prevent spawn, proving current_dir is applied"
-        );
-    }
-
-    #[test]
-    fn probe_requires_the_scip_subcommand_not_just_a_version() {
-        // `cargo` is on PATH and reports a `--version`, but has no `scip` subcommand — so the
-        // capability check fails and the tool is Blocked, not Available (#82 P3: `Blocked` must
-        // mean "can't produce SCIP," not merely "absent"). We borrow `cargo` as a stand-in
-        // for a binary that exists + versions but can't emit SCIP.
-        let manifest = ToolManifest {
-            tool: OracleTool::RustAnalyzer,
-            program: "cargo",
-            languages: &["rust"],
-            install_hint: "hint",
-        };
-        assert!(detect_version_in("cargo", None).is_some(), "cargo reports a version");
-        assert!(!manifest.can_emit_scip(), "cargo has no `scip` subcommand");
-        assert!(
-            !manifest.probe().is_available(),
-            "a versioned binary lacking `scip` must probe Blocked, not Available"
-        );
-    }
-
-    #[test]
-    fn scip_clang_consumes_a_compdb_not_a_root() {
-        // scip-clang's invocation differs from rust-analyzer's: --compdb-path / --index-output-path
-        // and cwd = root (so the compdb's relative paths resolve), no `scip` subcommand.
-        let manifest = ToolManifest::for_tool(OracleTool::ScipClang);
-        assert_eq!(manifest.program, "scip-clang");
-        let cmd = manifest.scip_command(Path::new("/repo"), Path::new("/tmp/out.scip"));
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        // `--compdb-path` is synthesized via `root.join(..).display()`, so it carries the
-        // platform's path separator (`\` on Windows) — scip-clang runs locally and wants
-        // the native path. Build the expectation the same way rather than hardcoding `/`,
-        // so the assertion holds on Windows.
-        let compdb = Path::new("/repo").join("compile_commands.json");
-        assert_eq!(args, vec![
-            format!("--compdb-path={}", compdb.display()),
-            "--index-output-path=/tmp/out.scip".to_string()
-        ]);
-        // No compile_commands.json under a bogus root → prerequisite Blocked (not a run error).
-        assert!(
-            manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some(),
-            "missing compile_commands.json must report a prerequisite block"
-        );
-        // rust-analyzer has no such prerequisite.
-        assert!(
-            ToolManifest::for_tool(OracleTool::RustAnalyzer)
-                .prerequisite_blocked(Path::new("/repo"))
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn scip_command_targets_output_path() {
-        let manifest = ToolManifest::for_tool(OracleTool::RustAnalyzer);
-        let cmd = manifest.scip_command(Path::new("/repo"), Path::new("/tmp/out.scip"));
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        assert_eq!(cmd.get_program().to_string_lossy(), "rust-analyzer");
-        assert_eq!(args, vec!["scip", "/repo", "--output", "/tmp/out.scip"]);
-    }
-
-    #[test]
-    fn scip_python_indexes_a_cwd_with_a_project_name() {
-        // scip-python's invocation: `scip-python index --project-name <root-basename> --cwd <root>
-        // --output <abs>`. The project name (the root's dir name) is what gives in-corpus symbols
-        // a non-empty moniker package, and `--cwd` is where it resolves the installed deps. No
-        // compile_commands.json prerequisite (the venv install is the corpus `prepare` step's job).
-        let manifest = ToolManifest::for_tool(OracleTool::ScipPython);
-        assert_eq!(manifest.program, "scip-python");
-        assert_eq!(manifest.languages, &["python"]);
-        let cmd = manifest.scip_command(Path::new("/work/requests"), Path::new("/tmp/out.scip"));
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        assert_eq!(args, vec![
-            "index",
-            "--project-name",
-            "requests",
-            // Pinned constant version (Codex #176): keeps monikers stable across commits.
-            "--project-version",
-            "_",
-            "--cwd",
-            "/work/requests",
-            "--output",
-            "/tmp/out.scip",
-        ]);
-        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_none());
-    }
-
-    #[test]
-    fn scip_typescript_indexes_a_cwd() {
-        // scip-typescript's invocation: `scip-typescript index --cwd <root> --output <abs>`. No
-        // `--project-name` / `--project-version` (package.json supplies both; the version is
-        // normalized downstream at moniker-write time). NO `--infer-tsconfig` — that flag writes a
-        // tsconfig into the source tree, so a missing tsconfig is a prerequisite Block instead.
-        let manifest = ToolManifest::for_tool(OracleTool::ScipTypescript);
-        assert_eq!(manifest.program, "scip-typescript");
-        assert_eq!(manifest.languages, &["typescript"]);
-        let cmd = manifest.scip_command(Path::new("/work/ky"), Path::new("/tmp/out.scip"));
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        assert_eq!(args, vec!["index", "--cwd", "/work/ky", "--output", "/tmp/out.scip"]);
-        assert!(!args.iter().any(|a| a == "--infer-tsconfig"), "must not dirty the source tree");
-    }
-
-    #[test]
-    fn scip_typescript_requires_a_tsconfig() {
-        // A checkout without a tsconfig.json is Blocked (install-hint UX), not silently run with
-        // `--infer-tsconfig` writing one into the tree — the read-only-on-source contract.
-        let manifest = ToolManifest::for_tool(OracleTool::ScipTypescript);
-        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
-        let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-prereq");
-        std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
-        assert!(manifest.prerequisite_blocked(&dir).is_none());
-    }
-
-    #[test]
-    fn scip_java_indexes_through_the_gradle_build_in_cwd() {
-        // scip-java's invocation: `scip-java index --build-tool Gradle --output <abs>`, run with
-        // cwd = root. `--build-tool Gradle` is pinned so a checkout that also has a `pom.xml`
-        // doesn't trip scip-java's "Multiple build tools detected" abort. No `--project-version` —
-        // scip-java emits `.` placeholders for the local project regardless of the build's
-        // group/version, so monikers are already commit-stable.
-        let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
-        assert_eq!(manifest.program, "scip-java");
-        assert_eq!(manifest.languages, &["kotlin"]);
-        let cmd = manifest.scip_command(Path::new("/work/app"), Path::new("/tmp/out.scip"));
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        assert_eq!(args, vec!["index", "--build-tool", "Gradle", "--output", "/tmp/out.scip"]);
-        assert_eq!(cmd.get_current_dir(), Some(Path::new("/work/app")), "runs in the project root");
-    }
-
-    #[test]
-    fn scip_java_requires_a_gradle_build() {
-        // scip-java indexes Kotlin THROUGH the Gradle build; without one it's Blocked (the JVM
-        // analog of scip-clang's compile_commands.json prerequisite). A Maven-only checkout is also
-        // Blocked: scip-java's auto-indexer supports Kotlin for Gradle only, so running it on a
-        // `pom.xml` Kotlin project would fail rather than index (Codex on #193).
-        let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
-        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
-        let dir = rag_rat_base::test_scratch::ScratchDir::new("java-prereq");
-        assert!(manifest.prerequisite_blocked(&dir).is_some(), "empty dir has no build → Blocked");
-        std::fs::write(dir.join("pom.xml"), "").unwrap();
+    fn the_live_typescript_backend_requires_a_warmable_tsconfig_project() {
+        // Not the batch backend's source-tree reason: typescript-language-server only reports its
+        // project-load progress for a real tsconfig project. With none anywhere it emits no signal
+        // ever, so the backend could only sit in `Warming` — correct, but silent. Block with a
+        // reason instead. The gate asks the same question the warm-up does ("is there a document
+        // whose open would signal readiness?"), so the two cannot disagree.
+        let manifest = ToolManifest::for_tool(OracleTool::TsLsp);
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-prereq");
+        let blocked = manifest.prerequisite_blocked(&dir).expect("no project ⇒ Blocked");
+        assert!(blocked.contains("tsconfig.json"), "{blocked}");
+        // A config need not sit at the ROOT, and it must have a file to open: the progress cycle
+        // reports a PROJECT load, so an empty project is nothing to warm on.
+        std::fs::create_dir_all(dir.join("packages/app")).unwrap();
+        std::fs::write(dir.join("packages/app/tsconfig.json"), "{}").unwrap();
         assert!(
             manifest.prerequisite_blocked(&dir).is_some(),
-            "Maven-only Kotlin is unsupported by scip-java → Blocked"
+            "a project with no TypeScript file cannot warm the server",
         );
-        // scip-java's GradleBuildTool does NOT recognize `settings.gradle.kts`, so neither do we —
-        // accepting it would pass the gate then fail with "no Gradle tool" (Codex on #193).
-        std::fs::write(dir.join("settings.gradle.kts"), "").unwrap();
-        assert!(
-            manifest.prerequisite_blocked(&dir).is_some(),
-            "settings.gradle.kts is not a scip-java Gradle sentinel → still Blocked"
-        );
-        // …but the `gradlew` wrapper IS one of scip-java's sentinels, so it satisfies the gate.
-        std::fs::write(dir.join("gradlew"), "").unwrap();
+        std::fs::write(dir.join("packages/app/main.ts"), "export function x() {}\n").unwrap();
         assert!(
             manifest.prerequisite_blocked(&dir).is_none(),
-            "a gradlew wrapper is a scip-java Gradle sentinel → satisfied"
+            "a nested project with a file satisfies the gate",
         );
+        // The Rust live backend has no such gate: its signal works for any checkout.
+        assert!(ToolManifest::for_tool(OracleTool::RaLsp).prerequisite_blocked(&dir).is_none());
     }
 }

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -157,6 +157,28 @@ impl ToolManifest {
         self.probe_with_cwd(Some(cwd))
     }
 
+    /// Probe from `root` AND fold in this tool's checkout prerequisite — "can this backend run
+    /// here?", the question status surfaces should ask.
+    ///
+    /// [`Self::probe_in`] answers only "is the binary installed", which is the more actionable
+    /// half when it is missing but a misleading answer when it is present and the checkout still
+    /// cannot support it: `scip-clang` without a compile_commands.json, `scip-java` without a
+    /// Gradle build, the live TypeScript client without a tsconfig project. Reporting those as
+    /// `Available` says nothing is wrong about a backend that can never produce a verdict. An
+    /// already-`Blocked` probe is returned untouched — an absent binary is the more actionable
+    /// hint, and a prerequisite is moot until the tool exists.
+    pub fn probe_runnable_in(&self, root: &Path) -> ToolAvailability {
+        let availability = self.probe_in(root);
+        match (&availability, self.prerequisite_blocked(root)) {
+            (ToolAvailability::Available { .. }, Some(hint)) => ToolAvailability::Blocked {
+                tool: self.tool.as_db_str().to_string(),
+                program: self.program.to_string(),
+                hint,
+            },
+            _ => availability,
+        }
+    }
+
     fn probe_with_cwd(&self, cwd: Option<&Path>) -> ToolAvailability {
         match detect_version_in(self.program, cwd) {
             Some(version) if self.can_emit_scip() => ToolAvailability::Available {
@@ -438,6 +460,60 @@ mod tests {
                 "{} is batch-only and must declare no live argv",
                 tool.as_db_str()
             );
+        }
+    }
+
+    #[test]
+    fn a_runnable_probe_reports_an_unmet_prerequisite_instead_of_available() {
+        // "installed" is not "can run here". A tool reported Available while its checkout
+        // prerequisite is unmet says nothing is wrong about a backend that can never produce a
+        // verdict — the worst of the three possible answers.
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("probe-runnable");
+        // Stand in for an installed binary whose checkout prerequisite is unmet: `cargo` reliably
+        // versions, scip-clang's capability check is a no-op (it IS the emitter), and its gate
+        // wants a compile_commands.json.
+        let installed_but_unprepared = ToolManifest {
+            tool: OracleTool::ScipClang,
+            program: "cargo",
+            live_args: &[],
+            languages: &["c"],
+            install_hint: "install hint",
+        };
+        assert!(
+            installed_but_unprepared.probe_in(&dir).is_available(),
+            "the stand-in must be installed, or this tests the wrong branch",
+        );
+        match installed_but_unprepared.probe_runnable_in(&dir) {
+            ToolAvailability::Blocked { hint, tool, program } => {
+                assert_eq!(tool, "scip-clang");
+                assert_eq!(program, "cargo");
+                assert!(
+                    hint.contains("compile_commands.json"),
+                    "the hint must name the fix, not repeat the install hint: {hint}",
+                );
+            },
+            other => panic!("an unmet prerequisite must not read as {other:?}"),
+        }
+        // Satisfy the prerequisite and the same probe reports the tool as runnable.
+        std::fs::write(dir.join("compile_commands.json"), "[]").unwrap();
+        assert!(installed_but_unprepared.probe_runnable_in(&dir).is_available());
+    }
+
+    #[test]
+    fn a_runnable_probe_keeps_the_install_hint_when_the_binary_is_absent() {
+        // An absent binary is the more actionable half, and a prerequisite is moot until the tool
+        // exists — so the missing-tool hint must survive, not be replaced by a prerequisite one.
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("probe-runnable-absent");
+        let absent = ToolManifest {
+            tool: OracleTool::ScipClang,
+            program: "rag-rat-no-such-tool-xyzzy",
+            live_args: &[],
+            languages: &["c"],
+            install_hint: "install scip-clang",
+        };
+        match absent.probe_runnable_in(&dir) {
+            ToolAvailability::Blocked { hint, .. } => assert_eq!(hint, "install scip-clang"),
+            other => panic!("expected Blocked, got {other:?}"),
         }
     }
 

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -982,3 +982,304 @@ fn live_pass_aborts_best_effort_when_the_server_dies_mid_pass() {
     assert_eq!(report.unfinished_paths, vec!["src.rs".to_string()]);
     assert_eq!(live_run_count(&h.conn), 0);
 }
+
+/// The TypeScript live backend (#536). These lock the behaviours that differ from `ra-lsp` — the
+/// readiness signal, the warm-up that makes that signal reachable, the `languageId` documents are
+/// opened under, and the sentinel namespace — against the same fake-server seam.
+mod typescript {
+    use super::*;
+    use crate::OracleTool;
+    use crate::lsp::client::test_support::client_with_server_policy;
+    use crate::lsp::readiness::ReadinessPolicy;
+
+    const TS_VERSION: &str = "ts-test-1";
+    /// `run` calls `greet`; the callee identifier sits at byte 20.
+    const TS_CALLER_SRC: &str = "export function run() { greet(); }\n";
+    const TS_CALLEE_START: usize = 24;
+    const TS_CALLEE_END: usize = 29;
+    const TS_DEFS_SRC: &str = "export function greet() {}\n";
+
+    /// The two-file TypeScript corpus: `lib.ts` defines `greet`, `main.ts` calls it unresolved.
+    /// A `tsconfig.json` makes them a real project, which is what the server needs before it will
+    /// report a project load at all — and what the backend's prerequisite gate requires.
+    fn seed_ts_corpus(h: &Harness) -> (i64, i64) {
+        std::fs::write(h.root().join("tsconfig.json"), "{}").unwrap();
+        let defs = h.add_file("lib.ts", TS_DEFS_SRC);
+        let target = h.add_symbol(defs, "greet", 0, 25);
+        let src = h.add_file("main.ts", TS_CALLER_SRC);
+        let edge = h.add_edge(src, "greet", TS_CALLEE_START, TS_CALLEE_END, "NameOnly", None);
+        (target, edge)
+    }
+
+    fn ts_run_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM oracle_runs WHERE tool = 'ts-lsp'", [], |row| {
+            row.get(0)
+        })
+        .unwrap()
+    }
+
+    /// A progress notification the fake server can interleave.
+    fn progress(token: &str, kind: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0", "method": "$/progress",
+            "params": {"token": token, "value": {"kind": kind}}
+        })
+    }
+
+    /// A TypeScript-backed session over a fake server, recording every method the client sent.
+    /// `emit_on_initialize` rides alongside the `initialize` response (the seam for handing the
+    /// session a completed progress cycle), and `emit_on_definition` before a definition result.
+    fn ts_session(
+        h: &Harness,
+        emit_on_initialize: Vec<Value>,
+        emit_on_definition: Vec<Value>,
+        resolve_to: Option<String>,
+    ) -> (LiveOracleSession, Arc<Mutex<Vec<String>>>) {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&sent);
+        let uri = root_uri(h);
+        let client = client_with_server_policy(
+            move |msg: &Value| {
+                let id = msg.get("id").cloned();
+                let method = msg.get("method").and_then(Value::as_str);
+                if let Some(method) = method {
+                    // Record the opened URI too: the warm-up asserts WHICH document was chosen.
+                    let entry = match method {
+                        "textDocument/didOpen" => format!(
+                            "didOpen:{}",
+                            msg["params"]["textDocument"]["uri"].as_str().unwrap_or_default()
+                        ),
+                        other => other.to_string(),
+                    };
+                    captured.lock().unwrap().push(entry);
+                }
+                match method {
+                    Some("initialize") => {
+                        let mut out = emit_on_initialize.clone();
+                        out.push(json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {"capabilities": {}}
+                        }));
+                        Some(out)
+                    },
+                    Some("textDocument/definition") => {
+                        let mut out = emit_on_definition.clone();
+                        let result = match &resolve_to {
+                            Some(target) => json!({
+                                "targetUri": target,
+                                "targetSelectionRange": {
+                                    "start": {"line": 0, "character": 16},
+                                    "end": {"line": 0, "character": 21}
+                                }
+                            }),
+                            None => Value::Null,
+                        };
+                        out.push(json!({"jsonrpc": "2.0", "id": id, "result": result}));
+                        Some(out)
+                    },
+                    _ if id.is_none() => Some(vec![]),
+                    _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+                }
+            },
+            ReadinessPolicy::WorkDoneProgress,
+        );
+        let session =
+            LiveOracleSession::from_warming_client_for(OracleTool::TsLsp, client, TS_VERSION, &uri);
+        (session, sent)
+    }
+
+    #[test]
+    fn an_unwarmed_session_opens_a_document_to_trigger_the_signal_it_is_waiting_for() {
+        // typescript-language-server starts its project load on the first didOpen, not at
+        // initialize, so a pass that waits for readiness without opening anything waits forever.
+        // The warm-up open breaks that deadlock — WITHOUT asking a single definition, because the
+        // answers during a load are wrong rather than null.
+        let h = Harness::new();
+        seed_ts_corpus(&h);
+        let (mut session, sent) = ts_session(&h, Vec::new(), Vec::new(), None);
+        let worklist = vec!["main.ts".to_string()];
+
+        let report =
+            live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+        assert_eq!(report.status, "Warming");
+        assert_eq!(report.unfinished_paths, worklist, "the work rides to the next pass");
+        assert_eq!(report.requests_used, 0);
+        // The warm-up is notification-only, so a synchronous round trip is what proves the
+        // server has seen it before the assertions read the recorded traffic.
+        session.barrier();
+        let sent = sent.lock().unwrap();
+        assert!(
+            sent.iter().any(|entry| entry.starts_with("didOpen:")),
+            "the warm-up must open a document: {sent:?}"
+        );
+        assert!(
+            !sent.iter().any(|method| method == "textDocument/definition"),
+            "a warming server must never be asked for a definition: {sent:?}"
+        );
+        assert_eq!(ts_run_count(&h.conn), 0);
+    }
+
+    #[test]
+    fn a_completed_progress_cycle_lets_the_next_pass_write_ts_lsp_verdicts() {
+        // The pass after warm-up finds the latched ready state and resolves normally, writing
+        // under the ts-lsp tool id with its own sentinel namespace.
+        let h = Harness::new();
+        let (target, edge) = seed_ts_corpus(&h);
+        let definition = def_uri(&h, "lib.ts");
+        let (mut session, sent) = ts_session(
+            &h,
+            vec![progress("load", "begin"), progress("load", "end")],
+            Vec::new(),
+            Some(definition),
+        );
+        let worklist = vec!["main.ts".to_string()];
+
+        let report =
+            live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+        assert_eq!(report.status, "Completed");
+        assert_eq!(report.rows_written, 1);
+        assert_eq!(report.upgraded, 1);
+        let (kind, resolved, symbol) = h.verdict(edge).expect("verdict persisted");
+        assert_eq!(kind, "upgrade");
+        assert_eq!(resolved, Some(target));
+        assert!(
+            symbol.starts_with("local ts-lsp-"),
+            "a live TS verdict must not borrow another backend's sentinel namespace: {symbol}"
+        );
+        assert_eq!(ts_run_count(&h.conn), 1, "the run row is written under the live TS tool id");
+        assert!(sent.lock().unwrap().iter().any(|method| method == "textDocument/definition"));
+    }
+
+    #[test]
+    fn a_project_load_starting_mid_batch_discards_the_whole_batch() {
+        // The empirical failure this backend exists to survive: asked during a project load,
+        // typescript-language-server answers an imported callee with the IMPORT STATEMENT in the
+        // calling file — a plausible non-null that would persist as a real verdict and never be
+        // revisited until the file's bytes change. A load that begins while the batch is in
+        // flight must therefore invalidate the batch, not merely be noted.
+        let h = Harness::new();
+        let (_target, edge) = seed_ts_corpus(&h);
+        let definition = def_uri(&h, "lib.ts");
+        let (mut session, _sent) = ts_session(
+            &h,
+            vec![progress("load", "begin"), progress("load", "end")],
+            vec![progress("reload", "begin")],
+            Some(definition),
+        );
+        let worklist = vec!["main.ts".to_string()];
+
+        let report =
+            live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+        assert_eq!(report.status, "Warming");
+        assert_eq!(report.rows_written, 0, "a batch that straddled a load must write nothing");
+        assert!(h.verdict(edge).is_none(), "no verdict may survive the discarded batch");
+        assert_eq!(report.unfinished_paths, worklist, "the file retries once the load settles");
+        assert_eq!(ts_run_count(&h.conn), 0);
+    }
+
+    #[test]
+    fn a_checkout_with_no_project_is_not_re_opened_every_pass() {
+        // Opening a project-less document emits no progress cycle, so it cannot warm anything.
+        // Doing it anyway would burn a notification per pass forever. (The manifest gate normally
+        // stops such a checkout before a session is even spawned; this pins the pass-level
+        // behaviour so the two layers agree.)
+        let h = Harness::new();
+        let src = h.add_file("main.ts", TS_CALLER_SRC);
+        h.add_edge(src, "greet", TS_CALLEE_START, TS_CALLEE_END, "NameOnly", None);
+        let (mut session, sent) = ts_session(&h, Vec::new(), Vec::new(), None);
+        let worklist = vec!["main.ts".to_string()];
+
+        let report =
+            live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+        assert_eq!(report.status, "Warming");
+        session.barrier();
+        let sent = sent.lock().unwrap();
+        assert!(
+            !sent.iter().any(|entry| entry.starts_with("didOpen:")),
+            "nothing in this checkout can signal readiness, so nothing is worth opening: {sent:?}",
+        );
+    }
+
+    #[test]
+    fn the_warmup_open_picks_a_file_that_can_actually_produce_the_signal() {
+        // typescript-language-server brackets a TSCONFIG PROJECT's load in a progress cycle;
+        // opening a file that belongs to no project creates an inferred project silently, with no
+        // cycle at all. Warming on such a file leaves the session exactly as un-warmed as before,
+        // so the worklist's first entry is the wrong choice when a sibling IS inside a project.
+        let h = Harness::new();
+        std::fs::create_dir_all(h.root().join("pkg/src")).unwrap();
+        std::fs::create_dir_all(h.root().join("scripts")).unwrap();
+        std::fs::write(h.root().join("pkg/tsconfig.json"), "{}").unwrap();
+        let defs = h.add_file("pkg/src/lib.ts", TS_DEFS_SRC);
+        h.add_symbol(defs, "greet", 0, 25);
+        let loose = h.add_file("scripts/tool.ts", TS_CALLER_SRC);
+        h.add_edge(loose, "greet", TS_CALLEE_START, TS_CALLEE_END, "NameOnly", None);
+        let inside = h.add_file("pkg/src/main.ts", TS_CALLER_SRC);
+        h.add_edge(inside, "greet", TS_CALLEE_START, TS_CALLEE_END, "NameOnly", None);
+
+        let (mut session, sent) = ts_session(&h, Vec::new(), Vec::new(), None);
+        // The project-less file comes FIRST in the worklist; the warm-up must skip past it.
+        let worklist = vec!["scripts/tool.ts".to_string(), "pkg/src/main.ts".to_string()];
+
+        let report =
+            live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+        assert_eq!(report.status, "Warming");
+        session.barrier();
+        let opened: Vec<String> = sent
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|entry| entry.strip_prefix("didOpen:").map(str::to_string))
+            .collect();
+        assert!(
+            opened.iter().all(|uri| uri.ends_with("pkg/src/main.ts")),
+            "the warm-up must open the file inside the tsconfig project, not {opened:?}",
+        );
+    }
+
+    #[test]
+    fn documents_are_opened_under_the_extension_s_language_id() {
+        // tsserver rejects (and other servers mis-parse) a document declared under the wrong
+        // languageId, so `.tsx` must open as typescriptreact even though it shares a backend.
+        let h = Harness::new();
+        let defs = h.add_file("lib.ts", TS_DEFS_SRC);
+        h.add_symbol(defs, "greet", 0, 25);
+        let src = h.add_file("view.tsx", TS_CALLER_SRC);
+        h.add_edge(src, "greet", TS_CALLEE_START, TS_CALLEE_END, "NameOnly", None);
+        let opened = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&opened);
+        let uri = root_uri(&h);
+        let client = client_with_server_policy(
+            move |msg: &Value| {
+                let id = msg.get("id").cloned();
+                if msg.get("method").and_then(Value::as_str) == Some("textDocument/didOpen") {
+                    captured.lock().unwrap().push(
+                        msg["params"]["textDocument"]["languageId"].as_str().unwrap().to_string(),
+                    );
+                }
+                match msg.get("method").and_then(Value::as_str) {
+                    Some("initialize") => Some(vec![
+                        progress("load", "begin"),
+                        progress("load", "end"),
+                        json!({"jsonrpc": "2.0", "id": id, "result": {"capabilities": {}}}),
+                    ]),
+                    _ if id.is_none() => Some(vec![]),
+                    _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+                }
+            },
+            ReadinessPolicy::WorkDoneProgress,
+        );
+        let mut session =
+            LiveOracleSession::from_warming_client_for(OracleTool::TsLsp, client, TS_VERSION, &uri);
+        let worklist = vec!["view.tsx".to_string()];
+
+        live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+        assert_eq!(opened.lock().unwrap().as_slice(), ["typescriptreact"]);
+    }
+}

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -1181,6 +1181,24 @@ mod typescript {
     }
 
     #[test]
+    fn an_unmet_prerequisite_is_reported_as_such_not_as_a_missing_tool() {
+        // The two ways a spawn declines are operationally different: a prerequisite block is
+        // permanent until the checkout changes and a human has to act on it, while an absent
+        // server is the ordinary degradation the watcher just keeps retrying. Collapsing them
+        // would leave an operator with a live oracle that silently never runs.
+        let h = Harness::new();
+        match LiveOracleSession::spawn(OracleTool::TsLsp, h.root()) {
+            Err(crate::LiveSpawnBlocked::Prerequisite(hint)) => {
+                assert!(hint.contains("tsconfig.json"), "the hint must name the fix: {hint}");
+            },
+            Err(crate::LiveSpawnBlocked::Unavailable) => {
+                panic!("an empty checkout is blocked by its missing project, not by the binary")
+            },
+            Ok(_) => panic!("a checkout with no TypeScript project must not spawn a session"),
+        }
+    }
+
+    #[test]
     fn a_checkout_with_no_project_is_not_re_opened_every_pass() {
         // Opening a project-less document emits no progress cycle, so it cannot warm anything.
         // Doing it anyway would burn a notification per pass forever. (The manifest gate normally

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -1199,6 +1199,102 @@ mod typescript {
     }
 
     #[test]
+    fn a_ts_pass_leaves_a_sibling_checkout_and_the_other_live_tool_untouched() {
+        // This backend is the SECOND writer into `edge_oracle`/`oracle_runs`, whose rows are keyed
+        // by (tool, tool_version, content, commit, worktree). Two dimensions therefore have to
+        // hold at once: a sibling checkout's rows must survive a pass in this one, and the two
+        // live tools must not read or overwrite each other's verdicts on their own edges.
+        let h = Harness::new();
+        let (target, edge) = seed_ts_corpus(&h);
+
+        // A SIBLING checkout with its own edge and its own ts-lsp verdict.
+        let sibling_file = h.add_file_in_scope("other.ts", OTHER_COMMIT, OTHER_WORKTREE);
+        let sibling_edge = h.add_edge(sibling_file, "greet", 9, 14, "NameOnly", None);
+        let sibling_key = h.edge_content_key(sibling_edge);
+        crate::store::write_edge_oracle(&h.conn, OracleTool::TsLsp, TS_VERSION, &{
+            crate::store::EdgeOracleRow {
+                source_path: &sibling_key.source_path,
+                source_start_byte: sibling_key.source_start_byte,
+                source_end_byte: sibling_key.source_end_byte,
+                callee_start_byte: sibling_key.callee_start_byte,
+                callee_end_byte: sibling_key.callee_end_byte,
+                edge_kind: &sibling_key.edge_kind,
+                file_sha: "sibling-sha",
+                resolved_symbol_id: None,
+                scip_symbol: "local ts-lsp-sibling",
+                kind: OracleResolutionKind::Upgrade,
+            }
+        })
+        .unwrap();
+
+        // A RUST edge in THIS checkout, already carrying an ra-lsp verdict from its own backend.
+        let rust_defs = h.add_file("defs.rs", DEFS_SRC);
+        h.add_symbol(rust_defs, "target", 0, 13);
+        let rust_src = h.add_file("caller.rs", CALLER_SRC);
+        let rust_edge = h.add_edge(
+            rust_src,
+            "target",
+            CALLER_CALLEE_START,
+            CALLER_CALLEE_END,
+            "NameOnly",
+            None,
+        );
+        let rust_key = h.edge_content_key(rust_edge);
+        crate::store::write_edge_oracle(&h.conn, OracleTool::RaLsp, LIVE_VERSION, &{
+            crate::store::EdgeOracleRow {
+                source_path: &rust_key.source_path,
+                source_start_byte: rust_key.source_start_byte,
+                source_end_byte: rust_key.source_end_byte,
+                callee_start_byte: rust_key.callee_start_byte,
+                callee_end_byte: rust_key.callee_end_byte,
+                edge_kind: &rust_key.edge_kind,
+                file_sha: "rust-sha",
+                resolved_symbol_id: None,
+                scip_symbol: "local ra-lsp-rust",
+                kind: OracleResolutionKind::Upgrade,
+            }
+        })
+        .unwrap();
+
+        let definition = def_uri(&h, "lib.ts");
+        let (mut session, _sent) = ts_session(
+            &h,
+            vec![progress("load", "begin"), progress("load", "end")],
+            Vec::new(),
+            Some(definition),
+        );
+        let worklist = vec!["main.ts".to_string()];
+        let report =
+            live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+        assert_eq!(report.rows_written, 1, "{report:?}");
+
+        // This checkout's TypeScript edge got its verdict under ts-lsp…
+        assert_eq!(h.verdict(edge).expect("a ts verdict").1, Some(target));
+        // …the sibling checkout's ts-lsp row is untouched (a pass here is not a whole-tool clear)…
+        // `edge_oracle` is CONTENT-keyed — checkout scope comes from the join to edges/files, not
+        // from a column — so the sibling's row is identified by its own source path.
+        let sibling_symbol: String = h
+            .conn
+            .query_row(
+                "SELECT scip_symbol FROM edge_oracle WHERE tool = 'ts-lsp' AND source_path = ?1",
+                rusqlite::params![sibling_key.source_path],
+                |row| row.get(0),
+            )
+            .expect("the sibling checkout's row survives");
+        assert_eq!(sibling_symbol, "local ts-lsp-sibling");
+        // …and the OTHER live tool's verdict on its own Rust edge is neither read nor rewritten.
+        let rust_symbol: String = h
+            .conn
+            .query_row("SELECT scip_symbol FROM edge_oracle WHERE tool = 'ra-lsp'", [], |row| {
+                row.get(0)
+            })
+            .expect("the ra-lsp row survives");
+        assert_eq!(rust_symbol, "local ra-lsp-rust");
+        // The run row is scoped to this checkout and this tool only.
+        assert_eq!(ts_run_count(&h.conn), 1);
+    }
+
+    #[test]
     fn a_checkout_with_no_project_is_not_re_opened_every_pass() {
         // Opening a project-less document emits no progress cycle, so it cannot warm anything.
         // Doing it anyway would burn a notification per pass forever. (The manifest gate normally

--- a/crates/rag-rat-oracle/src/tests/live_real_server.rs
+++ b/crates/rag-rat-oracle/src/tests/live_real_server.rs
@@ -1,0 +1,138 @@
+//! Real-server verification for the live TypeScript backend (#536).
+//!
+//! Every other live test drives the in-process fake server, which proves the write path but
+//! cannot prove the two things that are properties of the REAL server: that the spawn argv
+//! actually yields a session, and that the readiness policy actually brackets the window where
+//! `typescript-language-server` answers WRONG.
+//!
+//! That window is the whole reason this backend gates on readiness. Asked before its project has
+//! loaded, the server resolves an imported callee to the `import` statement in the CALLING file
+//! rather than to the definition — a plausible non-null that the write path would persist as a
+//! real verdict and (under the covered-skip budget) never revisit until the file's bytes change.
+//! This test asserts the resolved target is the definition, never the import.
+//!
+//! Ignored by default: it needs `typescript-language-server` on PATH plus a TypeScript install the
+//! server can resolve. Run it with a project's `node_modules` (one containing `typescript`):
+//!
+//! ```text
+//! RAG_RAT_TS_NODE_MODULES=/path/to/node_modules \
+//!   cargo nextest run -p rag-rat-oracle --run-ignored all -E 'test(real_typescript_server)'
+//! ```
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use super::*;
+use crate::live::{LiveOracleSession, LivePassInput, live_oracle_pass};
+
+/// `greet` is defined here; its identifier spans bytes 16..21 on line 0.
+const LIB_TS: &str =
+    "export function greet(name: string): string {\n  return `hello ${name}`;\n}\n";
+/// `greet` appears TWICE: the import binding (which a warming server wrongly resolves to) and the
+/// call. The edge is seeded on the call.
+const MAIN_TS: &str = "import { greet } from \"./lib.js\";\n\nexport function run(): void {\n  \
+                       console.log(greet(\"world\"));\n}\n";
+
+/// The live pass reports `Warming` until the server's project load completes. Poll passes rather
+/// than sleeping a fixed interval, so a slow machine waits longer and a fast one doesn't.
+const WARMUP_BUDGET: Duration = Duration::from_secs(60);
+
+fn write_ts_fixture(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.ts"), LIB_TS).unwrap();
+    std::fs::write(root.join("src/main.ts"), MAIN_TS).unwrap();
+    // A tsconfig is what makes the server emit the project-load progress cycle at all — the
+    // prerequisite the manifest enforces. Without it there is no readiness signal to wait for.
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"target":"ES2020","module":"ESNext","moduleResolution":"bundler",
+            "strict":true},"include":["src"]}"#,
+    )
+    .unwrap();
+    std::fs::write(root.join("package.json"), r#"{"name":"live-ts-fixture","version":"1.0.0"}"#)
+        .unwrap();
+}
+
+/// Point the fixture at a TypeScript install. The server falls back to a bundled compiler when it
+/// finds none, and that fallback does not resolve cross-file imports — which would make this test
+/// pass for the wrong reason (an unresolved callee writes no verdict either).
+fn link_typescript(root: &Path) {
+    let node_modules = std::env::var("RAG_RAT_TS_NODE_MODULES").expect(
+        "set RAG_RAT_TS_NODE_MODULES to a node_modules directory containing `typescript` — \
+         without a resolvable compiler the server cannot resolve the import, and the test would \
+         pass vacuously",
+    );
+    let source = Path::new(&node_modules);
+    assert!(source.join("typescript").is_dir(), "{node_modules} has no `typescript` package");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, root.join("node_modules")).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, root.join("node_modules")).unwrap();
+}
+
+#[test]
+#[ignore = "needs typescript-language-server on PATH + RAG_RAT_TS_NODE_MODULES"]
+fn real_typescript_server_warms_before_it_resolves_an_imported_callee() {
+    let h = Harness::new();
+    write_ts_fixture(h.root());
+    link_typescript(h.root());
+
+    // Seed the corpus against the fixture's real bytes: `greet`'s definition in lib.ts, and the
+    // unresolved call edge in main.ts (the CALL occurrence, not the import binding).
+    let defs = h.add_file("src/lib.ts", LIB_TS);
+    let target = h.add_symbol(defs, "greet", 0, LIB_TS.len());
+    let src = h.add_file("src/main.ts", MAIN_TS);
+    let call = MAIN_TS.rfind("greet").expect("the call site");
+    let edge = h.add_edge(src, "greet", call, call + "greet".len(), "NameOnly", None);
+
+    let Some(mut session) = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.root()) else {
+        panic!("typescript-language-server must be on PATH for this test");
+    };
+    let worklist = vec!["src/main.ts".to_string()];
+    let input = LivePassInput {
+        commit_sha: COMMIT,
+        worktree_id: WORKTREE,
+        checkout_root: h.root(),
+        worklist: &worklist,
+        max_requests: 100,
+        started_at_ms: 1_000,
+    };
+
+    // The FIRST pass must not resolve anything: the server has not loaded its project, so every
+    // answer it would give is a warm-up artifact.
+    let first = live_oracle_pass(&h.conn, &mut session, &input).unwrap();
+    assert_eq!(first.status, "Warming", "a cold server must not be asked for definitions");
+    assert_eq!(first.rows_written, 0);
+    assert_eq!(first.requests_used, 0);
+    assert!(h.verdict(edge).is_none(), "no verdict may be written before the project loads");
+
+    // Later passes retry until the project-load cycle latches the session ready.
+    let deadline = Instant::now() + WARMUP_BUDGET;
+    let report = loop {
+        let report = live_oracle_pass(&h.conn, &mut session, &input).unwrap();
+        if report.status != "Warming" {
+            break report;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the server never reported a completed project load within {WARMUP_BUDGET:?}",
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    };
+
+    assert_eq!(report.status, "Completed", "{report:?}");
+    assert_eq!(report.rows_written, 1, "{report:?}");
+    let (kind, resolved, symbol) = h.verdict(edge).expect("a verdict once the server is ready");
+    assert_eq!(kind, "upgrade");
+    // THE assertion this test exists for: the callee resolves to `greet`'s definition in lib.ts.
+    // A warming server would have pointed at the import statement in main.ts instead, which maps
+    // to no indexed symbol here — or, in a corpus that indexed one, to the wrong symbol entirely.
+    assert_eq!(
+        resolved,
+        Some(target),
+        "the callee must resolve to the definition in lib.ts, not the import in main.ts",
+    );
+    assert!(symbol.starts_with("local ts-lsp-"), "{symbol}");
+
+    session.shutdown();
+}

--- a/crates/rag-rat-oracle/src/tests/live_real_server.rs
+++ b/crates/rag-rat-oracle/src/tests/live_real_server.rs
@@ -85,9 +85,8 @@ fn real_typescript_server_warms_before_it_resolves_an_imported_callee() {
     let call = MAIN_TS.rfind("greet").expect("the call site");
     let edge = h.add_edge(src, "greet", call, call + "greet".len(), "NameOnly", None);
 
-    let Some(mut session) = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.root()) else {
-        panic!("typescript-language-server must be on PATH for this test");
-    };
+    let mut session = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.root())
+        .expect("typescript-language-server must be on PATH for this test");
     let worklist = vec!["src/main.ts".to_string()];
     let input = LivePassInput {
         commit_sha: COMMIT,

--- a/crates/rag-rat-oracle/src/tests/live_real_server.rs
+++ b/crates/rag-rat-oracle/src/tests/live_real_server.rs
@@ -136,3 +136,64 @@ fn real_typescript_server_warms_before_it_resolves_an_imported_callee() {
 
     session.shutdown();
 }
+
+#[test]
+#[ignore = "needs typescript-language-server on PATH + RAG_RAT_TS_NODE_MODULES"]
+fn a_file_its_ancestor_config_excludes_still_warms_the_server() {
+    // The warm-up picks a document by ANCESTOR config, not by evaluating `include`/`exclude`.
+    // This pins why that is enough: a file the ancestor config excludes still triggers an
+    // observable project load, because the server loads that project in order to decide the file
+    // is not in it. If this ever fails, the warm-up needs real project membership — until then,
+    // reimplementing tsconfig glob semantics would be a second source of truth for no gain.
+    let h = Harness::new();
+    std::fs::create_dir_all(h.root().join("src")).unwrap();
+    std::fs::create_dir_all(h.root().join("scripts")).unwrap();
+    // The config governs the whole checkout but INCLUDES only `src`.
+    std::fs::write(
+        h.root().join("tsconfig.json"),
+        r#"{"compilerOptions":{"target":"ES2020","module":"ESNext","moduleResolution":"bundler",
+            "strict":true},"include":["src"]}"#,
+    )
+    .unwrap();
+    std::fs::write(h.root().join("package.json"), r#"{"name":"excluded","version":"1.0.0"}"#)
+        .unwrap();
+    std::fs::write(h.root().join("scripts/lib.ts"), LIB_TS).unwrap();
+    link_typescript(h.root());
+
+    let defs = h.add_file("scripts/lib.ts", LIB_TS);
+    let target = h.add_symbol(defs, "greet", 0, LIB_TS.len());
+    let src = h.add_file("scripts/main.ts", MAIN_TS);
+    let call = MAIN_TS.rfind("greet").expect("the call site");
+    let edge = h.add_edge(src, "greet", call, call + "greet".len(), "NameOnly", None);
+
+    let mut session = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.root())
+        .expect("an excluded file still lives under a config, so the backend is not blocked");
+    let worklist = vec!["scripts/main.ts".to_string()];
+    let input = LivePassInput {
+        commit_sha: COMMIT,
+        worktree_id: WORKTREE,
+        checkout_root: h.root(),
+        worklist: &worklist,
+        max_requests: 100,
+        started_at_ms: 1_000,
+    };
+
+    assert_eq!(live_oracle_pass(&h.conn, &mut session, &input).unwrap().status, "Warming");
+    let deadline = Instant::now() + WARMUP_BUDGET;
+    let report = loop {
+        let report = live_oracle_pass(&h.conn, &mut session, &input).unwrap();
+        if report.status != "Warming" {
+            break report;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "an excluded file never warmed the server within {WARMUP_BUDGET:?} — the warm-up now \
+             needs real tsconfig membership, not ancestry",
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    };
+
+    assert_eq!(report.status, "Completed", "{report:?}");
+    assert_eq!(h.verdict(edge).expect("a verdict").1, Some(target));
+    session.shutdown();
+}

--- a/crates/rag-rat-oracle/src/tests/live_real_server.rs
+++ b/crates/rag-rat-oracle/src/tests/live_real_server.rs
@@ -53,9 +53,13 @@ fn write_ts_fixture(root: &Path) {
         .unwrap();
 }
 
-/// Point the fixture at a TypeScript install. The server falls back to a bundled compiler when it
-/// finds none, and that fallback does not resolve cross-file imports — which would make this test
-/// pass for the wrong reason (an unresolved callee writes no verdict either).
+/// Point the fixture at a TypeScript install, which the server needs to resolve the project at
+/// all.
+///
+/// Measured with none resolvable: the server emits NO project-load progress cycle and answers the
+/// definition `null`. That is safe — no cycle means the session never reports ready, so the pass
+/// never asks — but it would make this test pass for the wrong reason, since an unresolved callee
+/// writes no verdict either. (It is also why the watcher reports a backend that never warms.)
 fn link_typescript(root: &Path) {
     let node_modules = std::env::var("RAG_RAT_TS_NODE_MODULES").expect(
         "set RAG_RAT_TS_NODE_MODULES to a node_modules directory containing `typescript` — \

--- a/crates/rag-rat-oracle/src/tests/mod.rs
+++ b/crates/rag-rat-oracle/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod edge_view;
 mod join_tests;
 mod library_usage;
 mod live;
+mod live_real_server;
 mod monikers;
 mod persisted_enums;
 mod pre_spawn;

--- a/crates/rag-rat-oracle/src/tests/persisted_enums.rs
+++ b/crates/rag-rat-oracle/src/tests/persisted_enums.rs
@@ -8,17 +8,29 @@ use super::*;
 /// reject an unknown string — the `rust-modern-style` closed-enum contract.
 #[test]
 fn persisted_enums_round_trip_through_db_strings() {
-    for (tool, token) in [
+    // These strings are SCHEMA: they key `edge_oracle.tool` / `oracle_runs.tool`, so changing one
+    // makes existing rows unreadable. Spelled out literally rather than derived from `as_db_str`,
+    // which would make the test agree with any change it was meant to catch.
+    let tokens = [
         (OracleTool::RustAnalyzer, "rust-analyzer"),
         (OracleTool::ScipClang, "scip-clang"),
         (OracleTool::ScipPython, "scip-python"),
         (OracleTool::ScipTypescript, "scip-typescript"),
         (OracleTool::ScipJava, "scip-java"),
         (OracleTool::RaLsp, "ra-lsp"),
-    ] {
+        (OracleTool::TsLsp, "ts-lsp"),
+    ];
+    for (tool, token) in tokens {
         assert_eq!(tool.as_db_str(), token);
         assert_eq!(OracleTool::from_db_str(tool.as_db_str()), Some(tool));
     }
+    // A hand-written table silently falls behind the enum — a new variant would ship with an
+    // untested persisted token. Pin the coverage, not just the entries that happen to be listed.
+    assert_eq!(
+        tokens.map(|(tool, _)| tool).to_vec(),
+        OracleTool::ALL.to_vec(),
+        "every OracleTool variant needs its exact persisted token pinned here, in ALL order",
+    );
     assert_eq!(OracleTool::from_db_str("no-such-tool"), None);
 
     for (kind, token) in [

--- a/crates/rag-rat-oracle/src/tests/tool_defaults.rs
+++ b/crates/rag-rat-oracle/src/tests/tool_defaults.rs
@@ -43,32 +43,38 @@ fn default_position_encoding_is_utf16_for_typescript_and_java() {
     assert_eq!(OracleTool::ScipClang.default_position_encoding(), UNSPEC);
     assert_eq!(OracleTool::ScipPython.default_position_encoding(), UNSPEC);
     assert_eq!(OracleTool::RaLsp.default_position_encoding(), UNSPEC);
+    assert_eq!(OracleTool::TsLsp.default_position_encoding(), UNSPEC);
 }
 
-/// #534: the live `ra-lsp` tool is NEVER batch-capable — every batch driver (the auto-run loop,
-/// the init wizard, `produce_scip_with_tool`) must gate it out via the discriminator, and
+/// #534/#536: a live tool is NEVER batch-capable — every batch driver (the auto-run loop, the init
+/// wizard, `produce_scip_with_tool`) must gate it out via the discriminator, and
 /// `batch_moniker_source` names the batch tool whose monikers the live writer copies.
 #[test]
-fn ra_lsp_is_gated_out_of_the_batch_paths() {
+fn live_tools_are_gated_out_of_the_batch_paths() {
+    let live = [OracleTool::RaLsp, OracleTool::TsLsp];
     for &tool in OracleTool::ALL {
-        assert_eq!(tool.batch_capable(), tool != OracleTool::RaLsp, "{tool:?}");
+        assert_eq!(tool.batch_capable(), !live.contains(&tool), "{tool:?}");
     }
     assert_eq!(OracleTool::RaLsp.batch_moniker_source(), Some(OracleTool::RustAnalyzer));
+    assert_eq!(OracleTool::TsLsp.batch_moniker_source(), Some(OracleTool::ScipTypescript));
     for tool in OracleTool::ALL.iter().filter(|t| t.batch_capable()) {
         assert_eq!(tool.batch_moniker_source(), None, "{tool:?}");
     }
 
-    // `produce_scip_with_tool` on the live tool returns the documented Blocked hint and never
+    // `produce_scip_with_tool` on a live tool returns the documented Blocked hint and never
     // builds a `scip_command` (which would be an unreachable! panic).
-    let outcome =
-        produce_scip_with_tool(OracleTool::RaLsp, Path::new("/tmp"), Path::new("/tmp/x.scip"))
-            .unwrap();
-    match outcome {
-        ScipProduction::Blocked { tool, program, hint } => {
-            assert_eq!(tool, "ra-lsp");
-            assert_eq!(program, "rust-analyzer");
-            assert!(hint.contains("[oracle.live]"), "{hint}");
-        },
-        ScipProduction::Produced { .. } => panic!("a live tool must never produce a .scip"),
+    for (tool, program) in
+        [(OracleTool::RaLsp, "rust-analyzer"), (OracleTool::TsLsp, "typescript-language-server")]
+    {
+        let outcome =
+            produce_scip_with_tool(tool, Path::new("/tmp"), Path::new("/tmp/x.scip")).unwrap();
+        match outcome {
+            ScipProduction::Blocked { tool: blocked, program: blocked_program, hint } => {
+                assert_eq!(blocked, tool.as_db_str());
+                assert_eq!(blocked_program, program);
+                assert!(hint.contains("[oracle.live]"), "{hint}");
+            },
+            ScipProduction::Produced { .. } => panic!("a live tool must never produce a .scip"),
+        }
     }
 }

--- a/docs/config/oracle.md
+++ b/docs/config/oracle.md
@@ -27,25 +27,42 @@ run the oracle by hand.
 ## Live LSP oracle (`[oracle.live]`)
 
 The **live** oracle is the per-pass freshness path (#534): the resident watcher's maintenance pass
-resolves the callees of **just-changed Rust files** through a resident `rust-analyzer` language
-server and writes the same `edge_oracle` verdicts the batch pass writes, under a distinct `ra-lsp`
-tool id. The batch pass (`auto_run` / `oracle run`) stays the canonical whole-checkout writer —
-live rows are a freshness patch for files being edited, and where both tools cover the same edge
-the batch verdict wins.
+resolves the callees of **just-changed files** through a resident language server and writes the
+same `edge_oracle` verdicts the batch pass writes, under a distinct live tool id. The batch pass
+(`auto_run` / `oracle run`) stays the canonical whole-checkout writer — live rows are a freshness
+patch for files being edited, and where both tools cover the same edge the batch verdict wins.
+
+| Live tool | Language | Server | Extra requirement |
+|---|---|---|---|
+| `ra-lsp` | Rust | `rust-analyzer` | — |
+| `ts-lsp` | TypeScript / TSX | `typescript-language-server` | a `tsconfig.json` project (see below) |
 
 ```toml
 [oracle.live]
 enabled = false               # off by default — opt in explicitly
-idle_shutdown_secs = 900      # shut the language server down after 15 min idle
+idle_shutdown_secs = 900      # shut each language server down after 15 min idle
 max_requests_per_pass = 200   # positive cap per maintenance pass; zero is rejected
 ```
 
+One setting configures every live backend. A checkout indexed in several of these languages runs
+one resident server per language, each with its own backlog and respawn backoff, so a wedged
+server for one language never stalls another. `max_requests_per_pass` is **shared** across them —
+it bounds the pass, which holds the repository write lock — and the backends take turns claiming
+it so none is starved.
+
+**TypeScript needs a `tsconfig.json`.** `typescript-language-server` reports that it has finished
+loading a project only for a real tsconfig project, and the oracle waits for that signal before it
+trusts an answer (asked mid-load, the server resolves an imported callee to the *import statement*
+rather than the definition). The config does not have to be at the checkout root — a monorepo with
+`packages/*/tsconfig.json` is fine — but a checkout with none is reported `Blocked` rather than run
+blind.
+
 **Standalone:** `[oracle.live]` does NOT imply or require `[oracle] auto_run`. Without a batch
 baseline the live pass is *moniker-blind* — it upgrades edge confidence tiers under `local
-ra-lsp-<n>` sentinel monikers, but clone-collapse (`find_clones` scip refine mode) and
+<tool>-<n>` sentinel monikers, but clone-collapse (`find_clones` scip refine mode) and
 moniker-anchored memory relocation get nothing until a batch `oracle run` completes (`oracle
 status` says so when that's the case). Each completed batch run auto-upgrades subsequent live
 passes to the real monikers. Live runs only from the resident watcher (never one-shot hook/CLI
-maintenance passes, which would pay a language-server warm-up per invocation), and needs
-`rust-analyzer` on `PATH`; probe and launch run from the checkout root so rustup directory overrides
-apply. A missing tool degrades quietly like a missing embedding model.
+maintenance passes, which would pay a language-server warm-up per invocation), and needs the
+backend's server on `PATH`; probe and launch run from the checkout root so directory-scoped
+toolchain overrides apply. A missing tool degrades quietly like a missing embedding model.


### PR DESCRIPTION
The live oracle resolved only Rust, through `rust-analyzer`. This adds `typescript-language-server`
as a second backend under its own `ts-lsp` tool id, and moves the assumptions that were specific to
the first backend into two registries (`LiveBackend` + `ToolManifest`) so a third needs no protocol
code.

Part of #74. `clangd` and Kotlin stay open under #536 — neither server is installable here to audit,
and each needs the same measurement pass this one got before it can be trusted.

## Readiness is the load-bearing part

`rust-analyzer` reports quiescence explicitly and, while warming, answers a definition with `null` —
the cost is missing evidence.

`typescript-language-server` has no such notification, and its failure mode is materially worse.
Asked before its project has loaded, it does not answer `null`; it resolves an imported callee to
the **import statement in the calling file**:

| when | `textDocument/definition` on an imported `greet(...)` | correct? |
|---|---|---|
| project still loading | `targetUri` = the calling file, range = the `import` statement | no |
| project loaded | `targetUri` = the defining file, range = the `greet` identifier | yes |

That is a plausible non-null the write path would persist as a real `Upgrade`/`Contradict` verdict,
and the covered-skip budget means the edge would never be revisited until the file's bytes change.
So readiness gating here is a correctness requirement, not a latency optimisation.

The signal the server does emit is the work-done progress cycle (`$/progress` begin/end) bracketing
a project load, which becomes a second `ReadinessPolicy` alongside `experimental/serverStatus`. Two
measured properties shape the design:

- The cycle is triggered by the **first `didOpen`**, not by `initialize` — so an un-warmed session
  needs a warm-up open to break the deadlock (waiting for readiness without opening anything waits
  forever). The warm-up is fire-and-forget: the pass holds the repository write lock, so it defers
  its worklist rather than blocking on a multi-second project load, and the next pass finds the
  latched ready state.
- A document belonging to **no** tsconfig project loads silently, emitting no cycle at all — so the
  warm-up must choose a document that can actually produce the signal, not simply the first file on
  the worklist.

A checkout with no tsconfig project anywhere is reported `Blocked` with the reason rather than run
blind. The config need not sit at the checkout root, so monorepos with `packages/*/tsconfig.json`
work.

## Per-backend seams, previously hardcoded

| was | now |
|---|---|
| spawn argv `&[]` | `ToolManifest::live_args` (`--stdio` for TypeScript) |
| `experimental/serverStatus` inline in the reader pump | `ReadinessPolicy` |
| the literal `"rust"` languageId | per file extension (`.tsx` → `typescriptreact`) |
| `path.ends_with(".rs")` | the backend's `Language` |
| `local ra-lsp-<hash>` | namespaced by tool id; the hash input is unchanged, so existing `ra-lsp` rows still reproduce byte-identically |
| one session/backlog/backoff on the tail | one per backend, so a wedged server for one language cannot stall another |

`max_requests_per_pass` now bounds the pass **across** backends rather than each one separately — it
is a lock-hold bound, and a mixed-language checkout must not spend one allowance per language. The
backends claim it in a rotating order so none starves.

Batch-wins-on-overlap needed no change: the read-side merge sites already sort `batch_capable` first
with first-writer-wins, which generalises to any number of live tools. Copying monikers from
`ScipTypescript` is safe despite `stabilize_moniker_version` being non-identity for that tool,
because the source is the stored `logical_symbol_monikers` row the batch pass already wrote in final
form.

## Verification

- Unit tests against the in-process fake server: progress-driven readiness transitions, the warm-up
  trigger and its document choice, per-extension `languageId`, the `ts-lsp` sentinel, and a batch
  that straddles a project load being discarded.
- Watcher tests for per-backend worklist routing, independent backoff, and the shared-budget rotation.
- `crates/rag-rat-oracle/src/tests/live_real_server.rs` — an `#[ignore]`d end-to-end test against the
  real server asserting the warming pass issues no request and the following pass resolves to the
  definition rather than the import. Run with
  `RAG_RAT_TS_NODE_MODULES=<node_modules> cargo nextest run -p rag-rat-oracle --run-ignored all -E 'test(real_typescript_server)'`.
- Workspace `cargo nextest run` (4076 tests), all three CI clippy legs, and nightly `cargo fmt --check`.