### PR TITLE
fix(sync): reconcile each sync stream to a fixpoint across rounds

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -396,29 +396,33 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
 
         // 2) Restore-from-zero — pull the account log then `/3` content from the inviter, now that
         //    this device is roster-effective. Content rides on the account log's authority, so the
-        //    account log runs first. The inviter must still be serving (its `sync init` / `serve`).
+        //    account log runs first. Each stream reconciles to a fixpoint (#878): a single session
+        //    can report `Done` while the store is still incomplete, so re-run until dry (or the
+        //    round cap). The inviter must still be serving (its `sync init` / `serve`).
         let account_report = {
             let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
-            rag_rat_sync::connect_and_sync(
+            rag_rat_sync::connect_and_reconcile(
                 &endpoint,
                 peer.clone(),
                 rag_rat_sync::SYNC_ALPN,
                 &mut store,
                 AuthPolicy::Closed,
-                time::now_ms(),
+                time::now_ms,
+                rag_rat_sync::MAX_RECONCILE_ROUNDS,
             )
             .await
             .map_err(|e| anyhow!("restoring the account log from the inviter failed: {e}"))?
         };
         let content_report = {
             let mut store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
-            rag_rat_sync::connect_and_sync(
+            rag_rat_sync::connect_and_reconcile(
                 &endpoint,
                 peer,
                 rag_rat_sync::CONTENT_SYNC_ALPN,
                 &mut store,
                 AuthPolicy::Closed,
-                time::now_ms(),
+                time::now_ms,
+                rag_rat_sync::MAX_RECONCILE_ROUNDS,
             )
             .await
             .map_err(|e| anyhow!("restoring content from the inviter failed: {e}"))?
@@ -437,6 +441,9 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
             "account_id": hash::hex_lower(&account_id.to_bytes()),
             "account_entries_restored": account_report.entries_newly_stored,
             "content_entries_restored": content_report.entries_newly_stored,
+            // `converged=false` means the restore hit the reconciliation round cap and a later
+            // device-side sync should continue — the account/content stores may not be complete yet.
+            "converged": account_report.converged && content_report.converged,
             "inviter_node_id": inviter,
             "inviter_relay": ticket.relay_url,
             "note": "to keep syncing, add inviter_node_id to [sync] server_peers and set [sync] \
@@ -546,21 +553,29 @@ pub(crate) fn device_sync_run(
             // stays equal to the number of configured peers. `/3` content rides on top:
             // best-effort, attempted only once the account log reached the peer, and a
             // content hiccup is logged — never a peer failure.
+            // Reconcile each stream to a fixpoint (#878): a single session can report `Done` while
+            // the store is still incomplete (adversarial dependent-before-authorizer ordering, or a
+            // large active account), so re-run until a round is dry or the round cap is hit. A
+            // capped (non-converged) pass just defers the remainder to the next
+            // cadence.
             let account_ok = {
                 let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
-                match rag_rat_sync::connect_and_sync(
+                match rag_rat_sync::connect_and_reconcile(
                     &endpoint,
                     addr.clone(),
                     rag_rat_sync::SYNC_ALPN,
                     &mut store,
                     AuthPolicy::Closed,
-                    time::now_ms(),
+                    time::now_ms,
+                    rag_rat_sync::MAX_RECONCILE_ROUNDS,
                 )
                 .await
                 {
                     Ok(report) => {
                         tracing::info!(
                             peer,
+                            rounds = report.rounds,
+                            converged = report.converged,
                             sent = report.entries_sent,
                             stored = report.entries_newly_stored,
                             "device sync (account log) complete"
@@ -575,18 +590,21 @@ pub(crate) fn device_sync_run(
             };
             if account_ok {
                 let mut store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
-                match rag_rat_sync::connect_and_sync(
+                match rag_rat_sync::connect_and_reconcile(
                     &endpoint,
                     addr,
                     rag_rat_sync::CONTENT_SYNC_ALPN,
                     &mut store,
                     AuthPolicy::Closed,
-                    time::now_ms(),
+                    time::now_ms,
+                    rag_rat_sync::MAX_RECONCILE_ROUNDS,
                 )
                 .await
                 {
                     Ok(report) => tracing::info!(
                         peer,
+                        rounds = report.rounds,
+                        converged = report.converged,
                         sent = report.entries_sent,
                         stored = report.entries_newly_stored,
                         "device sync (content) complete"

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -377,6 +377,92 @@ pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     Ok(report)
 }
 
+/// The most times a dialer re-runs a sync session against ONE peer before giving up on convergence
+/// for this pass. A cooperative account reaches a fixpoint in a handful of rounds; a peer still not
+/// dry after this many re-syncs is withholding an authorizer or is pathologically active, so stop
+/// with `converged = false` and let the next maintenance pass continue — device-side sync re-runs
+/// the loop on its cadence, so a capped pass only defers the remainder, it never loses it.
+pub const MAX_RECONCILE_ROUNDS: usize = 8;
+
+/// What a multi-round reconciliation moved (aggregated across its rounds). `converged` is true when
+/// the loop stopped on a fully quiet round — nothing stored, sent, or received in either direction,
+/// so both peers hold the union of what each offered. It is false when the round cap was hit first:
+/// the store may still be incomplete and a later pass should continue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconcileReport {
+    pub rounds: usize,
+    pub entries_newly_stored: usize,
+    pub entries_sent: usize,
+    pub converged: bool,
+}
+
+/// Whether reconciliation should run another round, given the round just completed (#878). A single
+/// `run_session` can report `Done` while a store is still incomplete — an adversarial sender
+/// streaming dependents before their authorizer overruns the pre-verify eviction budget (only the
+/// survivors promote), and even a cooperative large account may not reach a fixpoint in one pass.
+/// Re-running converges: each store grows monotonically and every hello advertises parked entries
+/// (#877), so a re-sent dependent promotes once its authorizer is present on that side.
+///
+/// The fixpoint is a fully QUIET round — nothing stored, sent, OR received. All three matter:
+/// `sent` catches a PUSH that made the acceptor evict (the confirmation quiet round proves the
+/// re-pushed entries finally landed), `received` catches a peer that still has data for us, and
+/// `stored` catches local promotion progress. This is reliable because a store under
+/// [`MAX_HELLO_HASHES`] (65_536) advertises its COMPLETE inventory — parked entries included — so
+/// the counters reflect real gaps, not redelivery, for every store D targets. A store OVER that cap
+/// advertises only a bounded inventory, so a peer may re-offer already-held entries every round and
+/// the session never fully quiets; the round cap then stops it with `converged = false`, the honest
+/// outcome given the deliberate absence of a remainder-reconcile protocol for such stores.
+fn reconcile_step(report: &SessionReport, rounds_done: usize, max_rounds: usize) -> ReconcileStep {
+    let quiet = report.entries_newly_stored == 0
+        && report.entries_sent == 0
+        && report.entries_received == 0;
+    if quiet {
+        ReconcileStep::Stop { converged: true }
+    } else if rounds_done >= max_rounds {
+        // Still moving at the cap: the store may not be complete yet — a later maintenance pass
+        // continues from where this left off.
+        ReconcileStep::Stop { converged: false }
+    } else {
+        ReconcileStep::Continue
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileStep {
+    Continue,
+    Stop { converged: bool },
+}
+
+/// Dial `peer` repeatedly, running one [`connect_and_sync`] session per round until the transfer
+/// reaches a fixpoint or the round cap — the multi-round reconciliation #878 needs so a single
+/// session's `Done` is never mistaken for a complete store. The serve acceptor already loops
+/// accepting connections, so this dialer-side loop is all it takes: no wire change. `now_ms` is
+/// read fresh each round so every re-dialed session stamps the time it actually ran (a long
+/// reconciliation must not authorize against a pre-loop timestamp).
+pub async fn connect_and_reconcile<S: SyncStore + NodeAuth>(
+    endpoint: &Endpoint,
+    peer: EndpointAddr,
+    alpn: &[u8],
+    store: &mut S,
+    policy: AuthPolicy,
+    now_ms: impl Fn() -> i64,
+    max_rounds: usize,
+) -> Result<ReconcileReport, SyncFailure> {
+    let mut entries_newly_stored = 0;
+    let mut entries_sent = 0;
+    let mut rounds = 0;
+    loop {
+        let report =
+            connect_and_sync(endpoint, peer.clone(), alpn, store, policy, now_ms()).await?;
+        rounds += 1;
+        entries_newly_stored += report.entries_newly_stored;
+        entries_sent += report.entries_sent;
+        if let ReconcileStep::Stop { converged } = reconcile_step(&report, rounds, max_rounds) {
+            return Ok(ReconcileReport { rounds, entries_newly_stored, entries_sent, converged });
+        }
+    }
+}
+
 /// Accept ONE inbound connection and run a session against it. D4's `sync serve` loops this;
 /// keeping it single-shot here keeps the store's `!Send` connection on one task (no spawn).
 ///
@@ -603,6 +689,28 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         conn
+    }
+
+    #[test]
+    fn reconcile_step_loops_until_a_fully_quiet_round() {
+        let quiet = SessionReport::default();
+        // Nothing moved in either direction — the fixpoint.
+        assert_eq!(reconcile_step(&quiet, 1, 8), ReconcileStep::Stop { converged: true });
+        // Each direction of movement, on its own, keeps the loop going under the cap: `stored`
+        // (local promotion), `received` (peer still has data), and `sent` (our push may have made
+        // the acceptor evict — a quiet confirmation round must prove the re-push landed).
+        let stored =
+            SessionReport { entries_sent: 0, entries_received: 0, entries_newly_stored: 2 };
+        let received =
+            SessionReport { entries_sent: 0, entries_received: 5, entries_newly_stored: 0 };
+        let sent = SessionReport { entries_sent: 3, entries_received: 0, entries_newly_stored: 0 };
+        for report in [&stored, &received, &sent] {
+            assert_eq!(reconcile_step(report, 1, 8), ReconcileStep::Continue);
+        }
+        // Still moving at the cap stops UN-converged so a later maintenance pass continues.
+        assert_eq!(reconcile_step(&sent, 8, 8), ReconcileStep::Stop { converged: false });
+        // A quiet round at the cap is still the converged fixpoint.
+        assert_eq!(reconcile_step(&quiet, 8, 8), ReconcileStep::Stop { converged: true });
     }
 
     #[test]

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -28,9 +28,10 @@ pub use auth::{
     PeerCapability, SessionCapabilities, run_auth_phase,
 };
 pub use endpoint::{
-    EndpointError, SyncFailure, accept_and_dispatch, accept_and_sync, accept_enrollment,
-    build_endpoint, connect_and_enroll, connect_and_sync, discover_peers, endpoint_addr,
-    node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
+    EndpointError, MAX_RECONCILE_ROUNDS, ReconcileReport, SyncFailure, accept_and_dispatch,
+    accept_and_sync, accept_enrollment, build_endpoint, connect_and_enroll, connect_and_reconcile,
+    connect_and_sync, discover_peers, endpoint_addr, node_id_from_secret, node_id_to_string,
+    peer_addr, peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -676,6 +676,87 @@ fn direct_addr(endpoint: &iroh::Endpoint) -> iroh::EndpointAddr {
         .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
 }
 
+/// Multi-round reconciliation (#878): `connect_and_reconcile` re-dials until a round is dry, so a
+/// single session's `Done` is never mistaken for a complete store. Over loopback: a fresh peer
+/// takes TWO rounds (one transfers the account, one confirms the fixpoint), and re-running against
+/// the now-in-sync peer takes exactly ONE (immediately dry — no over-dialing). The serve side
+/// accepts each re-dial in a select loop and drops the pending accept once the client converges.
+#[tokio::test]
+async fn connect_and_reconcile_pulls_an_account_to_a_fixpoint_over_loopback() {
+    use rag_rat_sync::{
+        AuthPolicy, MAX_RECONCILE_ROUNDS, OplogSyncStore, ReconcileReport, SYNC_ALPN,
+        accept_and_sync, connect_and_reconcile,
+    };
+
+    let source = fresh_db();
+    let account = local_account(&source, NOW).unwrap();
+    let want = account_entries_for_sync(&source, account).unwrap();
+    assert!(!want.is_empty(), "the source has account entries to transfer");
+
+    let dest = fresh_db();
+    let (listener, dialer) = loopback_endpoints().await;
+    let listener_addr = direct_addr(&listener);
+    let policy = AuthPolicy::Open; // a fresh dest pulls the account log read-only
+
+    // Drive the client (which re-dials internally) while the serve side accepts each connection,
+    // stopping when the client resolves.
+    async fn reconcile_with_server(
+        source: &Connection,
+        dest: &Connection,
+        account: AccountId,
+        listener: &iroh::Endpoint,
+        dialer: &iroh::Endpoint,
+        addr: iroh::EndpointAddr,
+        policy: AuthPolicy,
+    ) -> ReconcileReport {
+        let mut src_store = OplogSyncStore::new(source, account, || NOW);
+        let mut dst_store = OplogSyncStore::new(dest, account, || NOW);
+        let client = connect_and_reconcile(
+            dialer,
+            addr,
+            SYNC_ALPN,
+            &mut dst_store,
+            policy,
+            || NOW,
+            MAX_RECONCILE_ROUNDS,
+        );
+        tokio::pin!(client);
+        loop {
+            tokio::select! {
+                resolved = &mut client => break resolved.unwrap(),
+                accepted = accept_and_sync(listener, &mut src_store, policy, || NOW) => {
+                    accepted.unwrap();
+                }
+            }
+        }
+    }
+
+    let report = reconcile_with_server(
+        &source,
+        &dest,
+        account,
+        &listener,
+        &dialer,
+        listener_addr.clone(),
+        policy,
+    )
+    .await;
+    assert_eq!(report.rounds, 2, "one round transfers the account, one confirms the fixpoint");
+    assert!(report.converged, "the reconciliation reached a fixpoint");
+    assert_eq!(
+        account_entries_for_sync(&dest, account).unwrap().len(),
+        want.len(),
+        "the whole account restored across the reconciliation",
+    );
+
+    let again =
+        reconcile_with_server(&source, &dest, account, &listener, &dialer, listener_addr, policy)
+            .await;
+    assert_eq!(again.rounds, 1, "an already-in-sync peer converges in a single dry round");
+    assert!(again.converged);
+    assert_eq!(again.entries_newly_stored, 0, "nothing new to store when already converged");
+}
+
 /// The pairing acceptance drill (#930): a FRESH device holding no account enrolls into an owner's
 /// account over the real iroh transport (loopback endpoints, no relay), then restores the account
 /// log and its `/3` content — byte-identical — over the same endpoints. This is the D4


### PR DESCRIPTION
A single sync session can report `Done` while a store is still incomplete, so the receiver trusts a false fixpoint. Two causes:

- **Adversarial ordering** — a sender streams dependents before their authorizer; once more than the pre-verify per-account budget (64) of entries for one unknown signer arrive before its introducer, the queue evicts the oldest, so only the survivors promote when the authorizer finally lands. The rest are dropped, yet the session sent `Done`.
- **Large active accounts** — even a cooperative one-shot session may not reach a fixpoint if promotion order and the eviction budget interact.

The honest outcome in both is degraded availability, not divergence (the receiver simply lacks some entries and can re-sync) — but reporting clean success while the store is incomplete is the defect.

## Fix — dialer-side reconciliation, no wire change

Re-running converges: each store grows monotonically and every hello already advertises parked entries, so a re-sent dependent promotes once its authorizer is present on that side. The serve acceptor already loops accepting connections, so a re-dialing loop is all this needs.

- `connect_and_reconcile` re-dials `connect_and_sync` until a **fully quiet round** (nothing stored, sent, or received) or a round cap (`MAX_RECONCILE_ROUNDS = 8`), returning a `ReconcileReport { rounds, entries_newly_stored, entries_sent, converged }`.
- All three movement counters gate convergence: `stored` catches local promotion progress, `received` catches a peer that still has data, and `sent` catches a push that made the acceptor evict — the quiet confirmation round proves the re-pushed entries landed. This is reliable because a store under `MAX_HELLO_HASHES` (65,536) advertises its complete inventory (parked entries included), so the counters reflect real gaps, not redelivery.
- Device-side sync (account log then content) and the `sync join` restore reconcile to a fixpoint instead of trusting one `Done`; `join` surfaces `converged`.
- A store over the hello cap can only advertise a bounded inventory, so it never fully quiets and the cap stops it with `converged = false` — the honest outcome given the deliberate absence of a remainder-reconcile protocol for such stores — never a false `Done`. A withholding peer likewise caps out at `converged = false`; a later maintenance pass continues.

## Verification

- `reconcile_step` unit test (each movement direction continues the loop independently; a quiet round converges; the cap stops un-converged while moving).
- Loopback integration test over relay-free endpoints: a fresh peer reconciles a full account in two rounds (transfer, then a quiet confirmation) and an already-in-sync peer converges in one quiet round with no over-dialing.
- `cargo nextest` + `cargo test` for `rag-rat-sync` + `rag-rat`, default and `--no-default-features`; all four CI clippy legs; `cargo +nightly fmt`.

Closes #878.