### PR TITLE
feat(sync): park table-sync entries this binary cannot fully project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,6 +5092,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strum",
  "tempfile",
  "x25519-dalek",
  "zeroize",

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -135,6 +135,13 @@ impl IndexDatabase {
         // V070-tables guard inside skips cleanly); idempotent and serialized by its own
         // IMMEDIATE txn, so racing openers converge.
         rag_rat_oplog::rebuild_all_content_projections_if_stale(storage.connection())?;
+        // #1001: the same discipline for the `/4` table-sync projection. An entry this binary could
+        // not project when it arrived is retained and marked; replaying it HERE — after migrations,
+        // before any produce — is what keeps a payload that arrived from being lost, since
+        // redelivery short-circuits on the entry already being present. Bounded by the pending set,
+        // so the steady state is one indexed probe, and a no-op today because no table is
+        // registered yet; wired now so registering the first one cannot forget it.
+        rag_rat_oplog::refold_stale_table_sync_projections(storage.connection())?;
         // #691 A1: mirror any accepted SYNCED /3 content into the local memory tables now that the
         // projection is current above — the reverse of the authoring reconcile. Store-global (one
         // pass per real repo). A repo with no minted account or no synced content is a cheap no-op,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1498,8 +1498,22 @@ fn migration_093_adds_table_sync_projection_state() {
     assert!(
         schema::column_exists(&bare, "table_sync_entries", "pending_projector_version").unwrap()
     );
+    assert!(schema::column_exists(&bare, "table_sync_entries", "quarantine_reason").unwrap());
     assert!(schema::column_exists(&bare, "sync_published_rows", "projector_version").unwrap());
     assert!(schema::table_exists(&bare, "table_sync_streams").unwrap());
+
+    // Each column is guarded INDIVIDUALLY. A store carrying only part of this migration's shape
+    // still gains the rest: the ladder records V093 as applied and never re-runs it, so a
+    // group-guarded add would leave a column missing on a store that reports itself current.
+    let partial = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_table_sync_tables(&partial).unwrap();
+    partial.execute("ALTER TABLE table_sync_entries ADD COLUMN pending_reason TEXT", []).unwrap();
+    schema::apply_table_sync_projection_state(&partial).unwrap();
+    assert!(
+        schema::column_exists(&partial, "table_sync_entries", "quarantine_reason").unwrap(),
+        "a partially-migrated store still gains the columns it is missing"
+    );
+    assert!(schema::column_exists(&partial, "sync_published_rows", "projector_version").unwrap());
 
     // The directory is STRICT and keyed by the stream id, so one stream resolves to exactly one
     // apply context.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1404,8 +1404,6 @@ fn migration_090_adds_account_candidate_reservations() {
 /// from the grow-only candidate DAG.
 #[test]
 fn migration_092_normalizes_invite_receipts() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 92, "move this pin with the next schema migration");
-
     let bare = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply_sync_invites(&bare).unwrap();
     bare.execute(
@@ -1461,7 +1459,7 @@ fn migration_092_normalizes_invite_receipts() {
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 92);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     let recorded: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM schema_version
@@ -1471,6 +1469,64 @@ fn migration_092_normalizes_invite_receipts() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V092");
+}
+
+/// V093 (#1001) records what the table-sync projector could not project, the apply context the
+/// one-way stream id hashes away, and the column set each anti-echo hash covers.
+#[test]
+fn migration_093_adds_table_sync_projection_state() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 93, "move this pin with the next schema migration");
+
+    // Absence is asserted against the PRE-V093 DDL in isolation, never against the full ladder
+    // (which now ends at V093 and would make the check vacuous).
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_table_sync_tables(&bare).unwrap();
+    assert!(
+        !schema::column_exists(&bare, "table_sync_entries", "pending_reason").unwrap(),
+        "the pending mark arrives with V093, not before"
+    );
+    assert!(
+        !schema::column_exists(&bare, "sync_published_rows", "projector_version").unwrap(),
+        "the anti-echo hash is unversioned before V093"
+    );
+    assert!(!schema::table_exists(&bare, "table_sync_streams").unwrap());
+
+    schema::apply_table_sync_projection_state(&bare).unwrap();
+    schema::apply_table_sync_projection_state(&bare).expect("replay is a no-op");
+
+    assert!(schema::column_exists(&bare, "table_sync_entries", "pending_reason").unwrap());
+    assert!(
+        schema::column_exists(&bare, "table_sync_entries", "pending_projector_version").unwrap()
+    );
+    assert!(schema::column_exists(&bare, "sync_published_rows", "projector_version").unwrap());
+    assert!(schema::table_exists(&bare, "table_sync_streams").unwrap());
+
+    // The directory is STRICT and keyed by the stream id, so one stream resolves to exactly one
+    // apply context.
+    bare.execute(
+        "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id)
+         VALUES (zeroblob(32), 'repo', zeroblob(32), 'anchors/1')",
+        [],
+    )
+    .unwrap();
+    let duplicate = bare.execute(
+        "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id)
+         VALUES (zeroblob(32), 'other', zeroblob(32), 'overlay/1')",
+        [],
+    );
+    assert!(duplicate.is_err(), "a stream id resolves to one apply context");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '093_table_sync_projection_state'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V093");
 }
 
 /// V091 (#949) tracks the live key-target count each invite reservation covers, so fold-time

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6285,14 +6285,19 @@ pub fn apply_sync_invites_normalized_receipts(conn: &Connection) -> rusqlite::Re
     tx.commit()
 }
 
-/// V093 (#1001): the table-sync forward-compat projection substrate — three facts the engine could
-/// not previously record, each of which silently corrupts a synced table once one registers.
+/// V093 (#1001): the table-sync forward-compat projection substrate — facts the engine could not
+/// previously record, each of which silently corrupts a synced table once one registers.
 ///
 /// - `table_sync_entries.pending_reason` / `.pending_projector_version`: an entry this binary
 ///   cannot fully project (unknown column, unknown op-kind, undecodable payload, table out of
 ///   scope) is retained but was never marked, so redelivery short-circuits on `entry_exists` and
 ///   the payload is unrecoverable. Marking it lets a later binary that understands it replay
 ///   exactly the outstanding set. NULL reason = fully projected.
+/// - `table_sync_entries.quarantine_reason`: the TERMINAL counterpart. A payload rejected on its
+///   own merits — a type mismatch, a constraint violation — is not a version gap, and no later
+///   binary makes those data fit, so it must leave the replay worklist. Recording WHY keeps it
+///   discoverable, instead of a retained entry that looks fully projected but was actually
+///   rejected.
 /// - `table_sync_streams`: `stream_id` is a ONE-WAY sha256 of `(repo_id, account_id, scope_id)`,
 ///   and entries store only the stream id. Replay needs `repo_id` to apply and the scope to resolve
 ///   the table spec, so without this directory a stored entry cannot be replayed at all.
@@ -6311,7 +6316,8 @@ pub fn apply_table_sync_projection_state(conn: &Connection) -> rusqlite::Result<
     if !column_exists(&tx, "table_sync_entries", "pending_reason")? {
         tx.execute_batch(
             "ALTER TABLE table_sync_entries ADD COLUMN pending_reason TEXT;
-             ALTER TABLE table_sync_entries ADD COLUMN pending_projector_version INTEGER;",
+             ALTER TABLE table_sync_entries ADD COLUMN pending_projector_version INTEGER;
+             ALTER TABLE table_sync_entries ADD COLUMN quarantine_reason TEXT;",
         )?;
     }
     if !column_exists(&tx, "sync_published_rows", "projector_version")? {

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6313,20 +6313,19 @@ pub fn apply_sync_invites_normalized_receipts(conn: &Connection) -> rusqlite::Re
 /// `projector_version` default of 0 is therefore unreachable rather than a lie about existing rows.
 pub fn apply_table_sync_projection_state(conn: &Connection) -> rusqlite::Result<()> {
     let tx = conn.unchecked_transaction()?;
-    if !column_exists(&tx, "table_sync_entries", "pending_reason")? {
-        tx.execute_batch(
-            "ALTER TABLE table_sync_entries ADD COLUMN pending_reason TEXT;
-             ALTER TABLE table_sync_entries ADD COLUMN pending_projector_version INTEGER;
-             ALTER TABLE table_sync_entries ADD COLUMN quarantine_reason TEXT;",
-        )?;
-    }
-    if !column_exists(&tx, "sync_published_rows", "projector_version")? {
-        tx.execute(
-            "ALTER TABLE sync_published_rows
-                 ADD COLUMN projector_version INTEGER NOT NULL DEFAULT 0",
-            [],
-        )?;
-    }
+    // Per-column, never one guard for the group: a store that applied an EARLIER shape of this
+    // migration already has the first column, so a group guard would skip the rest forever — the
+    // ladder records the migration as applied and never re-runs it, leaving a column missing on a
+    // store that reports itself current.
+    add_column_if_missing(&tx, "table_sync_entries", "pending_reason", "TEXT")?;
+    add_column_if_missing(&tx, "table_sync_entries", "pending_projector_version", "INTEGER")?;
+    add_column_if_missing(&tx, "table_sync_entries", "quarantine_reason", "TEXT")?;
+    add_column_if_missing(
+        &tx,
+        "sync_published_rows",
+        "projector_version",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
     tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS table_sync_streams(
              stream_id  BLOB NOT NULL PRIMARY KEY,

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1378,6 +1378,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_090_ID => Some(90),
             MIGRATION_091_ID => Some(91),
             MIGRATION_092_ID => Some(92),
+            MIGRATION_093_ID => Some(93),
             _ => None,
         })
         .max()
@@ -1479,6 +1480,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_090_ID
             | MIGRATION_091_ID
             | MIGRATION_092_ID
+            | MIGRATION_093_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1577,6 +1579,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_090_ID => migration.checksum != MIGRATION_090_CHECKSUM,
         MIGRATION_091_ID => migration.checksum != MIGRATION_091_CHECKSUM,
         MIGRATION_092_ID => migration.checksum != MIGRATION_092_CHECKSUM,
+        MIGRATION_093_ID => migration.checksum != MIGRATION_093_CHECKSUM,
         _ => false,
     }
 }
@@ -6279,6 +6282,58 @@ pub fn apply_sync_invites_normalized_receipts(conn: &Connection) -> rusqlite::Re
          CREATE INDEX IF NOT EXISTS sync_invites_account_expiry
              ON sync_invites(account_id, expires_at_ms);"
     ))?;
+    tx.commit()
+}
+
+/// V093 (#1001): the table-sync forward-compat projection substrate — three facts the engine could
+/// not previously record, each of which silently corrupts a synced table once one registers.
+///
+/// - `table_sync_entries.pending_reason` / `.pending_projector_version`: an entry this binary
+///   cannot fully project (unknown column, unknown op-kind, undecodable payload, table out of
+///   scope) is retained but was never marked, so redelivery short-circuits on `entry_exists` and
+///   the payload is unrecoverable. Marking it lets a later binary that understands it replay
+///   exactly the outstanding set. NULL reason = fully projected.
+/// - `table_sync_streams`: `stream_id` is a ONE-WAY sha256 of `(repo_id, account_id, scope_id)`,
+///   and entries store only the stream id. Replay needs `repo_id` to apply and the scope to resolve
+///   the table spec, so without this directory a stored entry cannot be replayed at all.
+/// - `sync_published_rows.projector_version`: the anti-echo hash is computed over the hashing
+///   binary's `spec.columns`, so a stored hash means "this row under column set C" with C implicit.
+///   Once a column set grows, every stored hash mismatches structurally and every row reads as a
+///   local delta — re-authoring the whole table at fresh winning lamports on every upgrading
+///   device. Recording the version makes a mismatched hash detectable as NOT COMPARABLE instead.
+///
+/// Additive and idempotent: the sanctioned `index --full` re-apply sees the V093 shape and skips
+/// the column adds. Nothing backfills, because no table is registered yet — `SYNCABLE_TABLES` is
+/// empty, so `table_sync_entries` and `sync_published_rows` are necessarily empty too, and the
+/// `projector_version` default of 0 is therefore unreachable rather than a lie about existing rows.
+pub fn apply_table_sync_projection_state(conn: &Connection) -> rusqlite::Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    if !column_exists(&tx, "table_sync_entries", "pending_reason")? {
+        tx.execute_batch(
+            "ALTER TABLE table_sync_entries ADD COLUMN pending_reason TEXT;
+             ALTER TABLE table_sync_entries ADD COLUMN pending_projector_version INTEGER;",
+        )?;
+    }
+    if !column_exists(&tx, "sync_published_rows", "projector_version")? {
+        tx.execute(
+            "ALTER TABLE sync_published_rows
+                 ADD COLUMN projector_version INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS table_sync_streams(
+             stream_id  BLOB NOT NULL PRIMARY KEY,
+             repo_id    TEXT NOT NULL,
+             account_id BLOB NOT NULL,
+             scope_id   TEXT NOT NULL
+         ) STRICT;
+         -- The refold's worklist. Partial, so a projector bump costs O(outstanding entries) rather
+         -- than a scan of the whole log, and the steady state (nothing pending) costs nothing.
+         CREATE INDEX IF NOT EXISTS table_sync_entries_pending
+             ON table_sync_entries(pending_reason)
+             WHERE pending_reason IS NOT NULL;",
+    )?;
     tx.commit()
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -26,7 +26,8 @@ pub use migrations::{
     apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
     apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
     apply_sync_invites, apply_sync_invites_normalized_receipts,
-    apply_sync_origin_and_edge_tombstone, apply_table_sync_tables,
+    apply_sync_origin_and_edge_tombstone, apply_table_sync_projection_state,
+    apply_table_sync_tables,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
@@ -49,7 +50,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 92;
+pub const LATEST_SCHEMA_VERSION: u32 = 93;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -696,6 +697,16 @@ const MIGRATION_092_DESCRIPTION: &str =
      DeviceAdd envelope; the account bootstrap is already durable in the grow-only candidate DAG, \
      and receipt replay reconstructs the snapshot from it instead of storing one full copy per \
      invite (quadratic growth across a fleet). Table rebuild preserving every row";
+const MIGRATION_093_ID: &str = "093_table_sync_projection_state";
+const MIGRATION_093_CHECKSUM: &str = "sha256:rag-rat-table-sync-projection-state-v93";
+const MIGRATION_093_DESCRIPTION: &str =
+    "Table-sync forward-compat projection substrate (#1001): mark entries this binary cannot \
+     fully project (pending_reason / pending_projector_version) so a later binary replays them \
+     instead of losing their payload; a table_sync_streams directory recovering the (repo_id, \
+     account_id, scope_id) apply context that the one-way stream id hashes away, without which a \
+     stored entry cannot be replayed at all; and sync_published_rows.projector_version, since the \
+     anti-echo hash covers the hashing binary's column set and is meaningless without that set's \
+     identity";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1444,6 +1455,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_092_CHECKSUM,
         description: MIGRATION_092_DESCRIPTION,
         apply: MigrationFn::Plain(apply_sync_invites_normalized_receipts),
+    },
+    Migration {
+        id: MIGRATION_093_ID,
+        checksum: MIGRATION_093_CHECKSUM,
+        description: MIGRATION_093_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_table_sync_projection_state),
     },
 ];
 

--- a/crates/rag-rat-oplog/Cargo.toml
+++ b/crates/rag-rat-oplog/Cargo.toml
@@ -26,6 +26,7 @@ rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+strum.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -62,13 +62,12 @@ mod project;
 mod store;
 mod stream;
 mod table_sync;
-
 // C1's curated authority seam for the C2 `/3` content envelope and candidate DAG. The account
-// implementation stays private; only typed ingest results and snapshot-consistent point queries
-// cross the phase boundary.
+// implementation stays private; only typed ingest results and snapshot-consistent point
+// queries cross the phase boundary.
 //
-// The C3.4 local-authoring surface `query::memory` reaches for once #664 retargets the live memory
-// path onto the owner-bound `/2`//3 substrate:
+// The C3.4 local-authoring surface `query::memory` reaches for once #664 retargets the live
+// memory path onto the owner-bound `/2`//3 substrate:
 // - `local_account` (C3.4a, #662): the store-global principal owner-bound `/3` content authors
 //   under.
 // - `ensure_owned_stream_v2_in_tx` (C3.4b-ii, #676): publish + resolve a repo's owned `/2` stream.
@@ -83,13 +82,13 @@ mod table_sync;
 // - `rotate_stream_key_in_tx` / `ensure_stream_key_current_in_tx` / `stream_key_rotation_needed`
 //   (C4.4, #607): lazy content-key rotation on device removal — re-seal a fresh higher-epoch key to
 //   the remaining roster when a removed device still holds the current key.
-// `prepare_content_authoring` / `author_prepared_content_batch_in_tx` / `SealPolicy` (C5, #608):
-// policy-aware `/3` authoring prepared before, then executed inside, a caller-owned transaction;
-// `author_content_batch` is the self-transacting convenience composition. The
+// `prepare_content_authoring` / `author_prepared_content_batch_in_tx` / `SealPolicy` (C5,
+// #608): policy-aware `/3` authoring prepared before, then executed inside, a caller-owned
+// transaction; `author_content_batch` is the self-transacting convenience composition. The
 // envelope-layer seal primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`)
-// take a `&DeviceSecret`, so — like `sign_content_entry` — they stay account-crate-internal. Keep
-// this crate-root API explicit: adding an account implementation seam must not silently make it a
-// public semver commitment.
+// take a `&DeviceSecret`, so — like `sign_content_entry` — they stay account-crate-internal.
+// Keep this crate-root API explicit: adding an account implementation seam must not silently
+// make it a public semver commitment.
 pub use account::{
     AccountId, AuthoredDurability, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason,
     AuthorityQuery, CapacityScope, CatchUpReport, ContentCapacityScope, ContentEntryHeader,
@@ -160,3 +159,6 @@ pub use op::{
 pub use project::ProjectedState;
 pub use store::{author_batch, author_op, load_projection};
 pub use stream::StreamId;
+// The table-sync forward-compat seam (#1001): replay entries retained but not projected when
+// they arrived. Belongs at store open, before producing — see the module docs.
+pub use table_sync::refold_stale_table_sync_projections;

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -560,11 +560,21 @@ pub(crate) fn row_has_unsent_local_change(
     repo_id: &str,
     pk_vals: &[TypedValue],
 ) -> anyhow::Result<bool> {
-    let Some(current) = synced_row_hash(tx, spec, pk_vals)? else {
-        // No row: nothing local to lose (the entry is establishing it).
+    // A malformed key never reached `apply_row_op`'s arity check (an entry parked as out-of-scope
+    // or unknown-kind was never validated), and binding it against `spec.pk`'s placeholders
+    // would be a parameter-count ERROR — which, propagating out of the refold, would roll back
+    // the transaction and fail every subsequent store open on the same entry. Defer to the
+    // normal path, which quarantines it.
+    if pk_vals.len() != spec.pk.len() {
         return Ok(false);
-    };
+    }
     let row_pk = row_op::row_pk_string(pk_vals);
+    let Some(current) = synced_row_hash(tx, spec, pk_vals)? else {
+        // No row — but a surviving published identity means the row was DELETED locally and not yet
+        // authored. That is precisely what the producer's `Remove` branch keys on, so replaying an
+        // upsert here would recreate the row and discard the unsent deletion for good.
+        return Ok(published_hash(tx, repo_id, spec.name, &row_pk)?.is_some());
+    };
     Ok(match published_hash(tx, repo_id, spec.name, &row_pk)? {
         // Comparable: a differing hash is a demonstrably unsent local change.
         Some((published, version)) if version == super::refold::TABLE_SYNC_PROJECTOR_VERSION =>

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -5,9 +5,11 @@
 //! fingerprint) — the winner replaces the whole row atomically; a loser is a no-op.
 //! Insert-vs-update is decided by row existence, never a blind upsert. A cell whose value disagrees
 //! with its column's declared type quarantines the whole op (a broken producer, surfaced, not
-//! silently coerced); a cell for a column this binary's registry doesn't know is skipped (a newer
-//! producer, forward compatible). After a winning apply the row's synced-column hash is recorded,
-//! which is what stops the producer re-emitting a row it just received (see [`super::produce`]).
+//! silently coerced); an op naming a column this binary's registry doesn't know is PARKED whole (a
+//! newer producer — see [`apply_upsert`]), never applied in part, so every local row stays a
+//! complete after-image some device actually authored. After a winning apply the row's
+//! synced-column hash is recorded WITH the projector version whose column set it covers, which is
+//! what stops the producer re-emitting a row it just received (see [`super::produce`]).
 //! Deletes and the resurrection guard use the same row clock plus a per-row tombstone; a losing op
 //! never touches the published hash, so an unsent local edit is never silently marked as sent.
 
@@ -16,14 +18,24 @@ use rusqlite::{OptionalExtension, Transaction, params_from_iter};
 
 use super::registry::{TableSpec, ValueType};
 use super::row_op::{self, Cell, RowOp, TypedValue};
+use super::store::PendingReason;
 use crate::op::OpMeta;
 
-/// The result of applying one row op. `Quarantined` means the op was structurally storable but its
-/// content is unprojectable (a type mismatch) — the entry is retained, the row is left untouched.
+/// The result of applying one row op.
+///
+/// `Quarantined` means the op was structurally storable but its content is unprojectable in a way a
+/// later binary will NOT fix (a type mismatch, a constraint violation, a partial after-image from a
+/// broken producer) — the entry is retained, the row is left untouched.
+///
+/// `Unprojectable` means this binary does not understand the payload YET — a newer producer used a
+/// column this registry lacks. Nothing is written and the entry is marked pending, so a later
+/// binary that learns the column replays it. The distinction matters: quarantine is terminal,
+/// pending is a version gap.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ApplyOutcome {
     Applied,
     Quarantined(String),
+    Unprojectable(PendingReason),
 }
 
 /// Fold `op` into `spec`'s table for `repo_id`, ordered by `meta`. See the module doc for the merge
@@ -136,6 +148,24 @@ fn apply_upsert(
     cells: &[Cell],
     meta: OpMeta,
 ) -> anyhow::Result<ApplyOutcome> {
+    // FORWARD COMPATIBILITY, decided on the PAYLOAD ALONE (before any row state is read): an op
+    // naming a column this registry does not know cannot be projected into a complete after-image.
+    // PARK it — store the entry, write NOTHING — rather than applying the subset we understand.
+    //
+    // Applying the known cells and skipping the rest would leave a row that NO device ever authored
+    // ({known: new, unknown: whatever this row already held}), and recording its anti-echo hash
+    // would then claim that chimera as a complete projection. Two failures follow: the skipped
+    // value is unrecoverable locally (redelivery short-circuits on `entry_exists`), and after an
+    // upgrade that learns the column the producer re-authors the row with the HOLE at a fresh
+    // winning lamport — destroying the real value on every peer. Parking makes the incomplete
+    // projection unrepresentable instead of containing it after the fact (#1001).
+    if let Some(unknown) =
+        cells.iter().find(|cell| !spec.columns.iter().any(|known| known.name == cell.column))
+    {
+        debug_assert!(!unknown.column.is_empty());
+        return Ok(ApplyOutcome::Unprojectable(PendingReason::UnknownColumn));
+    }
+
     let row_pk = &row_op::row_pk_string(pk_vals);
     let device_hex = &meta.device.to_string();
 
@@ -148,12 +178,13 @@ fn apply_upsert(
         return Ok(ApplyOutcome::Applied);
     }
 
-    // Classify each cell: a known synced column (type-checked), or an unknown column (skipped —
-    // forward compatibility). A type mismatch quarantines the WHOLE op before any write.
+    // Type-check each cell. Every cell's column is known here — an unknown one parked the whole op
+    // above, before any row state was touched. A type mismatch quarantines the op before any write.
     let mut known: Vec<(&str, &TypedValue)> = Vec::new();
     for cell in cells {
         let Some(column) = spec.columns.iter().find(|c| c.name == cell.column) else {
-            continue; // a column this registry doesn't know — a newer producer; skip the cell.
+            debug_assert!(false, "an unknown column parks the op before any cell is classified");
+            return Ok(ApplyOutcome::Unprojectable(PendingReason::UnknownColumn));
         };
         if !value_matches(&cell.value, column.value_type) {
             return Ok(ApplyOutcome::Quarantined(format!(
@@ -169,15 +200,15 @@ fn apply_upsert(
     // two peers with different prior values there would diverge. The producer always emits every
     // synced column (`read_all_rows`), so a partial op is malformed or a version-skew op that
     // cannot cleanly replace this binary's row; quarantine it rather than half-apply. (Decode
-    // rejects duplicate columns and unknown columns are skipped, so `known` holds distinct synced
-    // columns — a full count means all are present.)
+    // rejects duplicate columns and an unknown column parks the op, so `known` holds distinct
+    // synced columns — a full count means all are present.)
+    // PARK, not quarantine: the overwhelmingly likely cause is an OLDER producer whose complete row
+    // under its narrower spec is a partial one under ours — a version gap, redeemed from the
+    // sender's side by #1002's declared column defaults, not a broken producer whose data can never
+    // fit. Quarantining would drop it off the refold's worklist permanently; parking keeps it
+    // outstanding so the binary that can rebuild the missing cells lands it.
     if known.len() != spec.columns.len() {
-        return Ok(ApplyOutcome::Quarantined(format!(
-            "upsert on `{}` is not a full after-image ({} of {} synced columns present)",
-            spec.name,
-            known.len(),
-            spec.columns.len()
-        )));
+        return Ok(ApplyOutcome::Unprojectable(PendingReason::PartialAfterImage));
     }
 
     // Whole-row LWW: the op wins the ENTIRE row iff it beats the row's write clock (or the row is
@@ -483,24 +514,32 @@ fn clear_row_clock(
     Ok(())
 }
 
-/// The row's recorded anti-echo hash, or `None` if the producer has not published it yet. Read by
-/// [`super::produce`].
+/// The row's recorded anti-echo hash and the projector version whose column set it covers, or
+/// `None` if the producer has not published it yet. Read by [`super::produce`].
+///
+/// The version is NOT decoration. `cells_hash` hashes the cell LIST over `spec.columns` of
+/// whichever binary computed it, so a bare hash means "this row under column set C" with C
+/// implicit. Comparing hashes across different column sets is meaningless — they differ
+/// structurally even when the row is untouched — so the producer must know which set a stored hash
+/// covers before trusting a mismatch as a local change.
 pub(crate) fn published_hash(
     tx: &Transaction<'_>,
     repo_id: &str,
     table: &str,
     row_pk: &str,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Option<(String, i64)>> {
     Ok(tx
         .query_row(
-            "SELECT synced_hash FROM sync_published_rows
+            "SELECT synced_hash, projector_version FROM sync_published_rows
              WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
             rusqlite::params![repo_id, table, row_pk],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
         )
         .optional()?)
 }
 
+/// Claim `row_pk` as a COMPLETE projection: `hash` covers every synced column this binary knows,
+/// stamped with the projector version that defines that column set.
 pub(crate) fn record_published(
     tx: &Transaction<'_>,
     repo_id: &str,
@@ -509,10 +548,19 @@ pub(crate) fn record_published(
     hash: &str,
 ) -> anyhow::Result<()> {
     tx.execute(
-        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash)
-         VALUES (?1, ?2, ?3, ?4)
-         ON CONFLICT(repo_id, table_name, row_pk) DO UPDATE SET synced_hash = excluded.synced_hash",
-        rusqlite::params![repo_id, table, row_pk, hash],
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash,
+                                         projector_version)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(repo_id, table_name, row_pk) DO UPDATE
+             SET synced_hash = excluded.synced_hash,
+                 projector_version = excluded.projector_version",
+        rusqlite::params![
+            repo_id,
+            table,
+            row_pk,
+            hash,
+            super::refold::TABLE_SYNC_PROJECTOR_VERSION
+        ],
     )?;
     Ok(())
 }
@@ -803,7 +851,7 @@ mod tests {
     }
 
     #[test]
-    fn a_partial_upsert_missing_a_synced_column_is_quarantined() {
+    fn a_partial_upsert_missing_a_synced_column_is_parked() {
         // Whole-row LWW needs a full after-image; a two-column table given only one column can't be
         // cleanly replaced, so the op is quarantined rather than applied as a hybrid row.
         const TWO_COL: TableSpec = TableSpec {
@@ -835,19 +883,28 @@ mod tests {
         let out =
             apply_row_op(&tx, &TWO_COL, "repo", &partial, OpMeta { lamport: 1, device: device(2) })
                 .unwrap();
-        assert!(
-            matches!(out, ApplyOutcome::Quarantined(_)),
-            "a partial after-image is quarantined"
+        assert_eq!(
+            out,
+            ApplyOutcome::Unprojectable(PendingReason::PartialAfterImage),
+            "a partial after-image is PARKED, not quarantined: the likely cause is an older \
+             producer whose narrower complete row is partial under this spec, and #1002's \
+             declared defaults redeem it — quarantining would drop it off the refold worklist for \
+             good"
         );
         let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_two", [], |r| r.get(0)).unwrap();
         assert_eq!(count, 0, "nothing was written");
     }
 
     #[test]
-    fn an_unknown_column_is_skipped_and_the_rest_applies() {
+    fn an_unknown_column_parks_the_whole_op_and_writes_nothing() {
+        // A newer producer's column: this op cannot become a COMPLETE after-image here, so nothing
+        // is written and the entry is left for the refold. Applying the known cell instead (the
+        // pre-#1001 behavior) would leave a row no device authored and — once this binary learned
+        // the column — re-author it with the hole at a winning lamport, destroying the real value
+        // on every peer.
         let mut c = conn();
         let tx = c.transaction().unwrap();
-        apply_row_op(
+        let out = apply_row_op(
             &tx,
             &SPEC,
             "repo",
@@ -858,12 +915,79 @@ mod tests {
             OpMeta { lamport: 1, device: device(2) },
         )
         .unwrap();
+        assert_eq!(out, ApplyOutcome::Unprojectable(PendingReason::UnknownColumn));
+
+        let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
+        assert!(published_hash(&tx, "repo", "t_demo", &row_pk).unwrap().is_none());
+        assert!(current_row_clock(&tx, "repo", "t_demo", &row_pk).unwrap().is_none());
         tx.commit().unwrap();
+        assert_eq!(title(&c), None, "a parked op leaves the table untouched");
+    }
+
+    #[test]
+    fn an_unknown_column_parks_without_disturbing_the_row_it_would_have_replaced() {
+        // The dangerous variant: the row already exists from an earlier, fully-understood entry.
+        // The parked op must not partially overwrite it, and must not touch its clock or
+        // published hash — the existing row stays exactly the complete after-image its
+        // author signed.
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("v1".into()))]),
+            OpMeta { lamport: 5, device: device(2) },
+        )
+        .unwrap();
+        let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
+        let published_before = published_hash(&tx, "repo", "t_demo", &row_pk).unwrap();
+
+        // A LATER op (higher lamport, would otherwise win) carrying an unknown column.
+        let out = apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[
+                ("title", TypedValue::Text("v2".into())),
+                ("future_col", TypedValue::Text("unknown".into())),
+            ]),
+            OpMeta { lamport: 9, device: device(2) },
+        )
+        .unwrap();
+        assert_eq!(out, ApplyOutcome::Unprojectable(PendingReason::UnknownColumn));
         assert_eq!(
-            title(&c).as_deref(),
-            Some("kept"),
-            "the known cell applied, the unknown skipped"
+            current_row_clock(&tx, "repo", "t_demo", &row_pk).unwrap().unwrap().0,
+            5,
+            "a parked op does not advance the row clock"
         );
+        assert_eq!(
+            published_hash(&tx, "repo", "t_demo", &row_pk).unwrap(),
+            published_before,
+            "a parked op does not touch the anti-echo record"
+        );
+        tx.commit().unwrap();
+        assert_eq!(title(&c).as_deref(), Some("v1"), "the previous complete row survives intact");
+    }
+
+    #[test]
+    fn a_published_hash_carries_the_column_set_it_covers() {
+        // The hash alone is ambiguous across column-set changes, so the version it was recorded
+        // under is stored with it. `produce` relies on this to tell "changed locally" from
+        // "hashed under a different column set" (see `super::produce`).
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("v".into()))]),
+            OpMeta { lamport: 1, device: device(2) },
+        )
+        .unwrap();
+        let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
+        let (_, version) = published_hash(&tx, "repo", "t_demo", &row_pk).unwrap().unwrap();
+        assert_eq!(version, super::super::refold::TABLE_SYNC_PROJECTOR_VERSION);
     }
 
     #[test]
@@ -1013,7 +1137,8 @@ mod tests {
         );
         let current = synced_row_hash(&tx, &SPEC, &[TypedValue::Text("r1".into())]).unwrap();
         assert_ne!(
-            current, published_before,
+            current,
+            published_before.map(|(hash, _version)| hash),
             "the local edit is still pending, not silently dropped"
         );
     }

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -538,6 +538,45 @@ pub(crate) fn published_hash(
         .optional()?)
 }
 
+/// Whether this row holds a local change that has not been authored yet, so a caller replaying an
+/// older retained entry over it would DESTROY work no peer has seen.
+///
+/// A raw local write does not advance `sync_row_clocks` — only authoring-and-self-applying does —
+/// so the ordinary LWW comparison cannot see an unsent edit at all: it compares the incoming op
+/// against the clock of whatever was last *published*, and happily wins. The live ingest path
+/// accepts that exposure because the driver's contract is to author local rows before applying
+/// remote ones; the refold has no such driver, and runs at store open where an edit made just
+/// before the last exit is exactly what is sitting here.
+///
+/// Reports only what it can PROVE, which is what keeps it useful: a cross-column-set hash
+/// comparison is meaningless (the hashes cover different cell lists), so a row published by an
+/// older projector is NOT called unsent — treating it as such would make the refold skip precisely
+/// the rows it exists to repair. Those rows are in the ordinary last-writer-wins regime, where the
+/// refold behaves exactly as live ingest does and the driver's author-before-apply ordering
+/// governs.
+pub(crate) fn row_has_unsent_local_change(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    pk_vals: &[TypedValue],
+) -> anyhow::Result<bool> {
+    let Some(current) = synced_row_hash(tx, spec, pk_vals)? else {
+        // No row: nothing local to lose (the entry is establishing it).
+        return Ok(false);
+    };
+    let row_pk = row_op::row_pk_string(pk_vals);
+    Ok(match published_hash(tx, repo_id, spec.name, &row_pk)? {
+        // Comparable: a differing hash is a demonstrably unsent local change.
+        Some((published, version)) if version == super::refold::TABLE_SYNC_PROJECTOR_VERSION =>
+            published != current,
+        // Published under a different column set — not comparable, so nothing is proven either way.
+        Some(_) => false,
+        // A live row no apply ever published is purely local: the only content there came from this
+        // device, and no peer has seen it.
+        None => true,
+    })
+}
+
 /// Claim `row_pk` as a COMPLETE projection: `hash` covers every synced column this binary knows,
 /// stamped with the projector version that defines that column set.
 pub(crate) fn record_published(

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -13,10 +13,10 @@
 use rusqlite::Transaction;
 
 use super::apply::{self, ApplyOutcome};
-use super::produce;
 use super::registry::TableSpec;
 use super::scope_stream::scope_stream_id;
 use super::store::{self, AcceptOutcome};
+use super::{produce, refold};
 use crate::device::DevicePublic;
 use crate::op::OpMeta;
 use crate::{AccountId, LocalDevice};
@@ -56,9 +56,16 @@ pub(crate) fn produce_and_author(
     tx: &Transaction<'_>,
     ctx: &SyncCtx<'_>,
 ) -> anyhow::Result<Vec<Vec<u8>>> {
+    // Never author into a store a NEWER projector folded: our narrower column set would record
+    // anti-echo hashes and park decisions the newer binary has to distrust.
+    refold::assert_projector_not_newer(tx)?;
     let mut authored = Vec::new();
     for spec in ctx.registry {
         let stream = scope_stream_id(ctx.repo_id, ctx.account_id, spec.scope_id);
+        // Record the apply context for every stream we author on: the stream id hashes
+        // (repo_id, account_id, scope_id) one-way, so without the directory a retained entry could
+        // never be replayed by a later binary (see [`super::refold`]).
+        store::record_stream_context(tx, stream, ctx.repo_id, ctx.account_id, spec.scope_id)?;
         for op in produce::produce_row_ops(tx, spec, ctx.repo_id)? {
             let signed = store::author_row_entry(tx, stream, ctx.device.secret(), &op, ctx.now_ms)?;
             let meta =
@@ -73,23 +80,24 @@ pub(crate) fn produce_and_author(
             // copy: surface it and do NOT transmit the junk op.
             match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
                 apply::ApplyOutcome::Applied => authored.push(signed.signed_bytes),
-                apply::ApplyOutcome::Quarantined(reason) => {
-                    // A locally-produced op self-quarantining is UNREACHABLE for a registered
-                    // table: the lint rejects every shape that would quarantine
-                    // (nullable pk, cross-row constraint,
-                    // ValueType/physical-type mismatch), and the producer reads well-typed
-                    // values. If it somehow happens, FAIL the pass — `author_row_entry` has already
-                    // inserted this entry in the caller's txn, so bailing rolls it back rather than
-                    // leaving it stored-but-unpublished and re-authored (re-signed) every pass
-                    // (unbounded log growth). Assert first, so a test catches the lint/producer
-                    // gap.
+                // A locally-produced op failing to self-apply is UNREACHABLE for a registered
+                // table: the lint rejects every shape that would quarantine (nullable pk, cross-row
+                // constraint, ValueType/physical-type mismatch), the producer reads well-typed
+                // values, and it emits only columns from THIS registry so it can never carry one we
+                // do not know. If it somehow happens, FAIL the pass — `author_row_entry` has
+                // already inserted this entry in the caller's txn, so bailing rolls
+                // it back rather than leaving it stored-but-unpublished and
+                // re-authored (re-signed) every pass (unbounded log growth). Assert
+                // first, so a test catches the lint/producer gap.
+                outcome @ (apply::ApplyOutcome::Quarantined(_)
+                | apply::ApplyOutcome::Unprojectable(_)) => {
                     debug_assert!(
                         false,
-                        "table-sync: a locally-produced op self-quarantined on `{}`: {reason}",
+                        "table-sync: a locally-produced op did not self-apply on `{}`: {outcome:?}",
                         spec.name
                     );
                     anyhow::bail!(
-                        "table-sync: a locally-produced op self-quarantined on `{}`: {reason}",
+                        "table-sync: a locally-produced op did not self-apply on `{}`: {outcome:?}",
                         spec.name
                     );
                 },
@@ -111,7 +119,13 @@ pub(crate) fn ingest(
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
 ) -> anyhow::Result<IngestOutcome> {
+    // Same refusal as the producer: an older binary must not re-park, under its own version, an
+    // entry a newer projector already understood and folded.
+    refold::assert_projector_not_newer(tx)?;
     let stream = scope_stream_id(ctx.repo_id, ctx.account_id, scope_id);
+    // The apply context for anything this stream retains — recorded before the entry is stored, so
+    // a pending entry is never left without the mapping its replay needs.
+    store::record_stream_context(tx, stream, ctx.repo_id, ctx.account_id, scope_id)?;
     let scope_tables: Vec<&str> =
         ctx.registry.iter().filter(|s| s.scope_id == scope_id).map(|s| s.name).collect();
     Ok(
@@ -124,7 +138,7 @@ pub(crate) fn ingest(
             pubkey,
             ctx.now_ms,
         )? {
-            AcceptOutcome::Stored { op, meta } => {
+            AcceptOutcome::Stored { op, meta, entry_hash } => {
                 // `accept_row_entry` already validated the op's table is in `scope_tables`, so
                 // exactly one spec matches; the fallback is defensive, never
                 // reached.
@@ -136,9 +150,21 @@ pub(crate) fn ingest(
                 match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
                     ApplyOutcome::Applied => IngestOutcome::Applied,
                     ApplyOutcome::Quarantined(why) => IngestOutcome::Quarantined(why),
+                    // A newer producer's column: nothing was written. Mark the stored entry so the
+                    // refold replays it once this binary learns the column — only the applier can
+                    // see this, which is why `accept_row_entry` handed back the entry hash.
+                    ApplyOutcome::Unprojectable(reason) => {
+                        store::mark_entry_pending(
+                            tx,
+                            &entry_hash,
+                            reason,
+                            refold::TABLE_SYNC_PROJECTOR_VERSION,
+                        )?;
+                        IngestOutcome::Retained(reason.as_db_str())
+                    },
                 }
             },
-            AcceptOutcome::StoredInert(reason) => IngestOutcome::Retained(reason),
+            AcceptOutcome::StoredInert(reason) => IngestOutcome::Retained(reason.as_db_str()),
             AcceptOutcome::AlreadyPresent => IngestOutcome::AlreadyPresent,
             AcceptOutcome::MissingPredecessor => IngestOutcome::Parked("missing predecessor"),
             AcceptOutcome::Fork => IngestOutcome::Parked("fork"),

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -149,7 +149,12 @@ pub(crate) fn ingest(
                 };
                 match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
                     ApplyOutcome::Applied => IngestOutcome::Applied,
-                    ApplyOutcome::Quarantined(why) => IngestOutcome::Quarantined(why),
+                    // Durably recorded as well as returned: the caller sees this one, but nothing
+                    // later could tell a rejected payload from a projected one without the mark.
+                    ApplyOutcome::Quarantined(why) => {
+                        store::record_entry_quarantine(tx, &entry_hash, &why)?;
+                        IngestOutcome::Quarantined(why)
+                    },
                     // A newer producer's column: nothing was written. Mark the stored entry so the
                     // refold replays it once this binary learns the column — only the applier can
                     // see this, which is why `accept_row_entry` handed back the entry hash.

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -1,5 +1,5 @@
 //! The table→log sync engine: replicate derived/metadata table rows across an account's devices as
-//! self-describing typed-CBOR row ops on a signed per-scope stream, folded by per-column
+//! self-describing typed-CBOR row ops on a signed per-scope stream, folded by WHOLE-ROW
 //! last-writer-wins.
 //!
 //! Transport-independent. The wire form ([`row_op`]) and the fold/produce pipeline are exercised by
@@ -12,7 +12,12 @@
 mod apply;
 mod engine;
 mod produce;
+mod refold;
 mod registry;
 mod row_op;
 mod scope_stream;
 mod store;
+
+/// The store-open forward-compat seam: replay entries retained but not projected when they
+/// arrived.
+pub use refold::refold_stale_table_sync_projections;

--- a/crates/rag-rat-oplog/src/table_sync/produce.rs
+++ b/crates/rag-rat-oplog/src/table_sync/produce.rs
@@ -12,9 +12,9 @@ use std::collections::BTreeSet;
 
 use rusqlite::{Transaction, params};
 
-use super::apply;
 use super::registry::TableSpec;
 use super::row_op::{self, RowOp};
+use super::{apply, refold};
 
 /// The row ops that carry this device's current state of `spec`'s table for `repo_id` to peers.
 /// Empty when everything is already published (the steady state).
@@ -30,13 +30,30 @@ pub(crate) fn produce_row_ops(
         let row_pk = row_op::row_pk_string(&pk);
         live.insert(row_pk.clone());
         let hash = row_op::cells_hash(&cells);
-        if apply::published_hash(tx, repo_id, spec.name, &row_pk)?.as_deref() != Some(hash.as_str())
-        {
+        let changed = match apply::published_hash(tx, repo_id, spec.name, &row_pk)? {
+            // Published under THIS binary's column set: a differing hash is a real local change.
+            Some((published, version)) if version == refold::TABLE_SYNC_PROJECTOR_VERSION =>
+                published != hash,
+            // Published under a DIFFERENT column set. The two hashes cover different cell lists, so
+            // they differ structurally whether or not the row actually changed — the comparison
+            // says nothing. Reading that as a local delta would re-author EVERY row of the table at
+            // a fresh winning lamport on EVERY upgrading device (log growth O(rows x devices),
+            // lamport inflation, and every device claiming authorship of rows it merely received).
+            // So: not comparable, nothing claimed. #1002's per-op spec version replaces this
+            // conservatism by rebuilding a complete after-image from declared column defaults.
+            Some(_) => false,
+            // Never published: a genuinely new local row.
+            None => true,
+        };
+        if changed {
             ops.push(RowOp::Upsert { table: spec.name.to_string(), pk, cells });
         }
     }
 
-    // A published identity with no live row is a local delete.
+    // A published identity with no live row is a local delete. Deliberately version-AGNOSTIC: a
+    // `Remove` carries only the pk, so which column set the stored hash covered is irrelevant.
+    // Gating this on the version would make a locally-deleted row permanently undeletable across a
+    // column change — the delete could never be authored, and peers would keep the row forever.
     for row_pk in published_row_pks(tx, repo_id, spec.name)? {
         if !live.contains(&row_pk) {
             ops.push(RowOp::Remove {
@@ -199,5 +216,28 @@ mod tests {
         let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
         assert_eq!(ops.len(), 1);
         assert!(matches!(&ops[0], RowOp::Remove { .. }), "a deleted row produces a Remove");
+    }
+
+    #[test]
+    fn no_table_registers_while_a_stale_hash_blocks_authoring() {
+        // TRIPWIRE for #1002, guarding the one cost of the not-comparable rule above.
+        //
+        // Nothing refreshes a stored published record's version except a WINNING apply, and a row
+        // that never authors never wins — so after a column-set change every pre-existing row is a
+        // permanent authoring dead zone on that device: even a genuine local edit produces no op.
+        // Deleting the row escapes it (`Remove` is version-agnostic), and a peer can still win the
+        // row, but a fully-upgraded roster is symmetrically stuck.
+        //
+        // That is harmless only while no table is registered, because then no column set can
+        // change. #1002 (a per-op spec version + declared column defaults) removes the
+        // conservatism by rebuilding a complete after-image instead of declining to
+        // compare. Registering a table before it lands would ship the dead zone, so fail
+        // loudly at exactly that moment.
+        assert!(
+            super::super::registry::SYNCABLE_TABLES.is_empty(),
+            "a syncable table was registered while `produce_row_ops` still treats a \
+             version-mismatched anti-echo hash as not-comparable: land the per-op spec version \
+             (#1002) first, or the first column addition strands every existing row's local edits"
+        );
     }
 }

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -119,22 +119,30 @@ fn replay_pending_entry(
     registry: &[TableSpec],
     pending: &PendingEntry,
 ) -> anyhow::Result<()> {
-    // The stream id is a ONE-WAY hash of (repo_id, account_id, scope_id), so an entry whose stream
-    // predates the directory cannot be placed. Leave it pending rather than guessing a repo.
-    // Unreachable by construction — the directory row is written in the same transaction, before
-    // the entry is stored, on BOTH the ingest and produce paths — so assert rather than skip
-    // silently.
+    // The stream id is a ONE-WAY hash of (repo_id, account_id, scope_id), so an entry with no
+    // directory row cannot be placed at all — there is no repo to apply it to and no scope to
+    // resolve its spec. Skip it, still pending.
+    //
+    // Legitimately reachable, not just defensive: `rag-rat rm` sweeps every table carrying
+    // `repo_id`, which includes the directory, while the stream-keyed entry log is deliberately
+    // retained (the sync substrate is excluded from repo purge). A removed repo therefore leaves
+    // exactly this shape, and skipping is the RIGHT answer — a purged repo's history must not
+    // project. See #1004 for aligning the two halves of that purge.
     let Some(context) = store::stream_context(tx, pending.stream_id)? else {
-        debug_assert!(false, "a stored entry has no stream context to replay against");
         return Ok(());
     };
     // These bytes were signature-verified when accepted and have not left this store since, so a
-    // decode failure here means LOCAL corruption. Skip this entry (it stays pending, and stays
-    // stored as evidence) instead of propagating: one unreadable row must not wedge the replay of
-    // every other pending entry, which — because the stamp only advances on success — would
-    // otherwise repeat on every future open.
+    // decode failure here means LOCAL corruption. Record it TERMINALLY rather than propagating or
+    // re-parking: propagating would roll the whole refold back and re-fail on every future open,
+    // and leaving it pending would keep `refold_owed` true forever — an IMMEDIATE transaction and a
+    // pending scan at every store open, for bytes no future binary can decode. The entry stays
+    // stored as evidence, and the reason is discoverable.
     let Ok(signed) = entry::decode_signed(&pending.signed_bytes) else {
-        return Ok(());
+        return store::record_entry_quarantine(
+            tx,
+            &pending.entry_hash,
+            "stored entry bytes no longer decode",
+        );
     };
     let op = match row_op::decode(&signed.entry.op_bytes) {
         Ok(DecodedRowOp::Known(op)) => op,
@@ -673,6 +681,75 @@ mod tests {
     }
 
     #[test]
+    fn an_older_binary_refuses_to_ingest_into_a_store_a_newer_projector_folded() {
+        // The producer's refusal has a sibling on the ingest path, and it is the more important of
+        // the two: ingesting is what would re-park, under this binary's narrower understanding, an
+        // entry the newer projector already folded.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.conn
+            .execute("INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)", params![
+                TABLE_SYNC_PROJECTOR_VERSION_KEY,
+                (TABLE_SYNC_PROJECTOR_VERSION + 1).to_string()
+            ])
+            .unwrap();
+
+        let tx = b.conn.transaction().unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo",
+            account_id: account(),
+            device: &b.local,
+            registry: OLD_REGISTRY,
+            now_ms: 0,
+        };
+        let ingested = engine::ingest(&tx, &ctx, "demo/1", &entries[0], &a.pubkey());
+        assert!(ingested.is_err(), "an older projector must not ingest into a newer store");
+        assert!(
+            ingested.unwrap_err().to_string().contains("newer rag-rat"),
+            "the refusal names the cause"
+        );
+    }
+
+    #[test]
+    fn an_older_producers_partial_row_parks_and_is_replayed_when_the_gap_closes() {
+        // The mirror of the unknown-column case: a row that is COMPLETE under the author's narrower
+        // spec is PARTIAL under a wider one. Whole-row LWW cannot apply it, but it is a version gap
+        // — redeemed from the sender's side — so it parks and stays on the worklist rather than
+        // being quarantined off it.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'narrow', NULL)", [])
+            .unwrap();
+        let narrow = a.produce(OLD_REGISTRY, "repo");
+        assert_eq!(narrow.len(), 1, "authored under the narrow spec");
+
+        // B knows the wider column set, so the op is missing one of B's synced columns.
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(NEW_REGISTRY, "repo", &narrow, &a.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::PartialAfterImage.as_db_str())
+        ],);
+        assert_eq!(b.row(), None, "a partial after-image writes nothing");
+        assert_eq!(b.pending_count(), 1, "and stays outstanding, not quarantined off the worklist");
+
+        // Still outstanding after a refold that cannot close the gap either — only the SENDER's
+        // side can (declared column defaults, #1002), so the entry must not be dropped meanwhile.
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.pending_count(), 1, "a sender-side gap survives a receiver-side refold");
+        let quarantined: i64 = b
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE quarantine_reason IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(quarantined, 0, "a version gap is never recorded as a terminal rejection");
+    }
+
+    #[test]
     fn redelivery_of_a_parked_entry_changes_nothing_and_keeps_its_mark() {
         // Redelivery cannot rescue a parked entry (it short-circuits on `entry_exists`) — which is
         // exactly why the mark has to survive it. If redelivery cleared the mark, the refold would
@@ -769,6 +846,91 @@ mod tests {
         // Authoring it settles the race on the merits: the local edit takes a lamport above the
         // parked entry (authoring counts parked entries), so it wins wherever both are seen.
         assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1, "the local edit is still authorable");
+    }
+
+    #[test]
+    fn the_refold_never_resurrects_a_row_deleted_locally_but_not_yet_authored() {
+        // The delete counterpart of the unsent-edit guard, and the subtler half: the row is GONE,
+        // so there is no current state to compare — but the surviving published identity is
+        // exactly what the producer's `Remove` branch keys on. Replaying an upsert over it
+        // would recreate the row AND re-record its published hash, after which the producer
+        // sees no delta and the deletion is gone for good.
+        let mut a = Device::new();
+        let mut b = Device::new();
+
+        // B holds r1 from its own authored write, so the row is published at B's lamport 0.
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', NULL)", [])
+            .unwrap();
+        b.produce(OLD_REGISTRY, "repo");
+
+        // A authors r1 TWICE, so the entry that matters sits at a strictly HIGHER lamport than B's
+        // row clock. Without that the replay could lose the lamport-0 tie on fingerprint and the
+        // row would stay deleted for reasons having nothing to do with the guard under test.
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'first', 'wide')", [])
+            .unwrap();
+        let first = a.produce(NEW_REGISTRY, "repo");
+        a.conn.execute("UPDATE t_demo SET title = 'second' WHERE id = 'r1'", []).unwrap();
+        let second = a.produce(NEW_REGISTRY, "repo");
+        assert_eq!((first.len(), second.len()), (1, 1));
+
+        // Both park on B (each carries the column B does not know); the chain needs both.
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &first, &a.pubkey());
+        b.ingest(OLD_REGISTRY, "repo", &second, &a.pubkey());
+        assert_eq!(b.pending_count(), 2);
+
+        // B deletes the row locally and exits before the producer can author the removal.
+        b.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.row(), None, "the unsent deletion survives the refold");
+        // And it is still authorable, so the removal reaches peers.
+        assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1, "the delete is still authorable");
+    }
+
+    #[test]
+    fn a_malformed_key_is_quarantined_rather_than_failing_the_whole_refold() {
+        // An entry parked as out-of-scope never passed `apply_row_op`'s arity check. When a later
+        // registry recognizes its table, the unsent-change probe must not bind that key against a
+        // mismatched placeholder count — that is a parameter-count ERROR, and propagating it out of
+        // the refold would roll the transaction back and fail EVERY subsequent store open on the
+        // same entry. It has to reach the normal quarantine path instead.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let two_key = RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text("r1".to_string()), TypedValue::Text("extra".to_string())],
+            cells: vec![Cell { column: "title".to_string(), value: TypedValue::Text("v".into()) }],
+        };
+        let signed = {
+            let tx = a.conn.transaction().unwrap();
+            let stream = scope_stream_id("repo", account(), "demo/1");
+            let signed =
+                store::author_row_entry(&tx, stream, a.local.secret(), &two_key, 0).unwrap();
+            tx.commit().unwrap();
+            signed.signed_bytes
+        };
+
+        // Parked because this scope has no such table for the ingesting registry.
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(&[], "repo", &[signed], &a.pubkey()), vec![IngestOutcome::Retained(
+            PendingReason::TableNotInScope.as_db_str()
+        )],);
+
+        // The refold must complete — not error — and the malformed entry must be rejected durably.
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.pending_count(), 0);
+        let quarantined: i64 = b
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE quarantine_reason IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(quarantined, 1, "the malformed key is quarantined, not fatal");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -1,0 +1,704 @@
+//! The forward-compat refold: replay the entries this store retained but could not project.
+//!
+//! Storage is gated on the CHAIN, application on the PAYLOAD, so a chain-continuous entry is kept
+//! even when this binary cannot project it — an unknown column, an unknown op-kind, an undecodable
+//! payload, a table outside this scope. Each such entry is marked pending ([`super::store`]), and
+//! this module is what redeems the mark: when a later binary understands more, it replays exactly
+//! the outstanding set. Without the replay the payload is unrecoverable, because redelivery
+//! short-circuits on `entry_exists` and never reconsiders the op.
+//!
+//! Two properties keep the replay boring, and both are deliberate:
+//!
+//! - **It goes through the unmodified [`super::apply::apply_row_op`] gates**, with each entry's
+//!   ORIGINAL `OpMeta`. No clock bypass, no reordering. That is what makes every interaction
+//!   correct for free: a parked entry superseded by a later winner loses the LWW comparison; one
+//!   superseded by a delete loses to the tombstone and cannot resurrect the row; a parked `Remove`
+//!   needs no winner lookup. A bypass would have to re-derive all of that, and a bypass that skips
+//!   the clock comparison is one refactor away from skipping the tombstone comparison too.
+//! - **It is bounded by the pending set**, not the log: the steady state (nothing pending) costs
+//!   one indexed probe, so the cost is proportional to what is actually outstanding.
+//!
+//! Version discipline mirrors the `/3` content projector: [`refold_stale_table_sync_projections`]
+//! is the ONLY writer of the stamp, and a store stamped by a NEWER projector is refused rather than
+//! folded down by an older binary.
+
+use anyhow::Context;
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+
+use super::apply::{self, ApplyOutcome};
+use super::registry::TableSpec;
+use super::row_op::{self, DecodedRowOp};
+use super::store::{self, PendingEntry, PendingReason};
+use crate::entry;
+use crate::op::OpMeta;
+
+/// What this binary can project into synced tables.
+///
+/// BUMP THIS on any change that widens understanding — a table registered, a column added to a
+/// spec, a new row-op kind — because that is exactly when retained entries become projectable and
+/// when previously recorded anti-echo hashes stop covering the current column set. Forgetting the
+/// bump leaves pending entries unreplayed (data that arrived is never applied); it cannot corrupt,
+/// because the per-row `projector_version` still marks stale hashes as not comparable.
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 1;
+
+const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
+
+/// Replay every pending entry against this binary's registry, then stamp the projector version.
+/// Returns whether a refold ran.
+///
+/// Call at store open, BEFORE producing: an upgraded binary that produces first will simply emit
+/// nothing for rows whose hashes are no longer comparable (safe, by design), but the entries
+/// waiting on the new understanding stay unapplied until this runs.
+pub fn refold_stale_table_sync_projections(conn: &Connection) -> anyhow::Result<bool> {
+    refold_stale_projections_against(conn, super::registry::SYNCABLE_TABLES)
+}
+
+/// [`refold_stale_table_sync_projections`] against an explicit registry — the seam the engine tests
+/// drive with a synthetic spec, since `SYNCABLE_TABLES` is empty until the scope milestones land.
+pub(crate) fn refold_stale_projections_against(
+    conn: &Connection,
+    registry: &[TableSpec],
+) -> anyhow::Result<bool> {
+    // A store mid-migration has no projection state to refold and nothing to stamp against; mirrors
+    // the `/3` projector's pre-V070 guard, and runs before the meta read so a bare DB never errors.
+    if !projection_state_present(conn)? {
+        return Ok(false);
+    }
+    if !refold_owed(conn)? {
+        return Ok(false);
+    }
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // `refold_owed` already excludes a newer stamp; re-assert inside the write txn so this stays
+    // honest if that predicate ever changes.
+    assert_projector_not_newer(&tx)?;
+    for pending in store::pending_entries(&tx)? {
+        replay_pending_entry(&tx, registry, &pending)?;
+    }
+    stamp_projector_version(&tx)?;
+    tx.commit()?;
+    Ok(true)
+}
+
+/// Whether a refold is owed. TWO independent triggers, because the store-global stamp alone is not
+/// a complete record of what has been evaluated:
+///
+/// 1. **The stamp is behind** — the ordinary upgrade: this binary understands more than whatever
+///    last folded the store.
+/// 2. **Some entry was evaluated by an OLDER projector than this one**, even though the stamp is
+///    current. A shared store reached by binaries of different versions (linked worktrees are a
+///    first-class configuration here) produces exactly this: a newer binary stamps the store, an
+///    older one then ingests and parks an entry it cannot project, marking it with ITS version. On
+///    the stamp alone the newer binary would short-circuit and never replay an entry it fully
+///    understands — and redelivery cannot rescue it, because that short-circuits on `entry_exists`.
+///
+/// A newer stamp is never a trigger: an older binary must not re-park what a newer one understood.
+fn refold_owed(conn: &Connection) -> anyhow::Result<bool> {
+    let stamp_behind = match stored_projector_version(conn)? {
+        Some(version) => {
+            if version > TABLE_SYNC_PROJECTOR_VERSION {
+                return Ok(false);
+            }
+            version < TABLE_SYNC_PROJECTOR_VERSION
+        },
+        None => true,
+    };
+    Ok(stamp_behind
+        || oldest_pending_projector_version(conn)?
+            .is_some_and(|oldest| oldest < TABLE_SYNC_PROJECTOR_VERSION))
+}
+
+/// Re-attempt one retained entry under this binary's understanding.
+///
+/// The stored bytes were signature-verified when they were accepted and have not left this store
+/// since, so replay decodes without re-verifying: it is a re-projection of our own log, not a trust
+/// decision. (Authority was likewise settled at accept time — the roster gate cannot be re-run
+/// here, because a device legitimately removed since then would have its long-accepted entries
+/// dropped.)
+fn replay_pending_entry(
+    tx: &Transaction<'_>,
+    registry: &[TableSpec],
+    pending: &PendingEntry,
+) -> anyhow::Result<()> {
+    // The stream id is a ONE-WAY hash of (repo_id, account_id, scope_id), so an entry whose stream
+    // predates the directory cannot be placed. Leave it pending rather than guessing a repo.
+    // Unreachable by construction — the directory row is written in the same transaction, before
+    // the entry is stored, on BOTH the ingest and produce paths — so assert rather than skip
+    // silently.
+    let Some(context) = store::stream_context(tx, pending.stream_id)? else {
+        debug_assert!(false, "a stored entry has no stream context to replay against");
+        return Ok(());
+    };
+    // These bytes were signature-verified when accepted and have not left this store since, so a
+    // decode failure here means LOCAL corruption. Skip this entry (it stays pending, and stays
+    // stored as evidence) instead of propagating: one unreadable row must not wedge the replay of
+    // every other pending entry, which — because the stamp only advances on success — would
+    // otherwise repeat on every future open.
+    let Ok(signed) = entry::decode_signed(&pending.signed_bytes) else {
+        return Ok(());
+    };
+    let op = match row_op::decode(&signed.entry.op_bytes) {
+        Ok(DecodedRowOp::Known(op)) => op,
+        Ok(DecodedRowOp::Unknown { .. }) =>
+            return repark(tx, pending, PendingReason::UnknownOpKind),
+        Err(_) => return repark(tx, pending, PendingReason::UndecodablePayload),
+    };
+    let Some(spec) =
+        registry.iter().find(|s| s.scope_id == context.scope_id && s.name == op.table())
+    else {
+        return repark(tx, pending, PendingReason::TableNotInScope);
+    };
+    let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
+    match apply::apply_row_op(tx, spec, &context.repo_id, &op, meta)? {
+        // Folded. `Applied` also covers "deliberately lost" — superseded by a newer winner, or
+        // suppressed by a tombstone — which are correct folds, not outstanding work.
+        ApplyOutcome::Applied => store::clear_entry_pending(tx, &pending.entry_hash),
+        // Terminal, so it stops being outstanding: a type mismatch or a constraint violation is a
+        // BROKEN PRODUCER — the values do not fit the declared column types or the table's
+        // constraints, and no future binary makes them fit. (A missing column is NOT this case: it
+        // is an older producer, which reports `Unprojectable` and stays on the worklist.) The entry
+        // stays STORED — it still relays, and it is evidence — it just leaves the refold's worklist
+        // instead of being retried on every future bump.
+        ApplyOutcome::Quarantined(_) => store::clear_entry_pending(tx, &pending.entry_hash),
+        // Still ahead of us — record which gap, under this version, so the next bump can tell
+        // "newly stuck" from "stuck since v1".
+        ApplyOutcome::Unprojectable(reason) => repark(tx, pending, reason),
+    }
+}
+
+fn repark(
+    tx: &Transaction<'_>,
+    pending: &PendingEntry,
+    reason: PendingReason,
+) -> anyhow::Result<()> {
+    store::mark_entry_pending(tx, &pending.entry_hash, reason, TABLE_SYNC_PROJECTOR_VERSION)
+}
+
+/// Whether the V093 projection substrate exists yet (the directory is the load-bearing half — no
+/// apply context means no replay is possible at all).
+fn projection_state_present(conn: &Connection) -> anyhow::Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'table_sync_streams'",
+            [],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+/// Refuse to fold — or write into — a store a NEWER projector already folded: an older binary would
+/// re-park entries the newer one understood, stamp the version down, and record anti-echo hashes
+/// under its narrower column set, all of which the newer binary would then have to distrust.
+///
+/// Called both by the refold and by the engine's write entry points, so an older binary sharing a
+/// store (linked worktrees on different versions are a first-class configuration here) fails loudly
+/// instead of quietly degrading what the newer one already understood.
+pub(crate) fn assert_projector_not_newer(conn: &Connection) -> anyhow::Result<()> {
+    if let Some(stored) = stored_projector_version(conn)?
+        && stored > TABLE_SYNC_PROJECTOR_VERSION
+    {
+        anyhow::bail!(
+            "the table-sync projection was folded by a newer rag-rat (table-sync projector \
+             v{stored} > v{TABLE_SYNC_PROJECTOR_VERSION}); upgrade to write this store"
+        );
+    }
+    Ok(())
+}
+
+fn stamp_projector_version(tx: &Transaction<'_>) -> rusqlite::Result<()> {
+    tx.execute(
+        "INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![TABLE_SYNC_PROJECTOR_VERSION_KEY, TABLE_SYNC_PROJECTOR_VERSION.to_string()],
+    )?;
+    Ok(())
+}
+
+/// The oldest projector version that evaluated any still-pending entry, or `None` when nothing is
+/// pending — the second refold trigger (see [`refold_owed`]).
+fn oldest_pending_projector_version(conn: &Connection) -> anyhow::Result<Option<i64>> {
+    Ok(conn.query_row(
+        "SELECT MIN(pending_projector_version) FROM table_sync_entries
+          WHERE pending_reason IS NOT NULL",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?)
+}
+
+fn stored_projector_version(conn: &Connection) -> anyhow::Result<Option<i64>> {
+    conn.query_row(
+        "SELECT value FROM oplog_meta WHERE key = ?1",
+        params![TABLE_SYNC_PROJECTOR_VERSION_KEY],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|value| {
+        value.parse::<i64>().context("oplog table_sync_projector_version is not an integer")
+    })
+    .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::table_sync::engine::{self, IngestOutcome, SyncCtx};
+    use crate::table_sync::registry::{ColumnSpec, ValueType};
+    use crate::{AccountId, LocalDevice};
+
+    /// The physical table carries both columns; which of them a binary KNOWS is what the two specs
+    /// below differ on. That is exactly the real situation — the schema migration adds the column,
+    /// and the registry starts replicating it — so an "older" binary is modelled by a narrower spec
+    /// over the same table, not by a different table.
+    const OLD: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        local_columns: &["later_col"],
+        repo_column: None,
+    };
+    const NEW: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
+            name: "later_col",
+            value_type: ValueType::Text,
+        }],
+        local_columns: &[],
+        repo_column: None,
+    };
+    const OLD_REGISTRY: &[TableSpec] = &[OLD];
+    const NEW_REGISTRY: &[TableSpec] = &[NEW];
+
+    const ACCOUNT: [u8; 32] = [42; 32];
+
+    fn account() -> AccountId {
+        AccountId::from_bytes(ACCOUNT)
+    }
+
+    struct Device {
+        conn: rusqlite::Connection,
+        local: LocalDevice,
+    }
+
+    impl Device {
+        fn new() -> Self {
+            let conn = rusqlite::Connection::open_in_memory().unwrap();
+            rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT, later_col TEXT) STRICT;",
+            )
+            .unwrap();
+            let local = crate::local_device(&conn, 0).unwrap();
+            Self { conn, local }
+        }
+
+        fn pubkey(&self) -> crate::device::DevicePublic {
+            self.local.secret().public()
+        }
+
+        /// Enroll `fp` as a roster-effective writer, so the #935 ingest gate admits its entries.
+        fn enroll(&self, fp: crate::op::DeviceFingerprint) {
+            self.conn
+                .execute(
+                    "INSERT OR IGNORE INTO account_roster_history
+                         (roster_ref, account_id, device_fingerprint, role, effective_at, \
+                     closed_at)
+                     VALUES (?1, ?2, ?3, 'owner', 0, NULL)",
+                    params![fp.to_bytes().as_slice(), ACCOUNT.as_slice(), fp.to_bytes().as_slice()],
+                )
+                .unwrap();
+        }
+
+        fn produce(&mut self, registry: &[TableSpec], repo_id: &str) -> Vec<Vec<u8>> {
+            let tx = self.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id,
+                account_id: account(),
+                device: &self.local,
+                registry,
+                now_ms: 0,
+            };
+            let out = engine::produce_and_author(&tx, &ctx).unwrap();
+            tx.commit().unwrap();
+            out
+        }
+
+        fn ingest(
+            &mut self,
+            registry: &[TableSpec],
+            repo_id: &str,
+            entries: &[Vec<u8>],
+            from: &crate::device::DevicePublic,
+        ) -> Vec<IngestOutcome> {
+            let tx = self.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id,
+                account_id: account(),
+                device: &self.local,
+                registry,
+                now_ms: 0,
+            };
+            let out = entries
+                .iter()
+                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap())
+                .collect();
+            tx.commit().unwrap();
+            out
+        }
+
+        fn row(&self) -> Option<(String, Option<String>)> {
+            self.conn
+                .query_row("SELECT title, later_col FROM t_demo WHERE id = 'r1'", [], |r| {
+                    Ok((r.get(0)?, r.get(1)?))
+                })
+                .optional()
+                .unwrap()
+        }
+
+        fn pending_count(&self) -> i64 {
+            self.conn
+                .query_row(
+                    "SELECT COUNT(*) FROM table_sync_entries WHERE pending_reason IS NOT NULL",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        }
+    }
+
+    /// Author r1 on a NEW-registry device, carrying a column an OLD-registry peer cannot project.
+    fn author_wide_row(a: &mut Device) -> Vec<Vec<u8>> {
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', 'wide')", [])
+            .unwrap();
+        let entries = a.produce(NEW_REGISTRY, "repo");
+        assert_eq!(entries.len(), 1);
+        entries
+    }
+
+    #[test]
+    fn a_parked_column_is_recovered_by_the_refold_and_then_the_producer_stays_quiet() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+
+        // B (old registry) cannot project the op: it is retained and marked, NOT partially applied.
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::UnknownColumn.as_db_str())
+        ],);
+        assert_eq!(b.row(), None, "nothing is written for an op we cannot fully project");
+        assert_eq!(b.pending_count(), 1, "the entry is marked for replay");
+
+        // B upgrades: the refold replays exactly that entry, and the row lands COMPLETE — including
+        // the column the old binary could not read. Redelivery could never have restored it (it
+        // short-circuits on `entry_exists`), which is why the mark exists.
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.row(), Some(("v1".to_string(), Some("wide".to_string()))));
+        assert_eq!(b.pending_count(), 0, "the entry is no longer outstanding");
+
+        // And the recovered row is published under the new column set, so B's producer has nothing
+        // to say about it — no re-author, no echo.
+        assert!(b.produce(NEW_REGISTRY, "repo").is_empty());
+        // The refold is one-shot: the stamp is current, so a second open does no work.
+        assert!(!refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+    }
+
+    #[test]
+    fn a_column_set_change_alone_re_authors_nothing() {
+        // The storm case. Every row published by an older binary carries a hash over the OLD cell
+        // list, so under a grown column set every hash mismatches STRUCTURALLY — whether or not the
+        // row changed. If the producer read that as a local delta it would re-author the entire
+        // table at fresh winning lamports, on every upgrading device at once.
+        let mut a = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', NULL)", [])
+            .unwrap();
+        assert_eq!(a.produce(OLD_REGISTRY, "repo").len(), 1, "published under the old column set");
+
+        // Stamp the published row as recorded by an older projector (what an upgrade looks like).
+        a.conn
+            .execute("UPDATE sync_published_rows SET projector_version = ?1", params![
+                TABLE_SYNC_PROJECTOR_VERSION - 1
+            ])
+            .unwrap();
+
+        assert!(
+            a.produce(NEW_REGISTRY, "repo").is_empty(),
+            "a wider column set alone must not re-author a single row"
+        );
+    }
+
+    #[test]
+    fn a_local_delete_still_propagates_after_a_column_set_change() {
+        // The mirror of the storm guard: `Remove` carries only the pk, so it is deliberately NOT
+        // version-gated. Were it gated, a row deleted after a column change could never be
+        // authored as deleted, and every peer would keep it forever.
+        let mut a = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', NULL)", [])
+            .unwrap();
+        a.produce(OLD_REGISTRY, "repo");
+        a.conn
+            .execute("UPDATE sync_published_rows SET projector_version = ?1", params![
+                TABLE_SYNC_PROJECTOR_VERSION - 1
+            ])
+            .unwrap();
+
+        a.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
+        assert_eq!(a.produce(NEW_REGISTRY, "repo").len(), 1, "the delete is authored");
+    }
+
+    #[test]
+    fn a_local_edit_beats_a_parked_entry_and_survives_the_refold() {
+        // Whole-row LWW, working as specified: authoring takes the stream-global MAX(lamport)+1,
+        // which counts the PARKED entry, so a causally later local edit outranks it — and still
+        // does when the refold finally replays that entry.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+
+        // B edits the same row locally while the entry sits parked.
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'mine', NULL)", [])
+            .unwrap();
+        assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "the local edit is authored");
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(
+            b.row().unwrap().0,
+            "mine",
+            "the replayed entry loses to the causally later local edit"
+        );
+        assert_eq!(b.pending_count(), 0, "and it stops being outstanding either way");
+    }
+
+    #[test]
+    fn a_parked_entry_cannot_resurrect_a_row_deleted_after_it() {
+        // Replay goes through the unmodified gates, so the tombstone raised by the later delete
+        // suppresses the older parked upsert exactly as it would on the live path. A
+        // clock-bypassing replay is what would get this wrong.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+
+        // B creates and then deletes the row locally, both authored above the parked entry.
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'local', NULL)", [])
+            .unwrap();
+        b.produce(OLD_REGISTRY, "repo");
+        b.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
+        b.produce(OLD_REGISTRY, "repo");
+        assert_eq!(b.row(), None);
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.row(), None, "the replayed entry must not resurrect a row deleted after it");
+    }
+
+    #[test]
+    fn the_refold_covers_every_repo_in_the_store_not_just_one() {
+        // The store is shared across linked worktrees, and the projector stamp is store-global — so
+        // one refold must drain the pending entries of EVERY repo, not the caller's alone.
+        // Otherwise a bump triggered from one checkout would stamp the version current while
+        // leaving a sibling checkout's entries unreplayed forever.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        b.enroll(a.pubkey().fingerprint());
+
+        for repo in ["repo-one", "repo-two"] {
+            a.conn.execute("DELETE FROM t_demo", []).unwrap();
+            a.conn
+                .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', ?1, 'wide')", [
+                    repo,
+                ])
+                .unwrap();
+            let entries = a.produce(NEW_REGISTRY, repo);
+            b.ingest(OLD_REGISTRY, repo, &entries, &a.pubkey());
+        }
+        assert_eq!(b.pending_count(), 2, "one parked entry per repo");
+
+        // One refold, driven from a single checkout's connection.
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.pending_count(), 0, "both repos' entries were replayed");
+        let clocks: i64 = b
+            .conn
+            .query_row("SELECT COUNT(DISTINCT repo_id) FROM sync_row_clocks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(clocks, 2, "each repo's row was projected under its own scope");
+    }
+
+    #[test]
+    fn a_store_folded_by_a_newer_projector_is_refused() {
+        let b = Device::new();
+        b.conn
+            .execute("INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)", params![
+                TABLE_SYNC_PROJECTOR_VERSION_KEY,
+                (TABLE_SYNC_PROJECTOR_VERSION + 1).to_string()
+            ])
+            .unwrap();
+        // A newer binary already folded this store: an older one must not re-park what the newer
+        // one understood, nor stamp the version back down.
+        assert!(!refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+    }
+
+    #[test]
+    fn an_entry_parked_by_an_older_binary_is_replayed_even_under_a_current_stamp() {
+        // The mixed-version shared store: a NEWER binary folds and stamps the store, then an OLDER
+        // one ingests an op it cannot project and parks it under ITS version. Keying the refold on
+        // the store-global stamp alone would short-circuit here and strand an entry the newer
+        // binary fully understands — permanently, since redelivery short-circuits on
+        // `entry_exists`.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+        assert_eq!(b.pending_count(), 1);
+
+        // The store looks fully folded (stamp current) while the entry was evaluated by an older
+        // projector — exactly the state an older sibling binary leaves behind.
+        b.conn
+            .execute(
+                "UPDATE table_sync_entries SET pending_projector_version = ?1
+                  WHERE pending_reason IS NOT NULL",
+                params![TABLE_SYNC_PROJECTOR_VERSION - 1],
+            )
+            .unwrap();
+        b.conn
+            .execute("INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)", params![
+                TABLE_SYNC_PROJECTOR_VERSION_KEY,
+                TABLE_SYNC_PROJECTOR_VERSION.to_string()
+            ])
+            .unwrap();
+
+        assert!(
+            refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap(),
+            "an entry evaluated by an older projector is still owed a replay"
+        );
+        assert_eq!(b.row(), Some(("v1".to_string(), Some("wide".to_string()))));
+        assert_eq!(b.pending_count(), 0);
+    }
+
+    #[test]
+    fn an_older_binary_refuses_to_write_into_a_store_a_newer_projector_folded() {
+        // Loud failure rather than quiet degradation: an older binary would record anti-echo hashes
+        // over its narrower column set and re-park entries the newer projector already folded.
+        let mut b = Device::new();
+        b.conn
+            .execute("INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)", params![
+                TABLE_SYNC_PROJECTOR_VERSION_KEY,
+                (TABLE_SYNC_PROJECTOR_VERSION + 1).to_string()
+            ])
+            .unwrap();
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v', NULL)", [])
+            .unwrap();
+
+        let tx = b.conn.transaction().unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo",
+            account_id: account(),
+            device: &b.local,
+            registry: OLD_REGISTRY,
+            now_ms: 0,
+        };
+        let produced = engine::produce_and_author(&tx, &ctx);
+        assert!(produced.is_err(), "an older projector must not author into a newer store");
+        assert!(
+            produced.unwrap_err().to_string().contains("newer rag-rat"),
+            "the refusal names the cause"
+        );
+    }
+
+    #[test]
+    fn redelivery_of_a_parked_entry_changes_nothing_and_keeps_its_mark() {
+        // Redelivery cannot rescue a parked entry (it short-circuits on `entry_exists`) — which is
+        // exactly why the mark has to survive it. If redelivery cleared the mark, the refold would
+        // have nothing left to replay and the payload would be lost for good.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey()), vec![
+            IngestOutcome::AlreadyPresent
+        ],);
+        assert_eq!(b.pending_count(), 1, "redelivery leaves the entry outstanding");
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.row(), Some(("v1".to_string(), Some("wide".to_string()))));
+    }
+
+    #[test]
+    fn a_parked_entry_loses_to_a_later_winner_from_a_third_device() {
+        // Three devices: the parked entry must not resurface over a row a third device legitimately
+        // won in the meantime. Replay goes through the ordinary LWW comparison, so it simply loses.
+        let mut a = Device::new();
+        let mut c = Device::new();
+        let mut b = Device::new();
+        let wide = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.enroll(c.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &wide, &a.pubkey());
+
+        // C authors the same row later (its stream clock counts the parked entry), and B applies
+        // it.
+        c.enroll(a.pubkey().fingerprint());
+        c.ingest(NEW_REGISTRY, "repo", &wide, &a.pubkey());
+        c.conn.execute("UPDATE t_demo SET title = 'from-c' WHERE id = 'r1'", []).unwrap();
+        let from_c = c.produce(NEW_REGISTRY, "repo");
+        assert_eq!(from_c.len(), 1);
+        b.ingest(OLD_REGISTRY, "repo", &from_c, &c.pubkey());
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(
+            b.row().unwrap().0,
+            "from-c",
+            "the replayed entry loses to the later winner it was always behind"
+        );
+    }
+
+    #[test]
+    fn the_refold_leaves_an_unrelated_unsent_local_edit_unpublished() {
+        // The refold publishes ONLY what it actually replays. A row it never touches keeps its
+        // pending local edit unpublished, so the producer still emits it — the refold must not
+        // become a path that silently marks unsent work as sent.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+
+        // An unrelated row, authored and published, then edited raw (unsent).
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r2', 'v1', NULL)", [])
+            .unwrap();
+        b.produce(OLD_REGISTRY, "repo");
+        b.conn.execute("UPDATE t_demo SET title = 'edited' WHERE id = 'r2'", []).unwrap();
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        let ops = b.produce(NEW_REGISTRY, "repo");
+        assert_eq!(ops.len(), 1, "the unsent local edit is still pending, not silently published");
+    }
+
+    #[test]
+    fn pending_reasons_round_trip_through_their_stored_tokens() {
+        for reason in [
+            PendingReason::UnknownColumn,
+            PendingReason::PartialAfterImage,
+            PendingReason::UnknownOpKind,
+            PendingReason::UndecodablePayload,
+            PendingReason::TableNotInScope,
+        ] {
+            assert_eq!(PendingReason::from_db_str(reason.as_db_str()), Some(reason));
+        }
+        assert_eq!(PendingReason::from_db_str("not_a_reason"), None);
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -147,6 +147,15 @@ fn replay_pending_entry(
     else {
         return repark(tx, pending, PendingReason::TableNotInScope);
     };
+    // NEVER replay over an unsent local edit. A raw local write does not advance the row clock, so
+    // the LWW comparison cannot see it and this older entry would simply win — silently destroying
+    // a change no peer has ever seen, at store open, before anything has had a chance to author
+    // it. Leaving the entry pending costs nothing: once the producer authors that edit (at a
+    // lamport above this entry's, since authoring counts parked entries), a later replay lands
+    // and loses on the merits.
+    if apply::row_has_unsent_local_change(tx, spec, &context.repo_id, op.pk())? {
+        return Ok(());
+    }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
     match apply::apply_row_op(tx, spec, &context.repo_id, &op, meta)? {
         // Folded. `Applied` also covers "deliberately lost" — superseded by a newer winner, or
@@ -155,10 +164,11 @@ fn replay_pending_entry(
         // Terminal, so it stops being outstanding: a type mismatch or a constraint violation is a
         // BROKEN PRODUCER — the values do not fit the declared column types or the table's
         // constraints, and no future binary makes them fit. (A missing column is NOT this case: it
-        // is an older producer, which reports `Unprojectable` and stays on the worklist.) The entry
-        // stays STORED — it still relays, and it is evidence — it just leaves the refold's worklist
-        // instead of being retried on every future bump.
-        ApplyOutcome::Quarantined(_) => store::clear_entry_pending(tx, &pending.entry_hash),
+        // is an older producer, which reports `Unprojectable` and stays on the worklist.) Recorded
+        // rather than merely cleared: this path has no caller to return an outcome to, so without a
+        // durable reason a rejected payload would be indistinguishable from a projected one.
+        ApplyOutcome::Quarantined(why) =>
+            store::record_entry_quarantine(tx, &pending.entry_hash, &why),
         // Still ahead of us — record which gap, under this version, so the next bump can tell
         // "newly stuck" from "stuck since v1".
         ApplyOutcome::Unprojectable(reason) => repark(tx, pending, reason),
@@ -243,6 +253,8 @@ mod tests {
     use super::*;
     use crate::table_sync::engine::{self, IngestOutcome, SyncCtx};
     use crate::table_sync::registry::{ColumnSpec, ValueType};
+    use crate::table_sync::row_op::{Cell, RowOp, TypedValue};
+    use crate::table_sync::scope_stream::scope_stream_id;
     use crate::{AccountId, LocalDevice};
 
     /// The physical table carries both columns; which of them a binary KNOWS is what the two specs
@@ -462,11 +474,19 @@ mod tests {
         b.enroll(a.pubkey().fingerprint());
         b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
 
-        // B edits the same row locally while the entry sits parked.
+        // B edits the same row locally while the entry sits parked, and AUTHORS it — so the row is
+        // published, not unsent (the unsent case is its own test below).
         b.conn
             .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'mine', NULL)", [])
             .unwrap();
         assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "the local edit is authored");
+        // Published by the OLD binary, so its hash covers the old column set (the single projector
+        // const cannot express two binaries; stamping models it, as the storm test does).
+        b.conn
+            .execute("UPDATE sync_published_rows SET projector_version = ?1", params![
+                TABLE_SYNC_PROJECTOR_VERSION - 1
+            ])
+            .unwrap();
 
         assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
         assert_eq!(
@@ -507,24 +527,60 @@ mod tests {
         // one refold must drain the pending entries of EVERY repo, not the caller's alone.
         // Otherwise a bump triggered from one checkout would stamp the version current while
         // leaving a sibling checkout's entries unreplayed forever.
+        // Repo-SCOPED specs, because a registered table must be (an unscoped table replicated
+        // through per-repo streams has no per-repo bookkeeping and cannot fold under LWW at all —
+        // the deferred account-global gap). Each repo therefore owns a distinct physical row.
+        const SCOPED_OLD: TableSpec = TableSpec {
+            name: "t_scoped",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
+                name: "id",
+                value_type: ValueType::Text,
+            }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            local_columns: &["later_col"],
+            repo_column: Some("repo_id"),
+        };
+        const SCOPED_NEW: TableSpec = TableSpec {
+            name: "t_scoped",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
+                name: "id",
+                value_type: ValueType::Text,
+            }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
+                name: "later_col",
+                value_type: ValueType::Text,
+            }],
+            local_columns: &[],
+            repo_column: Some("repo_id"),
+        };
+        let scoped_table = "CREATE TABLE t_scoped(
+                 repo_id TEXT NOT NULL, id TEXT NOT NULL, title TEXT, later_col TEXT,
+                 PRIMARY KEY(repo_id, id)
+             ) STRICT;";
         let mut a = Device::new();
         let mut b = Device::new();
+        a.conn.execute_batch(scoped_table).unwrap();
+        b.conn.execute_batch(scoped_table).unwrap();
         b.enroll(a.pubkey().fingerprint());
 
         for repo in ["repo-one", "repo-two"] {
-            a.conn.execute("DELETE FROM t_demo", []).unwrap();
             a.conn
-                .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', ?1, 'wide')", [
-                    repo,
-                ])
+                .execute(
+                    "INSERT INTO t_scoped(repo_id, id, title, later_col)
+                     VALUES (?1, 'r1', ?1, 'wide')",
+                    [repo],
+                )
                 .unwrap();
-            let entries = a.produce(NEW_REGISTRY, repo);
-            b.ingest(OLD_REGISTRY, repo, &entries, &a.pubkey());
+            let entries = a.produce(&[SCOPED_NEW], repo);
+            assert_eq!(entries.len(), 1, "one row authored for {repo}");
+            b.ingest(&[SCOPED_OLD], repo, &entries, &a.pubkey());
         }
         assert_eq!(b.pending_count(), 2, "one parked entry per repo");
 
         // One refold, driven from a single checkout's connection.
-        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert!(refold_stale_projections_against(&b.conn, &[SCOPED_NEW]).unwrap());
         assert_eq!(b.pending_count(), 0, "both repos' entries were replayed");
         let clocks: i64 = b
             .conn
@@ -689,16 +745,100 @@ mod tests {
     }
 
     #[test]
+    fn the_refold_never_overwrites_an_unsent_local_edit() {
+        // The refold runs at STORE OPEN, before anything has had a chance to author. A raw local
+        // write does not advance the row clock, so an older retained entry would win the ordinary
+        // LWW comparison and destroy a change no peer has ever seen — the one thing this pass must
+        // never do. (The live ingest path tolerates the same exposure only because the driver's
+        // contract is to author local rows first; there is no driver here.)
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+
+        // B writes the same row locally and exits before the next producer pass.
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'unsent', NULL)", [])
+            .unwrap();
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.row().unwrap().0, "unsent", "the unsent local edit survives the refold");
+        assert_eq!(b.pending_count(), 1, "and the entry stays outstanding rather than being lost");
+
+        // Authoring it settles the race on the merits: the local edit takes a lamport above the
+        // parked entry (authoring counts parked entries), so it wins wherever both are seen.
+        assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1, "the local edit is still authorable");
+    }
+
+    #[test]
+    fn a_quarantine_found_during_replay_is_recorded_rather_than_silently_cleared() {
+        // An entry can park under a narrow registry and then be REJECTED under a wider one: here
+        // the op types `later_col` as an integer while the wider spec declares it text.
+        // That is a broken producer, not a version gap, so it leaves the worklist — but the
+        // rejection has to be durable, or a retained-but-rejected payload is
+        // indistinguishable from a projected one and nothing downstream could ever report
+        // it. This path has no caller to return an outcome to.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let mistyped = RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text("r1".to_string())],
+            cells: vec![
+                Cell { column: "later_col".to_string(), value: TypedValue::I64(7) },
+                Cell { column: "title".to_string(), value: TypedValue::Text("v".to_string()) },
+            ],
+        };
+        let signed = {
+            let tx = a.conn.transaction().unwrap();
+            let stream = scope_stream_id("repo", account(), "demo/1");
+            let signed =
+                store::author_row_entry(&tx, stream, a.local.secret(), &mistyped, 0).unwrap();
+            tx.commit().unwrap();
+            signed.signed_bytes
+        };
+
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &[signed], &a.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::UnknownColumn.as_db_str())
+        ],);
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.pending_count(), 0, "a broken payload leaves the retry worklist");
+        let quarantine: Option<String> = b
+            .conn
+            .query_row("SELECT quarantine_reason FROM table_sync_entries", [], |r| r.get(0))
+            .unwrap();
+        assert!(
+            quarantine.is_some_and(|why| why.contains("later_col")),
+            "the rejection is durable and names what did not fit"
+        );
+        assert_eq!(b.row(), None, "and nothing was written");
+    }
+
+    #[test]
     fn pending_reasons_round_trip_through_their_stored_tokens() {
-        for reason in [
-            PendingReason::UnknownColumn,
-            PendingReason::PartialAfterImage,
-            PendingReason::UnknownOpKind,
-            PendingReason::UndecodablePayload,
-            PendingReason::TableNotInScope,
-        ] {
+        // Exhaustive over the enum, so a variant added later cannot skip the round trip.
+        for reason in <PendingReason as strum::IntoEnumIterator>::iter() {
             assert_eq!(PendingReason::from_db_str(reason.as_db_str()), Some(reason));
         }
-        assert_eq!(PendingReason::from_db_str("not_a_reason"), None);
+        assert_eq!(
+            PendingReason::from_db_str("not_a_reason"),
+            None,
+            "unknown tokens do not coerce"
+        );
+    }
+
+    #[test]
+    fn pending_reason_tokens_are_pinned() {
+        // These strings are STORED, so they are schema: changing one (or the `serialize_all` rule
+        // that derives them) silently reclassifies every row a prior binary wrote. Pin them
+        // literally — the derive keeps write and parse in step, this keeps the values themselves
+        // from moving.
+        assert_eq!(PendingReason::UnknownColumn.as_db_str(), "unknown_column");
+        assert_eq!(PendingReason::PartialAfterImage.as_db_str(), "partial_after_image");
+        assert_eq!(PendingReason::UnknownOpKind.as_db_str(), "unknown_op_kind");
+        assert_eq!(PendingReason::UndecodablePayload.as_db_str(), "undecodable_payload");
+        assert_eq!(PendingReason::TableNotInScope.as_db_str(), "table_not_in_scope");
     }
 }

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -41,9 +41,15 @@ const MAX_LAMPORT_ADVANCE: u64 = 1 << 32;
 /// mark, redelivery short-circuits on `entry_exists` and the payload is unrecoverable.
 ///
 /// These tokens are SCHEMA: they are written to `table_sync_entries.pending_reason` and read back
-/// by a future binary, so every variant round-trips through [`PendingReason::as_db_str`] /
-/// [`PendingReason::from_db_str`] and a rename needs a migration, exactly like a column rename.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// by a future binary, so a rename needs a migration exactly like a column rename. The tokens are
+/// strum-derived rather than hand-matched so the write and parse sides cannot drift apart as
+/// variants are added, and [`PendingReason::as_db_str`] / [`PendingReason::from_db_str`] stay the
+/// only paths to the stored form. The exact strings are pinned by test, so a `serialize_all` change
+/// cannot silently move them.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr, strum::EnumIter,
+)]
+#[strum(serialize_all = "snake_case")]
 pub(crate) enum PendingReason {
     /// The op carries a column this registry does not know — a newer producer. Nothing is written:
     /// applying the known subset would leave a row NO device ever authored, and publishing that row
@@ -65,24 +71,14 @@ pub(crate) enum PendingReason {
 
 impl PendingReason {
     pub(crate) fn as_db_str(self) -> &'static str {
-        match self {
-            Self::UnknownColumn => "unknown_column",
-            Self::PartialAfterImage => "partial_after_image",
-            Self::UnknownOpKind => "unknown_op_kind",
-            Self::UndecodablePayload => "undecodable_payload",
-            Self::TableNotInScope => "table_not_in_scope",
-        }
+        self.into()
     }
 
+    /// Exact-token parse: an unrecognized value is `None`, never coerced to a default — a stored
+    /// token this binary does not know means a NEWER binary wrote it, and guessing would silently
+    /// reclassify why an entry is outstanding.
     pub(crate) fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "unknown_column" => Some(Self::UnknownColumn),
-            "partial_after_image" => Some(Self::PartialAfterImage),
-            "unknown_op_kind" => Some(Self::UnknownOpKind),
-            "undecodable_payload" => Some(Self::UndecodablePayload),
-            "table_not_in_scope" => Some(Self::TableNotInScope),
-            _ => None,
-        }
+        value.parse().ok()
     }
 }
 
@@ -377,6 +373,28 @@ pub(crate) fn mark_entry_pending(
             SET pending_reason = ?2, pending_projector_version = ?3
           WHERE entry_hash = ?1",
         params![entry_hash.as_slice(), reason.as_db_str(), projector_version],
+    )?;
+    Ok(())
+}
+
+/// Record that an entry was rejected on its own merits — a type mismatch, a constraint violation —
+/// and drop it from the replay worklist.
+///
+/// TERMINAL, unlike a pending mark: those are version gaps a later binary redeems, this is data
+/// that does not fit the table and never will. Both facts have to be durable. Leaving it merely
+/// unmarked would make a rejected payload indistinguishable from a fully projected one, so nothing
+/// downstream could ever report it; leaving it PENDING would retry it on every future projector
+/// bump forever. The entry itself stays stored — it still relays, and it is the evidence.
+pub(crate) fn record_entry_quarantine(
+    tx: &Transaction<'_>,
+    entry_hash: &[u8; 32],
+    reason: &str,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "UPDATE table_sync_entries
+            SET pending_reason = NULL, pending_projector_version = NULL, quarantine_reason = ?2
+          WHERE entry_hash = ?1",
+        params![entry_hash.as_slice(), reason],
     )?;
     Ok(())
 }

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -36,18 +36,72 @@ const MAX_ENTRY_LAMPORT: u64 = 1 << 62;
 /// not one. (A peer griefing WITHIN the bound is the auth/roster milestone's job — device removal.)
 const MAX_LAMPORT_ADVANCE: u64 = 1 << 32;
 
+/// Why a retained entry is NOT projected into its table — persisted per entry so a later binary
+/// that understands the payload replays exactly the outstanding set (#1001). Without a durable
+/// mark, redelivery short-circuits on `entry_exists` and the payload is unrecoverable.
+///
+/// These tokens are SCHEMA: they are written to `table_sync_entries.pending_reason` and read back
+/// by a future binary, so every variant round-trips through [`PendingReason::as_db_str`] /
+/// [`PendingReason::from_db_str`] and a rename needs a migration, exactly like a column rename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PendingReason {
+    /// The op carries a column this registry does not know — a newer producer. Nothing is written:
+    /// applying the known subset would leave a row NO device ever authored, and publishing that row
+    /// lets the producer re-author the hole at a winning lamport (see [`super::apply`]).
+    UnknownColumn,
+    /// The op omits a column this registry requires — an OLDER producer, whose complete row under
+    /// its narrower spec is a partial after-image under ours. Whole-row LWW needs the full
+    /// after-image, so nothing is written. Unlike a broken producer this is a version gap, and it
+    /// is redeemed from the SENDER's side: #1002's declared column defaults rebuild the missing
+    /// cells into a complete row, at which point the replay lands it.
+    PartialAfterImage,
+    /// The op-kind is outside this binary's row-op vocabulary.
+    UnknownOpKind,
+    /// The op bytes do not decode at all.
+    UndecodablePayload,
+    /// The op's table is not in this binary's registry for the entry's scope.
+    TableNotInScope,
+}
+
+impl PendingReason {
+    pub(crate) fn as_db_str(self) -> &'static str {
+        match self {
+            Self::UnknownColumn => "unknown_column",
+            Self::PartialAfterImage => "partial_after_image",
+            Self::UnknownOpKind => "unknown_op_kind",
+            Self::UndecodablePayload => "undecodable_payload",
+            Self::TableNotInScope => "table_not_in_scope",
+        }
+    }
+
+    pub(crate) fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "unknown_column" => Some(Self::UnknownColumn),
+            "partial_after_image" => Some(Self::PartialAfterImage),
+            "unknown_op_kind" => Some(Self::UnknownOpKind),
+            "undecodable_payload" => Some(Self::UndecodablePayload),
+            "table_not_in_scope" => Some(Self::TableNotInScope),
+            _ => None,
+        }
+    }
+}
+
 /// The result of accepting a foreign entry. A chain-continuous entry is ALWAYS stored (so one bad
 /// payload cannot wedge the device's chain); whether its payload is APPLIED is a separate decision.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum AcceptOutcome {
-    /// Stored, and its known in-scope row op is ready to apply.
+    /// Stored, and its known in-scope row op is ready to apply. `entry_hash` lets the caller mark
+    /// the entry pending if the APPLY turns out to be incomplete (an unknown column), which only
+    /// the registry-aware applier can detect.
     Stored {
         op: RowOp,
         meta: OpMeta,
+        entry_hash: [u8; 32],
     },
     /// Stored and retained, but NOT applied — an undecodable payload, a future op-kind, or a table
-    /// not in this scope. The chain still advanced; the `&str` is the reason, for reporting.
-    StoredInert(&'static str),
+    /// not in this scope. The chain still advanced, and the entry is marked pending so a later
+    /// binary replays it.
+    StoredInert(PendingReason),
     AlreadyPresent,
     /// The lamport advances past the tail but the entry does not link to it (a gap): the
     /// predecessor has not arrived. Routine under out-of-order delivery; the transport retries
@@ -84,7 +138,9 @@ pub(crate) fn author_row_entry(
     let prev_hash = chain_tail(tx, stream, device)?.map(|(_, entry_hash)| entry_hash);
     let signed =
         entry::sign_entry_from_op_bytes(secret, stream, prev_hash, lamport, row_op::encode(op));
-    insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms)?;
+    // A locally-authored op is projected by construction: the producer builds it from THIS
+    // registry, so it can never carry a column or op-kind this binary does not understand.
+    insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms, None)?;
     Ok(signed)
 }
 
@@ -180,23 +236,32 @@ pub(crate) fn accept_row_entry(
         ChainFit::Gap => return Ok(AcceptOutcome::MissingPredecessor),
         ChainFit::Conflict => return Ok(AcceptOutcome::Fork),
     }
-    // Chain-continuous: store now so a bad payload can never wedge the device's chain.
-    insert_entry(tx, &verified, signed_bytes, now_ms)?;
-
-    // Classify the payload for application — the entry is already durably stored either way.
-    Ok(match row_op::decode(&verified.op_bytes) {
-        Err(_) => AcceptOutcome::StoredInert("undecodable op payload"),
-        Ok(DecodedRowOp::Unknown { .. }) => AcceptOutcome::StoredInert("unknown op-kind"),
+    // Classify the payload BEFORE storing, so the entry lands with its projection state recorded in
+    // the same INSERT — no store-then-mark window, and no second write.
+    let outcome = match row_op::decode(&verified.op_bytes) {
+        Err(_) => AcceptOutcome::StoredInert(PendingReason::UndecodablePayload),
+        Ok(DecodedRowOp::Unknown { .. }) =>
+            AcceptOutcome::StoredInert(PendingReason::UnknownOpKind),
         Ok(DecodedRowOp::Known(op)) =>
             if expected_tables.contains(&op.table()) {
                 AcceptOutcome::Stored {
                     op,
                     meta: OpMeta { lamport: verified.lamport, device: verified.device_fingerprint },
+                    entry_hash: verified.entry_hash,
                 }
             } else {
-                AcceptOutcome::StoredInert("table not in scope")
+                AcceptOutcome::StoredInert(PendingReason::TableNotInScope)
             },
-    })
+    };
+    // Chain-continuous: store now so a bad payload can never wedge the device's chain.
+    let pending = match &outcome {
+        AcceptOutcome::StoredInert(reason) => Some(*reason),
+        // A `Stored` op may still fail to project on an unknown COLUMN, which only the
+        // registry-aware applier sees; the caller marks it pending via `entry_hash` in that case.
+        _ => None,
+    };
+    insert_entry(tx, &verified, signed_bytes, now_ms, pending)?;
+    Ok(outcome)
 }
 
 /// How a verified entry fits its `(stream, device)` chain tail.
@@ -266,11 +331,14 @@ fn entry_exists(tx: &Transaction<'_>, entry_hash: &[u8; 32]) -> anyhow::Result<b
         .is_some())
 }
 
+/// Store a chain-continuous entry, carrying its projection state (`pending`: `None` = fully
+/// projected) in the same INSERT.
 fn insert_entry(
     tx: &Transaction<'_>,
     verified: &VerifiedEntry,
     signed_bytes: &[u8],
     now_ms: i64,
+    pending: Option<PendingReason>,
 ) -> anyhow::Result<()> {
     let stream_bytes = verified.stream_id.to_bytes();
     let device_bytes = verified.device_fingerprint.to_bytes();
@@ -278,8 +346,8 @@ fn insert_entry(
     tx.execute(
         "INSERT INTO table_sync_entries(
              entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
-             received_at_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+             received_at_ms, pending_reason, pending_projector_version)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         params![
             verified.entry_hash.as_slice(),
             stream_bytes.as_slice(),
@@ -288,9 +356,116 @@ fn insert_entry(
             prev_hash,
             signed_bytes,
             now_ms,
+            pending.map(PendingReason::as_db_str),
+            pending.map(|_| super::refold::TABLE_SYNC_PROJECTOR_VERSION),
         ],
     )?;
     Ok(())
+}
+
+/// Mark a stored entry as not-yet-projected under `projector_version` — the caller-side counterpart
+/// of [`insert_entry`]'s `pending`, for the unknown-COLUMN case that only the registry-aware
+/// applier can detect (the entry is already stored by then).
+pub(crate) fn mark_entry_pending(
+    tx: &Transaction<'_>,
+    entry_hash: &[u8; 32],
+    reason: PendingReason,
+    projector_version: i64,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "UPDATE table_sync_entries
+            SET pending_reason = ?2, pending_projector_version = ?3
+          WHERE entry_hash = ?1",
+        params![entry_hash.as_slice(), reason.as_db_str(), projector_version],
+    )?;
+    Ok(())
+}
+
+/// Clear an entry's pending mark — it now projects completely.
+pub(crate) fn clear_entry_pending(
+    tx: &Transaction<'_>,
+    entry_hash: &[u8; 32],
+) -> anyhow::Result<()> {
+    tx.execute(
+        "UPDATE table_sync_entries
+            SET pending_reason = NULL, pending_projector_version = NULL
+          WHERE entry_hash = ?1",
+        params![entry_hash.as_slice()],
+    )?;
+    Ok(())
+}
+
+/// One retained-but-unprojected entry, with everything replay needs except its apply context (which
+/// comes from [`stream_context`], since the stream id hashes that away).
+pub(crate) struct PendingEntry {
+    pub(crate) entry_hash: [u8; 32],
+    pub(crate) stream_id: StreamId,
+    pub(crate) signed_bytes: Vec<u8>,
+}
+
+/// Every entry this binary has not fully projected, in stream/lamport order. Ordered for
+/// determinism and reproducible diagnostics, NOT for correctness: each replay goes through the
+/// unchanged LWW gates, which are arrival-order independent.
+pub(crate) fn pending_entries(tx: &Transaction<'_>) -> anyhow::Result<Vec<PendingEntry>> {
+    let mut stmt = tx.prepare(
+        "SELECT entry_hash, stream_id, signed_bytes FROM table_sync_entries
+          WHERE pending_reason IS NOT NULL
+          ORDER BY stream_id, lamport, device_fingerprint",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.into_iter()
+        .map(|(hash, stream, signed_bytes)| {
+            Ok(PendingEntry {
+                entry_hash: fixed32(hash)?,
+                stream_id: StreamId::from_bytes(fixed32(stream)?),
+                signed_bytes,
+            })
+        })
+        .collect()
+}
+
+/// The apply context a stored entry needs to be replayed. `scope_stream_id` is a ONE-WAY sha256 of
+/// `(repo_id, account_id, scope_id)` and entries store only the stream id, so without this
+/// directory a retained entry can never be re-applied: `repo_id` scopes every projected write and
+/// `scope_id` resolves the op's table spec.
+pub(crate) struct StreamContext {
+    pub(crate) repo_id: String,
+    pub(crate) scope_id: String,
+}
+
+/// Record a stream's apply context, idempotently. Called on every authored and ingested entry, so
+/// the directory covers exactly the streams whose entries could ever need replaying.
+pub(crate) fn record_stream_context(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    repo_id: &str,
+    account_id: AccountId,
+    scope_id: &str,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(stream_id) DO NOTHING",
+        params![stream.to_bytes().as_slice(), repo_id, account_id.to_bytes().as_slice(), scope_id],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn stream_context(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+) -> anyhow::Result<Option<StreamContext>> {
+    Ok(tx
+        .query_row(
+            "SELECT repo_id, scope_id FROM table_sync_streams WHERE stream_id = ?1",
+            params![stream.to_bytes().as_slice()],
+            |row| Ok(StreamContext { repo_id: row.get(0)?, scope_id: row.get(1)? }),
+        )
+        .optional()?)
 }
 
 fn fixed32(bytes: Vec<u8>) -> anyhow::Result<[u8; 32]> {
@@ -379,7 +554,8 @@ mod tests {
         .unwrap();
         assert_eq!(outcome, AcceptOutcome::Stored {
             op: op("r1"),
-            meta: OpMeta { lamport: 0, device: secret.public().fingerprint() }
+            meta: OpMeta { lamport: 0, device: secret.public().fingerprint() },
+            entry_hash: signed.entry.entry_hash,
         });
     }
 
@@ -502,7 +678,7 @@ mod tests {
                 0
             )
             .unwrap(),
-            AcceptOutcome::StoredInert("table not in scope"),
+            AcceptOutcome::StoredInert(PendingReason::TableNotInScope),
         );
         // The chain is not wedged: the next entry (which links to the first) still stores +
         // applies.
@@ -530,7 +706,7 @@ mod tests {
             let mut a = conn();
             let tx = a.transaction().unwrap();
             let garbage = entry::sign_entry_from_op_bytes(&secret, stream(), None, 0, vec![0x00]);
-            insert_entry(&tx, &garbage.entry, &garbage.signed_bytes, 0).unwrap();
+            insert_entry(&tx, &garbage.entry, &garbage.signed_bytes, 0, None).unwrap();
             let valid = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
             tx.commit().unwrap();
             (garbage, valid)
@@ -548,7 +724,7 @@ mod tests {
                 0
             )
             .unwrap(),
-            AcceptOutcome::StoredInert("undecodable op payload"),
+            AcceptOutcome::StoredInert(PendingReason::UndecodablePayload),
         );
         // One bad payload does not wedge the chain: the next valid entry still applies.
         assert!(matches!(


### PR DESCRIPTION
Wire-readiness item from #892: projector versioning plus replay of retained entries after an upgrade.

Table-sync stores a chain-continuous entry even when this binary cannot project its payload — storage is gated on the chain, application on the payload. But nothing recorded that the payload had been left unapplied, and the anti-echo hash did not record which column set it covered. Two failures follow once a real table registers. Neither can fire today, because `SYNCABLE_TABLES` is empty — which is exactly why the invariant is worth establishing before the first table registers rather than repaired afterward.

## Failure 1 — partial projection corrupts the roster

An op carrying a column this registry does not know was applied in part: the known cells landed, the unknown ones were dropped, and the row's hash was recorded as though the projection were complete. The dropped value was then unrecoverable locally, because redelivery short-circuits on the entry already being present. Worse, the surviving row was a state **no device ever authored**, so after an upgrade that learned the column the producer re-authored it with the hole at a fresh higher Lamport — which wins whole-row last-writer-wins on every peer and destroys the real value roster-wide, under a valid signature.

## Failure 2 — a re-author storm on any column growth

The hash covers `spec.columns` of whichever binary computed it, and `cells_hash` hashes the cell *list*. A stored hash therefore means "this row under column set C" with C implicit. Once a column set grows, every stored hash mismatches structurally — whether or not the row changed — so every row reads as a local delta and every upgrading device re-authors the entire table at fresh winning Lamports: log growth proportional to rows times devices, Lamport inflation, and every device becoming the nominal author of rows it merely received.

## Change

Establish that **every local row is a complete, signed after-image that some device authored**.

- **Park, do not partially apply.** An op naming an unknown column, or omitting one this registry requires, is stored and touches nothing — no row write, no clock, no tombstone, no published hash. That makes a partial projection unrepresentable rather than a state to contain after the fact. Unified with the existing inert cases (undecodable, unknown op-kind, table out of scope) into one persisted per-entry pending state.
- **Record the apply context.** The scope stream id is a one-way hash of `(repo_id, account_id, scope_id)` and entries store only the stream id, so without a stream directory a retained entry cannot be replayed at all.
- **Projector version plus an eager, targeted refold** that replays only the pending entries, through the *unmodified* apply gates with each entry's original op metadata. No clock bypass and no reordering, which is what makes the interactions correct for free: a parked entry superseded by a later winner loses the comparison, one superseded by a delete loses to the tombstone and cannot resurrect the row, and a parked `Remove` needs no winner lookup.
- **Version the anti-echo hash**, so a hash recorded under a different column set is treated as not comparable rather than as a local delta. Deletes stay version-agnostic: a `Remove` carries only the primary key, and gating it would leave a row deleted after a column change permanently undeletable.

The store-global stamp is not by itself a complete record of what has been evaluated, so a refold is owed when the stamp is behind **or** when any pending entry was evaluated by an older projector. A store shared by binaries of different versions produces exactly that case: a newer binary stamps the store, an older one then parks an entry under its own version, and keying only on the stamp would strand an entry the newer binary fully understands. Both engine write paths refuse to write under a *newer* stamp, so an older binary fails loudly instead of quietly re-parking what a newer projector already folded.

The refold is wired at the open/migrate seam next to the content projection's, so registering the first table cannot forget it.

## Follow-up

A per-op spec version with declared column defaults (#1002) removes the remaining conservatism: it lets an older producer's op rebuild into a complete after-image instead of being declined, which unfreezes older-to-newer replication and makes adding a column cost nothing. Until it lands, a version-mismatched row cannot be re-authored from this device even when locally edited — harmless only while no table is registered, and a tripwire test fails the moment one is.

## Tests

Adds schema V093 coverage and end-to-end refold cases: an unknown column parks and the refold later recovers the true value; a column-set change alone re-authors nothing (the storm guard); a local delete still propagates across a column change; a parked entry loses to a later local edit, to a later winner from a third device, and to a tombstone without resurrecting the row; redelivery leaves the pending mark intact; the refold covers every repo in a shared store; an entry parked by an older binary is still replayed under a current stamp; and an older binary refuses to write into a newer-stamped store. The storm guard and the older-binary replay were mutation-checked — both fail when the fix is reverted.

Closes #1001. Part of #892.