### PR TITLE
feat(sync): carry a per-table spec version in table-sync ops

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1471,6 +1471,122 @@ fn migration_092_normalizes_invite_receipts() {
     assert_eq!(recorded, 1, "the forward migration records V092");
 }
 
+/// V095 (#1002) records the TABLE's spec version on each published row, so an unrelated projector
+/// bump no longer marks every table's rows incomparable.
+#[test]
+fn migration_095_records_the_table_spec_version() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 95, "move this pin with the next schema migration");
+
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_table_sync_tables(&bare).unwrap();
+    schema::apply_table_sync_projection_state(&bare).unwrap();
+    assert!(
+        schema::column_exists(&bare, "sync_published_rows", "projector_version").unwrap(),
+        "V093 records the store-global projector version"
+    );
+
+    use rusqlite::OptionalExtension;
+    // A row published under V093 must SURVIVE the rebuild, not be dropped with the old table.
+    bare.execute(
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, \
+         projector_version)
+         VALUES ('repo', 't', 'carried', 'h0', 1)",
+        [],
+    )
+    .unwrap();
+
+    schema::apply_table_sync_spec_version(&bare).unwrap();
+    schema::apply_table_sync_spec_version(&bare).expect("replay is a no-op");
+    let carried: Option<i64> = bare
+        .query_row(
+            "SELECT spec_version FROM sync_published_rows WHERE row_pk = 'carried'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap();
+    assert_eq!(
+        carried,
+        Some(0),
+        "the rebuild carries existing records across, stamped as an unknown column set — dropping \
+         a published record would strand that row's unsent deletion permanently"
+    );
+    assert!(schema::column_exists(&bare, "sync_published_rows", "spec_version").unwrap());
+    assert!(
+        !schema::column_exists(&bare, "sync_published_rows", "projector_version").unwrap(),
+        "the store-global version is replaced, not left behind as a dead column"
+    );
+
+    // The rebuilt table keeps its identity and its NOT NULL version.
+    bare.execute(
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, spec_version)
+         VALUES ('repo', 't', 'r', 'h', 2)",
+        [],
+    )
+    .unwrap();
+    let duplicate = bare.execute(
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, spec_version)
+         VALUES ('repo', 't', 'r', 'other', 2)",
+        [],
+    );
+    assert!(duplicate.is_err(), "one published record per row identity");
+    let missing_version = bare.execute(
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash)
+         VALUES ('repo', 't', 'r2', 'h')",
+        [],
+    );
+    assert!(missing_version.is_err(), "a published hash always states the column set it covers");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '095_table_sync_spec_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V095");
+
+    // `schema::apply` is the `index --full` recovery, and it re-runs the WHOLE ladder over an
+    // EXISTING store — so V093 would re-add the column V095 replaced, and V095 can only restore its
+    // shape by REBUILDING the table. Both halves of that must hold: the replay converges on the
+    // fresh schema, and it does not destroy publication state on the way. The second is the sharp
+    // one — `produce_row_ops` finds a locally-deleted row by its surviving published record, so a
+    // dropped table strands every unsent deletion and leaves peers holding the row forever.
+    conn.execute(
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, spec_version)
+         VALUES ('repo', 't', 'live', 'hash', 3)",
+        [],
+    )
+    .unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).expect("the ladder replays");
+    assert!(
+        schema::column_exists(&conn, "sync_published_rows", "spec_version").unwrap(),
+        "the replayed ladder still ends at the V095 shape"
+    );
+    assert!(
+        !schema::column_exists(&conn, "sync_published_rows", "projector_version").unwrap(),
+        "V093's column must not come back on a full-ladder replay — the recovery path has to \
+         converge on the same schema as a fresh install"
+    );
+    let survivor: Option<i64> = conn
+        .query_row(
+            "SELECT spec_version FROM sync_published_rows WHERE row_pk = 'live'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap();
+    assert_eq!(
+        survivor,
+        Some(3),
+        "the replay must not rebuild a populated table — a dropped published record reads as an \
+         unsent deletion that can never be authored"
+    );
+}
+
 /// V093 (#1001) records what the table-sync projector could not project, the apply context the
 /// one-way stream id hashes away, and the column set each anti-echo hash covers.
 #[test]
@@ -1582,8 +1698,6 @@ fn migration_091_adds_account_candidate_reservation_targets() {
 
 #[test]
 fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 94, "move this pin with the next schema migration");
-
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     conn.execute(

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1380,6 +1380,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_092_ID => Some(92),
             MIGRATION_093_ID => Some(93),
             MIGRATION_094_ID => Some(94),
+            MIGRATION_095_ID => Some(95),
             _ => None,
         })
         .max()
@@ -1483,6 +1484,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_092_ID
             | MIGRATION_093_ID
             | MIGRATION_094_ID
+            | MIGRATION_095_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1583,6 +1585,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_092_ID => migration.checksum != MIGRATION_092_CHECKSUM,
         MIGRATION_093_ID => migration.checksum != MIGRATION_093_CHECKSUM,
         MIGRATION_094_ID => migration.checksum != MIGRATION_094_CHECKSUM,
+        MIGRATION_095_ID => migration.checksum != MIGRATION_095_CHECKSUM,
         _ => false,
     }
 }
@@ -6423,12 +6426,21 @@ pub fn apply_table_sync_projection_state(conn: &Connection) -> rusqlite::Result<
     add_column_if_missing(&tx, "table_sync_entries", "pending_reason", "TEXT")?;
     add_column_if_missing(&tx, "table_sync_entries", "pending_projector_version", "INTEGER")?;
     add_column_if_missing(&tx, "table_sync_entries", "quarantine_reason", "TEXT")?;
-    add_column_if_missing(
-        &tx,
-        "sync_published_rows",
-        "projector_version",
-        "INTEGER NOT NULL DEFAULT 0",
-    )?;
+    // V095 REPLACED this column with the per-table `spec_version`. `schema::apply` — the
+    // `index --full` recovery — re-runs the WHOLE ladder over an existing store, so without this
+    // check a store already at V095 would get the dead column back on every full reindex, and V095
+    // (which can only restore its shape by rebuilding the table) would have to DROP a table that by
+    // then holds live publication state. Losing that state is not merely churn: `produce_row_ops`
+    // finds a locally-deleted row by its surviving published record, so wiping the table strands
+    // every unsent deletion and leaves peers holding the row forever.
+    if !column_exists(&tx, "sync_published_rows", "spec_version")? {
+        add_column_if_missing(
+            &tx,
+            "sync_published_rows",
+            "projector_version",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+    }
     tx.execute_batch(
         "CREATE TABLE IF NOT EXISTS table_sync_streams(
              stream_id  BLOB NOT NULL PRIMARY KEY,
@@ -6495,6 +6507,59 @@ fn create_repo_scoped_lens_revision_triggers(
                   END;"
     ))?;
     Ok(())
+}
+
+/// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
+///
+/// `sync_published_rows.spec_version` replaces V093's `projector_version`. The anti-echo hash
+///   covers one TABLE's synced column set, so recording the store-global projector version was too
+///   coarse: registering an unrelated table (or learning a new op-kind) bumps that version and
+/// would   mark EVERY table's rows incomparable, freezing their producers and forcing needless
+/// winner   lookups. The projector version keeps its own job — deciding when parked entries are
+/// replayed. The row's winning entry is NOT denormalized onto the clock: `sync_row_clocks` already
+/// carries `(lamport, device_fingerprint)`, and `table_sync_entries` is UNIQUE on
+/// `(stream_id, device_fingerprint, lamport)`, so the producer resolves it exactly once it knows
+/// the stream — which it derives from the account it is already syncing. The only cost is
+/// reconciling the two encodings of a fingerprint (hex TEXT on the clock, BLOB on the entry), which
+/// the fingerprint type already round-trips.
+///
+/// The table is necessarily EMPTY: no table is registered (`SYNCABLE_TABLES` is empty) and there
+/// is no transport, so nothing has ever written either. The published-rows table is therefore
+/// rebuilt into its final shape rather than accumulating a dead column, and no backfill is owed.
+pub fn apply_table_sync_spec_version(conn: &Connection) -> rusqlite::Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    // The rebuild PRESERVES rows rather than dropping them, even though the table is provably empty
+    // at this transition today. Emptiness is an emergent property of another crate
+    // (`SYNCABLE_TABLES` has no entries yet) and the one-shot-ness depends on V093 declining to
+    // re-add the column it replaced — a conjunction spanning two files that nothing enforces. A
+    // bare DROP would make this migration's data safety rest on that conjunction holding
+    // forever, and the failure would be silent and severe: `produce_row_ops` finds a
+    // locally-deleted row by its surviving published record, so a wiped table strands every
+    // unsent deletion and leaves peers holding the row. Copying instead demotes the guard below
+    // to a performance detail, and costs nothing on an empty table.
+    //
+    // `spec_version` backfills to 0, which is below every real spec version (the registry lint
+    // bounds those at >= 1), so a carried row reads as "column set unknown" — the not-comparable
+    // path that resolves itself on the next produce. That is strictly better than deleting it.
+    if !column_exists(&tx, "sync_published_rows", "spec_version")? {
+        tx.execute_batch(
+            "ALTER TABLE sync_published_rows RENAME TO sync_published_rows_pre_v095;
+             CREATE TABLE sync_published_rows(
+                 repo_id      TEXT    NOT NULL,
+                 table_name   TEXT    NOT NULL,
+                 row_pk       TEXT    NOT NULL,
+                 synced_hash  TEXT    NOT NULL,
+                 spec_version INTEGER NOT NULL,
+                 PRIMARY KEY(repo_id, table_name, row_pk)
+             ) STRICT;
+             INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, \
+             spec_version)
+                 SELECT repo_id, table_name, row_pk, synced_hash, 0
+                   FROM sync_published_rows_pre_v095;
+             DROP TABLE sync_published_rows_pre_v095;",
+        )?;
+    }
+    tx.commit()
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -27,7 +27,7 @@ pub use migrations::{
     apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
     apply_scip_moniker_anchors, apply_sync_invites, apply_sync_invites_normalized_receipts,
     apply_sync_origin_and_edge_tombstone, apply_table_sync_projection_state,
-    apply_table_sync_tables,
+    apply_table_sync_spec_version, apply_table_sync_tables,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
@@ -50,7 +50,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 94;
+pub const LATEST_SCHEMA_VERSION: u32 = 95;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -717,6 +717,14 @@ const MIGRATION_094_DESCRIPTION: &str =
      git-history imports and Oracle verdict passes — increment the same clock once at their \
      transaction boundary instead of once per row. The Lens SSE freshness probe reads only O(1) \
      indexed rows instead of rescanning enrichment and files tables every polling interval";
+
+const MIGRATION_095_ID: &str = "095_table_sync_spec_version";
+const MIGRATION_095_CHECKSUM: &str = "sha256:rag-rat-table-sync-spec-version-v95";
+const MIGRATION_095_DESCRIPTION: &str =
+    "Per-table spec versioning for table-sync (#1002): sync_published_rows records the TABLE's \
+     spec_version rather than the store-global projector version, so an unrelated projector bump \
+     no longer marks every table's rows incomparable. The table is necessarily empty (no table is \
+     registered), so it is rebuilt into its final shape rather than carrying a dead column";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1477,6 +1485,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_094_CHECKSUM,
         description: MIGRATION_094_DESCRIPTION,
         apply: MigrationFn::Plain(apply_lens_enrichment_revision),
+    },
+    Migration {
+        id: MIGRATION_095_ID,
+        checksum: MIGRATION_095_CHECKSUM,
+        description: MIGRATION_095_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_table_sync_spec_version),
     },
 ];
 

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -16,10 +16,11 @@
 use rusqlite::types::Value as SqlValue;
 use rusqlite::{OptionalExtension, Transaction, params_from_iter};
 
-use super::registry::{TableSpec, ValueType};
+use super::registry::{DefaultValue, TableSpec, ValueType};
 use super::row_op::{self, Cell, RowOp, TypedValue};
 use super::store::PendingReason;
 use crate::op::OpMeta;
+use crate::stream::StreamId;
 
 /// The result of applying one row op.
 ///
@@ -34,6 +35,17 @@ use crate::op::OpMeta;
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ApplyOutcome {
     Applied,
+    /// The op landed but did NOT take effect: a newer write already owns the row, or a tombstone
+    /// suppresses it. A correct fold, not outstanding work — receivers treat it exactly like
+    /// `Applied`.
+    ///
+    /// It is separate from `Applied` for ONE caller. A locally-authored op takes the stream's
+    /// `MAX(lamport) + 1`, so while a row's bookkeeping belongs to the stream being authored on it
+    /// cannot lose — which makes this outcome, at the produce seam, proof that the two have come
+    /// apart (a row clock carrying a lamport from another stream). Folded into `Applied` that reads
+    /// as settlement while nothing is published, so the producer re-derives the same delta and
+    /// re-signs it on every pass.
+    Superseded,
     Quarantined(String),
     Unprojectable(PendingReason),
 }
@@ -48,6 +60,22 @@ pub(crate) fn apply_row_op(
     meta: OpMeta,
 ) -> anyhow::Result<ApplyOutcome> {
     debug_assert_eq!(op.table(), spec.name, "caller resolves the spec from the op's table");
+    // "We do not understand this generation" OUTRANKS "this op looks malformed to us", so the
+    // version gate goes before every structural check below — those all return `Quarantined`, which
+    // is TERMINAL. A newer producer's UPSERT that happens to trip one of them would be discarded
+    // for good rather than parked for the binary that understands it, which is the exact
+    // failure this version exists to prevent. The additive-only rule makes that unreachable
+    // today (pk shape and types cannot change within a table's life), but that rule is
+    // explicitly un-lintable, so it must not be what stands between a recoverable payload and
+    // permanent loss.
+    //
+    // `Remove` is EXCLUDED, and must stay excluded: it names only the row identity, so no column
+    // set is involved and there is nothing a later binary would understand better. Parking one
+    // would delay a deletion across a version skew for no benefit, and a row deleted after a column
+    // change would become permanently undeletable — a convergence wedge.
+    if matches!(op, RowOp::Upsert { .. }) && op.spec_version() > spec.spec_version {
+        return Ok(ApplyOutcome::Unprojectable(PendingReason::NewerSpecVersion));
+    }
     let pk_vals = op.pk();
     if pk_vals.len() != spec.pk.len() {
         return Ok(ApplyOutcome::Quarantined(format!(
@@ -90,8 +118,12 @@ pub(crate) fn apply_row_op(
         )));
     }
     match op {
+        // A remove names only the row identity, so no column set is involved: its `spec_version` is
+        // carried for wire symmetry and diagnostics, never acted on. Gating a deletion on a version
+        // skew would delay it for no benefit.
         RowOp::Remove { .. } => apply_remove(tx, spec, repo_id, pk_vals, meta),
-        RowOp::Upsert { cells, .. } => apply_upsert(tx, spec, repo_id, pk_vals, cells, meta),
+        RowOp::Upsert { spec_version, cells, .. } =>
+            apply_upsert(tx, spec, repo_id, pk_vals, *spec_version, cells, meta),
     }
 }
 
@@ -137,7 +169,96 @@ fn apply_remove(
     // Raise the tombstone only once the remove has actually applied (the row was deleted, or a
     // newer write kept it): the tombstone guards against an older upsert resurrecting the row.
     raise_tombstone(tx, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
-    Ok(ApplyOutcome::Applied)
+    // The tombstone is raised either way, but a delete a newer write outranks did not delete
+    // anything — and, crucially, left the published record in place. Say so.
+    Ok(if survives { ApplyOutcome::Superseded } else { ApplyOutcome::Applied })
+}
+
+/// What an op's cells resolve to under THIS registry.
+#[derive(Debug, PartialEq)]
+enum Projection {
+    /// A full after-image: every synced column, in registry order.
+    Complete(Vec<(&'static str, TypedValue)>),
+    /// Not projectable YET — a version gap a later binary (or a later sender) redeems.
+    Park(PendingReason),
+    /// Not projectable EVER — the values do not fit the declared types.
+    Quarantine(String),
+}
+
+/// Resolve an upsert's cells into the complete after-image this registry expects, from the payload
+/// alone (#1002). The single place the spec-version rule lives, shared by the applier and by the
+/// producer's stale-row comparison — any divergence between those two would be a convergence bug.
+///
+/// - **Op NEWER than this binary** → park. We cannot know what a later column set means, and the op
+///   may name columns we lack. #1001's refold replays it once this binary catches up.
+/// - **Op EQUAL** → strict full after-image, as before.
+/// - **Op OLDER** → columns it predates are filled from their DECLARED defaults, yielding a
+///   complete row. That is what unfreezes older→newer replication.
+///
+/// The fill window is PER COLUMN — an op is completed only for the columns its own version
+/// predates. A column absent from an op old enough to lack it is filled; a column absent from an op
+/// whose version already had it is a partial after-image and parks, rather than being invented.
+///
+/// Whole-row semantics are preserved deliberately: an older producer's winning op resets a
+/// newly-added column to its default on every receiver. That is what a whole-row write from a
+/// device that does not know the column MEANS — deterministic and convergent. Letting the receiver
+/// keep its own value there would be a per-column merge, which this engine does not do.
+fn project_cells(spec: &TableSpec, op_spec_version: u32, cells: &[Cell]) -> Projection {
+    if op_spec_version > spec.spec_version {
+        return Projection::Park(PendingReason::NewerSpecVersion);
+    }
+    // A cell naming a column we do not know, at or below our own version, is a producer that
+    // mis-stamped (most likely a forgotten bump) — park, so the binary that stamps correctly
+    // redeems it, rather than quarantining the likeliest operator error terminally.
+    for cell in cells {
+        let Some(column) = spec.columns.iter().find(|column| column.name == cell.column) else {
+            return Projection::Park(PendingReason::UnknownColumn);
+        };
+        // A cell for a column introduced AFTER the version the op claims. The op contradicts
+        // itself — a producer at version V cannot have known a column added at V+1 — so the stamp
+        // is wrong, and trusting it would default-fill every column the (understated) version
+        // predates, resetting them for every receiver. This is the one half of the advisory stamp a
+        // receiver CAN check without registry history, because `in_version` is a fixed historical
+        // fact under additive-only evolution. Park, like every other mis-stamp.
+        if column.added.is_some_and(|added| op_spec_version < added.in_version) {
+            return Projection::Park(PendingReason::MisstampedSpecVersion);
+        }
+    }
+    let mut complete = Vec::with_capacity(spec.columns.len());
+    for column in spec.columns {
+        match cells.iter().find(|cell| cell.column == column.name) {
+            Some(cell) => {
+                if !value_matches(&cell.value, column.value_type) {
+                    return Projection::Quarantine(format!(
+                        "cell `{}` value does not match declared type on `{}`",
+                        cell.column, spec.name
+                    ));
+                }
+                complete.push((column.name, cell.value.clone()));
+            },
+            // Absent. Filled from the declared default only if the op PREDATES THE COLUMN — its
+            // own introducing version, not merely the spec's current one. An op stamped at or
+            // above that version was obliged to carry the column, so its absence is a partial
+            // after-image and parks. (Keying on the spec's current version instead would, once a
+            // table reached a third version, silently default a column the op's own version
+            // already had — resetting it for every receiver under whole-row LWW.)
+            None => match column.added.filter(|added| op_spec_version < added.in_version) {
+                Some(added) => complete.push((column.name, default_as_value(added.default))),
+                None => return Projection::Park(PendingReason::PartialAfterImage),
+            },
+        }
+    }
+    Projection::Complete(complete)
+}
+
+fn default_as_value(default: DefaultValue) -> TypedValue {
+    match default {
+        DefaultValue::Null => TypedValue::Null,
+        DefaultValue::Bool(b) => TypedValue::Bool(b),
+        DefaultValue::I64(n) => TypedValue::I64(n),
+        DefaultValue::Text(text) => TypedValue::Text(text.to_string()),
+        DefaultValue::Blob(bytes) => TypedValue::Blob(bytes.to_vec()),
+    }
 }
 
 fn apply_upsert(
@@ -145,26 +266,17 @@ fn apply_upsert(
     spec: &TableSpec,
     repo_id: &str,
     pk_vals: &[TypedValue],
+    op_spec_version: u32,
     cells: &[Cell],
     meta: OpMeta,
 ) -> anyhow::Result<ApplyOutcome> {
-    // FORWARD COMPATIBILITY, decided on the PAYLOAD ALONE (before any row state is read): an op
-    // naming a column this registry does not know cannot be projected into a complete after-image.
-    // PARK it — store the entry, write NOTHING — rather than applying the subset we understand.
-    //
-    // Applying the known cells and skipping the rest would leave a row that NO device ever authored
-    // ({known: new, unknown: whatever this row already held}), and recording its anti-echo hash
-    // would then claim that chimera as a complete projection. Two failures follow: the skipped
-    // value is unrecoverable locally (redelivery short-circuits on `entry_exists`), and after an
-    // upgrade that learns the column the producer re-authors the row with the HOLE at a fresh
-    // winning lamport — destroying the real value on every peer. Parking makes the incomplete
-    // projection unrepresentable instead of containing it after the fact (#1001).
-    if let Some(unknown) =
-        cells.iter().find(|cell| !spec.columns.iter().any(|known| known.name == cell.column))
-    {
-        debug_assert!(!unknown.column.is_empty());
-        return Ok(ApplyOutcome::Unprojectable(PendingReason::UnknownColumn));
-    }
+    // Resolve the payload into the full after-image THIS registry expects, decided on the PAYLOAD
+    // ALONE — before any row state is read, so the decision is deterministic and idempotent.
+    let known = match project_cells(spec, op_spec_version, cells) {
+        Projection::Complete(cells) => cells,
+        Projection::Park(reason) => return Ok(ApplyOutcome::Unprojectable(reason)),
+        Projection::Quarantine(why) => return Ok(ApplyOutcome::Quarantined(why)),
+    };
 
     let row_pk = &row_op::row_pk_string(pk_vals);
     let device_hex = &meta.device.to_string();
@@ -175,40 +287,7 @@ fn apply_upsert(
     if let Some((t_lamport, t_device)) = current_tombstone(tx, repo_id, spec.name, row_pk)?
         && !beats(meta.lamport, device_hex, t_lamport, &t_device)
     {
-        return Ok(ApplyOutcome::Applied);
-    }
-
-    // Type-check each cell. Every cell's column is known here — an unknown one parked the whole op
-    // above, before any row state was touched. A type mismatch quarantines the op before any write.
-    let mut known: Vec<(&str, &TypedValue)> = Vec::new();
-    for cell in cells {
-        let Some(column) = spec.columns.iter().find(|c| c.name == cell.column) else {
-            debug_assert!(false, "an unknown column parks the op before any cell is classified");
-            return Ok(ApplyOutcome::Unprojectable(PendingReason::UnknownColumn));
-        };
-        if !value_matches(&cell.value, column.value_type) {
-            return Ok(ApplyOutcome::Quarantined(format!(
-                "cell `{}` value does not match declared type on `{}`",
-                cell.column, spec.name
-            )));
-        }
-        known.push((column.name, &cell.value));
-    }
-
-    // Whole-row LWW requires a full after-image: a winning op replaces the ENTIRE row, so an op
-    // missing a synced column would leave that column at a stale value under the winning clock —
-    // two peers with different prior values there would diverge. The producer always emits every
-    // synced column (`read_all_rows`), so a partial op is malformed or a version-skew op that
-    // cannot cleanly replace this binary's row; quarantine it rather than half-apply. (Decode
-    // rejects duplicate columns and an unknown column parks the op, so `known` holds distinct
-    // synced columns — a full count means all are present.)
-    // PARK, not quarantine: the overwhelmingly likely cause is an OLDER producer whose complete row
-    // under its narrower spec is a partial one under ours — a version gap, redeemed from the
-    // sender's side by #1002's declared column defaults, not a broken producer whose data can never
-    // fit. Quarantining would drop it off the refold's worklist permanently; parking keeps it
-    // outstanding so the binary that can rebuild the missing cells lands it.
-    if known.len() != spec.columns.len() {
-        return Ok(ApplyOutcome::Unprojectable(PendingReason::PartialAfterImage));
+        return Ok(ApplyOutcome::Superseded);
     }
 
     // Whole-row LWW: the op wins the ENTIRE row iff it beats the row's write clock (or the row is
@@ -219,7 +298,7 @@ fn apply_upsert(
         None => true, // no prior write — this op establishes the row.
     };
     if !wins {
-        return Ok(ApplyOutcome::Applied);
+        return Ok(ApplyOutcome::Superseded);
     }
 
     // The winner replaces the whole row in ONE statement (so a constraint failure can't leave a
@@ -246,7 +325,7 @@ fn apply_upsert(
     // Anti-echo: the winning op now owns the whole current row state, so record its synced hash.
     // (A losing op returned above without touching the published hash.)
     if let Some(hash) = synced_row_hash(tx, spec, pk_vals)? {
-        record_published(tx, repo_id, spec.name, row_pk, &hash)?;
+        record_published(tx, repo_id, spec.name, row_pk, &hash, spec.spec_version)?;
     }
     Ok(ApplyOutcome::Applied)
 }
@@ -440,7 +519,7 @@ fn insert_row(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     pk_vals: &[TypedValue],
-    winning: &[(&str, &TypedValue)],
+    winning: &[(&'static str, TypedValue)],
 ) -> anyhow::Result<()> {
     let mut columns: Vec<String> = spec.pk.iter().map(|c| quote_ident(c.name)).collect();
     let mut values: Vec<SqlValue> = pk_vals.iter().map(sql_value).collect();
@@ -463,7 +542,7 @@ fn insert_row(
 fn update_row(
     tx: &Transaction<'_>,
     spec: &TableSpec,
-    cells: &[(&str, &TypedValue)],
+    cells: &[(&'static str, TypedValue)],
     pk_vals: &[TypedValue],
 ) -> anyhow::Result<()> {
     let assignments = cells
@@ -527,15 +606,91 @@ pub(crate) fn published_hash(
     repo_id: &str,
     table: &str,
     row_pk: &str,
-) -> anyhow::Result<Option<(String, i64)>> {
-    Ok(tx
+) -> anyhow::Result<Option<(String, u32)>> {
+    let row = tx
         .query_row(
-            "SELECT synced_hash, projector_version FROM sync_published_rows
+            "SELECT synced_hash, spec_version FROM sync_published_rows
              WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
             rusqlite::params![repo_id, table, row_pk],
             |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
         )
-        .optional()?)
+        .optional()?;
+    row.map(|(hash, version)| Ok((hash, u32::try_from(version)?))).transpose()
+}
+
+/// How a row whose published record predates the current spec version compares against the op that
+/// actually established it.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum StaleRow {
+    /// The row still matches its winning op, projected under the current spec — untouched since it
+    /// landed, so its bookkeeping can simply be restamped.
+    Unchanged,
+    /// The row differs from its winning op: a local change nothing has authored yet.
+    LocallyChanged,
+    /// Nothing can be concluded — the winning entry is gone, or does not project here.
+    Unknown,
+}
+
+/// Compare a stale-version row against its own winning op, projected under the CURRENT spec.
+///
+/// This is what lets a column-set change resolve instead of freezing. The published hash and the
+/// current hash cover different cell lists, so comparing them proves nothing — but the row's
+/// WINNING ENTRY is the exact op that produced the row, and projecting it under today's registry
+/// (filling columns it predates from their declared defaults) yields what the row SHOULD look like
+/// now. Equal means untouched; different means a genuine local change.
+///
+/// Deliberately a comparison and NOT a re-apply: re-applying the winner through the LWW gates
+/// writes nothing (its clock equals the row's by definition, so it never beats it), and bypassing
+/// those gates to force it would overwrite exactly the local changes this exists to detect.
+pub(crate) fn stale_row_disposition(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    stream: StreamId,
+    pk_vals: &[TypedValue],
+    current: &[Cell],
+) -> anyhow::Result<StaleRow> {
+    let row_pk = row_op::row_pk_string(pk_vals);
+    let Some((lamport, device_hex)) = current_row_clock(tx, repo_id, spec.name, &row_pk)? else {
+        return Ok(StaleRow::Unknown);
+    };
+    let Some(op) = super::store::winning_entry_op(tx, stream, &device_hex, lamport)? else {
+        // The entry is gone. Nothing prunes today; when retention lands it must refresh a row
+        // before dropping that row's winner, or this arm becomes a permanent stale state.
+        return Ok(StaleRow::Unknown);
+    };
+    // The entry is located by `(stream, device, lamport)`, which identifies it uniquely WITHIN a
+    // stream — so the hit is this row's op only while the row's clock and the stream being queried
+    // belong to the same stream. That holds today, but it is not an enforced property: a table's
+    // stream is derived from `(repo_id, account_id, scope_id)`, and moving a registered table to a
+    // different scope is an ordinary registry edit. The row's clock would then carry a lamport
+    // allocated on the OLD stream, and the same `(device, lamport)` on the new one belongs to some
+    // SIBLING table's op. Verify the identity rather than trusting the derivation: a mismatch must
+    // read as "cannot resolve" (and be handled conservatively), never as a verdict about this row.
+    // Without this, two tables with coincidentally similar columns can project `Complete` and
+    // return `Unchanged` for a row that actually holds an unsent edit — which lets the refold
+    // replay straight over it.
+    if op.table() != spec.name || op.pk() != pk_vals {
+        return Ok(StaleRow::Unknown);
+    }
+    // A winning REMOVE clears the row clock, so a live clock can only ever point at an upsert.
+    let RowOp::Upsert { spec_version, cells, .. } = &op else {
+        return Ok(StaleRow::Unknown);
+    };
+    match project_cells(spec, *spec_version, cells) {
+        Projection::Complete(projected) => {
+            let as_cells: Vec<Cell> = projected
+                .into_iter()
+                .map(|(column, value)| Cell { column: column.to_string(), value })
+                .collect();
+            Ok(if row_op::cells_hash(&as_cells) == row_op::cells_hash(current) {
+                StaleRow::Unchanged
+            } else {
+                StaleRow::LocallyChanged
+            })
+        },
+        Projection::Park(_) | Projection::Quarantine(_) => Ok(StaleRow::Unknown),
+    }
 }
 
 /// Whether this row holds a local change that has not been authored yet, so a caller replaying an
@@ -558,6 +713,7 @@ pub(crate) fn row_has_unsent_local_change(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     repo_id: &str,
+    stream: StreamId,
     pk_vals: &[TypedValue],
 ) -> anyhow::Result<bool> {
     // A malformed key never reached `apply_row_op`'s arity check (an entry parked as out-of-scope
@@ -569,18 +725,26 @@ pub(crate) fn row_has_unsent_local_change(
         return Ok(false);
     }
     let row_pk = row_op::row_pk_string(pk_vals);
-    let Some(current) = synced_row_hash(tx, spec, pk_vals)? else {
+    let Some(current_cells) = read_synced_cells(tx, spec, pk_vals)? else {
         // No row — but a surviving published identity means the row was DELETED locally and not yet
         // authored. That is precisely what the producer's `Remove` branch keys on, so replaying an
         // upsert here would recreate the row and discard the unsent deletion for good.
         return Ok(published_hash(tx, repo_id, spec.name, &row_pk)?.is_some());
     };
+    let current = row_op::cells_hash(&current_cells);
     Ok(match published_hash(tx, repo_id, spec.name, &row_pk)? {
         // Comparable: a differing hash is a demonstrably unsent local change.
-        Some((published, version)) if version == super::refold::TABLE_SYNC_PROJECTOR_VERSION =>
-            published != current,
-        // Published under a different column set — not comparable, so nothing is proven either way.
-        Some(_) => false,
+        Some((published, version)) if version == spec.spec_version => published != current,
+        // Published under a different column set, so the hashes cannot be compared — but the row's
+        // WINNING op can be, projected under this spec. This proof path is required, not an
+        // optimization: once an older-spec op can be filled from declared defaults (#1002) a parked
+        // entry can WIN over an unsent raw edit here, where before it could not apply at all.
+        // Unprovable stays conservative: refuse to replay rather than risk overwriting.
+        Some(_) => match stale_row_disposition(tx, spec, repo_id, stream, pk_vals, &current_cells)?
+        {
+            StaleRow::LocallyChanged | StaleRow::Unknown => true,
+            StaleRow::Unchanged => false,
+        },
         // A live row no apply ever published is purely local: the only content there came from this
         // device, and no peer has seen it.
         None => true,
@@ -588,28 +752,23 @@ pub(crate) fn row_has_unsent_local_change(
 }
 
 /// Claim `row_pk` as a COMPLETE projection: `hash` covers every synced column this binary knows,
-/// stamped with the projector version that defines that column set.
+/// stamped with the TABLE's spec version, which is what defines that column set. Deliberately not
+/// the store-global projector version — that would make an unrelated table's registration mark this
+/// row incomparable.
 pub(crate) fn record_published(
     tx: &Transaction<'_>,
     repo_id: &str,
     table: &str,
     row_pk: &str,
     hash: &str,
+    spec_version: u32,
 ) -> anyhow::Result<()> {
     tx.execute(
-        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash,
-                                         projector_version)
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, spec_version)
          VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(repo_id, table_name, row_pk) DO UPDATE
-             SET synced_hash = excluded.synced_hash,
-                 projector_version = excluded.projector_version",
-        rusqlite::params![
-            repo_id,
-            table,
-            row_pk,
-            hash,
-            super::refold::TABLE_SYNC_PROJECTOR_VERSION
-        ],
+             SET synced_hash = excluded.synced_hash, spec_version = excluded.spec_version",
+        rusqlite::params![repo_id, table, row_pk, hash, spec_version],
     )?;
     Ok(())
 }
@@ -701,8 +860,9 @@ mod tests {
     const SPEC: TableSpec = TableSpec {
         name: "t_demo",
         scope_id: "demo/1",
-        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
         local_columns: &["resolved_rowid"],
         repo_column: None,
     };
@@ -723,6 +883,7 @@ mod tests {
 
     fn upsert(cells: &[(&str, TypedValue)]) -> RowOp {
         RowOp::Upsert {
+            spec_version: 1,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Text("r1".to_string())],
             cells: cells
@@ -767,11 +928,12 @@ mod tests {
         const TWO_COL: TableSpec = TableSpec {
             name: "t_two",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
-                name: "count",
-                value_type: ValueType::I64,
-            }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+            ],
             local_columns: &[],
             repo_column: None,
         };
@@ -782,6 +944,7 @@ mod tests {
         )
         .unwrap();
         let full = |title: &str, count: i64| RowOp::Upsert {
+            spec_version: 1,
             table: "t_two".to_string(),
             pk: vec![TypedValue::Text("r1".into())],
             cells: vec![
@@ -797,11 +960,12 @@ mod tests {
         })
         .unwrap();
         // ...a lower-lamport op editing a different column loses the WHOLE row, not just `title`.
-        apply_row_op(&tx, &TWO_COL, "repo", &full("B", 2), OpMeta {
+        let out = apply_row_op(&tx, &TWO_COL, "repo", &full("B", 2), OpMeta {
             lamport: 5,
             device: device(1),
         })
         .unwrap();
+        assert_eq!(out, ApplyOutcome::Superseded, "outranked by the row's write clock");
         tx.commit().unwrap();
         let row: (String, i64) = c
             .query_row("SELECT title, count FROM t_two WHERE id = 'r1'", [], |r| {
@@ -906,11 +1070,12 @@ mod tests {
         const TWO_COL: TableSpec = TableSpec {
             name: "t_two",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
-                name: "count",
-                value_type: ValueType::I64,
-            }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+            ],
             local_columns: &[],
             repo_column: None,
         };
@@ -922,6 +1087,7 @@ mod tests {
         .unwrap();
         let tx = c.transaction().unwrap();
         let partial = RowOp::Upsert {
+            spec_version: 1,
             table: "t_two".to_string(),
             pk: vec![TypedValue::Text("r1".into())],
             cells: vec![Cell {
@@ -942,6 +1108,159 @@ mod tests {
         );
         let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_two", [], |r| r.get(0)).unwrap();
         assert_eq!(count, 0, "nothing was written");
+    }
+
+    #[test]
+    fn a_newer_op_parks_on_its_version_alone_even_carrying_only_known_columns() {
+        // The version gate must do work the unknown-column gate does not. Every "newer" fixture
+        // elsewhere ALSO names a column the receiver lacks, so deleting the version check entirely
+        // only changed a reason string — the op parked either way. Here the op is well within this
+        // registry's vocabulary and is refused purely for claiming a later generation, which is the
+        // whole point: a later spec may mean something by these same columns that we cannot know.
+        assert_eq!(
+            project_cells(&SPEC, SPEC.spec_version + 1, &[Cell {
+                column: "title".into(),
+                value: TypedValue::Text("known".into()),
+            }]),
+            Projection::Park(PendingReason::NewerSpecVersion),
+            "a newer generation parks on the version alone"
+        );
+        // And the converse, so the gate cannot simply park everything.
+        assert!(matches!(
+            project_cells(&SPEC, SPEC.spec_version, &[Cell {
+                column: "title".into(),
+                value: TypedValue::Text("known".into()),
+            }]),
+            Projection::Complete(_)
+        ));
+    }
+
+    #[test]
+    fn a_cell_newer_than_the_ops_own_claimed_version_is_a_misstamp() {
+        // Self-contradictory: a producer at v1 cannot have known a column introduced at v2. Left
+        // unchecked, the understated version would default-fill every column it claims to predate,
+        // resetting them on every receiver — so this is the one half of the advisory stamp a
+        // receiver can verify against its own registry.
+        const WIDE: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("d")),
+            ],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let cells = |version: u32| {
+            project_cells(&WIDE, version, &[
+                Cell { column: "later".into(), value: TypedValue::Text("v".into()) },
+                Cell { column: "title".into(), value: TypedValue::Text("t".into()) },
+            ])
+        };
+        assert_eq!(
+            cells(1),
+            Projection::Park(PendingReason::MisstampedSpecVersion),
+            "claiming v1 while carrying a v2 column is a mis-stamp, not an old complete row"
+        );
+        assert!(matches!(cells(2), Projection::Complete(_)), "the honest stamp projects");
+    }
+
+    #[test]
+    fn every_default_variant_fills_its_own_typed_value() {
+        // One case per `DefaultValue` variant. Without this, only `Text` and `Null` were exercised,
+        // and collapsing `Bool`/`I64`/`Blob` to `TypedValue::Null` passed the whole suite — which
+        // on a NOT NULL column quarantines the op terminally, and on a nullable one
+        // diverges from the migration's backfill at the same clock.
+        const TYPED: TableSpec = TableSpec {
+            name: "t_typed",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::added("flag", ValueType::Bool, 2, DefaultValue::Bool(true)),
+                ColumnSpec::added("count", ValueType::I64, 2, DefaultValue::I64(7)),
+                ColumnSpec::added("note", ValueType::Text, 2, DefaultValue::Text("d")),
+                ColumnSpec::added("raw", ValueType::Blob, 2, DefaultValue::Blob(&[1, 2])),
+                ColumnSpec::added("empty", ValueType::Text, 2, DefaultValue::Null),
+            ],
+            local_columns: &[],
+            repo_column: None,
+        };
+        assert_eq!(
+            project_cells(&TYPED, 1, &[]),
+            Projection::Complete(vec![
+                ("flag", TypedValue::Bool(true)),
+                ("count", TypedValue::I64(7)),
+                ("note", TypedValue::Text("d".into())),
+                ("raw", TypedValue::Blob(vec![1, 2])),
+                ("empty", TypedValue::Null),
+            ]),
+            "each declared default fills as its own typed value, not as NULL"
+        );
+    }
+
+    #[test]
+    fn the_default_fill_window_is_per_column_not_merely_older_than_the_spec() {
+        // Once a table reaches a THIRD version, "older than the current spec" stops being a safe
+        // test for "predates this column". A v2 op that omits a column v2 already had is a broken
+        // partial, and must park — filling it would reset that column to its default for EVERY
+        // receiver under whole-row LWW, silently and with no local edit to signal it. Only an op
+        // older than the column's OWN introducing version may be filled.
+        const THREE: TableSpec = TableSpec {
+            name: "t_three",
+            scope_id: "demo/1",
+            spec_version: 3,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("v2-default")),
+                ColumnSpec::added("latest", ValueType::Text, 3, DefaultValue::Text("v3-default")),
+            ],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let project = |version: u32, cells: &[(&str, &str)]| {
+            let cells: Vec<Cell> = cells
+                .iter()
+                .map(|(c, v)| Cell {
+                    column: (*c).to_string(),
+                    value: TypedValue::Text((*v).to_string()),
+                })
+                .collect();
+            project_cells(&THREE, version, &cells)
+        };
+
+        // v1 predates BOTH added columns — each is filled from its own declared default.
+        assert_eq!(
+            project(1, &[("title", "t")]),
+            Projection::Complete(vec![
+                ("title", TypedValue::Text("t".into())),
+                ("later", TypedValue::Text("v2-default".into())),
+                ("latest", TypedValue::Text("v3-default".into())),
+            ]),
+            "an op older than both columns is completed from both defaults"
+        );
+
+        // v2 predates only `latest`; `later` existed in v2, so a v2 op carrying it is complete.
+        assert_eq!(
+            project(2, &[("title", "t"), ("later", "sent")]),
+            Projection::Complete(vec![
+                ("title", TypedValue::Text("t".into())),
+                ("later", TypedValue::Text("sent".into())),
+                ("latest", TypedValue::Text("v3-default".into())),
+            ]),
+            "only the column the op's own version predates is filled"
+        );
+
+        // THE REGRESSION: a v2 op omitting `later` is a broken partial, not an old complete row.
+        assert_eq!(
+            project(2, &[("title", "t")]),
+            Projection::Park(PendingReason::PartialAfterImage),
+            "a column the op's own version already had must never be defaulted — the op is a \
+             partial and parks"
+        );
     }
 
     #[test]
@@ -1036,7 +1355,7 @@ mod tests {
         .unwrap();
         let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
         let (_, version) = published_hash(&tx, "repo", "t_demo", &row_pk).unwrap().unwrap();
-        assert_eq!(version, super::super::refold::TABLE_SYNC_PROJECTOR_VERSION);
+        assert_eq!(version, SPEC.spec_version);
     }
 
     #[test]
@@ -1055,7 +1374,11 @@ mod tests {
             &tx,
             &SPEC,
             "repo",
-            &RowOp::Remove { table: "t_demo".into(), pk: vec![TypedValue::Text("r1".into())] },
+            &RowOp::Remove {
+                spec_version: 1,
+                table: "t_demo".into(),
+                pk: vec![TypedValue::Text("r1".into())],
+            },
             OpMeta { lamport: 2, device: device(2) },
         )
         .unwrap();
@@ -1067,7 +1390,11 @@ mod tests {
     }
 
     fn remove() -> RowOp {
-        RowOp::Remove { table: "t_demo".to_string(), pk: vec![TypedValue::Text("r1".to_string())] }
+        RowOp::Remove {
+            spec_version: 1,
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text("r1".to_string())],
+        }
     }
 
     #[test]
@@ -1083,8 +1410,15 @@ mod tests {
         )
         .unwrap();
         // A delete older than the row's cell clock loses — the row survives.
-        apply_row_op(&tx, &SPEC, "repo", &remove(), OpMeta { lamport: 3, device: device(2) })
-            .unwrap();
+        let out =
+            apply_row_op(&tx, &SPEC, "repo", &remove(), OpMeta { lamport: 3, device: device(2) })
+                .unwrap();
+        assert_eq!(
+            out,
+            ApplyOutcome::Superseded,
+            "the delete landed but did not delete: reported distinctly from a delete that took \
+             effect, because a locally-authored op can never legitimately land here"
+        );
         tx.commit().unwrap();
         assert_eq!(title(&c).as_deref(), Some("keep"), "a stale delete cannot remove a newer row");
     }
@@ -1096,7 +1430,7 @@ mod tests {
         apply_row_op(&tx, &SPEC, "repo", &remove(), OpMeta { lamport: 5, device: device(2) })
             .unwrap();
         // An insert older than the tombstone is suppressed.
-        apply_row_op(
+        let out = apply_row_op(
             &tx,
             &SPEC,
             "repo",
@@ -1104,6 +1438,7 @@ mod tests {
             OpMeta { lamport: 3, device: device(2) },
         )
         .unwrap();
+        assert_eq!(out, ApplyOutcome::Superseded, "suppressed by the tombstone, not applied");
         tx.commit().unwrap();
         assert_eq!(title(&c), None, "an insert older than the delete cannot resurrect the row");
     }
@@ -1199,8 +1534,9 @@ mod tests {
         const HASHED: TableSpec = TableSpec {
             name: "t_io",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "hash", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("hash", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -1209,12 +1545,16 @@ mod tests {
         c.execute_batch("CREATE TABLE t_io(id TEXT PRIMARY KEY, hash TEXT) STRICT;").unwrap();
         let tx = c.transaction().unwrap();
         let io_upsert = RowOp::Upsert {
+            spec_version: 1,
             table: "t_io".to_string(),
             pk: vec![TypedValue::Text("r".into())],
             cells: vec![Cell { column: "hash".into(), value: TypedValue::Text("h".into()) }],
         };
-        let io_remove =
-            RowOp::Remove { table: "t_io".to_string(), pk: vec![TypedValue::Text("r".into())] };
+        let io_remove = RowOp::Remove {
+            spec_version: 1,
+            table: "t_io".to_string(),
+            pk: vec![TypedValue::Text("r".into())],
+        };
 
         apply_row_op(&tx, &HASHED, "repo", &io_upsert, OpMeta { lamport: 5, device: device(2) })
             .unwrap();
@@ -1237,11 +1577,12 @@ mod tests {
         const SCOPED: TableSpec = TableSpec {
             name: "t_scoped",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
-                name: "id",
-                value_type: ValueType::Text,
-            }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[
+                ColumnSpec::required("repo_id", ValueType::Text),
+                ColumnSpec::required("id", ValueType::Text),
+            ],
+            columns: &[ColumnSpec::required("title", ValueType::Text)],
             local_columns: &[],
             repo_column: Some("repo_id"),
         };
@@ -1255,6 +1596,7 @@ mod tests {
         .unwrap();
         let tx = c.transaction().unwrap();
         let foreign = RowOp::Upsert {
+            spec_version: 1,
             table: "t_scoped".to_string(),
             pk: vec![TypedValue::Text("B".into()), TypedValue::Text("r1".into())],
             cells: vec![Cell { column: "title".into(), value: TypedValue::Text("x".into()) }],
@@ -1268,6 +1610,7 @@ mod tests {
         assert_eq!(count, 0, "no cross-repo row was written");
         // The matching-repo op applies.
         let own = RowOp::Upsert {
+            spec_version: 1,
             table: "t_scoped".to_string(),
             pk: vec![TypedValue::Text("A".into()), TypedValue::Text("r1".into())],
             cells: vec![Cell { column: "title".into(), value: TypedValue::Text("x".into()) }],
@@ -1284,6 +1627,7 @@ mod tests {
         let mut c = conn();
         let tx = c.transaction().unwrap();
         let op = RowOp::Upsert {
+            spec_version: 1,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Null],
             cells: vec![Cell { column: "title".to_string(), value: TypedValue::Text("x".into()) }],
@@ -1303,6 +1647,7 @@ mod tests {
         let mut c = conn();
         let tx = c.transaction().unwrap();
         let op = RowOp::Upsert {
+            spec_version: 1,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::I64(1)],
             cells: vec![Cell { column: "title".to_string(), value: TypedValue::Text("x".into()) }],
@@ -1325,8 +1670,9 @@ mod tests {
         const NOT_NULL: TableSpec = TableSpec {
             name: "t_nn",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("title", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -1338,6 +1684,7 @@ mod tests {
         // A well-typed NULL cell (Text column, Null value) passes the type check but violates the
         // table's NOT NULL constraint on insert.
         let op = RowOp::Upsert {
+            spec_version: 1,
             table: "t_nn".to_string(),
             pk: vec![TypedValue::Text("r".into())],
             cells: vec![Cell { column: "title".to_string(), value: TypedValue::Null }],
@@ -1360,8 +1707,9 @@ mod tests {
         const FLAG: TableSpec = TableSpec {
             name: "t_flag",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "active", value_type: ValueType::Bool }],
-            columns: &[ColumnSpec { name: "label", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("active", ValueType::Bool)],
+            columns: &[ColumnSpec::required("label", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -1381,6 +1729,7 @@ mod tests {
 
         // The op the producer would sign applies cleanly on a peer (the typed-pk check passes).
         let op = RowOp::Upsert {
+            spec_version: 1,
             table: "t_flag".to_string(),
             pk: rows[0].0.clone(),
             cells: rows[0].1.clone(),
@@ -1406,8 +1755,9 @@ mod tests {
         const FLAGGED: TableSpec = TableSpec {
             name: "t_flagged",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "flag", value_type: ValueType::Bool }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("flag", ValueType::Bool)],
             local_columns: &[],
             repo_column: None,
         };
@@ -1430,8 +1780,9 @@ mod tests {
         const PARENT: TableSpec = TableSpec {
             name: "parent",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -1447,8 +1798,11 @@ mod tests {
         )
         .unwrap();
         let tx = c.transaction().unwrap();
-        let op =
-            RowOp::Remove { table: "parent".to_string(), pk: vec![TypedValue::Text("r".into())] };
+        let op = RowOp::Remove {
+            spec_version: 1,
+            table: "parent".to_string(),
+            pk: vec![TypedValue::Text("r".into())],
+        };
         let out = apply_row_op(&tx, &PARENT, "repo", &op, OpMeta { lamport: 1, device: device(2) })
             .unwrap();
         assert!(

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -66,7 +66,7 @@ pub(crate) fn produce_and_author(
         // (repo_id, account_id, scope_id) one-way, so without the directory a retained entry could
         // never be replayed by a later binary (see [`super::refold`]).
         store::record_stream_context(tx, stream, ctx.repo_id, ctx.account_id, spec.scope_id)?;
-        for op in produce::produce_row_ops(tx, spec, ctx.repo_id)? {
+        for op in produce::produce_row_ops(tx, spec, ctx.repo_id, stream)? {
             let signed = store::author_row_entry(tx, stream, ctx.device.secret(), &op, ctx.now_ms)?;
             let meta =
                 OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
@@ -80,6 +80,33 @@ pub(crate) fn produce_and_author(
             // copy: surface it and do NOT transmit the junk op.
             match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
                 apply::ApplyOutcome::Applied => authored.push(signed.signed_bytes),
+                // A locally-authored op CANNOT lose its own self-apply while the row's bookkeeping
+                // belongs to this stream: the entry took `MAX(lamport) + 1` over the whole stream,
+                // so it outranks every clock any op on it could have set. Losing therefore proves
+                // the row's clock came from a DIFFERENT stream — the shape a changed scope or
+                // account leaves behind, where `sync_row_clocks` (keyed only by
+                // `(repo_id, table_name, row_pk)`) survives a move its lamports have no meaning
+                // after.
+                //
+                // FAIL rather than accept it. A superseded self-apply writes no published record,
+                // so the next pass re-derives the identical delta and signs it again — growing the
+                // log without bound and broadcasting entries every peer will also discard, until
+                // the new stream's lamport happens to climb past the stale clock. Bailing rolls
+                // back the entry `author_row_entry` just inserted, exactly as the quarantine arm
+                // below does, and leaves an attributable error instead of silent churn.
+                // No `debug_assert` here, unlike the arm below: that one is provably unreachable
+                // (the lint rejects every shape that quarantines), so asserting is a dev-time
+                // tripwire for a lint gap. This one is REACHABLE whenever a row's bookkeeping and
+                // its stream come apart, which is precisely the condition worth reporting — a
+                // panic would replace a diagnosable error with a crash.
+                apply::ApplyOutcome::Superseded => {
+                    anyhow::bail!(
+                        "table-sync: a locally-produced op lost its own self-apply on `{}` — the \
+                         row's write clock carries a lamport from another stream, so authoring \
+                         cannot settle it",
+                        spec.name
+                    );
+                },
                 // A locally-produced op failing to self-apply is UNREACHABLE for a registered
                 // table: the lint rejects every shape that would quarantine (nullable pk, cross-row
                 // constraint, ValueType/physical-type mismatch), the producer reads well-typed
@@ -148,7 +175,9 @@ pub(crate) fn ingest(
                     return Ok(IngestOutcome::Parked("table not in scope"));
                 };
                 match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
-                    ApplyOutcome::Applied => IngestOutcome::Applied,
+                    // A received op that lost on the merits still landed: the entry is
+                    // stored, nothing is outstanding, and redelivery stays idempotent.
+                    ApplyOutcome::Applied | ApplyOutcome::Superseded => IngestOutcome::Applied,
                     // Durably recorded as well as returned: the caller sees this one, but nothing
                     // later could tell a rejected payload from a projected one without the mark.
                     ApplyOutcome::Quarantined(why) => {
@@ -186,8 +215,9 @@ mod tests {
     const SPEC: TableSpec = TableSpec {
         name: "t_demo",
         scope_id: "demo/1",
-        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
         local_columns: &[],
         repo_column: None,
     };
@@ -326,16 +356,18 @@ mod tests {
         const TA: TableSpec = TableSpec {
             name: "t_a",
             scope_id: "multi/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
         const TB: TableSpec = TableSpec {
             name: "t_b",
             scope_id: "multi/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -15,6 +15,7 @@ mod produce;
 mod refold;
 mod registry;
 mod row_op;
+mod schema_facts;
 mod scope_stream;
 mod store;
 

--- a/crates/rag-rat-oplog/src/table_sync/produce.rs
+++ b/crates/rag-rat-oplog/src/table_sync/produce.rs
@@ -12,16 +12,24 @@ use std::collections::BTreeSet;
 
 use rusqlite::{Transaction, params};
 
+use super::apply;
 use super::registry::TableSpec;
 use super::row_op::{self, RowOp};
-use super::{apply, refold};
+use crate::stream::StreamId;
 
 /// The row ops that carry this device's current state of `spec`'s table for `repo_id` to peers.
 /// Empty when everything is already published (the steady state).
+///
+/// NOT READ-ONLY, despite reading like a query: settling a stale-version row that turns out to be
+/// unchanged rewrites its `sync_published_rows` record in place (#1002). An empty return therefore
+/// does NOT mean "nothing to commit" — a caller that skips the commit on `Ok(vec![])` merely
+/// discards the restamps and repeats the winner lookups next pass, and a read-only transaction
+/// would fail here outright.
 pub(crate) fn produce_row_ops(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     repo_id: &str,
+    stream: StreamId,
 ) -> anyhow::Result<Vec<RowOp>> {
     let mut ops = Vec::new();
     let mut live: BTreeSet<String> = BTreeSet::new();
@@ -32,21 +40,56 @@ pub(crate) fn produce_row_ops(
         let hash = row_op::cells_hash(&cells);
         let changed = match apply::published_hash(tx, repo_id, spec.name, &row_pk)? {
             // Published under THIS binary's column set: a differing hash is a real local change.
-            Some((published, version)) if version == refold::TABLE_SYNC_PROJECTOR_VERSION =>
-                published != hash,
-            // Published under a DIFFERENT column set. The two hashes cover different cell lists, so
-            // they differ structurally whether or not the row actually changed — the comparison
-            // says nothing. Reading that as a local delta would re-author EVERY row of the table at
-            // a fresh winning lamport on EVERY upgrading device (log growth O(rows x devices),
-            // lamport inflation, and every device claiming authorship of rows it merely received).
-            // So: not comparable, nothing claimed. #1002's per-op spec version replaces this
-            // conservatism by rebuilding a complete after-image from declared column defaults.
-            Some(_) => false,
+            Some((published, version)) if version == spec.spec_version => published != hash,
+            // Published under a DIFFERENT column set: the two hashes cover different cell lists, so
+            // comparing them says nothing (they differ structurally whether or not the row
+            // changed). Resolve it against the op that actually established the row,
+            // projected under this spec — the only thing that CAN settle it.
+            //
+            // Reading the raw mismatch as a delta instead would re-author EVERY row of the table at
+            // a fresh winning lamport on EVERY upgrading device; ignoring it entirely (the #1001
+            // conservatism this replaces) left the row permanently un-authorable, even when
+            // genuinely edited.
+            Some(_) =>
+                match apply::stale_row_disposition(tx, spec, repo_id, stream, &pk, &cells)? {
+                    // Untouched since it landed: nothing to say, just restamp the bookkeeping so
+                    // the row is comparable again from here on.
+                    apply::StaleRow::Unchanged => {
+                        apply::record_published(
+                            tx,
+                            repo_id,
+                            spec.name,
+                            &row_pk,
+                            &hash,
+                            spec.spec_version,
+                        )?;
+                        false
+                    },
+                    // A proven local change — author it. This is the exit from the frozen state.
+                    apply::StaleRow::LocallyChanged => true,
+                    // Unprovable (the winning entry is gone, does not project here, or is not this
+                    // row's op). AUTHOR IT — the two readers of this verdict must not both defer.
+                    // `row_has_unsent_local_change` reads `Unknown` as "there may be an unsent
+                    // edit, so refuse to replay over it"; if the producer also
+                    // declined, the row would be permanently unauthorable AND
+                    // would permanently block its own pending entries, silently
+                    // losing a genuine local edit with no way out and nothing to report it.
+                    // Authoring is the safe direction: at worst it re-emits a row that was already
+                    // correct (bounded churn, and the restamp makes the next pass cheap), and at
+                    // best it publishes an edit that would otherwise have been lost. Not authoring
+                    // has no such floor.
+                    apply::StaleRow::Unknown => true,
+                },
             // Never published: a genuinely new local row.
             None => true,
         };
         if changed {
-            ops.push(RowOp::Upsert { table: spec.name.to_string(), pk, cells });
+            ops.push(RowOp::Upsert {
+                table: spec.name.to_string(),
+                spec_version: spec.spec_version,
+                pk,
+                cells,
+            });
         }
     }
 
@@ -58,6 +101,7 @@ pub(crate) fn produce_row_ops(
         if !live.contains(&row_pk) {
             ops.push(RowOp::Remove {
                 table: spec.name.to_string(),
+                spec_version: spec.spec_version,
                 pk: row_op::row_pk_values(&row_pk)?,
             });
         }
@@ -89,11 +133,21 @@ mod tests {
     const SPEC: TableSpec = TableSpec {
         name: "t_demo",
         scope_id: "demo/1",
-        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
         local_columns: &["resolved_rowid"],
         repo_column: None,
     };
+
+    /// Any stable stream id: these tests never reach the winner lookup (no row is ever stale).
+    fn test_stream() -> crate::stream::StreamId {
+        crate::table_sync::scope_stream::scope_stream_id(
+            "repo",
+            crate::AccountId::from_bytes([7; 32]),
+            "demo/1",
+        )
+    }
 
     fn conn() -> rusqlite::Connection {
         let c = rusqlite::Connection::open_in_memory().unwrap();
@@ -107,6 +161,7 @@ mod tests {
 
     fn upsert(id: &str, title: &str) -> RowOp {
         RowOp::Upsert {
+            spec_version: 1,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Text(id.to_string())],
             cells: vec![Cell {
@@ -122,7 +177,7 @@ mod tests {
         let tx = c.transaction().unwrap();
         // A row written WITHOUT going through the published-hash record (a raw local insert).
         tx.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'hi')", []).unwrap();
-        let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
+        let ops = produce_row_ops(&tx, &SPEC, "repo", test_stream()).unwrap();
         assert_eq!(ops.len(), 1, "an unpublished local row is produced");
         assert!(matches!(&ops[0], RowOp::Upsert { .. }));
 
@@ -133,7 +188,7 @@ mod tests {
         })
         .unwrap();
         assert!(
-            produce_row_ops(&tx, &SPEC, "repo").unwrap().is_empty(),
+            produce_row_ops(&tx, &SPEC, "repo", test_stream()).unwrap().is_empty(),
             "a published row is not re-produced"
         );
     }
@@ -150,7 +205,7 @@ mod tests {
         })
         .unwrap();
         assert!(
-            produce_row_ops(&tx, &SPEC, "repo").unwrap().is_empty(),
+            produce_row_ops(&tx, &SPEC, "repo", test_stream()).unwrap().is_empty(),
             "a row received from a peer must not be re-signed and rebroadcast",
         );
     }
@@ -166,7 +221,7 @@ mod tests {
         .unwrap();
         // A raw local edit (not through apply) leaves the published hash stale.
         tx.execute("UPDATE t_demo SET title = 'v2' WHERE id = 'r1'", []).unwrap();
-        let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
+        let ops = produce_row_ops(&tx, &SPEC, "repo", test_stream()).unwrap();
         assert_eq!(ops.len(), 1, "a changed row is produced again");
     }
 
@@ -175,11 +230,12 @@ mod tests {
         const SCOPED: TableSpec = TableSpec {
             name: "t_scoped",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
-                name: "id",
-                value_type: ValueType::Text,
-            }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[
+                ColumnSpec::required("repo_id", ValueType::Text),
+                ColumnSpec::required("id", ValueType::Text),
+            ],
+            columns: &[ColumnSpec::required("title", ValueType::Text)],
             local_columns: &[],
             repo_column: Some("repo_id"),
         };
@@ -193,7 +249,7 @@ mod tests {
         )
         .unwrap();
         let tx = c.transaction().unwrap();
-        let ops = produce_row_ops(&tx, &SCOPED, "A").unwrap();
+        let ops = produce_row_ops(&tx, &SCOPED, "A", test_stream()).unwrap();
         assert_eq!(ops.len(), 1, "only repo A's row is produced — never repo B's");
         assert_eq!(
             ops[0].pk()[0],
@@ -213,31 +269,8 @@ mod tests {
         .unwrap();
         // Row gone but its published identity remains → a Remove is produced.
         tx.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
-        let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
+        let ops = produce_row_ops(&tx, &SPEC, "repo", test_stream()).unwrap();
         assert_eq!(ops.len(), 1);
         assert!(matches!(&ops[0], RowOp::Remove { .. }), "a deleted row produces a Remove");
-    }
-
-    #[test]
-    fn no_table_registers_while_a_stale_hash_blocks_authoring() {
-        // TRIPWIRE for #1002, guarding the one cost of the not-comparable rule above.
-        //
-        // Nothing refreshes a stored published record's version except a WINNING apply, and a row
-        // that never authors never wins — so after a column-set change every pre-existing row is a
-        // permanent authoring dead zone on that device: even a genuine local edit produces no op.
-        // Deleting the row escapes it (`Remove` is version-agnostic), and a peer can still win the
-        // row, but a fully-upgraded roster is symmetrically stuck.
-        //
-        // That is harmless only while no table is registered, because then no column set can
-        // change. #1002 (a per-op spec version + declared column defaults) removes the
-        // conservatism by rebuilding a complete after-image instead of declining to
-        // compare. Registering a table before it lands would ship the dead zone, so fail
-        // loudly at exactly that moment.
-        assert!(
-            super::super::registry::SYNCABLE_TABLES.is_empty(),
-            "a syncable table was registered while `produce_row_ops` still treats a \
-             version-mismatched anti-echo hash as not-comparable: land the per-op spec version \
-             (#1002) first, or the first column addition strands every existing row's local edits"
-        );
     }
 }

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -38,7 +38,13 @@ use crate::op::OpMeta;
 /// spec, a new row-op kind — because that is exactly when retained entries become projectable and
 /// when previously recorded anti-echo hashes stop covering the current column set. Forgetting the
 /// bump leaves pending entries unreplayed (data that arrived is never applied); it cannot corrupt,
-/// because the per-row `projector_version` still marks stale hashes as not comparable.
+/// because the per-row `spec_version` still marks stale hashes as not comparable.
+///
+/// This is NOT left to discipline for the registry-driven cases. It equals the length of
+/// [`super::registry::PROJECTOR_GENERATIONS`], whose last entry must match the live registry — so
+/// registering a table or widening a spec forces an append, and an append is the bump. A widening
+/// that is not a registry change (a new row-op kind) still has to append a generation by hand,
+/// repeating the previous snapshot.
 pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 1;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
@@ -161,14 +167,16 @@ fn replay_pending_entry(
     // it. Leaving the entry pending costs nothing: once the producer authors that edit (at a
     // lamport above this entry's, since authoring counts parked entries), a later replay lands
     // and loses on the merits.
-    if apply::row_has_unsent_local_change(tx, spec, &context.repo_id, op.pk())? {
+    if apply::row_has_unsent_local_change(tx, spec, &context.repo_id, pending.stream_id, op.pk())? {
         return Ok(());
     }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
     match apply::apply_row_op(tx, spec, &context.repo_id, &op, meta)? {
-        // Folded. `Applied` also covers "deliberately lost" — superseded by a newer winner, or
-        // suppressed by a tombstone — which are correct folds, not outstanding work.
-        ApplyOutcome::Applied => store::clear_entry_pending(tx, &pending.entry_hash),
+        // Folded. `Superseded` — outranked by a newer winner, or suppressed by a tombstone — is
+        // equally a correct fold and equally not outstanding work: the entry was evaluated and
+        // lost on the merits, and no later binary changes that.
+        ApplyOutcome::Applied | ApplyOutcome::Superseded =>
+            store::clear_entry_pending(tx, &pending.entry_hash),
         // Terminal, so it stops being outstanding: a type mismatch or a constraint violation is a
         // BROKEN PRODUCER — the values do not fit the declared column types or the table's
         // constraints, and no future binary makes them fit. (A missing column is NOT this case: it
@@ -260,7 +268,7 @@ fn stored_projector_version(conn: &Connection) -> anyhow::Result<Option<i64>> {
 mod tests {
     use super::*;
     use crate::table_sync::engine::{self, IngestOutcome, SyncCtx};
-    use crate::table_sync::registry::{ColumnSpec, ValueType};
+    use crate::table_sync::registry::{ColumnSpec, DefaultValue, ValueType};
     use crate::table_sync::row_op::{Cell, RowOp, TypedValue};
     use crate::table_sync::scope_stream::scope_stream_id;
     use crate::{AccountId, LocalDevice};
@@ -272,19 +280,23 @@ mod tests {
     const OLD: TableSpec = TableSpec {
         name: "t_demo",
         scope_id: "demo/1",
-        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
         local_columns: &["later_col"],
         repo_column: None,
     };
     const NEW: TableSpec = TableSpec {
         name: "t_demo",
         scope_id: "demo/1",
-        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
-            name: "later_col",
-            value_type: ValueType::Text,
-        }],
+        // A LATER column set: `later_col` was added, so ops from the older spec fill it from the
+        // declared default (the physical column has no DEFAULT clause, hence `Null`).
+        spec_version: 2,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[
+            ColumnSpec::required("title", ValueType::Text),
+            ColumnSpec::added("later_col", ValueType::Text, 2, DefaultValue::Null),
+        ],
         local_columns: &[],
         repo_column: None,
     };
@@ -404,10 +416,11 @@ mod tests {
         let mut b = Device::new();
         let entries = author_wide_row(&mut a);
 
-        // B (old registry) cannot project the op: it is retained and marked, NOT partially applied.
+        // B (old registry) cannot project an op from a NEWER column set: retained and marked, never
+        // partially applied.
         b.enroll(a.pubkey().fingerprint());
         assert_eq!(b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey()), vec![
-            IngestOutcome::Retained(PendingReason::UnknownColumn.as_db_str())
+            IngestOutcome::Retained(PendingReason::NewerSpecVersion.as_db_str())
         ],);
         assert_eq!(b.row(), None, "nothing is written for an op we cannot fully project");
         assert_eq!(b.pending_count(), 1, "the entry is marked for replay");
@@ -438,13 +451,6 @@ mod tests {
             .unwrap();
         assert_eq!(a.produce(OLD_REGISTRY, "repo").len(), 1, "published under the old column set");
 
-        // Stamp the published row as recorded by an older projector (what an upgrade looks like).
-        a.conn
-            .execute("UPDATE sync_published_rows SET projector_version = ?1", params![
-                TABLE_SYNC_PROJECTOR_VERSION - 1
-            ])
-            .unwrap();
-
         assert!(
             a.produce(NEW_REGISTRY, "repo").is_empty(),
             "a wider column set alone must not re-author a single row"
@@ -461,12 +467,6 @@ mod tests {
             .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', NULL)", [])
             .unwrap();
         a.produce(OLD_REGISTRY, "repo");
-        a.conn
-            .execute("UPDATE sync_published_rows SET projector_version = ?1", params![
-                TABLE_SYNC_PROJECTOR_VERSION - 1
-            ])
-            .unwrap();
-
         a.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
         assert_eq!(a.produce(NEW_REGISTRY, "repo").len(), 1, "the delete is authored");
     }
@@ -488,13 +488,6 @@ mod tests {
             .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'mine', NULL)", [])
             .unwrap();
         assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "the local edit is authored");
-        // Published by the OLD binary, so its hash covers the old column set (the single projector
-        // const cannot express two binaries; stamping models it, as the storm test does).
-        b.conn
-            .execute("UPDATE sync_published_rows SET projector_version = ?1", params![
-                TABLE_SYNC_PROJECTOR_VERSION - 1
-            ])
-            .unwrap();
 
         assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
         assert_eq!(
@@ -503,6 +496,199 @@ mod tests {
             "the replayed entry loses to the causally later local edit"
         );
         assert_eq!(b.pending_count(), 0, "and it stops being outstanding either way");
+    }
+
+    #[test]
+    fn the_refold_never_overwrites_an_unsent_edit_on_a_row_published_under_an_older_column_set() {
+        // THE CROSS-COLUMN-SET PROTECTIVE ARM. The row IS published (so the never-published guard
+        // does not fire) but under a NARROWER column set, so the anti-echo hashes are not directly
+        // comparable and the only way to tell an unsent edit from an untouched row is to project
+        // the row's winning entry and compare. If that arm answers "no unsent change", the refold
+        // replays A's higher-lamport entry straight over work no peer has ever seen.
+        //
+        // This is not a hypothetical: with the arm returning `false` the assertion below fails with
+        // the row holding A's value instead of the local edit. Nothing else in the suite reaches
+        // this arm with a non-`Unchanged` verdict — the neighbouring tests hit the never-published
+        // arm, the absent-row arm, or an AUTHORED edit (which settles as `Unchanged`).
+        let mut a = Device::new();
+        let mut b = Device::new();
+
+        // B publishes r1 FIRST, under the old column set, at lamport 0.
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'mine', NULL)", [])
+            .unwrap();
+        assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "r1 is published under the old spec");
+
+        // B then edits it RAW — no authoring, so no clock advance and no peer has seen it.
+        b.conn.execute("UPDATE t_demo SET title = 'edited' WHERE id = 'r1'", []).unwrap();
+
+        // A authors the same row three times under the wider spec, so its winning lamport (2)
+        // strictly beats B's clock (0) — no fingerprint tie deciding this by accident.
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'a1', 'wide')", [])
+            .unwrap();
+        let mut entries = a.produce(NEW_REGISTRY, "repo");
+        for title in ["a2", "a3"] {
+            a.conn.execute("UPDATE t_demo SET title = ?1 WHERE id = 'r1'", [title]).unwrap();
+            entries.extend(a.produce(NEW_REGISTRY, "repo"));
+        }
+        assert_eq!(entries.len(), 3, "three authored generations, lamports 0..2");
+
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+        assert_eq!(b.pending_count(), 3, "all three park — B cannot project the wider spec");
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(
+            b.row().unwrap().0,
+            "edited",
+            "the unsent local edit must survive the replay of a strictly higher-lamport entry"
+        );
+        assert_eq!(b.pending_count(), 3, "the entries stay outstanding rather than landing");
+    }
+
+    #[test]
+    fn authoring_that_cannot_win_its_own_self_apply_fails_instead_of_looping() {
+        // A locally-authored op takes the stream's `MAX(lamport) + 1`, so while a row's clock was
+        // set by an op on THIS stream it cannot lose. A clock holding a lamport the stream cannot
+        // reach therefore means the row's bookkeeping and the stream have come apart — the shape a
+        // changed scope or account leaves behind, since `sync_row_clocks` is keyed only by
+        // `(repo_id, table_name, row_pk)` and survives a move its lamports have no meaning after.
+        //
+        // Folded into `Applied`, that reads as settlement: no publication record is written, so the
+        // next pass re-derives the identical delta and signs it again — unbounded log growth, and
+        // every peer discards the entries too. Fail attributably instead.
+        let mut b = Device::new();
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v', NULL)", [])
+            .unwrap();
+        assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "published on this stream");
+
+        // A clock from a stream this one cannot catch: nothing local can outrank it.
+        b.conn
+            .execute("UPDATE sync_row_clocks SET lamport = 9_999 WHERE table_name = 't_demo'", [])
+            .unwrap();
+        b.conn.execute("UPDATE t_demo SET title = 'edited' WHERE id = 'r1'", []).unwrap();
+
+        let tx = b.conn.transaction().unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo",
+            account_id: account(),
+            device: &b.local,
+            registry: OLD_REGISTRY,
+            now_ms: 0,
+        };
+        let err = engine::produce_and_author(&tx, &ctx)
+            .expect_err("a self-apply that cannot win must not be reported as settled");
+        assert!(
+            err.to_string().contains("lost its own self-apply"),
+            "the error names the condition: {err}"
+        );
+    }
+
+    #[test]
+    fn a_winner_lookup_that_lands_on_another_rows_entry_resolves_to_unknown() {
+        // The lookup keys on `(stream, device, lamport)`, which identifies an entry uniquely WITHIN
+        // a stream — so it is this row's op only while the row's clock and the queried stream are
+        // the same stream. Moving a table to another scope re-derives the stream while the clocks
+        // survive, and the same `(device, lamport)` then belongs to some other op entirely.
+        //
+        // The dangerous outcome is not a wrong `LocallyChanged` (conservative anyway) but a wrong
+        // `Unchanged`, so both rows are given the SAME synced cells: the foreign op then projects
+        // to exactly what this row holds, and an unverified lookup reports "untouched" for a row
+        // that actually carries an unsent edit — which is a licence to replay over it.
+        let mut b = Device::new();
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'x', NULL)", [])
+            .unwrap();
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r2', 'shared', NULL)", [])
+            .unwrap();
+        assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 2, "both rows are published");
+
+        // r1 now holds an unsent edit that happens to equal r2's published content.
+        b.conn.execute("UPDATE t_demo SET title = 'shared' WHERE id = 'r1'", []).unwrap();
+
+        let stream = scope_stream_id("repo", account(), "demo/1");
+        let (r2_lamport, r2_device): (i64, String) = b
+            .conn
+            .query_row(
+                "SELECT lamport, device_fingerprint FROM sync_row_clocks
+                  WHERE table_name = 't_demo' AND row_pk = ?1",
+                [&row_op::row_pk_string(&[TypedValue::Text("r2".into())])],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        // Repoint r1's clock at r2's entry — the shape a stream change produces.
+        b.conn
+            .execute(
+                "UPDATE sync_row_clocks SET lamport = ?1, device_fingerprint = ?2
+                  WHERE table_name = 't_demo' AND row_pk = ?3",
+                params![
+                    r2_lamport,
+                    r2_device,
+                    row_op::row_pk_string(&[TypedValue::Text("r1".into())])
+                ],
+            )
+            .unwrap();
+
+        let tx = b.conn.transaction().unwrap();
+        let verdict = apply::stale_row_disposition(
+            &tx,
+            &OLD,
+            "repo",
+            stream,
+            &[TypedValue::Text("r1".into())],
+            &[Cell { column: "title".to_string(), value: TypedValue::Text("shared".into()) }],
+        )
+        .unwrap();
+        assert_eq!(
+            verdict,
+            apply::StaleRow::Unknown,
+            "an entry that is not this row's op must not produce a verdict about this row"
+        );
+    }
+
+    #[test]
+    fn the_refold_defers_when_the_rows_winner_cannot_be_resolved_at_all() {
+        // The UNPROVABLE arm of the same guard. When a row's winning entry cannot be resolved, the
+        // projection comparison is unavailable and there is no way to tell an untouched row from an
+        // unsent edit — so the refold must refuse to replay, exactly as it does for a proven edit.
+        // Answering "no unsent change" here silently destroys the edit.
+        //
+        // The entry is deleted to model what entry retention/GC will do once it lands: it MUST
+        // refresh a row's publication record before dropping that row's winner, or every such row
+        // enters this state. (The producer's half of that contract is to author on the same verdict
+        // rather than also deferring — otherwise the row would be stuck from both sides forever.)
+        let mut a = Device::new();
+        let mut b = Device::new();
+
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'mine', NULL)", [])
+            .unwrap();
+        assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "r1 is published under the old spec");
+        b.conn.execute("UPDATE t_demo SET title = 'edited' WHERE id = 'r1'", []).unwrap();
+        // Drop B's own winning entry, leaving the row's clock pointing at nothing.
+        b.conn.execute("DELETE FROM table_sync_entries", []).unwrap();
+
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'a1', 'wide')", [])
+            .unwrap();
+        let mut entries = a.produce(NEW_REGISTRY, "repo");
+        for title in ["a2", "a3"] {
+            a.conn.execute("UPDATE t_demo SET title = ?1 WHERE id = 'r1'", [title]).unwrap();
+            entries.extend(a.produce(NEW_REGISTRY, "repo"));
+        }
+
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey());
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(
+            b.row().unwrap().0,
+            "edited",
+            "an unresolvable winner must not license replaying over the row"
+        );
     }
 
     #[test]
@@ -541,25 +727,27 @@ mod tests {
         const SCOPED_OLD: TableSpec = TableSpec {
             name: "t_scoped",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
-                name: "id",
-                value_type: ValueType::Text,
-            }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[
+                ColumnSpec::required("repo_id", ValueType::Text),
+                ColumnSpec::required("id", ValueType::Text),
+            ],
+            columns: &[ColumnSpec::required("title", ValueType::Text)],
             local_columns: &["later_col"],
             repo_column: Some("repo_id"),
         };
         const SCOPED_NEW: TableSpec = TableSpec {
             name: "t_scoped",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
-                name: "id",
-                value_type: ValueType::Text,
-            }],
-            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
-                name: "later_col",
-                value_type: ValueType::Text,
-            }],
+            spec_version: 1,
+            pk: &[
+                ColumnSpec::required("repo_id", ValueType::Text),
+                ColumnSpec::required("id", ValueType::Text),
+            ],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("later_col", ValueType::Text),
+            ],
             local_columns: &[],
             repo_column: Some("repo_id"),
         };
@@ -713,11 +901,12 @@ mod tests {
     }
 
     #[test]
-    fn an_older_producers_partial_row_parks_and_is_replayed_when_the_gap_closes() {
-        // The mirror of the unknown-column case: a row that is COMPLETE under the author's narrower
-        // spec is PARTIAL under a wider one. Whole-row LWW cannot apply it, but it is a version gap
-        // — redeemed from the sender's side — so it parks and stays on the worklist rather than
-        // being quarantined off it.
+    fn an_older_producers_row_applies_with_its_missing_columns_defaulted() {
+        // The unfreeze. A row that is COMPLETE under the author's narrower spec is PARTIAL under a
+        // wider one, and before the op stated its version the receiver could only park it forever —
+        // nothing on the receiving side could ever redeem it. Now the version says "this predates
+        // `later_col`", so the column it predates is filled from its declared default and the row
+        // applies immediately.
         let mut a = Device::new();
         let mut b = Device::new();
         a.conn
@@ -726,27 +915,195 @@ mod tests {
         let narrow = a.produce(OLD_REGISTRY, "repo");
         assert_eq!(narrow.len(), 1, "authored under the narrow spec");
 
-        // B knows the wider column set, so the op is missing one of B's synced columns.
         b.enroll(a.pubkey().fingerprint());
-        assert_eq!(b.ingest(NEW_REGISTRY, "repo", &narrow, &a.pubkey()), vec![
+        assert_eq!(
+            b.ingest(NEW_REGISTRY, "repo", &narrow, &a.pubkey()),
+            vec![IngestOutcome::Applied],
+            "an older producer's row is no longer frozen out",
+        );
+        assert_eq!(
+            b.row(),
+            Some(("narrow".to_string(), None)),
+            "the column the op predates takes its declared default"
+        );
+        assert_eq!(b.pending_count(), 0, "nothing is left outstanding");
+        // And the applied row is published under THIS spec, so the producer has nothing to say.
+        assert!(b.produce(NEW_REGISTRY, "repo").is_empty());
+    }
+
+    #[test]
+    fn a_column_without_a_declared_default_still_parks_an_older_op() {
+        // Default-fill is opt-in per column: a column with no declared default cannot be invented,
+        // so an op omitting it is still a partial after-image. That is what keeps a genuinely
+        // broken producer from being silently completed.
+        const NO_DEFAULT: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("later_col", ValueType::Text),
+            ],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'narrow', NULL)", [])
+            .unwrap();
+        let narrow = a.produce(OLD_REGISTRY, "repo");
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(&[NO_DEFAULT], "repo", &narrow, &a.pubkey()), vec![
             IngestOutcome::Retained(PendingReason::PartialAfterImage.as_db_str())
         ],);
-        assert_eq!(b.row(), None, "a partial after-image writes nothing");
-        assert_eq!(b.pending_count(), 1, "and stays outstanding, not quarantined off the worklist");
+        assert_eq!(b.row(), None, "nothing is invented for a column with no declared default");
+    }
 
-        // Still outstanding after a refold that cannot close the gap either — only the SENDER's
-        // side can (declared column defaults, #1002), so the entry must not be dropped meanwhile.
-        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
-        assert_eq!(b.pending_count(), 1, "a sender-side gap survives a receiver-side refold");
-        let quarantined: i64 = b
+    #[test]
+    fn a_stale_version_row_edited_locally_is_authored_rather_than_frozen() {
+        // The dead zone, closed. Before the op stated its version, a row published under an older
+        // column set could never be re-authored — its hash was not comparable, so even a genuine
+        // local edit produced nothing and the change could never reach a peer. Now the row is
+        // settled against the op that established it: different means a real local change, and it
+        // is authored.
+        let mut a = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', NULL)", [])
+            .unwrap();
+        assert_eq!(a.produce(OLD_REGISTRY, "repo").len(), 1, "published under the old column set");
+
+        // The binary learns `later_col`, and the user edits the row before anything re-publishes
+        // it.
+        a.conn.execute("UPDATE t_demo SET title = 'edited' WHERE id = 'r1'", []).unwrap();
+
+        let ops = a.produce(NEW_REGISTRY, "repo");
+        assert_eq!(ops.len(), 1, "the edit is authored, not frozen out");
+        match authored_op(&ops[0]) {
+            RowOp::Upsert { spec_version, cells, .. } => {
+                assert_eq!(spec_version, NEW.spec_version, "authored under the current spec");
+                assert!(
+                    cells.iter().any(
+                        |c| c.column == "title" && c.value == TypedValue::Text("edited".into())
+                    ),
+                    "and carries the local edit"
+                );
+            },
+            other => panic!("expected an upsert, got {other:?}"),
+        }
+    }
+
+    /// Decode the row op inside one authored entry's signed wire bytes.
+    fn authored_op(signed_bytes: &[u8]) -> RowOp {
+        let signed = crate::entry::decode_signed(signed_bytes).unwrap();
+        match crate::table_sync::row_op::decode(&signed.entry.op_bytes).unwrap() {
+            crate::table_sync::row_op::DecodedRowOp::Known(op) => op,
+            other => panic!("expected a known op, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_untouched_stale_version_row_is_restamped_without_authoring() {
+        // The other half: a row that has NOT changed since it landed is simply restamped, so it
+        // becomes comparable again without a signed entry. Re-authoring it instead would put every
+        // row of the table back on the wire on every upgrading device.
+        let mut a = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v1', NULL)", [])
+            .unwrap();
+        a.produce(OLD_REGISTRY, "repo");
+
+        assert!(
+            a.produce(NEW_REGISTRY, "repo").is_empty(),
+            "nothing to say about an untouched row"
+        );
+        let version: i64 = a
             .conn
-            .query_row(
-                "SELECT COUNT(*) FROM table_sync_entries WHERE quarantine_reason IS NOT NULL",
+            .query_row("SELECT spec_version FROM sync_published_rows", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(version, i64::from(NEW.spec_version), "and it is comparable again");
+        // Comparable means an ordinary later edit is authored by the ordinary path.
+        a.conn.execute("UPDATE t_demo SET title = 'later' WHERE id = 'r1'", []).unwrap();
+        assert_eq!(a.produce(NEW_REGISTRY, "repo").len(), 1);
+    }
+
+    #[test]
+    fn a_remove_crosses_a_spec_version_skew_unimpeded() {
+        // A remove names only the row identity, so no column set is involved and its version is
+        // never acted on. Gating it would delay deletions across a skew for no benefit.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v', 'wide')", [])
+            .unwrap();
+        let created = a.produce(NEW_REGISTRY, "repo");
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(NEW_REGISTRY, "repo", &created, &a.pubkey());
+        assert!(b.row().is_some());
+
+        a.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
+        let removed = a.produce(NEW_REGISTRY, "repo");
+        assert_eq!(removed.len(), 1);
+        // B is on the OLDER spec — the delete still lands.
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &removed, &a.pubkey()), vec![
+            IngestOutcome::Applied
+        ],);
+        assert_eq!(b.row(), None, "a newer-spec remove still deletes on an older peer");
+    }
+
+    #[test]
+    fn devices_at_different_spec_versions_converge_in_both_directions() {
+        // The property the whole change rests on. An op's projection is a pure function of (op,
+        // receiver registry) — never of prior row state — so whole-row LWW lands every receiver on
+        // the same result regardless of arrival order or who authored last.
+        let mut old_dev = Device::new();
+        let mut new_dev = Device::new();
+        old_dev.enroll(new_dev.pubkey().fingerprint());
+        old_dev.enroll(old_dev.local.fingerprint());
+        new_dev.enroll(old_dev.pubkey().fingerprint());
+        new_dev.enroll(new_dev.local.fingerprint());
+
+        // NEWER authors first; the older peer cannot project it and parks.
+        new_dev
+            .conn
+            .execute(
+                "INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'from-new', 'wide')",
                 [],
-                |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(quarantined, 0, "a version gap is never recorded as a terminal rejection");
+        let from_new = new_dev.produce(NEW_REGISTRY, "repo");
+        assert_eq!(old_dev.ingest(OLD_REGISTRY, "repo", &from_new, &new_dev.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::NewerSpecVersion.as_db_str())
+        ],);
+
+        // OLDER then authors its own row; the newer peer APPLIES it, filling the column it
+        // predates.
+        old_dev
+            .conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'from-old', NULL)", [])
+            .unwrap();
+        let from_old = old_dev.produce(OLD_REGISTRY, "repo");
+        assert_eq!(
+            new_dev.ingest(NEW_REGISTRY, "repo", &from_old, &old_dev.pubkey()),
+            vec![IngestOutcome::Applied],
+            "older→newer is no longer frozen",
+        );
+
+        // The older device's write is causally later (authoring counts the parked entry), so it
+        // wins on the newer device — and the newer device's row reflects it with the column
+        // defaulted.
+        assert_eq!(new_dev.row(), Some(("from-old".to_string(), None)));
+
+        // Once the older device upgrades, the parked entry replays and loses on the merits, so both
+        // devices agree on the same winner.
+        assert!(refold_stale_projections_against(&old_dev.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(
+            old_dev.row(),
+            new_dev.row(),
+            "the two devices converge on the same row once both understand the column set"
+        );
+        assert_eq!(old_dev.pending_count(), 0, "and nothing is left outstanding");
     }
 
     #[test]
@@ -900,6 +1257,7 @@ mod tests {
         let mut a = Device::new();
         let mut b = Device::new();
         let two_key = RowOp::Upsert {
+            spec_version: 1,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Text("r1".to_string()), TypedValue::Text("extra".to_string())],
             cells: vec![Cell { column: "title".to_string(), value: TypedValue::Text("v".into()) }],
@@ -943,7 +1301,11 @@ mod tests {
         // it. This path has no caller to return an outcome to.
         let mut a = Device::new();
         let mut b = Device::new();
+        // Stamped at the WIDER spec, consistent with carrying `later_col` — a v1 stamp on an op
+        // that names a column introduced at v2 is self-contradictory and parks as a mis-stamp
+        // before any type check runs, which would test something else entirely.
         let mistyped = RowOp::Upsert {
+            spec_version: 2,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Text("r1".to_string())],
             cells: vec![
@@ -962,7 +1324,7 @@ mod tests {
 
         b.enroll(a.pubkey().fingerprint());
         assert_eq!(b.ingest(OLD_REGISTRY, "repo", &[signed], &a.pubkey()), vec![
-            IngestOutcome::Retained(PendingReason::UnknownColumn.as_db_str())
+            IngestOutcome::Retained(PendingReason::NewerSpecVersion.as_db_str())
         ],);
 
         assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
@@ -997,10 +1359,26 @@ mod tests {
         // that derives them) silently reclassifies every row a prior binary wrote. Pin them
         // literally — the derive keeps write and parse in step, this keeps the values themselves
         // from moving.
-        assert_eq!(PendingReason::UnknownColumn.as_db_str(), "unknown_column");
-        assert_eq!(PendingReason::PartialAfterImage.as_db_str(), "partial_after_image");
-        assert_eq!(PendingReason::UnknownOpKind.as_db_str(), "unknown_op_kind");
-        assert_eq!(PendingReason::UndecodablePayload.as_db_str(), "undecodable_payload");
-        assert_eq!(PendingReason::TableNotInScope.as_db_str(), "table_not_in_scope");
+        //
+        // Pinned as the WHOLE SET, not variant by variant: a per-variant list silently omits any
+        // variant added later (`NewerSpecVersion` was added and left unpinned exactly that way),
+        // which is the case that most needs the pin. Adding a variant now fails here until it is
+        // listed.
+        let pinned: Vec<(PendingReason, &str)> = <PendingReason as strum::IntoEnumIterator>::iter()
+            .map(|reason| (reason, reason.as_db_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            pinned,
+            vec![
+                (PendingReason::UnknownColumn, "unknown_column"),
+                (PendingReason::NewerSpecVersion, "newer_spec_version"),
+                (PendingReason::PartialAfterImage, "partial_after_image"),
+                (PendingReason::MisstampedSpecVersion, "misstamped_spec_version"),
+                (PendingReason::UnknownOpKind, "unknown_op_kind"),
+                (PendingReason::UndecodablePayload, "undecodable_payload"),
+                (PendingReason::TableNotInScope, "table_not_in_scope"),
+            ],
+            "a stored classification token moved, or a new variant is unpinned"
+        );
     }
 }

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -15,6 +15,8 @@ use std::collections::BTreeSet;
 
 use rusqlite::Connection;
 
+use super::schema_facts::{self, CheckVerdict, PhysicalColumn};
+
 /// The storage/wire type of a synced column. A cell whose runtime value disagrees with its column's
 /// declared type is quarantined by the applier rather than silently coerced.
 ///
@@ -30,12 +32,65 @@ pub(crate) enum ValueType {
     Blob,
 }
 
-/// One synced, non-pk column: its name and wire type. Merge is whole-row (all synced columns move
-/// together under the row's write clock), so a column carries no per-column merge policy.
+/// A column's declared default — the value an op authored BEFORE this column existed contributes
+/// when it is projected here (#1002). Literal forms only: a non-literal SQL default
+/// (`CURRENT_TIMESTAMP`, `unixepoch()`) is per-device non-deterministic, so two receivers filling
+/// the same op would produce different rows. That is the determinism requirement, not a style rule.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum DefaultValue {
+    Null,
+    Bool(bool),
+    I64(i64),
+    Text(&'static str),
+    Blob(&'static [u8]),
+}
+
+/// When a column entered the spec, and what an op authored before that contributes for it. The
+/// version is what makes the default SAFE to apply: without it, an op merely older than the CURRENT
+/// spec would have every added column defaulted, including ones that already existed in the op's
+/// own version — so a broken producer that dropped a column it was obliged to send would have that
+/// column silently reset to its default on every receiver instead of parking as the partial it is.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct AddedColumn {
+    /// The spec version that introduced the column. An op stamped BELOW this predates the column
+    /// and legitimately omits it; an op stamped at or above it was obliged to send it.
+    pub in_version: u32,
+    pub default: DefaultValue,
+}
+
+/// One synced, non-pk column: its name, wire type, and — for a column added after the table's first
+/// spec version — when it arrived plus the value an older producer's op contributes for it. Merge
+/// is whole-row (all synced columns move together under the row's write clock), so a column carries
+/// no per-column merge policy.
+///
+/// `added` is `None` for a column that has existed since the table's first version: no op can ever
+/// legitimately omit it, so there is nothing to fill, and demanding a default would force a
+/// meaningless one onto an original `NOT NULL` column. It also keeps failure contained — an op
+/// missing such a column is a genuinely broken partial, and parks rather than being silently
+/// filled.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ColumnSpec {
     pub name: &'static str,
     pub value_type: ValueType,
+    pub added: Option<AddedColumn>,
+}
+
+impl ColumnSpec {
+    /// A column every op must carry — the shape for pk columns and for any column present since the
+    /// table's first spec version.
+    pub const fn required(name: &'static str, value_type: ValueType) -> Self {
+        Self { name, value_type, added: None }
+    }
+
+    /// A column introduced in `in_version`, carrying the value an op older than that contributes.
+    pub const fn added(
+        name: &'static str,
+        value_type: ValueType,
+        in_version: u32,
+        default: DefaultValue,
+    ) -> Self {
+        Self { name, value_type, added: Some(AddedColumn { in_version, default }) }
+    }
 }
 
 /// One syncable table. `pk` names the identity columns (encoded as the row op's `pk`); `columns`
@@ -48,6 +103,34 @@ pub(crate) struct ColumnSpec {
 pub(crate) struct TableSpec {
     pub name: &'static str,
     pub scope_id: &'static str,
+    /// Which synced column set this binary authors against — stamped into every op it produces, so
+    /// a receiver can tell an OLDER producer's complete row from a NEWER producer's partial
+    /// one (#1002). BUMP whenever `columns` changes; `local_columns` never cross the wire, so
+    /// they do not count.
+    ///
+    /// EVOLUTION IS ADDITIVE ONLY. A column may be ADDED (with a bump and a declared default);
+    /// removing, renaming, or retyping one means a NEW TABLE. Default-fill closes older→newer for
+    /// additions alone — an older op naming a column the current spec dropped parks forever, and
+    /// no future binary redeems it. This cannot be linted (it needs registry history), so it
+    /// is an invariant on whoever edits a spec.
+    ///
+    /// The version is largely ADVISORY, and the asymmetry matters. A receiver CAN reject an
+    /// OVER-stamp (a version above its own → park) and a *partial* under-stamp (a cell for a
+    /// column introduced after the claimed version is self-contradictory → park, since
+    /// `in_version` is a fixed historical fact under additive-only evolution). What it CANNOT
+    /// detect is a WHOLE-CLOTH under-stamp: an op carrying only the columns its claimed
+    /// version had, stamped lower than the producer actually authored against. That case is
+    /// indistinguishable from an honest un-upgraded peer, and it is the DESTRUCTIVE direction
+    /// — every column added since the claimed version is reset to its default on every
+    /// receiver, at a winning lamport, silently.
+    ///
+    /// That is not privilege escalation (an authorized writer can already write any value into
+    /// those columns under whole-row LWW, and the reset is the deliberate meaning of a whole-row
+    /// write from a device that does not know the column), but it does mean a buggy producer
+    /// degrades data fleet-wide rather than failing loudly. STAMP CORRECTLY; the rest of the rule
+    /// assumes it. A mis-stamp PARKS rather than quarantining because a forgotten bump is the
+    /// likeliest cause and parking is what lets the next binary redeem it.
+    pub spec_version: u32,
     /// The identity columns, with types — the applier validates each incoming pk value against its
     /// declared type so SQLite affinity can't coerce a mismatched pk (e.g. `I64(1)` onto a `TEXT`
     /// key `'1'`) and split a row's bookkeeping.
@@ -76,12 +159,62 @@ impl TableSpec {
 /// nothing here is load-bearing yet — the mechanism is proven against a synthetic spec in tests.
 pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[];
 
+/// One table's REPLICATED CONTRACT within a projector generation — everything that decides what
+/// this binary can project from the wire, and nothing that does not.
+///
+/// `scope_id` is part of it, not decoration: it selects the stream a table rides, so moving a table
+/// between scopes turns entries the old registry parked as `TableNotInScope` into entries the new
+/// one understands. Omitting it would let that edit land without a projector bump, and those
+/// entries would never be retried. `pk` and each column's `ValueType` are recorded for a different
+/// reason — changing either means a NEW TABLE under the additive-only rule, which is stated as an
+/// un-lintable invariant precisely because a single binary has no history to check against. A
+/// generation list IS that history, so the cross-generation test can enforce part of it.
+///
+/// `local_columns` is deliberately absent: it never crosses the wire, so changing it widens
+/// nothing and must not force a generation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct TableGeneration {
+    pub table: &'static str,
+    pub scope_id: &'static str,
+    pub spec_version: u32,
+    pub repo_column: Option<&'static str>,
+    /// `(column, value_type)` per identity column, in registry order.
+    pub pk: &'static [(&'static str, ValueType)],
+    /// `(column, value_type, added)` per synced column, in registry order. `added` is `None` for a
+    /// column present since the table's first version.
+    pub columns: &'static [(&'static str, ValueType, Option<AddedColumn>)],
+}
+
+/// The registry as of EACH projector generation, oldest first: a generation's index + 1 is the
+/// [`TABLE_SYNC_PROJECTOR_VERSION`] it describes, and the LAST entry must equal the live registry.
+///
+/// This is the mechanical coupling between a registry change and a projector bump, and it is
+/// load-bearing rather than documentation. A refold is owed only when the store's stamp is behind
+/// the current projector version, or some entry was parked by an older one — so if the registry
+/// widens (a table registered, a column added) WITHOUT the version moving, a store already stamped
+/// at that version keeps entries parked as `TableNotInScope` / `NewerSpecVersion` with a
+/// `pending_projector_version` equal to the current one. Neither trigger fires, they are never
+/// replayed, and redelivery cannot rescue them because it short-circuits on `entry_exists`. The
+/// payload is simply lost.
+///
+/// A pinned copy of the current registry cannot enforce this: updating the pin to match a change is
+/// exactly as easy as making the change. Recording a generation PER VERSION can, because the live
+/// registry must equal the last entry — so widening the registry forces an APPEND, and appending
+/// moves `len()`, which is the version. Widenings that are not registry changes (a new op-kind)
+/// append a generation that repeats the previous snapshot.
+///
+/// Entries here are HISTORY. Append only; never edit a landed generation.
+pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
+    // v1: the engine exists; no table is registered yet.
+    &[],
+];
+
 /// Assert a spec classifies EVERY physical column of its table exactly once — as pk, a synced
 /// column, or a local column — and names no column the table doesn't have. This is the invariant
 /// that stops a new column being silently unclassified: it is either replicated or deliberately
 /// local, never neither. Returns a human-readable diff on mismatch.
 pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> Result<(), String> {
-    let columns = physical_column_info(conn, spec.name)
+    let columns = schema_facts::physical_column_info(conn, spec.name)
         .map_err(|err| format!("cannot read columns of `{}`: {err}", spec.name))?;
     let physical: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
 
@@ -193,7 +326,7 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
     // predicates, but `row_op::row_pk_string` encodes them as DIFFERENT bookkeeping identities
     // — so one physical row would carry two write clocks / published hashes and diverge (or
     // suppress the wrong update).
-    if let Some(col) = pk_column_with_non_binary_collation(conn, spec.name)
+    if let Some(col) = schema_facts::pk_column_with_non_binary_collation(conn, spec.name)
         .map_err(|err| format!("cannot read the pk collation of `{}`: {err}", spec.name))?
     {
         return Err(format!(
@@ -210,7 +343,7 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
     // quarantined, and WHICH loses depends on order), so peers diverge with no dirty-local edit. A
     // foreign key is the same class (a delete/insert can fail against another row). Reject both
     // until a deterministic cross-row conflict rule exists.
-    if table_has_foreign_key(conn, spec.name)
+    if schema_facts::table_has_foreign_key(conn, spec.name)
         .map_err(|err| format!("cannot read foreign keys of `{}`: {err}", spec.name))?
     {
         return Err(format!(
@@ -222,7 +355,7 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
     // The inbound direction is the same hazard: a table REFERENCED by another's FK can have a
     // `Remove` blocked (FK RESTRICT) on a peer that holds a child row but not on one that doesn't →
     // the delete quarantines on one side, applies on the other, and the replicas diverge.
-    if table_is_referenced_by_foreign_key(conn, spec.name)
+    if schema_facts::table_is_referenced_by_foreign_key(conn, spec.name)
         .map_err(|err| format!("cannot scan foreign keys referencing `{}`: {err}", spec.name))?
     {
         return Err(format!(
@@ -235,7 +368,7 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
     // deterministic: an INSERT/UPDATE/DELETE trigger can adjust the row (or others) from local
     // derived state, so the SAME received op folds to different physical results on two devices,
     // and apply_upsert then publishes each divergent result — the replicas stay divergent.
-    if let Some(trigger) = table_trigger(conn, spec.name)
+    if let Some(trigger) = schema_facts::table_trigger(conn, spec.name)
         .map_err(|err| format!("cannot read triggers of `{}`: {err}", spec.name))?
     {
         return Err(format!(
@@ -244,7 +377,7 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
             spec.name
         ));
     }
-    if let Some(index) = non_pk_unique_index(conn, spec.name)
+    if let Some(index) = schema_facts::non_pk_unique_index(conn, spec.name)
         .map_err(|err| format!("cannot read indexes of `{}`: {err}", spec.name))?
     {
         return Err(format!(
@@ -255,6 +388,127 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
         ));
     }
 
+    // A synced column's DECLARED default must equal its physical SQL default, exactly (#1002).
+    //
+    // This is a CONVERGENCE check for the upgrade path, not hygiene. `ALTER TABLE ADD COLUMN`
+    // backfills existing rows with the SQL default, while the applier fills a column an older op
+    // omits with the DECLARED one. If the two disagree, a device that applied an op BEFORE
+    // upgrading and one that applied the same op AFTER hold different rows AT THE SAME CLOCK —
+    // silent divergence with no local edit to signal it, and nothing to repair it while the
+    // authoring entry is unavailable.
+    //
+    // KNOW ITS LIMIT. The real invariant is "the migration that introduces the column backfills
+    // existing rows with the DECLARED default", and this reads `PRAGMA table_info.dflt_value` — the
+    // DEFAULT CLAUSE. Those coincide only for `ALTER TABLE ADD COLUMN … DEFAULT x`. They do NOT
+    // coincide for a table REBUILD (`CREATE new; INSERT INTO new SELECT …, <expr> FROM old; DROP;
+    // RENAME`), which is a routine migration idiom in this repo: the `SELECT` expression is
+    // invisible here, so a rebuild that backfills anything other than the declared default passes
+    // this check while violating the invariant. INTRODUCE A SYNCED COLUMN WITH `ADD COLUMN …
+    // DEFAULT x`, which satisfies it structurally. A rebuild that computes per-row values is not
+    // wrong, but it is new content peers have not seen, and it re-authors the whole table once on
+    // every device — budget for that deliberately rather than discovering it.
+    //
+    // A declared default must also match its column's `ValueType`: the fill goes straight into the
+    // row, so a mistyped default would write a value the applier would have quarantined on the
+    // wire.
+    // An IDENTITY column can never be `added`. The declared default is unreachable for it: an op
+    // authored before the key grew carries fewer pk values, and `apply_row_op`'s arity check
+    // quarantines it TERMINALLY before projection ever runs — so the evolution the `added` shape
+    // promises simply does not exist here, and declaring it would advertise a redemption path that
+    // silently drops every older op instead. A changed primary key is a new table identity.
+    for key in spec.pk {
+        if key.added.is_some() {
+            return Err(format!(
+                "`{}`: identity column `{}` declares an introduction version — a primary key \
+                 cannot grow (an older op carries fewer pk values and is quarantined on arity \
+                 before its default could apply); a changed key means a NEW TABLE",
+                spec.name, key.name
+            ));
+        }
+    }
+
+    // Read and lex the table's DDL ONCE: its declarations and constraints are a fact about the
+    // table, not about each column.
+    let ddl = schema_facts::read_table_ddl(conn, spec.name)
+        .map_err(|err| format!("cannot read the DDL of `{}`: {err}", spec.name))?;
+    for column in spec.columns {
+        let Some(added) = column.added else {
+            continue;
+        };
+        let declared = added.default;
+        let Some(physical) = columns.iter().find(|c| c.name == column.name) else {
+            continue; // an unknown column name is already reported by the exhaustiveness diff above.
+        };
+        // The introducing version must sit inside this spec's history. `1` is the first version, so
+        // a column "added" there was present from the start and is `required`; a version above the
+        // spec's own names a column this binary carries but does not announce — a forgotten bump,
+        // which would make the fill window wrong in both directions.
+        if added.in_version < 2 || added.in_version > spec.spec_version {
+            return Err(format!(
+                "`{}`: column `{}` claims to be added in spec version {} — it must be between 2 \
+                 and the spec's own version {} (a column present since version 1 is `required`)",
+                spec.name, column.name, added.in_version, spec.spec_version
+            ));
+        }
+        if !default_matches_value_type(declared, column.value_type) {
+            return Err(format!(
+                "`{}`: column `{}` declares a {declared:?} default, which is not a {:?} value",
+                spec.name, column.name, column.value_type
+            ));
+        }
+        // A NOT NULL column cannot be filled with NULL. The declared default goes straight into the
+        // row, so this would fail the constraint at INSERT and quarantine the op TERMINALLY —
+        // older→newer replication for the table would be dead, with nothing to redeem it. The
+        // SQL-default check below does not catch it: a NOT NULL column with no DEFAULT clause reads
+        // as an absent physical default, which a declared `Null` matches.
+        if physical.not_null && matches!(declared, DefaultValue::Null) {
+            return Err(format!(
+                "`{}`: column `{}` is NOT NULL but declares a Null default — filling an older op \
+                 from it would fail the constraint and quarantine the op permanently",
+                spec.name, column.name
+            ));
+        }
+        // The column must ACCEPT its own declared default, and its constraints must depend on
+        // nothing but this column. Both are decided by rebuilding the column alone and attempting
+        // the insert the applier would perform — see `schema_facts::default_satisfies_check`.
+        //
+        // Both failures end the same way and are equally silent: the applier fills this column from
+        // the default while every other column comes from the OP, so a constraint the default
+        // violates (or one whose other inputs the op supplies) fails at INSERT and the op is
+        // QUARANTINED — terminally, so older→newer replication for the table simply stops.
+        match schema_facts::default_satisfies_check(&ddl, spec.name, column.name, declared) {
+            CheckVerdict::Satisfied => {},
+            CheckVerdict::Violated(why) => {
+                return Err(format!(
+                    "`{}`: column `{}` declares default {declared:?}, which the column itself \
+                     REJECTS ({why}) — every op older than the column would be filled with a \
+                     value the table refuses, and quarantined terminally",
+                    spec.name, column.name
+                ));
+            },
+            CheckVerdict::NotSelfContained(why) => {
+                return Err(format!(
+                    "`{}`: column `{}` has a declared default but its constraints read something \
+                     other than that column ({why}) — the default supplies this column while the \
+                     OP supplies the rest, so a constraint can fail for a valid older op and \
+                     quarantine it terminally. Keep a synced column's CHECK self-contained.",
+                    spec.name, column.name
+                ));
+            },
+        }
+        let physical_default = physical.default_sql.as_deref();
+        if !default_matches_sql(declared, physical_default) {
+            return Err(format!(
+                "`{}`: column `{}` declares default {declared:?} but the table's DEFAULT is {} — \
+                 they must agree exactly, or a row backfilled by the migration and a row rebuilt \
+                 from an older op differ at the same write clock",
+                spec.name,
+                column.name,
+                physical_default.unwrap_or("absent")
+            ));
+        }
+    }
+
     // Every local (never-replicated) column must be nullable or carry a DB default: a remote upsert
     // INSERTs only the pk + synced columns (a local column is re-derived here, not sent), so a NOT
     // NULL local column with no default makes that insert fail and the applier quarantine the op —
@@ -262,7 +516,7 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
     for local in spec.local_columns {
         if let Some(col) = columns.iter().find(|c| c.name == *local)
             && col.not_null
-            && !col.has_default
+            && col.default_sql.is_none()
         {
             return Err(format!(
                 "`{}`: local column `{local}` is NOT NULL without a default, so a remote insert \
@@ -277,7 +531,24 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
     // type — which would make the post-write `synced_row_hash` read-back throw and wedge ingest
     // after the row was already written. It also makes pk columns NOT NULL. It is the schema
     // convention for every new table regardless.
-    if !table_is_strict(conn, spec.name)
+    // A GENERATED column is invisible to the rest of this lint and to the applier alike:
+    // `PRAGMA table_info` omits it, so the exhaustiveness diff never classifies it, and the
+    // applier never supplies it. It is not inert, though — its expression can read a synced column,
+    // and its own NOT NULL and CHECK constraints then apply to a value derived from whatever the
+    // applier filled in. That makes a constraint reachable through it depend on this column
+    // transitively, which the probe models by name and therefore cannot see.
+    if let Some(generated) = schema_facts::generated_column(conn, spec.name)
+        .map_err(|err| format!("cannot read the columns of `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: column `{generated}` is GENERATED — it is absent from `PRAGMA table_info`, so \
+             it can be neither replicated nor classified as local, and a constraint on it depends \
+             on the synced columns its expression reads. Derive it outside the table.",
+            spec.name
+        ));
+    }
+
+    if !schema_facts::table_is_strict(conn, spec.name)
         .map_err(|err| format!("cannot read the schema of `{}`: {err}", spec.name))?
     {
         return Err(format!(
@@ -303,22 +574,6 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
         }
     }
     Ok(())
-}
-
-/// Whether `table` is a STRICT table. SQLite exposes no pragma for this, so read the table options
-/// that follow the column-list's closing `)` (all column-level parens nest inside it, so the LAST
-/// `)` is always that closer) and look for the `STRICT` keyword.
-fn table_is_strict(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
-    let sql: String = conn.query_row(
-        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
-        [table],
-        |row| row.get(0),
-    )?;
-    let options = sql.rsplit(')').next().unwrap_or_default();
-    Ok(options
-        .to_ascii_uppercase()
-        .split(|c: char| c == ',' || c.is_whitespace())
-        .any(|token| token == "STRICT"))
 }
 
 /// Whether a declared `ValueType` matches a physical STRICT column type. `Bool` and `I64` both
@@ -352,152 +607,71 @@ pub(crate) fn assert_registry_consistent(registry: &[TableSpec]) -> Result<(), S
     Ok(())
 }
 
-/// One physical column of a table, from `PRAGMA table_info` (`conn.pragma` quotes the table name,
-/// so a spec name never needs manual escaping). `pk_position` is the 1-based position within the
-/// primary key, or `0` for a non-key column. `decl_type` is the declared column type (uppercased) —
-/// on a STRICT table one of `INT`/`INTEGER`/`REAL`/`TEXT`/`BLOB`/`ANY`.
-struct PhysicalColumn {
-    name: String,
-    decl_type: String,
-    not_null: bool,
-    has_default: bool,
-    pk_position: i64,
+/// Whether a declared default is a value of the column's declared wire type.
+fn default_matches_value_type(default: DefaultValue, value_type: ValueType) -> bool {
+    matches!(
+        (default, value_type),
+        (DefaultValue::Null, _)
+            | (DefaultValue::Bool(_), ValueType::Bool)
+            | (DefaultValue::I64(_), ValueType::I64)
+            | (DefaultValue::Text(_), ValueType::Text)
+            | (DefaultValue::Blob(_), ValueType::Blob)
+    )
 }
 
-/// Whether `table` declares any foreign key (`PRAGMA foreign_key_list` returns a row per FK).
-fn table_has_foreign_key(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
-    let mut any = false;
-    conn.pragma(None, "foreign_key_list", table, |_row| {
-        any = true;
-        Ok(())
-    })?;
-    Ok(any)
-}
-
-/// The name of `table`'s first UNIQUE index that is NOT the primary key, if any (a cross-row
-/// constraint). `PRAGMA index_list` columns: 0 seq, 1 name, 2 unique, 3 origin, 4 partial; `origin`
-/// is `pk` for the primary key's implicit index, `u` for a UNIQUE constraint, `c` for a
-/// `CREATE UNIQUE INDEX`.
-fn non_pk_unique_index(conn: &Connection, table: &str) -> rusqlite::Result<Option<String>> {
-    let mut found = None;
-    conn.pragma(None, "index_list", table, |row| {
-        let unique: i64 = row.get(2)?;
-        let origin: String = row.get(3)?;
-        if unique != 0 && origin != "pk" && found.is_none() {
-            found = Some(row.get::<_, String>(1)?);
-        }
-        Ok(())
-    })?;
-    Ok(found)
-}
-
-/// The first pk column that uses a non-BINARY collation, if any. Reads the primary key's index
-/// (`PRAGMA index_list` origin=`pk` → `index_xinfo`, whose col 2 is the column name — NULL for the
-/// implicit rowid — and col 4 the collation). An INTEGER-rowid pk has no such index (integers have
-/// no collation), so it returns `None`.
-fn pk_column_with_non_binary_collation(
-    conn: &Connection,
-    table: &str,
-) -> rusqlite::Result<Option<String>> {
-    let mut pk_index = None;
-    conn.pragma(None, "index_list", table, |row| {
-        if row.get::<_, String>(3)? == "pk" {
-            pk_index = Some(row.get::<_, String>(1)?);
-        }
-        Ok(())
-    })?;
-    let Some(index) = pk_index else { return Ok(None) };
-    let mut offending = None;
-    conn.pragma(None, "index_xinfo", &index, |row| {
-        // index_xinfo columns: 0 seqno, 1 cid, 2 name (NULL for the rowid), 3 desc, 4 coll, 5 key.
-        let name: Option<String> = row.get(2)?;
-        let collation: String = row.get(4)?;
-        if let Some(name) = name
-            && !collation.eq_ignore_ascii_case("BINARY")
-            && offending.is_none()
-        {
-            offending = Some(name);
-        }
-        Ok(())
-    })?;
-    Ok(offending)
-}
-
-/// The name of the first trigger on `table`, if any (`sqlite_master` type='trigger'). A trigger can
-/// mutate the row (or other rows) from local/derived state, so the SAME received op could fold to
-/// different physical results on two devices — divergence the whole-row fold can't detect.
-fn table_trigger(conn: &Connection, table: &str) -> rusqlite::Result<Option<String>> {
-    let mut stmt =
-        conn.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?1")?;
-    let mut rows = stmt.query([table])?;
-    match rows.next()? {
-        Some(row) => Ok(Some(row.get(0)?)),
-        None => Ok(None),
+/// Whether a declared default equals the column's physical `DEFAULT` clause.
+///
+/// SQLite reports `dflt_value` as the literal AS WRITTEN, so this compares against the canonical
+/// spelling of each literal form. Anything else — an expression, a function call, a differently
+/// spelled literal — does NOT match and is reported: a non-literal default is per-device
+/// non-deterministic, and two receivers filling the same op from it would produce different rows.
+/// `DefaultValue::Null` corresponds to an absent DEFAULT clause (SQLite's own default) as well as
+/// an explicit `DEFAULT NULL`.
+fn default_matches_sql(declared: DefaultValue, physical: Option<&str>) -> bool {
+    let physical = physical.map(str::trim);
+    match declared {
+        DefaultValue::Null => matches!(physical, None | Some("NULL") | Some("null")),
+        DefaultValue::Bool(b) => physical == Some(if b { "1" } else { "0" }),
+        DefaultValue::I64(n) => physical.is_some_and(|sql| sql.parse::<i64>() == Ok(n)),
+        // SQLite reports a text default with its quotes; compare the unquoted content so an
+        // embedded quote (doubled in SQL) still round-trips. It must be exactly ONE literal — see
+        // `single_quoted_literal`.
+        DefaultValue::Text(text) => physical
+            .and_then(schema_facts::single_quoted_literal)
+            .is_some_and(|inner| inner == text),
+        // A blob default is written as X'..' — compare the hex, case-insensitively. Unlike text,
+        // the comparison already cannot admit an expression: a concatenation carries quotes and
+        // pipes, and the target is pure hex of a fixed length, so it can never compare equal. The
+        // digit check states that rather than leaving it to be re-derived.
+        DefaultValue::Blob(bytes) => physical
+            .and_then(|sql| {
+                let hex = sql.strip_prefix("X'").or_else(|| sql.strip_prefix("x'"))?;
+                hex.strip_suffix('\'')
+            })
+            .is_some_and(|hex| {
+                hex.len() == bytes.len() * 2
+                    && hex.bytes().all(|b| b.is_ascii_hexdigit())
+                    && hex.eq_ignore_ascii_case(
+                        &bytes.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                    )
+            }),
     }
-}
-
-/// Whether any OTHER table declares a foreign key REFERENCING `table` (an inbound reference). Scans
-/// every base table's `PRAGMA foreign_key_list` (col 2 is the referenced table).
-fn table_is_referenced_by_foreign_key(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
-    let mut tables = Vec::new();
-    {
-        let mut stmt = conn.prepare(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
-        )?;
-        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-        for row in rows {
-            tables.push(row?);
-        }
-    }
-    for other in tables {
-        if other == table {
-            continue;
-        }
-        let mut references = false;
-        conn.pragma(None, "foreign_key_list", &other, |row| {
-            // foreign_key_list columns: 0 id, 1 seq, 2 table (the referenced table), 3 from, 4 to.
-            if row.get::<_, String>(2)? == table {
-                references = true;
-            }
-            Ok(())
-        })?;
-        if references {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-fn physical_column_info(conn: &Connection, table: &str) -> rusqlite::Result<Vec<PhysicalColumn>> {
-    let mut cols = Vec::new();
-    conn.pragma(None, "table_info", table, |row| {
-        // PRAGMA table_info columns: 0 cid, 1 name, 2 type, 3 notnull, 4 dflt_value, 5 pk.
-        cols.push(PhysicalColumn {
-            name: row.get::<_, String>(1)?,
-            decl_type: row.get::<_, String>(2)?.to_ascii_uppercase(),
-            not_null: row.get::<_, i64>(3)? != 0,
-            has_default: row.get::<_, Option<String>>(4)?.is_some(),
-            pk_position: row.get::<_, i64>(5)?,
-        });
-        Ok(())
-    })?;
-    Ok(cols)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const DEMO_PK: &[ColumnSpec] = &[ColumnSpec { name: "id", value_type: ValueType::Text }];
-    const DEMO_COLUMNS: &[ColumnSpec] =
-        &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
-            name: "count",
-            value_type: ValueType::I64,
-        }];
+    const DEMO_PK: &[ColumnSpec] = &[ColumnSpec::required("id", ValueType::Text)];
+    const DEMO_COLUMNS: &[ColumnSpec] = &[
+        ColumnSpec::required("title", ValueType::Text),
+        ColumnSpec::required("count", ValueType::I64),
+    ];
     const DEMO_LOCAL: &[&str] = &["resolved_rowid"];
     const DEMO_SPEC: TableSpec = TableSpec {
         name: "t_demo",
         scope_id: "demo/1",
+        spec_version: 1,
         pk: DEMO_PK,
         columns: DEMO_COLUMNS,
         local_columns: DEMO_LOCAL,
@@ -518,9 +692,1382 @@ mod tests {
         conn
     }
 
+    /// The comparable shape of one generation: `(table, spec_version, [(column, in_version,
+    /// default)])`, table order preserved.
+    /// One table's replicated contract, in a shape both a recorded generation and the live registry
+    /// can be reduced to.
+    type TableShape = (
+        &'static str,                                        // table
+        &'static str,                                        // scope_id
+        u32,                                                 // spec_version
+        Option<&'static str>,                                // repo_column
+        Vec<(&'static str, ValueType)>,                      // pk
+        Vec<(&'static str, ValueType, Option<AddedColumn>)>, // synced columns
+    );
+    type Snapshot = Vec<TableShape>;
+
+    fn snapshot_of_generation(generation: &[TableGeneration]) -> Snapshot {
+        generation
+            .iter()
+            .map(|t| {
+                (
+                    t.table,
+                    t.scope_id,
+                    t.spec_version,
+                    t.repo_column,
+                    t.pk.to_vec(),
+                    t.columns.to_vec(),
+                )
+            })
+            .collect()
+    }
+
+    fn snapshot_of_live_registry() -> Snapshot {
+        SYNCABLE_TABLES
+            .iter()
+            .map(|spec| {
+                (
+                    spec.name,
+                    spec.scope_id,
+                    spec.spec_version,
+                    spec.repo_column,
+                    spec.pk.iter().map(|c| (c.name, c.value_type)).collect(),
+                    spec.columns.iter().map(|c| (c.name, c.value_type, c.added)).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_registry_change_cannot_land_without_a_projector_generation() {
+        // The coupling that makes a widened registry actually reach parked entries. A refold is
+        // owed only when the store's stamp is behind or an entry was parked by an OLDER projector,
+        // so registering a table (or widening a spec) without moving the version leaves a store
+        // already stamped at that version with entries it will never retry — and redelivery
+        // short-circuits on `entry_exists`, so the payload is gone.
+        //
+        // A pin of the CURRENT registry cannot enforce this: editing the pin is exactly as easy as
+        // making the change it is supposed to guard. Requiring the live registry to equal the LAST
+        // recorded generation does, because the only way to satisfy it after a change is to append
+        // — and the version IS the number of generations.
+        assert_eq!(
+            usize::try_from(super::super::refold::TABLE_SYNC_PROJECTOR_VERSION).unwrap(),
+            PROJECTOR_GENERATIONS.len(),
+            "the projector version is the count of recorded generations — append one, do not \
+             renumber"
+        );
+        assert_eq!(
+            snapshot_of_generation(PROJECTOR_GENERATIONS.last().expect("at least one generation")),
+            snapshot_of_live_registry(),
+            "the live registry differs from the newest recorded generation — APPEND a generation \
+             (which bumps the projector version), rather than editing the last one"
+        );
+    }
+
+    #[test]
+    fn each_generation_only_extends_the_one_before_it() {
+        // EVOLUTION IS ADDITIVE ONLY, enforced across history rather than asserted in prose. A
+        // single binary cannot check this — it has no past registry to compare against — which is
+        // why the rule is documented as un-lintable. The generation list IS that past, so every
+        // consecutive pair can be checked.
+        //
+        // Both directions of "additive" matter, and they fail differently:
+        //
+        // - A column that DISAPPEARS (dropped or renamed) strands every stored or received op
+        //   naming it on `project_cells`' `UnknownColumn` path — parked forever, since no future
+        //   binary reintroduces the name, and redelivery short-circuits on `entry_exists`.
+        // - A column that CHANGES its type or introduction tuple diverges silently. A declared
+        //   default is the value every receiver synthesizes for an op predating the column, so
+        //   changing it — even in step with the table's SQL default, which keeps the schema lint
+        //   happy because that lint only ever sees the CURRENT schema — makes a device that folded
+        //   an op before the change and one that folded it after hold different rows AT THE SAME
+        //   CLOCK, with no local edit to signal it. `in_version` decides WHICH ops a column is
+        //   filled for, so moving it retroactively rewrites what every stored op means.
+        //
+        // An accumulate-and-compare map catches only the second: a key that never reappears is
+        // never revisited. Comparing each generation against its predecessor catches both.
+        for (index, pair) in PROJECTOR_GENERATIONS.windows(2).enumerate() {
+            let (previous, next) = (pair[0], pair[1]);
+            let version = index + 2;
+            for old in previous {
+                let Some(new) = next.iter().find(|t| t.table == old.table) else {
+                    panic!(
+                        "`{}` disappeared from the registry by generation {version} — ops already \
+                         stored for it would park as `TableNotInScope` with nothing to redeem \
+                         them. Retiring a table is a deliberate act, not a registry edit.",
+                        old.table
+                    );
+                };
+                assert_eq!(
+                    old.pk, new.pk,
+                    "`{}` changed its primary key by generation {version} — the identity is what \
+                     every clock, tombstone and published record is keyed on; a changed identity \
+                     means a NEW TABLE, not a new spec version",
+                    old.table
+                );
+                // The scope selects the STREAM, and a projector bump cannot repair a move. Three
+                // separate things break, none of them recoverable by replay:
+                //   - a retained entry resolves its spec by the scope RECORDED ON THE ENTRY
+                //     (`refold::replay_pending_entry`), so every stored op for this table reparks
+                //     as `TableNotInScope` forever, whatever the projector version becomes;
+                //   - `sync_row_clocks` / tombstones / `sync_published_rows` are keyed `(repo_id,
+                //     table_name, row_pk)` with NO stream component, so they carry across silently
+                //     and now hold lamports from a stream nobody writes — a locally-authored op
+                //     starts from the NEW stream's max and loses its own self-apply;
+                //   - the winner lookup keys on `(stream, device, lamport)`, so it lands on some
+                //     sibling table's entry (guarded, but only down to "cannot resolve").
+                // Moving a table between scopes is a data migration, not a registry edit.
+                assert_eq!(
+                    old.scope_id, new.scope_id,
+                    "`{}` moved from scope `{}` to `{}` by generation {version} — its stream, and \
+                     with it every retained entry and row clock, is derived from that scope; a \
+                     scope change means a NEW TABLE",
+                    old.table, old.scope_id, new.scope_id
+                );
+                // The repo dimension decides WHICH rows this table replicates and which incoming
+                // ops are accepted, while the bookkeeping it writes stays keyed by the caller's
+                // repo either way. Dropping it to `None` is the sharp case: `read_all_rows` stops
+                // filtering, so every physical row is emitted into EVERY repo's stream, and the
+                // applier's repo-identity gate stops rejecting foreign ops — while one physical row
+                // now collects an independent clock per repo. That is cross-repo leakage and
+                // divergence at once, and no replay repairs it.
+                assert_eq!(
+                    old.repo_column, new.repo_column,
+                    "`{}` changed its repo column from {:?} to {:?} by generation {version} — the \
+                     repo dimension selects what replicates and what is accepted, but the clocks \
+                     and published records it writes are keyed the same either way; changing it \
+                     means a NEW TABLE",
+                    old.table, old.repo_column, new.repo_column
+                );
+                assert!(
+                    new.spec_version >= old.spec_version,
+                    "`{}`'s spec version went backwards by generation {version}",
+                    old.table
+                );
+                for (column, value_type, added) in old.columns {
+                    let carried = new.columns.iter().find(|(name, ..)| name == column);
+                    let Some((_, new_type, new_added)) = carried else {
+                        panic!(
+                            "`{}`.`{column}` disappeared by generation {version} — every op that \
+                             names it would park as `UnknownColumn` forever. Removing or renaming \
+                             a synced column means a NEW TABLE.",
+                            old.table
+                        );
+                    };
+                    assert_eq!(
+                        (new_type, new_added),
+                        (value_type, added),
+                        "`{}`.`{column}` changed its type or introduction tuple by generation \
+                         {version} — both are history the projection of older ops depends on",
+                        old.table
+                    );
+                }
+                // A column that APPEARS must be fillable for every op the previous generation could
+                // have authored, or older→newer replication stops for this table. The schema lint
+                // cannot see this: it bounds `in_version` against the CURRENT spec version and
+                // skips `required` columns entirely, both of which are judgements about one
+                // generation in isolation. Only the predecessor says which versions are still out
+                // there.
+                for (column, _, added) in new.columns {
+                    if old.columns.iter().any(|(name, ..)| name == column) {
+                        continue;
+                    }
+                    let Some(added) = added else {
+                        panic!(
+                            "`{}`.`{column}` was added in generation {version} as a REQUIRED \
+                             column — an op from spec version {} omits it and parks as \
+                             `PartialAfterImage` forever. A column added to a live table needs \
+                             `ColumnSpec::added` with a declared default.",
+                            old.table, old.spec_version
+                        );
+                    };
+                    assert!(
+                        added.in_version > old.spec_version,
+                        "`{}`.`{column}` was added in generation {version} claiming to exist \
+                         since spec version {}, but the previous generation shipped spec version \
+                         {} — an op stamped {} omits the column yet is not old enough to have it \
+                         filled, so it parks forever. Its introduction version must FOLLOW the \
+                         previous spec.",
+                        old.table,
+                        added.in_version,
+                        old.spec_version,
+                        old.spec_version
+                    );
+                    assert!(
+                        added.in_version <= new.spec_version,
+                        "`{}`.`{column}` claims an introduction version above the spec version \
+                         that introduces it ({} > {})",
+                        old.table,
+                        added.in_version,
+                        new.spec_version
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn a_spec_that_classifies_every_column_passes() {
         assert!(assert_spec_covers_schema(&demo_conn(), &DEMO_SPEC).is_ok());
+    }
+
+    /// A table with a later column, matching what an `ALTER TABLE ADD COLUMN` leaves behind.
+    fn widened_conn(default_clause: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later TEXT{default_clause},
+                 resolved_rowid INTEGER
+             ) STRICT;"
+        ))
+        .unwrap();
+        conn
+    }
+
+    macro_rules! widened_spec {
+        ($later:expr) => {
+            TableSpec {
+                name: "t_demo",
+                scope_id: "demo/1",
+                spec_version: 2,
+                pk: DEMO_PK,
+                columns: &[
+                    ColumnSpec::required("title", ValueType::Text),
+                    ColumnSpec::required("count", ValueType::I64),
+                    $later,
+                ],
+                local_columns: DEMO_LOCAL,
+                repo_column: None,
+            }
+        };
+    }
+
+    #[test]
+    fn a_declared_default_must_equal_the_physical_default() {
+        // THE CONVERGENCE GUARANTEE, not hygiene. Adding a column backfills existing rows with the
+        // SQL default, while the applier fills a column an older op omits with the DECLARED one. If
+        // the two disagree, a device that applied an op before upgrading and one that applied the
+        // same op after hold DIFFERENT ROWS AT THE SAME CLOCK — silent divergence, with no local
+        // edit to signal it.
+        const MATCHING: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("x")));
+        assert!(assert_spec_covers_schema(&widened_conn(" DEFAULT 'x'"), &MATCHING).is_ok());
+
+        const DISAGREES: TableSpec = widened_spec!(ColumnSpec::added(
+            "later",
+            ValueType::Text,
+            2,
+            DefaultValue::Text("other")
+        ));
+        let err = assert_spec_covers_schema(&widened_conn(" DEFAULT 'x'"), &DISAGREES)
+            .expect_err("a declared default that disagrees with the schema is refused");
+        assert!(err.contains("later"), "the error names the column: {err}");
+
+        // An absent DEFAULT clause is SQLite's own NULL, and matches a declared Null.
+        const NULL_DEFAULT: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Null));
+        assert!(assert_spec_covers_schema(&widened_conn(""), &NULL_DEFAULT).is_ok());
+        assert!(assert_spec_covers_schema(&widened_conn(" DEFAULT 'x'"), &NULL_DEFAULT).is_err());
+    }
+
+    #[test]
+    fn a_non_literal_default_is_refused() {
+        // A per-device non-deterministic default would have two receivers fill the same op with
+        // different values — divergence by construction. The lint cannot match it, so it refuses.
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("x")));
+        assert!(
+            assert_spec_covers_schema(&widened_conn(" DEFAULT (unixepoch())"), &SPEC).is_err(),
+            "a non-literal default cannot be honored deterministically"
+        );
+    }
+
+    #[test]
+    fn a_declared_default_must_match_the_columns_type() {
+        // The fill goes straight into the row, so a mistyped default would write a value the
+        // applier would have quarantined had it arrived on the wire.
+        const MISTYPED: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::I64(7)));
+        assert!(assert_spec_covers_schema(&widened_conn(" DEFAULT 7"), &MISTYPED).is_err());
+    }
+
+    #[test]
+    fn each_default_type_is_matched_against_its_own_sql_spelling() {
+        // One case per `DefaultValue` variant, each asserted BOTH ways. Testing only `Text` left
+        // every other arm of `default_matches_sql` free to return `true` unconditionally — i.e. a
+        // declared default could disagree with the migration's backfill for any non-text column and
+        // the lint that exists to catch exactly that would pass.
+        for (declared, value_type, agrees, disagrees) in [
+            (DefaultValue::Bool(true), ValueType::Bool, " DEFAULT 1", " DEFAULT 0"),
+            (DefaultValue::I64(7), ValueType::I64, " DEFAULT 7", " DEFAULT 8"),
+            (DefaultValue::Text("x"), ValueType::Text, " DEFAULT 'x'", " DEFAULT 'y'"),
+            (DefaultValue::Blob(&[0xab]), ValueType::Blob, " DEFAULT X'ab'", " DEFAULT X'cd'"),
+        ] {
+            let sql_type = match value_type {
+                ValueType::Bool | ValueType::I64 => "INTEGER",
+                ValueType::Text => "TEXT",
+                ValueType::Blob => "BLOB",
+            };
+            let conn = |clause: &str| {
+                let conn = Connection::open_in_memory().unwrap();
+                conn.execute_batch(&format!(
+                    "CREATE TABLE t_demo(
+                         id TEXT PRIMARY KEY,
+                         title TEXT NOT NULL,
+                         count INTEGER NOT NULL,
+                         later {sql_type}{clause},
+                         resolved_rowid INTEGER
+                     ) STRICT;"
+                ))
+                .unwrap();
+                conn
+            };
+            let spec = TableSpec {
+                name: "t_demo",
+                scope_id: "demo/1",
+                spec_version: 2,
+                pk: DEMO_PK,
+                // `columns` is `&'static`, and these vary per iteration — leaking a test-sized
+                // array is simpler than a const per type.
+                columns: Box::leak(Box::new([
+                    ColumnSpec::required("title", ValueType::Text),
+                    ColumnSpec::required("count", ValueType::I64),
+                    ColumnSpec::added("later", value_type, 2, declared),
+                ])),
+                local_columns: DEMO_LOCAL,
+                repo_column: None,
+            };
+            assert!(
+                assert_spec_covers_schema(&conn(agrees), &spec).is_ok(),
+                "{declared:?} must match the SQL default `{agrees}`"
+            );
+            assert!(
+                assert_spec_covers_schema(&conn(disagrees), &spec).is_err(),
+                "{declared:?} must NOT match the SQL default `{disagrees}`"
+            );
+        }
+    }
+
+    #[test]
+    fn a_text_default_must_be_one_literal_not_an_expression() {
+        // SQLite strips the outer parentheses from a parenthesized default, so `DEFAULT ('x'||'y')`
+        // comes back as `'x'||'y'` — quoted at both ends, but a CONCATENATION. Matching on the
+        // outer quotes alone would accept it while SQLite backfills `xy` and the applier
+        // synthesizes the raw text, which is the exact divergence the check exists to prevent.
+        assert_eq!(schema_facts::single_quoted_literal("'x'"), Some("x".to_string()));
+        assert_eq!(schema_facts::single_quoted_literal("'it''s'"), Some("it's".to_string()));
+        assert_eq!(schema_facts::single_quoted_literal("''"), Some(String::new()));
+        assert_eq!(
+            schema_facts::single_quoted_literal("'x'||'y'"),
+            None,
+            "a concatenation is not a literal"
+        );
+        assert_eq!(schema_facts::single_quoted_literal("'a'||b"), None);
+        assert_eq!(schema_facts::single_quoted_literal("unixepoch()"), None);
+
+        // End to end: the spec declaring exactly what SQLite would evaluate is still refused,
+        // because the physical default is not a literal at all.
+        const SPEC: TableSpec = widened_spec!(ColumnSpec::added(
+            "later",
+            ValueType::Text,
+            2,
+            DefaultValue::Text("x'||'y")
+        ));
+        assert!(
+            assert_spec_covers_schema(&widened_conn(" DEFAULT ('x'||'y')"), &SPEC).is_err(),
+            "an expression default cannot be honored deterministically"
+        );
+
+        // Blobs need no equivalent case: a concatenation carries quotes and pipes, which cannot
+        // compare equal to fixed-length pure hex, so the expression form is excluded already.
+        const BLOB: TableSpec = widened_spec!(ColumnSpec::added(
+            "later",
+            ValueType::Blob,
+            2,
+            DefaultValue::Blob(&[0xab])
+        ));
+        assert!(assert_spec_covers_schema(&blob_conn(" DEFAULT X'ab'"), &BLOB).is_ok());
+        assert!(
+            assert_spec_covers_schema(&blob_conn(" DEFAULT (X'ab'||X'cd')"), &BLOB).is_err(),
+            "an expression default is refused whatever it would evaluate to"
+        );
+    }
+
+    /// `widened_conn`, but the later column is a BLOB.
+    fn blob_conn(default_clause: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later BLOB{default_clause},
+                 resolved_rowid INTEGER
+             ) STRICT;"
+        ))
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn a_default_that_violates_its_own_check_is_refused() {
+        // The sharp case, and the one a static reading of the constraint cannot decide: the CHECK
+        // names ONLY this column, so it looks self-contained, and every other lint passes — the
+        // declared default matches the SQL default, matches the ValueType, and is not Null on a
+        // NOT NULL column. It is simply a value the table rejects. Every op older than the column
+        // would be filled with it, fail the constraint at INSERT, and be quarantined TERMINALLY.
+        //
+        // `ALTER TABLE ... ADD COLUMN later INTEGER NOT NULL DEFAULT 0 CHECK(later > 0)` is
+        // accepted by SQLite on an empty table, so this schema is reachable, not hypothetical.
+        let violates = Connection::open_in_memory().unwrap();
+        violates
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 0 CHECK(later > 0),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&violates, &SPEC)
+            .expect_err("a default its own CHECK rejects cannot be a default");
+        assert!(err.contains("REJECTS"), "the error says what is wrong: {err}");
+
+        // The same shape with a default the constraint accepts is fine — the lint DECIDES the
+        // question rather than refusing the shape.
+        let satisfied = Connection::open_in_memory().unwrap();
+        satisfied
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 1 CHECK(later > 0),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const OK_SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(1)));
+        assert!(assert_spec_covers_schema(&satisfied, &OK_SPEC).is_ok());
+    }
+
+    #[test]
+    fn the_probe_honors_the_columns_collation_and_sqlites_truth_semantics() {
+        // Both cases are ones an EVALUATED expression gets wrong, silently and in opposite
+        // directions — which is why the probe re-declares the column instead.
+
+        // COLLATION. A bare expression compares BINARY, so `'x' <> 'X'` reads true and the default
+        // looks fine; the real column is NOCASE, where it is FALSE and the insert is refused. Under
+        // an expression-based probe this schema would be accepted and then quarantine every older
+        // op.
+        let nocase = Connection::open_in_memory().unwrap();
+        nocase
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later TEXT COLLATE NOCASE NOT NULL DEFAULT 'x' CHECK(later <> 'X'),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const COLLATED: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("x")));
+        assert!(
+            assert_spec_covers_schema(&nocase, &COLLATED).is_err(),
+            "the column's own collation decides, not BINARY"
+        );
+
+        // TRUTH SEMANTICS. SQLite violates a CHECK only when it evaluates to ZERO, so a REAL 0.5 is
+        // satisfied. Reading the expression's result as an integer would fail to decode and refuse
+        // a schema that works.
+        let real = Connection::open_in_memory().unwrap();
+        real.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0
+                     CHECK(CASE WHEN later = 0 THEN 0.5 ELSE 1 END),
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        const REAL_TRUTHY: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        assert!(
+            assert_spec_covers_schema(&real, &REAL_TRUTHY).is_ok(),
+            "a non-zero REAL satisfies a CHECK, so the default is fine"
+        );
+    }
+
+    #[test]
+    fn a_check_keywords_case_does_not_hide_it() {
+        // The keyword's case is not normalised in `sqlite_master.sql`, and locating the body by
+        // trimming the literal text `CHECK` drops a mixed-case constraint SILENTLY — the
+        // false-negative direction, where an unsafe default sails through.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 ChEcK(later > 0)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a mixed-case CHECK is still a CHECK");
+        assert!(err.contains("REJECTS"), "the default is caught violating it: {err}");
+    }
+
+    #[test]
+    fn a_column_may_be_named_like_a_keyword_or_the_rowid() {
+        // A QUOTED head is always a column name, never the keyword; and a table that DECLARES a
+        // column called `rowid` shadows the implicit alias, so the name is an ordinary reference
+        // rather than per-device state. Both were refused as impossible.
+        let quoted = Connection::open_in_memory().unwrap();
+        quoted
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     \"check\" INTEGER NOT NULL DEFAULT 0 CHECK(\"check\" >= 0),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const QUOTED: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: DEMO_PK,
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+                ColumnSpec::added("check", ValueType::I64, 2, DefaultValue::I64(0)),
+            ],
+            local_columns: DEMO_LOCAL,
+            repo_column: None,
+        };
+        assert!(
+            assert_spec_covers_schema(&quoted, &QUOTED).is_ok(),
+            "`\"check\"` is a column, not a constraint"
+        );
+
+        let shadowing = Connection::open_in_memory().unwrap();
+        shadowing
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     rowid INTEGER NOT NULL DEFAULT 0 CHECK(rowid >= 0),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const SHADOWING: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: DEMO_PK,
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+                ColumnSpec::added("rowid", ValueType::I64, 2, DefaultValue::I64(0)),
+            ],
+            local_columns: DEMO_LOCAL,
+            repo_column: None,
+        };
+        assert!(
+            assert_spec_covers_schema(&shadowing, &SHADOWING).is_ok(),
+            "a declared `rowid` column shadows the implicit alias"
+        );
+    }
+
+    #[test]
+    fn a_named_constraint_is_still_a_check() {
+        // `CONSTRAINT c CHECK(...)` is the same constraint as a bare `CHECK(...)`. Missing the
+        // named form drops it silently — the false-negative direction, where the unsafe default is
+        // simply accepted.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 CONSTRAINT later_is_positive CHECK(later > 0)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a named constraint is still a constraint");
+        assert!(err.contains("REJECTS"), "the default is caught violating it: {err}");
+    }
+
+    #[test]
+    fn a_double_quoted_column_reference_is_not_read_as_a_string() {
+        // SQLite's double-quoted-string misfeature: `"later"` falls back to a STRING LITERAL when
+        // no such column is in scope. Asking "does this resolve WITHOUT the column?" first would
+        // therefore see it resolve and call the constraint irrelevant — accepting an unsafe
+        // default. Asking "does it resolve with ONLY the column?" first settles it correctly.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 CHECK(\"later\" > 10)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a quoted reference to the column is a reference, not a string");
+        assert!(err.contains("REJECTS"), "the default is caught violating it: {err}");
+    }
+
+    #[test]
+    fn a_check_whose_result_can_differ_between_devices_is_refused() {
+        // Self-contained and satisfiable, yet worthless as a guarantee: the identical replicated op
+        // can be accepted on one peer and quarantined on another, which is divergence with no local
+        // edit to signal it.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 CHECK(later >= 0 AND random() <> 0)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a non-deterministic constraint cannot be relied on");
+        assert!(err.contains("random"), "the error names the function: {err}");
+
+        // A QUOTED function name is still a call: matching only bare words would let it past.
+        let quoted_fn = Connection::open_in_memory().unwrap();
+        quoted_fn
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 0,
+                     resolved_rowid INTEGER,
+                     CHECK(later >= 0 AND \"random\"() <> 0)
+                 ) STRICT;",
+            )
+            .unwrap();
+        let err = assert_spec_covers_schema(&quoted_fn, &SPEC)
+            .expect_err("a quoted function name is still a call");
+        assert!(err.contains("random"), "the error names the function: {err}");
+
+        // A date/time call is deterministic in its INPUTS; only an environment-dependent argument
+        // reads the device. Refusing the whole family would block a legitimate schema.
+        let dated = Connection::open_in_memory().unwrap();
+        dated
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later TEXT NOT NULL DEFAULT '2020-01-01'
+                         CHECK(date(later) >= date('2000-01-01')),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const DATED: TableSpec = widened_spec!(ColumnSpec::added(
+            "later",
+            ValueType::Text,
+            2,
+            DefaultValue::Text("2020-01-01")
+        ));
+        assert!(
+            assert_spec_covers_schema(&dated, &DATED).is_ok(),
+            "date() over the column's own value is deterministic"
+        );
+
+        // ...but the same function reading the clock is refused.
+        let clock = Connection::open_in_memory().unwrap();
+        clock
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later TEXT NOT NULL DEFAULT '2020-01-01'
+                         CHECK(date(later) <= date('now')),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        assert!(
+            assert_spec_covers_schema(&clock, &DATED).is_err(),
+            "date('now') reads the device clock"
+        );
+
+        // The environment literal must be an ARGUMENT of the date/time call, not merely present
+        // somewhere in the constraint: here `'now'` is a value the column is compared against.
+        let unrelated = Connection::open_in_memory().unwrap();
+        unrelated
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later TEXT NOT NULL DEFAULT '2020-01-01'
+                         CHECK(date(later) IS NOT NULL AND later <> 'now'),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        assert!(
+            assert_spec_covers_schema(&unrelated, &DATED).is_ok(),
+            "a `'now'` outside the call's arguments does not make it clock-reading"
+        );
+
+        // A comment inside the call's arguments is not an argument. Scanning the raw text would
+        // read it as one.
+        let commented = Connection::open_in_memory().unwrap();
+        commented
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later TEXT NOT NULL DEFAULT '2020-01-01'
+                         CHECK(date(later /* not 'now' */) IS NOT NULL),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        assert!(
+            assert_spec_covers_schema(&commented, &DATED).is_ok(),
+            "a commented-out `'now'` is not an argument"
+        );
+
+        // A build-varying function is refused even though SQLite flags it DETERMINISTIC: that flag
+        // means "same answer for the same arguments within this build", which is not the question.
+        // `fts5_source_id()` satisfies it and still returns a different string on a peer compiled
+        // against another SQLite — which is why the rule is an allowlist rather than a denylist.
+        let build_varying = Connection::open_in_memory().unwrap();
+        build_varying
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 0
+                         CHECK(later = 0 AND fts5_source_id() IS NOT NULL),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const ZERO: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&build_varying, &ZERO)
+            .expect_err("a build-varying function is not a shared guarantee");
+        assert!(err.contains("fts5_source_id"), "the error names it: {err}");
+
+        // A DETERMINISTIC builtin is fine — the rule is about per-device variation, not calls.
+        let ok = Connection::open_in_memory().unwrap();
+        ok.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later TEXT NOT NULL DEFAULT 'ab' CHECK(length(later) = 2),
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        const DETERMINISTIC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("ab")));
+        assert!(assert_spec_covers_schema(&ok, &DETERMINISTIC).is_ok());
+    }
+
+    #[test]
+    fn a_sibling_named_after_a_keyword_does_not_break_the_probe() {
+        // The probe's "does this resolve without the column" world lists the OTHER columns by name.
+        // A column may legally be named after a keyword, and splicing such a name in bare fails
+        // that CREATE on syntax — refusing a valid schema for a reason unrelated to the
+        // constraint.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 \"order\" INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 CHECK(title <> '')
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: DEMO_PK,
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("order", ValueType::I64),
+                ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)),
+            ],
+            local_columns: DEMO_LOCAL,
+            repo_column: None,
+        };
+        assert!(
+            assert_spec_covers_schema(&conn, &SPEC).is_ok(),
+            "a sibling's name is quoted into the probe, so a keyword name is harmless"
+        );
+    }
+
+    #[test]
+    fn a_check_sharing_a_segment_with_another_constraint_is_still_found() {
+        // SQLite does not require a comma between table constraints, so a CHECK can share a segment
+        // with a PRIMARY KEY. Dispatching on the segment's HEAD dropped that check entirely — the
+        // verdict turned on where the author happened to put a comma.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT NOT NULL,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 PRIMARY KEY(id) CHECK(later >= count)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a CHECK is a CHECK wherever it is written");
+        assert!(
+            err.contains("read something other than that column"),
+            "refused as cross-column: {err}"
+        );
+    }
+
+    #[test]
+    fn a_trailing_line_comment_does_not_break_the_probe() {
+        // A declaration is spliced VERBATIM into the probe's DDL, so one ending in a `--` comment
+        // would comment out everything after it on that line and the CREATE would fail as
+        // incomplete input — refusing a perfectly ordinary table.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 resolved_rowid INTEGER,
+                 later INTEGER NOT NULL DEFAULT 0 CHECK(later >= 0) -- how many
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        assert!(
+            assert_spec_covers_schema(&conn, &SPEC).is_ok(),
+            "a comment on the declaration is not a defect in the table"
+        );
+    }
+
+    #[test]
+    fn a_generated_column_is_refused() {
+        // A generated column is absent from `PRAGMA table_info`, so the exhaustiveness diff cannot
+        // classify it as synced or local, and the applier never supplies it — yet it is not inert.
+        // Its expression reads synced columns, so its own NOT NULL and CHECK constraints apply to a
+        // value derived from whatever the applier filled in. Here `CHECK(derived > count)` fails
+        // for a valid older op carrying `count = 5`, and the probe — which models the other columns
+        // by NAME — cannot see the dependency that runs through `derived`. Refuse the shape.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 derived INTEGER GENERATED ALWAYS AS (later) VIRTUAL CHECK(derived > count)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: DEMO_PK,
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+                ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)),
+            ],
+            local_columns: DEMO_LOCAL,
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a generated column cannot be classified or modelled");
+        assert!(
+            err.contains("GENERATED") && err.contains("derived"),
+            "refused for being generated, not incidentally: {err}"
+        );
+    }
+
+    #[test]
+    fn an_inline_check_on_a_sibling_column_is_still_a_constraint() {
+        // An inline CHECK constrains the ROW, not the column it happens to be attached to. Reading
+        // only table-level constraints plus the added column's own declaration therefore misses one
+        // written on a SIBLING — and a valid older op carrying `count = 5` would be filled with
+        // `later = 0`, rejected by SQLite, and quarantined terminally.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL CHECK(later >= count),
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("where the constraint is WRITTEN does not change what it constrains");
+        assert!(
+            err.contains("read something other than that column"),
+            "refused as cross-column: {err}"
+        );
+
+        // A sibling's inline CHECK that does NOT read this column is still irrelevant to it.
+        let unrelated = Connection::open_in_memory().unwrap();
+        unrelated
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL CHECK(count >= 0),
+                     later INTEGER NOT NULL DEFAULT 0,
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        assert!(
+            assert_spec_covers_schema(&unrelated, &SPEC).is_ok(),
+            "a sibling constraint that never reads this column does not concern it"
+        );
+    }
+
+    #[test]
+    fn a_clock_reading_date_call_is_refused_by_the_probe() {
+        // Omitting the time value IS `'now'`: `date()` means `date('now')`, and `strftime('%s')` —
+        // one argument, the format — reads the clock too.
+        //
+        // Nothing in this lint decides that. SQLite refuses a clock-reading date/time call inside a
+        // CHECK at INSERT, which is exactly what the probe performs, so the verdict comes back as
+        // not-self-contained on its own. That is why the date/time family sits on the allowlist:
+        // SQLite draws the line more precisely than this lint could — it also catches a
+        // `'localtime'` modifier, and it correctly permits `date(column, 'now')`, which is not a
+        // clock read. This test pins that reliance so a future change cannot quietly lose it.
+        let table = |constraint: &str| {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(&format!(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later TEXT NOT NULL DEFAULT '2020-01-01' CHECK({constraint}),
+                     resolved_rowid INTEGER
+                 ) STRICT;"
+            ))
+            .unwrap();
+            conn
+        };
+        const SPEC: TableSpec = widened_spec!(ColumnSpec::added(
+            "later",
+            ValueType::Text,
+            2,
+            DefaultValue::Text("2020-01-01")
+        ));
+
+        // The WHOLE boundary is pinned, not just the two forms that prompted it: this lint now
+        // depends on where SQLite draws the line, so a change in that line must fail here rather
+        // than silently widen or narrow what the lint accepts.
+        for constraint in [
+            "later <= date()",                   // time value omitted
+            "later <= strftime('%s')",           // format only, time value omitted
+            "later <= date('now')",              // the clock, explicitly
+            "later <= date(later, 'localtime')", // the device's timezone
+        ] {
+            let err = assert_spec_covers_schema(&table(constraint), &SPEC)
+                .expect_err("a clock-reading call cannot be a shared guarantee");
+            assert!(
+                err.contains("non-deterministic use"),
+                "refused because SQLite itself will not evaluate it: {err}"
+            );
+        }
+
+        // ...and the forms SQLite permits stay permitted. `date(column, 'now')` is the sharp one:
+        // `'now'` in a MODIFIER position is not a clock read, and a hand-rolled rule that scanned
+        // for the literal would wrongly refuse it.
+        for constraint in [
+            "date(later) >= date('2000-01-01')",
+            "strftime('%Y', later) >= '2000'",
+            "date(later, '+1 day') > date('2000-01-01')",
+            "date(later, 'now') > date('2000-01-01')",
+        ] {
+            assert!(
+                assert_spec_covers_schema(&table(constraint), &SPEC).is_ok(),
+                "deterministic in its inputs, so it is a shared guarantee: {constraint}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_connection_configurable_operator_is_refused() {
+        // `PRAGMA case_sensitive_like` changes both `a LIKE b` and `like(a, b)`, so the constraint
+        // means different things on two peers. The OPERATOR form is the one a call-shaped scan
+        // cannot see.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later TEXT NOT NULL DEFAULT 'ab' CHECK(later NOT LIKE 'Z%'),
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Text("ab")));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("LIKE is connection state, not a property of its operands");
+        assert!(err.contains("like"), "the error names it: {err}");
+    }
+
+    #[test]
+    fn per_device_references_are_refused_in_every_form_they_take() {
+        // The call-shaped scan and the bare-word rowid scan each missed a form. Neither gap is
+        // visible from inside the other, and both are silent: the probe passes at ITS values, then
+        // the same op is quarantined on a peer whose clock or insertion order differs.
+        let table = |constraint: &str| {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(&format!(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 2 CHECK({constraint}),
+                     resolved_rowid INTEGER
+                 ) STRICT;"
+            ))
+            .unwrap();
+            conn
+        };
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(2)));
+
+        // A QUOTED rowid alias resolves to the implicit rowid exactly as a bare one does. The
+        // default passes at the probe's rowid 1 and fails on a peer whose row lands at rowid 2.
+        let quoted = table("later <> \"rowid\"");
+        let err = assert_spec_covers_schema(&quoted, &SPEC)
+            .expect_err("a quoted rowid alias is still the rowid");
+        assert!(err.contains("assigned per device"), "refused for the rowid rule: {err}");
+
+        // A clock KEYWORD takes no parentheses, so a scan shaped around calls never reaches it.
+        let clock = table("later > 0 AND CURRENT_TIMESTAMP IS NOT NULL");
+        let err =
+            assert_spec_covers_schema(&clock, &SPEC).expect_err("a clock keyword reads the device");
+        assert!(err.contains("current_timestamp"), "the error names what reads the device: {err}");
+    }
+
+    #[test]
+    fn a_check_reading_the_implicit_rowid_is_refused() {
+        // The rowid resolves in ANY rowid table — including the probe — so a constraint reading it
+        // looks self-contained and passes. It is also per-device, assigned by insertion order, so
+        // the same op lands at a different rowid on every peer.
+        //
+        // The body is deliberately one the default SATISFIES at the probe's rowid (1): a body that
+        // merely fails there would be reported as `Violated` and the test would pass off SQLite's
+        // own error text without ever exercising the rowid rule — which is how the first version of
+        // this test was vacuous.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0 CHECK(later = 0 AND rowid < 10),
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&conn, &SPEC)
+            .expect_err("a rowid-dependent constraint cannot be proven safe");
+        assert!(
+            err.contains("assigned per device"),
+            "refused for the rowid rule, not incidentally: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unrelated_constraint_is_not_dragged_into_the_probe() {
+        // Which constraints involve the column is SQLite's answer, not a token match. `text` here
+        // is a TYPE NAME inside a CAST, and the constraint does not read the `text` column at all —
+        // a token match would import it into the probe, where `other` fails to resolve and the
+        // schema is refused for a constraint that never concerned it.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 text TEXT NOT NULL DEFAULT '',
+                 CHECK(CAST(title AS text) <> 'zz')
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: DEMO_PK,
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+                ColumnSpec::added("text", ValueType::Text, 2, DefaultValue::Text("")),
+            ],
+            local_columns: &[],
+            repo_column: None,
+        };
+        assert!(
+            assert_spec_covers_schema(&conn, &SPEC).is_ok(),
+            "a constraint that does not read the column must not decide its fate"
+        );
+    }
+
+    #[test]
+    fn a_table_qualified_self_reference_is_self_contained() {
+        // `t_demo.later` names this very column. The probe rebuilds the column under the real
+        // table's NAME so the qualification still resolves; otherwise a legal, genuinely
+        // self-contained constraint would read as cross-column.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later INTEGER NOT NULL DEFAULT 0,
+                 resolved_rowid INTEGER,
+                 CHECK(t_demo.later >= 0)
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        assert!(
+            assert_spec_covers_schema(&conn, &SPEC).is_ok(),
+            "a qualified reference to the column itself is self-contained"
+        );
+    }
+
+    #[test]
+    fn a_function_call_is_not_a_cross_column_reference() {
+        // A built-in whose name matches a column of the table is not a reference to that column.
+        // Token comparison alone cannot tell them apart; evaluation can, because SQLite resolves
+        // `length(...)` as a function regardless of what the table's columns are called.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 length INTEGER NOT NULL DEFAULT 0,
+                 later INTEGER NOT NULL DEFAULT 0 CHECK(later <= length('abc')),
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        const SPEC: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: DEMO_PK,
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+                ColumnSpec::required("length", ValueType::I64),
+                ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)),
+            ],
+            local_columns: DEMO_LOCAL,
+            repo_column: None,
+        };
+        assert!(
+            assert_spec_covers_schema(&conn, &SPEC).is_ok(),
+            "`length(...)` is a call, not a reference to the `length` column"
+        );
+    }
+
+    #[test]
+    fn an_added_column_may_not_participate_in_a_cross_column_check() {
+        // The default and the other columns come from different places — the applier synthesizes
+        // this one and takes the rest from the OP — so a constraint relating them can fail for a
+        // perfectly valid older op and quarantine it TERMINALLY, ending older→newer replication.
+        let cross = Connection::open_in_memory().unwrap();
+        cross
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 0 CHECK(later >= count),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        const CROSS: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::I64, 2, DefaultValue::I64(0)));
+        let err = assert_spec_covers_schema(&cross, &CROSS)
+            .expect_err("a default cannot satisfy a constraint that depends on the op's values");
+        assert!(err.contains("later") && err.contains("count"), "names both sides: {err}");
+
+        // A SELF-CONTAINED check is fine: it constrains only the synthesized value, statically.
+        let alone = Connection::open_in_memory().unwrap();
+        alone
+            .execute_batch(
+                "CREATE TABLE t_demo(
+                     id TEXT PRIMARY KEY,
+                     title TEXT NOT NULL,
+                     count INTEGER NOT NULL,
+                     later INTEGER NOT NULL DEFAULT 0 CHECK(later IN (0, 1)),
+                     resolved_rowid INTEGER
+                 ) STRICT;",
+            )
+            .unwrap();
+        assert!(
+            assert_spec_covers_schema(&alone, &CROSS).is_ok(),
+            "a check on the added column alone is decidable and allowed"
+        );
+    }
+
+    #[test]
+    fn an_identity_column_may_not_declare_an_introduction_version() {
+        // `added` promises a redemption path that does not exist for a key: an op authored before
+        // the key grew carries fewer pk values, so `apply_row_op`'s arity check quarantines it
+        // TERMINALLY before any default could apply. Declaring it would advertise older→newer
+        // replication while silently dropping every older op.
+        const GROWN_KEY: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            spec_version: 2,
+            pk: &[
+                ColumnSpec::required("id", ValueType::Text),
+                ColumnSpec::added("shard", ValueType::Text, 2, DefaultValue::Text("d")),
+            ],
+            columns: &[
+                ColumnSpec::required("title", ValueType::Text),
+                ColumnSpec::required("count", ValueType::I64),
+            ],
+            local_columns: DEMO_LOCAL,
+            repo_column: None,
+        };
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT NOT NULL,
+                 shard TEXT NOT NULL DEFAULT 'd',
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 resolved_rowid INTEGER,
+                 PRIMARY KEY(id, shard)
+             ) STRICT;",
+        )
+        .unwrap();
+        let err = assert_spec_covers_schema(&conn, &GROWN_KEY)
+            .expect_err("a primary key cannot grow within a table's life");
+        assert!(err.contains("shard") && err.contains("NEW TABLE"), "names the remedy: {err}");
+    }
+
+    #[test]
+    fn a_not_null_column_may_not_declare_a_null_default() {
+        // Filling an older op from a Null default on a NOT NULL column fails the constraint at
+        // INSERT, and the applier quarantines the op TERMINALLY — older→newer replication for the
+        // table would be dead with nothing to redeem it. The SQL-default check cannot catch this:
+        // a NOT NULL column with no DEFAULT clause reads as an absent physical default, which a
+        // declared Null matches.
+        const NULL_ON_NOT_NULL: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Null));
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 later TEXT NOT NULL,
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        let err = assert_spec_covers_schema(&conn, &NULL_ON_NOT_NULL)
+            .expect_err("a Null default on a NOT NULL column is refused");
+        assert!(err.contains("later") && err.contains("NOT NULL"), "the error is specific: {err}");
+
+        // The same declaration is fine once the column is nullable — the fill can succeed.
+        assert!(assert_spec_covers_schema(&widened_conn(""), &NULL_ON_NOT_NULL).is_ok());
+    }
+
+    #[test]
+    fn an_added_columns_version_must_sit_inside_the_specs_history() {
+        // `1` is the first version, so a column "added" there was present from the start and is
+        // `required`; a version above the spec's own names a column this binary carries but does
+        // not announce — a forgotten bump, which puts the fill window wrong in both directions.
+        const AT_VERSION_1: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 1, DefaultValue::Text("x")));
+        let err = assert_spec_covers_schema(&widened_conn(" DEFAULT 'x'"), &AT_VERSION_1)
+            .expect_err("a column added in version 1 is `required`, not `added`");
+        assert!(err.contains("later"), "the error names the column: {err}");
+
+        // `widened_spec!` is spec_version 2, so 3 is beyond this spec's own history.
+        const BEYOND_THE_SPEC: TableSpec =
+            widened_spec!(ColumnSpec::added("later", ValueType::Text, 3, DefaultValue::Text("x")));
+        assert!(
+            assert_spec_covers_schema(&widened_conn(" DEFAULT 'x'"), &BEYOND_THE_SPEC).is_err(),
+            "a column introduced beyond the spec's own version is a forgotten bump"
+        );
     }
 
     #[test]
@@ -556,6 +2103,7 @@ mod tests {
         const DOUBLED: TableSpec = TableSpec {
             name: "t_demo",
             scope_id: "demo/1",
+            spec_version: 1,
             pk: DEMO_PK,
             // `title` is both a synced column and (wrongly) a local column.
             columns: DEMO_COLUMNS,
@@ -574,8 +2122,9 @@ mod tests {
         const BAD: TableSpec = TableSpec {
             name: "t_x",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("repo_id", ValueType::Text)],
             local_columns: &[],
             repo_column: Some("repo_id"), /* a synced column, not a pk — the ingest gate would
                                            * miss it */
@@ -597,10 +2146,11 @@ mod tests {
         const KEY_ONLY: TableSpec = TableSpec {
             name: "t_members",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "group_id", value_type: ValueType::Text }, ColumnSpec {
-                name: "member_id",
-                value_type: ValueType::Text,
-            }],
+            spec_version: 1,
+            pk: &[
+                ColumnSpec::required("group_id", ValueType::Text),
+                ColumnSpec::required("member_id", ValueType::Text),
+            ],
             columns: &[],
             local_columns: &[],
             repo_column: None,
@@ -626,11 +2176,12 @@ mod tests {
         const WRONG_PK: TableSpec = TableSpec {
             name: "t_pk",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "a", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "b", value_type: ValueType::Text }, ColumnSpec {
-                name: "v",
-                value_type: ValueType::Text,
-            }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("a", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("b", ValueType::Text),
+                ColumnSpec::required("v", ValueType::Text),
+            ],
             local_columns: &[],
             repo_column: None,
         };
@@ -653,8 +2204,9 @@ mod tests {
         const NN_LOCAL: TableSpec = TableSpec {
             name: "t_nn_local",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "syn", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("syn", ValueType::Text)],
             local_columns: &["loc"],
             repo_column: None,
         };
@@ -678,8 +2230,9 @@ mod tests {
         const DEF_LOCAL: TableSpec = TableSpec {
             name: "t_def_local",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "syn", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("syn", ValueType::Text)],
             local_columns: &["loc"],
             repo_column: None,
         };
@@ -695,8 +2248,9 @@ mod tests {
         const NP: TableSpec = TableSpec {
             name: "t_np",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -718,11 +2272,12 @@ mod tests {
         const FK: TableSpec = TableSpec {
             name: "t_fk",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }, ColumnSpec {
-                name: "p",
-                value_type: ValueType::Text,
-            }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("v", ValueType::Text),
+                ColumnSpec::required("p", ValueType::Text),
+            ],
             local_columns: &[],
             repo_column: None,
         };
@@ -742,8 +2297,9 @@ mod tests {
         const U: TableSpec = TableSpec {
             name: "t_u",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "email", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("email", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -760,8 +2316,9 @@ mod tests {
         const NS: TableSpec = TableSpec {
             name: "t_ns",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -778,8 +2335,9 @@ mod tests {
         const TM: TableSpec = TableSpec {
             name: "t_tm",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "n", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("n", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -795,16 +2353,18 @@ mod tests {
         const A: TableSpec = TableSpec {
             name: "t_dup",
             scope_id: "scope-a/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
         const B: TableSpec = TableSpec {
             name: "t_dup",
             scope_id: "scope-b/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -826,11 +2386,12 @@ mod tests {
         const RI: TableSpec = TableSpec {
             name: "t_ri",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "rid", value_type: ValueType::I64 }, ColumnSpec {
-                name: "id",
-                value_type: ValueType::Text,
-            }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[
+                ColumnSpec::required("rid", ValueType::I64),
+                ColumnSpec::required("id", ValueType::Text),
+            ],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: Some("rid"),
         };
@@ -853,8 +2414,9 @@ mod tests {
         const REF: TableSpec = TableSpec {
             name: "t_ref",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -874,8 +2436,9 @@ mod tests {
         const CI: TableSpec = TableSpec {
             name: "t_ci",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("v", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
@@ -898,11 +2461,12 @@ mod tests {
         const TRIG: TableSpec = TableSpec {
             name: "t_trig",
             scope_id: "demo/1",
-            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
-            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }, ColumnSpec {
-                name: "n",
-                value_type: ValueType::I64,
-            }],
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[
+                ColumnSpec::required("v", ValueType::Text),
+                ColumnSpec::required("n", ValueType::I64),
+            ],
             local_columns: &[],
             repo_column: None,
         };

--- a/crates/rag-rat-oplog/src/table_sync/row_op.rs
+++ b/crates/rag-rat-oplog/src/table_sync/row_op.rs
@@ -54,10 +54,19 @@ pub enum TypedValue {
 #[derive(Debug, Clone, PartialEq)]
 pub enum RowOp {
     /// Insert-or-update the row identified by `pk` with `cells` (the synced columns). The applier
-    /// resolves insert-vs-update by row existence and merges each cell under per-column LWW.
-    Upsert { table: String, pk: Vec<TypedValue>, cells: Vec<Cell> },
+    /// resolves insert-vs-update by row existence, and the WHOLE row moves as a unit under its
+    /// write clock — there is no per-column merge.
+    ///
+    /// `spec_version` states which synced column set the author wrote against, so a receiver can
+    /// tell an OLDER producer's complete row (fill the columns it predates from their declared
+    /// defaults) from a NEWER producer's partial one (park until this binary catches up).
+    Upsert { table: String, spec_version: u32, pk: Vec<TypedValue>, cells: Vec<Cell> },
     /// Delete the row identified by `pk` (and its LWW clock rows).
-    Remove { table: String, pk: Vec<TypedValue> },
+    ///
+    /// `spec_version` is carried for wire symmetry and diagnostics but NOT acted on: a remove names
+    /// only the row identity, so no column set is involved and no default can apply. Gating a
+    /// deletion on a version skew would delay it for no benefit.
+    Remove { table: String, spec_version: u32, pk: Vec<TypedValue> },
 }
 
 impl RowOp {
@@ -72,6 +81,13 @@ impl RowOp {
     pub fn pk(&self) -> &[TypedValue] {
         match self {
             Self::Upsert { pk, .. } | Self::Remove { pk, .. } => pk,
+        }
+    }
+
+    /// The synced column set this op was authored against.
+    pub fn spec_version(&self) -> u32 {
+        match self {
+            Self::Upsert { spec_version, .. } | Self::Remove { spec_version, .. } => *spec_version,
         }
     }
 
@@ -113,15 +129,17 @@ pub fn encode(op: &RowOp) -> Vec<u8> {
 /// Write the op-specific payload as exactly ONE CBOR item (the envelope's element 2).
 fn encode_payload(enc: &mut VecEncoder<'_>, op: &RowOp) {
     match op {
-        RowOp::Upsert { table, pk, cells } => {
-            enc.array(3).expect(INFALLIBLE);
+        RowOp::Upsert { table, spec_version, pk, cells } => {
+            enc.array(4).expect(INFALLIBLE);
             enc.str(table).expect(INFALLIBLE);
+            enc.u32(*spec_version).expect(INFALLIBLE);
             encode_values(enc, pk);
             encode_cells(enc, cells);
         },
-        RowOp::Remove { table, pk } => {
-            enc.array(2).expect(INFALLIBLE);
+        RowOp::Remove { table, spec_version, pk } => {
+            enc.array(3).expect(INFALLIBLE);
             enc.str(table).expect(INFALLIBLE);
+            enc.u32(*spec_version).expect(INFALLIBLE);
             encode_values(enc, pk);
         },
     }
@@ -181,17 +199,19 @@ fn decode_envelope(bytes: &[u8]) -> Result<DecodedRowOp, CborError> {
     let kind = d.str()?.to_string();
     let known = match kind.as_str() {
         "upsert" => {
-            cbor::expect_array(&mut d, 3)?;
+            cbor::expect_array(&mut d, 4)?;
             let table = d.str()?.to_string();
+            let spec_version = d.u32()?;
             let pk = decode_values(&mut d)?;
             let cells = decode_cells(&mut d)?;
-            Some(RowOp::Upsert { table, pk, cells })
+            Some(RowOp::Upsert { table, spec_version, pk, cells })
         },
         "remove" => {
-            cbor::expect_array(&mut d, 2)?;
+            cbor::expect_array(&mut d, 3)?;
             let table = d.str()?.to_string();
+            let spec_version = d.u32()?;
             let pk = decode_values(&mut d)?;
-            Some(RowOp::Remove { table, pk })
+            Some(RowOp::Remove { table, spec_version, pk })
         },
         // A future op-kind this binary doesn't know — retained opaque, canonicity checked below.
         _ => None,
@@ -337,6 +357,7 @@ mod tests {
 
     fn sample_upsert() -> RowOp {
         RowOp::Upsert {
+            spec_version: 1,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Text("r".to_string()), TypedValue::I64(7)],
             // Deliberately out of column order — encode must canonicalize.
@@ -364,14 +385,34 @@ mod tests {
         assert_eq!(encode(&decoded), bytes);
     }
 
-    #[test]
-    fn remove_round_trips() {
-        let op = RowOp::Remove {
+    fn sample_remove() -> RowOp {
+        // `spec_version` deliberately differs from the array arity and from the upsert sample, so a
+        // field-order swap or a hardcoded version cannot round-trip or match the golden bytes.
+        RowOp::Remove {
+            spec_version: 7,
             table: "t_demo".to_string(),
             pk: vec![TypedValue::Text("r".to_string()), TypedValue::I64(7)],
-        };
+        }
+    }
+
+    #[test]
+    fn remove_round_trips() {
+        let op = sample_remove();
         let bytes = encode(&op);
         assert_eq!(decode(&bytes).unwrap(), DecodedRowOp::Known(op));
+    }
+
+    /// Golden vector for `Remove`, held to the same discipline as [`upsert_golden_vector`].
+    ///
+    /// A round-trip alone pins NOTHING about the format: `decode(encode(op)) == op` holds under any
+    /// symmetric change — reordering the payload, dropping `spec_version`, retyping it — so half
+    /// the wire was unprotected while the other half was pinned. #1002 changed this payload's
+    /// arity from 2 to 3 and inserted an element in the MIDDLE, which is exactly the kind of
+    /// change a round-trip cannot see.
+    #[test]
+    fn remove_golden_vector() {
+        let bytes = encode(&sample_remove());
+        assert_eq!(rag_rat_base::hash::hex_lower(&bytes), GOLDEN_REMOVE_HEX);
     }
 
     #[test]
@@ -384,8 +425,9 @@ mod tests {
             enc.array(3).unwrap();
             enc.str(DOMAIN).unwrap();
             enc.str("upsert").unwrap();
-            enc.array(3).unwrap();
+            enc.array(4).unwrap();
             enc.str("t_demo").unwrap();
+            enc.u32(1).unwrap(); // spec_version
             enc.array(0).unwrap(); // empty pk
             enc.array(2).unwrap();
             enc.array(2).unwrap();
@@ -395,7 +437,12 @@ mod tests {
             enc.str("a").unwrap(); // duplicate column
             enc.i64(2).unwrap();
         }
-        assert!(decode(&buf).is_err(), "a duplicate column is not canonical");
+        // Assert the REASON, not merely `is_err()`. A hand-built fixture drifts out of shape
+        // whenever the payload arity changes, and a bare `is_err()` then passes on the arity gate
+        // while the rule it names goes untested — which is what happened when #1002 widened this
+        // payload from 3 elements to 4.
+        let err = decode(&buf).expect_err("a duplicate column is not canonical").to_string();
+        assert!(err.contains("not sorted or duplicated"), "rejected for the stated reason: {err}");
     }
 
     #[test]
@@ -453,20 +500,56 @@ mod tests {
             enc.array(3).unwrap();
             enc.str(DOMAIN).unwrap();
             enc.str("upsert").unwrap();
-            enc.array(3).unwrap();
+            enc.array(4).unwrap();
             enc.str("t").unwrap();
+            enc.u32(1).unwrap(); // spec_version
             enc.array(1_000_000_000).unwrap(); // absurd declared pk length, no elements follow
         }
-        assert!(decode(&buf).is_err(), "an oversized array length is capped, not allocated");
+        // Assert the CAP is what rejected it. A bare `is_err()` here proves nothing: the array is
+        // truncated, so decoding would fail on end-of-input even with no cap at all — the test
+        // passed with `MAX_ROW_OP_ELEMENTS` raised to `u64::MAX`. The whole point is that the
+        // attacker-controlled length header is refused BEFORE it sizes an allocation.
+        let err = decode(&buf).expect_err("an oversized array length is refused").to_string();
+        assert!(err.contains("exceeds the protocol cap"), "refused by the cap, not by EOF: {err}");
+    }
+
+    #[test]
+    fn an_array_length_at_the_cap_is_not_refused_by_the_cap() {
+        // The other side of the boundary: the cap must reject only what is ABOVE it, or a
+        // legitimate op near the limit would be unparseable. Declared length == the cap,
+        // still truncated, so it must fail on the CONTENT rather than the header.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("upsert").unwrap();
+            enc.array(4).unwrap();
+            enc.str("t").unwrap();
+            enc.u32(1).unwrap();
+            enc.array(MAX_ROW_OP_ELEMENTS).unwrap();
+        }
+        let err = decode(&buf).expect_err("still truncated, so it cannot decode").to_string();
+        assert!(!err.contains("exceeds the protocol cap"), "the cap is exclusive: {err}");
     }
 
     /// Golden vector: the exact canonical bytes of `sample_upsert`. A change here is a wire-format
     /// change — bump `DOMAIN` deliberately, never edit this hex to make the test pass.
+    ///
+    /// This hex WAS edited once, when #1002 added `spec_version` to the payload, WITHOUT a domain
+    /// bump. That was sound exactly once and is not a precedent: at the time no released binary
+    /// could ever have produced or read a table op — `SYNCABLE_TABLES` had been empty since the
+    /// engine was written and no transport carried the format — so `/1` had never existed on a wire
+    /// or in a store, and bumping would have asserted a compatibility generation that never was.
+    /// That is no longer true. Any FURTHER change to these bytes bumps the domain.
     #[test]
     fn upsert_golden_vector() {
         let bytes = encode(&sample_upsert());
         assert_eq!(rag_rat_base::hash::hex_lower(&bytes), GOLDEN_UPSERT_HEX);
     }
 
-    const GOLDEN_UPSERT_HEX: &str = "83727261672d7261742f7461626c652d6f702f31667570736572748366745f64656d6f82617207848265636f756e74038264646f6e65f582646e6f7465f682657469746c65626869";
+    const GOLDEN_REMOVE_HEX: &str =
+        "83727261672d7261742f7461626c652d6f702f316672656d6f76658366745f64656d6f0782617207";
+
+    const GOLDEN_UPSERT_HEX: &str = "83727261672d7261742f7461626c652d6f702f31667570736572748466745f64656d6f0182617207848265636f756e74038264646f6e65f582646e6f7465f682657469746c65626869";
 }

--- a/crates/rag-rat-oplog/src/table_sync/schema_facts.rs
+++ b/crates/rag-rat-oplog/src/table_sync/schema_facts.rs
@@ -1,0 +1,1002 @@
+//! What the LIVE SQLite schema says about a syncable table.
+//!
+//! [`super::registry`] declares what a table's replicated shape is *meant* to be; this module reads
+//! what it actually is — column types and defaults, primary-key collation, triggers, foreign keys,
+//! unique indexes, `STRICT`ness, and check constraints. Keeping the two apart means the registry
+//! module stays spec + lint policy, and the reading of `PRAGMA` output and `sqlite_master.sql` —
+//! including the small SQL lexer that makes constraint reading trustworthy — lives in one place.
+//!
+//! Nothing here interprets the registry's intent; every function answers a question about the
+//! database as it stands.
+
+use rusqlite::Connection;
+
+use super::registry::DefaultValue;
+
+/// Whether `table` is a STRICT table. SQLite exposes no pragma for this, so read the table options
+/// that follow the column-list's closing `)` (all column-level parens nest inside it, so the LAST
+/// `)` is always that closer) and look for the `STRICT` keyword.
+pub(super) fn table_is_strict(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    let sql: String = conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get(0),
+    )?;
+    let options = sql.rsplit(')').next().unwrap_or_default();
+    Ok(options
+        .to_ascii_uppercase()
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .any(|token| token == "STRICT"))
+}
+
+/// One physical column of a table, from `PRAGMA table_info` (`conn.pragma` quotes the table name,
+/// so a spec name never needs manual escaping). `pk_position` is the 1-based position within the
+/// primary key, or `0` for a non-key column. `decl_type` is the declared column type (uppercased) —
+/// on a STRICT table one of `INT`/`INTEGER`/`REAL`/`TEXT`/`BLOB`/`ANY`.
+pub(super) struct PhysicalColumn {
+    pub(super) name: String,
+    pub(super) decl_type: String,
+    pub(super) not_null: bool,
+    /// SQLite's `dflt_value` verbatim (the literal AS WRITTEN, e.g. `0`, `'x'`, `NULL`), or `None`
+    /// for a column with no DEFAULT clause. Compared against a synced column's declared default so
+    /// the two can never disagree — see `default_matches`.
+    pub(super) default_sql: Option<String>,
+    pub(super) pk_position: i64,
+}
+
+/// The content of `sql` if it is EXACTLY ONE single-quoted SQL string literal, with `''` unescaped
+/// to `'`. `None` for anything else.
+///
+/// Being a single literal is the whole point, not a formality. SQLite drops the outer parentheses
+/// from a parenthesized default in `PRAGMA table_info`, so `DEFAULT ('x'||'y')` is reported as
+/// `'x'||'y'` — which starts and ends with a quote. Accepting that on those two characters alone
+/// would let a CONCATENATION pass as a literal: SQLite backfills the column with `xy` while the
+/// applier synthesizes the raw text `x'||'y`, which is precisely the backfill-versus-projection
+/// divergence this check exists to prevent. A lone interior quote is what distinguishes them.
+pub(super) fn single_quoted_literal(sql: &str) -> Option<String> {
+    let inner = sql.strip_prefix('\'')?.strip_suffix('\'')?;
+    let mut out = String::with_capacity(inner.len());
+    let mut rest = inner.chars();
+    while let Some(ch) = rest.next() {
+        if ch != '\'' {
+            out.push(ch);
+            continue;
+        }
+        // A quote inside a literal is only legal doubled; a lone one closed the literal early, so
+        // whatever follows is an expression, not part of the value.
+        if rest.next() != Some('\'') {
+            return None;
+        }
+        out.push('\'');
+    }
+    Some(out)
+}
+
+/// One lexical unit of SQL — enough structure to find constraints and identifiers without ever
+/// mistaking the inside of a string or a comment for either.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum SqlToken {
+    /// A bare word: a keyword or an unquoted identifier, ASCII-lowercased — SQLite folds
+    /// identifier case for ASCII ONLY, so `to_lowercase` (full Unicode) would equate identifiers
+    /// SQLite keeps distinct.
+    Word(String),
+    /// A quoted identifier — `"x"`, `` `x` ``, `[x]` — its content, ASCII-lowercased.
+    Ident(String),
+    /// A literal: a string, a blob (`X'ff'`), or a number. It is NEVER a reference — its text can
+    /// spell anything, including `CHECK(` or a column name — so structure never reads it. A string
+    /// literal carries its unescaped content for the one question that is legitimately about a
+    /// VALUE: whether a date/time call was handed `'now'`.
+    Literal(Option<String>),
+    /// Anything else, one character at a time — parentheses, operators, commas.
+    Punct(char),
+}
+
+/// Lex SQL into [`SqlToken`]s, skipping whitespace and both comment forms.
+///
+/// Scanning SQL as raw text does not work here, and the failure is silent in the dangerous
+/// direction: a parenthesis inside a string literal (`CHECK(later <> ')' OR count = 0)`) truncates
+/// a naive balanced-paren scan, so the rest of the constraint — including the other column it
+/// references — is never examined and an unsafe CHECK passes. Literals and comments equally can
+/// spell a column name or the word CHECK and produce the opposite error, refusing a schema that is
+/// fine. Lexing once removes both classes.
+///
+/// Character-based throughout, so a multi-byte identifier can never split a slice.
+pub(super) fn lex_sql(sql: &str) -> Vec<(SqlToken, usize, usize)> {
+    let chars: Vec<char> = sql.chars().collect();
+    let mut tokens = Vec::new();
+    let mut i = 0usize;
+    while i < chars.len() {
+        let start = i;
+        let ch = chars[i];
+        match ch {
+            c if c.is_whitespace() => i += 1,
+            '-' if chars.get(i + 1) == Some(&'-') =>
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                },
+            '/' if chars.get(i + 1) == Some(&'*') => {
+                i += 2;
+                while i < chars.len() && !(chars[i] == '*' && chars.get(i + 1) == Some(&'/')) {
+                    i += 1;
+                }
+                i = (i + 2).min(chars.len());
+            },
+            '\'' => {
+                i += 1;
+                let mut content = String::new();
+                while i < chars.len() {
+                    if chars[i] == '\'' {
+                        // A doubled quote is an escaped quote, not the end of the literal.
+                        if chars.get(i + 1) == Some(&'\'') {
+                            content.push('\'');
+                            i += 2;
+                            continue;
+                        }
+                        i += 1;
+                        break;
+                    }
+                    content.push(chars[i]);
+                    i += 1;
+                }
+                tokens.push((SqlToken::Literal(Some(content)), start, i));
+            },
+            '"' | '`' | '[' => {
+                let close = if ch == '[' { ']' } else { ch };
+                i += 1;
+                let mut ident = String::new();
+                while i < chars.len() {
+                    if chars[i] == close {
+                        // `""` inside a quoted identifier is an escaped quote, as for strings.
+                        if close != ']' && chars.get(i + 1) == Some(&close) {
+                            ident.push(close);
+                            i += 2;
+                            continue;
+                        }
+                        i += 1;
+                        break;
+                    }
+                    ident.push(chars[i]);
+                    i += 1;
+                }
+                tokens.push((SqlToken::Ident(ident.to_ascii_lowercase()), start, i));
+            },
+            // A blob literal is `X'..'` with NO space before the quote. Lexed here so its `x` is
+            // never mistaken for a reference to a column named `x` — which is a plausible name, and
+            // `CHECK(later != X'ff')` is perfectly legal SQL.
+            'x' | 'X' if chars.get(i + 1) == Some(&'\'') => {
+                i += 2;
+                while i < chars.len() && chars[i] != '\'' {
+                    i += 1;
+                }
+                i = (i + 1).min(chars.len());
+                tokens.push((SqlToken::Literal(None), start, i));
+            },
+            // A number: an identifier can never begin with a digit, so this is always a literal.
+            c if c.is_ascii_digit() => {
+                while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '.') {
+                    i += 1;
+                }
+                tokens.push((SqlToken::Literal(None), start, i));
+            },
+            c if c.is_alphanumeric() || c == '_' => {
+                let mut word = String::new();
+                while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                    word.push(chars[i]);
+                    i += 1;
+                }
+                tokens.push((SqlToken::Word(word.to_ascii_lowercase()), start, i));
+            },
+            c => {
+                i += 1;
+                tokens.push((SqlToken::Punct(c), start, i));
+            },
+        }
+    }
+    tokens
+}
+
+/// A table's DDL, read and lexed ONCE: which columns it declares (verbatim), its table-level CHECK
+/// constraints, and whether it is `STRICT`.
+pub(super) struct TableDdl {
+    pub(super) is_strict: bool,
+    /// Lowercased column name → that column's verbatim declaration, in order.
+    pub(super) columns: Vec<(String, String)>,
+    /// EVERY `CHECK` the table declares, from any source.
+    pub(super) checks: Vec<TableCheck>,
+}
+
+/// One `CHECK` constraint and where it was written.
+///
+/// An inline check is semantically table-level — `count INTEGER CHECK(later >= count)` constrains
+/// the row, not the column it is attached to — so collecting only table-level ones misses a
+/// constraint on a SIBLING that reads the column under test. Provenance is kept so the column's
+/// OWN inline checks are not added twice: they already travel with its verbatim declaration.
+pub(super) struct TableCheck {
+    /// The column whose declaration carries this check, or `None` for a table-level constraint.
+    pub(super) owner: Option<String>,
+    pub(super) body: String,
+}
+
+/// Read `table`'s `CREATE TABLE` and take it apart.
+///
+/// `PRAGMA table_info` carries neither collation nor check constraints, and rebuilding a column
+/// from its parts would be a re-implementation of SQLite's DDL that could only ever approximate it.
+/// Lifting the original text is exact.
+pub(super) fn read_table_ddl(conn: &Connection, table: &str) -> rusqlite::Result<TableDdl> {
+    let sql: String = conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get(0),
+    )?;
+    let chars: Vec<char> = sql.chars().collect();
+    let tokens = lex_sql(&sql);
+    let mut ddl = TableDdl { is_strict: false, columns: Vec::new(), checks: Vec::new() };
+
+    // Table options follow the column list's closing parenthesis.
+    let Some(open) = tokens.iter().position(|(t, ..)| *t == SqlToken::Punct('(')) else {
+        return Ok(ddl);
+    };
+    let mut depth = 0usize;
+    let mut segment_start: Option<usize> = None;
+    let mut segment_head: Option<SqlToken> = None;
+    let mut tail = tokens.len();
+
+    // Each top-level segment of the column list is either a column declaration (it starts with the
+    // column's name) or a table-level constraint (it starts with a keyword).
+    let finish = |ddl: &mut TableDdl, head: &Option<SqlToken>, from: usize, to: usize| {
+        let text: String = chars[from..to].iter().collect();
+        // EVERY segment is searched for checks, whatever heads it. SQLite does not require a comma
+        // between table constraints, so `PRIMARY KEY(id) CHECK(later >= count)` is one segment —
+        // and a head-keyed dispatch that only searched `CHECK`/`CONSTRAINT` segments dropped that
+        // check entirely, which is the direction that accepts an unsafe default. The head decides
+        // only whether the segment ALSO declares a column, and hence who owns the checks.
+        //
+        // A QUOTED head is always a column name: `"check"` is a legal column, not the keyword.
+        let declares_column = match head {
+            Some(SqlToken::Word(word)) => !is_constraint_keyword(word),
+            Some(SqlToken::Ident(_)) => true,
+            _ => false,
+        };
+        let owner = match (declares_column, head) {
+            (true, Some(SqlToken::Word(word) | SqlToken::Ident(word))) => Some(word.clone()),
+            _ => None,
+        };
+        for body in check_bodies(&text) {
+            ddl.checks.push(TableCheck { owner: owner.clone(), body });
+        }
+        if let Some(name) = owner {
+            ddl.columns.push((name, text.trim().to_string()));
+        }
+    };
+
+    for (index, (token, from, to)) in tokens.iter().enumerate().skip(open) {
+        match token {
+            SqlToken::Punct('(') => {
+                depth += 1;
+                if depth == 1 {
+                    segment_start = Some(*to);
+                    segment_head = None;
+                    continue;
+                }
+            },
+            SqlToken::Punct(')') => {
+                depth -= 1;
+                if depth == 0 {
+                    if let Some(begin) = segment_start {
+                        finish(&mut ddl, &segment_head, begin, *from);
+                    }
+                    tail = index + 1;
+                    break;
+                }
+            },
+            SqlToken::Punct(',') if depth == 1 => {
+                if let Some(begin) = segment_start {
+                    finish(&mut ddl, &segment_head, begin, *from);
+                }
+                segment_start = Some(*to);
+                segment_head = None;
+                continue;
+            },
+            _ => {},
+        }
+        if depth == 1 && segment_head.is_none() {
+            segment_head = Some(token.clone());
+        }
+    }
+    ddl.is_strict =
+        tokens[tail..].iter().any(|(t, ..)| matches!(t, SqlToken::Word(word) if word == "strict"));
+    Ok(ddl)
+}
+
+/// Every `CHECK( ... )` body in one segment of the column list, located by TOKENS.
+///
+/// Applies to both kinds of segment. A table-level one holds at most one — but it may be named
+/// (`CONSTRAINT c CHECK(...)`), so the keyword is found rather than assumed to lead, and a
+/// differently-named constraint (`CONSTRAINT c UNIQUE(a)`) is not mistaken for one. A COLUMN
+/// declaration may carry several, and each is semantically table-level.
+///
+/// Locating by token also means the keyword's case cannot hide it: the source is not normalised,
+/// so `ChEcK(...)` defeats a literal prefix strip — and defeating it drops the constraint silently,
+/// which is the FALSE-NEGATIVE direction.
+fn check_bodies(segment: &str) -> Vec<String> {
+    let chars: Vec<char> = segment.chars().collect();
+    let tokens = lex_sql(segment);
+    let mut bodies = Vec::new();
+    let mut index = 0usize;
+    while index < tokens.len() {
+        let is_keyword = matches!(&tokens[index].0, SqlToken::Word(word) if word == "check");
+        if !is_keyword || tokens.get(index + 1).map(|t| &t.0) != Some(&SqlToken::Punct('(')) {
+            index += 1;
+            continue;
+        }
+        index += 1;
+        let (_, _, body_start) = tokens[index];
+        let mut depth = 0usize;
+        while index < tokens.len() {
+            match &tokens[index].0 {
+                SqlToken::Punct('(') => depth += 1,
+                SqlToken::Punct(')') => {
+                    depth -= 1;
+                    if depth == 0 {
+                        bodies.push(chars[body_start..tokens[index].1].iter().collect());
+                        break;
+                    }
+                },
+                _ => {},
+            }
+            index += 1;
+        }
+        index += 1;
+    }
+    bodies
+}
+
+/// Whether a top-level segment beginning with `word` is a table-level CONSTRAINT rather than a
+/// column declaration. (A column may not be named any of these unquoted.)
+fn is_constraint_keyword(word: &str) -> bool {
+    matches!(word, "constraint" | "primary" | "unique" | "check" | "foreign")
+}
+
+/// The outcome of testing a declared default against the constraints on its column.
+pub(super) enum CheckVerdict {
+    /// The column accepts the default, and its constraints depend on nothing else.
+    Satisfied,
+    /// The column REJECTS the default — every older op would be quarantined on arrival.
+    Violated(String),
+    /// A constraint reads something other than this column, so no default can be proven safe.
+    NotSelfContained(String),
+}
+
+/// Names of the implicit rowid, which resolve in ANY rowid table.
+const ROWID_ALIASES: [&str; 3] = ["rowid", "_rowid_", "oid"];
+
+/// Decide, BY CONSTRUCTION, whether `default` is a value this column actually accepts — and whether
+/// its constraints depend only on this column.
+///
+/// Rebuilds the column ALONE in a scratch database, under the real table's NAME (so a qualified
+/// self-reference still resolves) and `STRICT`ness, from its own verbatim DDL plus every
+/// table-level CHECK that genuinely involves it, then attempts the insert the applier would
+/// perform. SQLite answers both questions itself.
+///
+/// EVALUATING THE EXPRESSION INSTEAD IS NOT FAITHFUL, and both ways it lied were silent: a bare
+/// expression carries BINARY collation and no affinity, so a `COLLATE NOCASE` or differently-typed
+/// column disagreed with it in both directions; and SQLite treats a CHECK as violated only when it
+/// evaluates to zero, so reading the result as an integer misread a REAL or a NULL. Re-declaring
+/// the column keeps the type, the collation, and the truth semantics actually in force.
+///
+/// WHICH constraints involve the column is also SQLite's answer, not a token match: a name that
+/// merely looks like the column (a type name inside `CAST`, a keyword) would otherwise drag an
+/// unrelated constraint into the probe, where its foreign names produce the verdict.
+///
+/// The scratch database is SEPARATE, so this never mutates the caller's connection. A custom
+/// collation registered only on that connection therefore fails to resolve and reads as
+/// not-self-contained — the right answer regardless, since a collation defined by the application
+/// is per-device state a synced column must not depend on.
+pub(super) fn default_satisfies_check(
+    ddl: &TableDdl,
+    table: &str,
+    column: &str,
+    default: DefaultValue,
+) -> CheckVerdict {
+    let wanted = column.to_ascii_lowercase();
+    let Some((_, definition)) = ddl.columns.iter().find(|(name, _)| *name == wanted) else {
+        return CheckVerdict::NotSelfContained(format!("no declaration found for `{column}`"));
+    };
+    let others: Vec<&str> = ddl
+        .columns
+        .iter()
+        .filter(|(name, _)| *name != wanted)
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    // The implicit rowid resolves in any rowid table, INCLUDING the probe — so a constraint reading
+    // it would look self-contained and pass. It is also per-device (assigned by insertion order),
+    // so a synced column must never depend on it. Refuse it lexically, which is the only way to see
+    // it at all.
+    // A table may DECLARE a column named `rowid`; that shadows the implicit alias, so the name is
+    // then an ordinary column reference and the involvement test handles it like any other.
+    let declared: Vec<&str> = ddl.columns.iter().map(|(name, _)| name.as_str()).collect();
+    let reads_rowid = |body: &str| {
+        lex_sql(body).iter().any(|(t, ..)| {
+            // Word OR Ident: `"rowid"` resolves to the implicit rowid exactly as `rowid` does.
+            matches!(t, SqlToken::Word(w) | SqlToken::Ident(w)
+                if ROWID_ALIASES.contains(&w.as_str()) && !declared.contains(&w.as_str()))
+        })
+    };
+    if reads_rowid(definition) {
+        return CheckVerdict::NotSelfContained(
+            "the declaration reads the implicit rowid, which is assigned per device".to_string(),
+        );
+    }
+    if let Some(function) = per_device_reference(definition) {
+        return CheckVerdict::NotSelfContained(format!(
+            "the declaration calls `{function}`, whose result can differ between devices"
+        ));
+    }
+
+    let mut applicable = Vec::new();
+    for check in &ddl.checks {
+        // This column's own inline checks are already enforced by its verbatim declaration below;
+        // adding them again would only duplicate them into the probe's DDL and its error messages.
+        if check.owner.as_deref() == Some(wanted.as_str()) {
+            continue;
+        }
+        let body = &check.body;
+        match constraint_involvement(table, definition, &others, body) {
+            Involvement::Irrelevant => continue,
+            Involvement::SelfContained => {
+                if reads_rowid(body) {
+                    return CheckVerdict::NotSelfContained(format!(
+                        "CHECK ({body}) reads the implicit rowid, which is assigned per device"
+                    ));
+                }
+                if let Some(function) = per_device_reference(body) {
+                    return CheckVerdict::NotSelfContained(format!(
+                        "CHECK ({body}) calls `{function}`, whose result can differ between \
+                         devices — the same op would be accepted on one peer and quarantined on \
+                         another"
+                    ));
+                }
+                applicable.push(body.as_str());
+            },
+            Involvement::CrossColumn(why) => return CheckVerdict::NotSelfContained(why),
+        }
+    }
+
+    let Ok(scratch) = Connection::open_in_memory() else {
+        return CheckVerdict::NotSelfContained("cannot open a scratch database".to_string());
+    };
+    if let Err(err) =
+        scratch.execute_batch(&probe_ddl(table, definition, &applicable, ddl.is_strict))
+    {
+        // The column's OWN declaration naming something else lands here.
+        return CheckVerdict::NotSelfContained(err.to_string());
+    }
+    let bound: rusqlite::types::Value = match default {
+        DefaultValue::Null => rusqlite::types::Value::Null,
+        DefaultValue::Bool(b) => rusqlite::types::Value::Integer(i64::from(b)),
+        DefaultValue::I64(n) => rusqlite::types::Value::Integer(n),
+        DefaultValue::Text(text) => rusqlite::types::Value::Text(text.to_string()),
+        DefaultValue::Blob(bytes) => rusqlite::types::Value::Blob(bytes.to_vec()),
+    };
+    let quoted_table = table.replace('"', "\"\"");
+    let quoted_column = column.replace('"', "\"\"");
+    let insert = format!("INSERT INTO \"{quoted_table}\"(\"{quoted_column}\") VALUES (?1)");
+    match scratch.execute(&insert, [bound]) {
+        Ok(_) => CheckVerdict::Satisfied,
+        Err(err) if is_constraint_failure(&err) => CheckVerdict::Violated(err.to_string()),
+        Err(err) => CheckVerdict::NotSelfContained(err.to_string()),
+    }
+}
+
+fn probe_ddl(table: &str, definition: &str, checks: &[&str], strict: bool) -> String {
+    let quoted = table.replace('"', "\"\"");
+    // Newlines for the same reason as in `constraint_involvement`: the declaration is verbatim
+    // source and may end in a line comment.
+    let mut ddl = format!("CREATE TABLE \"{quoted}\"(\n{definition}\n");
+    for check in checks {
+        ddl.push_str(&format!(", CHECK({check})\n"));
+    }
+    ddl.push(')');
+    // Carried for structural fidelity rather than effect: the bound value's type is already pinned
+    // to the declared type by the registry's own type lints, so no test can distinguish this. It
+    // keeps the probe identical to the real table, which is the point of re-declaring at all.
+    if strict {
+        ddl.push_str(" STRICT");
+    }
+    ddl
+}
+
+/// How a table-level CHECK relates to the column under test.
+enum Involvement {
+    /// It does not read the column at all — it was already satisfied before the column existed.
+    Irrelevant,
+    /// It reads only the column.
+    SelfContained,
+    /// It reads the column AND something else, so no default can be proven safe.
+    CrossColumn(String),
+}
+
+/// Ask SQLite which columns a CHECK body actually reads, by offering it two different worlds:
+/// one holding every column EXCEPT this one, and one holding only this one.
+fn constraint_involvement(
+    table: &str,
+    definition: &str,
+    others: &[&str],
+    body: &str,
+) -> Involvement {
+    let quoted = table.replace('"', "\"\"");
+    // NEWLINES around a spliced declaration: it is verbatim source and may end in a `--` comment,
+    // which on one line would comment out everything after it.
+    let alone = format!("CREATE TABLE \"{quoted}\"(\n{definition}\n, CHECK({body})\n)");
+    if let Ok(scratch) = Connection::open_in_memory()
+        && scratch.execute_batch(&alone).is_ok()
+    {
+        return Involvement::SelfContained;
+    }
+    // The other columns go in as bare NAMES. This world exists only to answer "does the body
+    // resolve WITHOUT this column", and a name is exactly that question — splicing their
+    // declarations in would let a sibling's own constraints fail this CREATE for reasons that have
+    // nothing to do with the column under test. The one dependency a bare name would erase is a
+    // GENERATED column whose expression reads the column under test, and that cannot arise here:
+    // `assert_spec_covers_schema` refuses a generated column outright.
+    let without = {
+        // QUOTED: a column may legally be named after a keyword (`check`, `order`), and splicing
+        // such a name in bare would fail this CREATE on syntax — refusing a valid schema for a
+        // reason that has nothing to do with the constraint being classified.
+        let columns = if others.is_empty() {
+            "\"__none__\"".to_string()
+        } else {
+            others
+                .iter()
+                .map(|name| format!("\"{}\"", name.replace('"', "\"\"")))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        format!("CREATE TABLE \"{quoted}\"({columns}, CHECK({body}))")
+    };
+    match Connection::open_in_memory() {
+        Ok(scratch) => match scratch.execute_batch(&without) {
+            // It resolves without this column, so it never reads it.
+            Ok(()) => Involvement::Irrelevant,
+            Err(err) => Involvement::CrossColumn(err.to_string()),
+        },
+        Err(err) => Involvement::CrossColumn(err.to_string()),
+    }
+}
+
+/// SQLite's clock KEYWORDS. They read the time like `date('now')` but take no parentheses, so a
+/// scan shaped around calls cannot see them at all. Only the bare forms matter: quoted, they are
+/// ordinary identifiers that resolve to nothing and are refused as unresolvable.
+const CLOCK_KEYWORDS: [&str; 3] = ["current_date", "current_time", "current_timestamp"];
+
+/// Operators whose meaning is CONNECTION state, not their operands. `PRAGMA case_sensitive_like`
+/// changes both `a LIKE b` and `like(a, b)`, so two peers can disagree about the same row. Refused
+/// as a bare word, which catches the operator form as well as the call — a scan shaped around calls
+/// would see only half of it.
+const CONNECTION_CONFIGURABLE: [&str; 2] = ["like", "glob"];
+
+/// Functions whose result depends ONLY on their arguments, and identically on every SQLite build.
+///
+/// An ALLOWLIST, not a denylist, and the direction matters. `pragma_function_list`'s
+/// `SQLITE_DETERMINISTIC` flag answers a different question than this one: it means "same answer
+/// for the same arguments WITHIN THIS BUILD", which `fts5_source_id()` satisfies while returning a
+/// different string on a peer compiled against another SQLite. Denying the flagged-nondeterministic
+/// set therefore cannot be complete — any present or future build-varying builtin passes it.
+/// Listing what is safe cannot have that failure mode; the cost is that a constraint using
+/// something unlisted is refused until someone adds it deliberately.
+const ARGUMENT_ONLY_FUNCTIONS: &[&str] = &[
+    // The date/time family is listed on purpose. SQLite ENFORCES the clock restriction itself, at
+    // INSERT — which the probe performs — and more precisely than this lint could: it refuses
+    // `date()`, `date('now')` and a `'localtime'` modifier inside a CHECK, while allowing
+    // `date(column)` and `strftime(format, column)`. Reproducing that here was both redundant and
+    // WRONG in the strict direction, since `date(column, 'now')` is not a clock read at all.
+    "date",
+    "datetime",
+    "julianday",
+    "strftime",
+    "time",
+    "unixepoch",
+    // `like` and `glob` are deliberately ABSENT: `PRAGMA case_sensitive_like` is connection state,
+    // so they are refused as bare words (operator form included) by `CONNECTION_CONFIGURABLE`.
+    "abs",
+    "char",
+    "coalesce",
+    "format",
+    "hex",
+    "ifnull",
+    "iif",
+    "instr",
+    "json_array",
+    "json_extract",
+    "json_object",
+    "json_quote",
+    "json_type",
+    "json_valid",
+    "length",
+    "likelihood",
+    "likely",
+    "lower",
+    "ltrim",
+    "max",
+    "min",
+    "nullif",
+    "octet_length",
+    "printf",
+    "quote",
+    "replace",
+    "round",
+    "rtrim",
+    "sign",
+    "substr",
+    "substring",
+    "trim",
+    "typeof",
+    "unhex",
+    "unicode",
+    "unlikely",
+    "upper",
+    "zeroblob",
+];
+
+/// The name of anything in `body` whose value can differ between two databases holding identical
+/// rows — a clock keyword, or a call this cannot vouch for.
+///
+/// A CHECK is only usable as a shared guarantee if every peer agrees about it. `CHECK(random() >
+/// 0)` is self-contained and satisfiable, yet the identical replicated op can be accepted on one
+/// peer and quarantined on another — divergence with no local edit to signal it.
+fn per_device_reference(body: &str) -> Option<String> {
+    let tokens = lex_sql(body);
+    let scratch = Connection::open_in_memory().ok()?;
+    for (index, (token, ..)) in tokens.iter().enumerate() {
+        // A clock keyword stands alone — check it before the call-shaped test below, which would
+        // never reach it.
+        if let SqlToken::Word(word) = token
+            && (CLOCK_KEYWORDS.contains(&word.as_str())
+                || CONNECTION_CONFIGURABLE.contains(&word.as_str()))
+        {
+            return Some(word.clone());
+        }
+        // A function may be named with a bare word or a QUOTED identifier — `"random"()` is a legal
+        // call, and matching only bare words would let it through unexamined.
+        let (SqlToken::Word(name) | SqlToken::Ident(name)) = token else {
+            continue;
+        };
+        if tokens.get(index + 1).map(|t| &t.0) != Some(&SqlToken::Punct('(')) {
+            continue;
+        }
+        // A name SQLite does not know as a function is a KEYWORD that happens to be followed by a
+        // parenthesis — `CHECK(`, `IN (`, `CAST(` — not a call. It cannot be a user-defined
+        // function either: those live on the caller's connection, so the self-contained probe
+        // (which runs on a scratch one) would already have failed to create the table.
+        let is_function: bool = scratch
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = ?1)",
+                [name],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+        if !is_function {
+            continue;
+        }
+        if !ARGUMENT_ONLY_FUNCTIONS.contains(&name.as_str()) {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+/// Whether `err` is SQLite refusing the VALUE (a CHECK or NOT NULL), rather than refusing to
+/// resolve the statement.
+fn is_constraint_failure(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(inner, _)
+            if inner.code == rusqlite::ErrorCode::ConstraintViolation
+    )
+}
+
+/// The first GENERATED column of `table`, if any. `PRAGMA table_xinfo` reports `hidden` as 2 for a
+/// VIRTUAL generated column and 3 for a STORED one; `table_info` omits them entirely, which is why
+/// the ordinary column classification cannot see them at all.
+pub(super) fn generated_column(conn: &Connection, table: &str) -> rusqlite::Result<Option<String>> {
+    let mut found = None;
+    conn.pragma(None, "table_xinfo", table, |row| {
+        let hidden: i64 = row.get("hidden")?;
+        if (hidden == 2 || hidden == 3) && found.is_none() {
+            found = Some(row.get::<_, String>("name")?);
+        }
+        Ok(())
+    })?;
+    Ok(found)
+}
+
+/// Whether `table` declares any foreign key (`PRAGMA foreign_key_list` returns a row per FK).
+pub(super) fn table_has_foreign_key(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    let mut any = false;
+    conn.pragma(None, "foreign_key_list", table, |_row| {
+        any = true;
+        Ok(())
+    })?;
+    Ok(any)
+}
+
+/// The name of `table`'s first UNIQUE index that is NOT the primary key, if any (a cross-row
+/// constraint). `PRAGMA index_list` columns: 0 seq, 1 name, 2 unique, 3 origin, 4 partial; `origin`
+/// is `pk` for the primary key's implicit index, `u` for a UNIQUE constraint, `c` for a
+/// `CREATE UNIQUE INDEX`.
+pub(super) fn non_pk_unique_index(
+    conn: &Connection,
+    table: &str,
+) -> rusqlite::Result<Option<String>> {
+    let mut found = None;
+    conn.pragma(None, "index_list", table, |row| {
+        let unique: i64 = row.get(2)?;
+        let origin: String = row.get(3)?;
+        if unique != 0 && origin != "pk" && found.is_none() {
+            found = Some(row.get::<_, String>(1)?);
+        }
+        Ok(())
+    })?;
+    Ok(found)
+}
+
+/// The first pk column that uses a non-BINARY collation, if any. Reads the primary key's index
+/// (`PRAGMA index_list` origin=`pk` → `index_xinfo`, whose col 2 is the column name — NULL for the
+/// implicit rowid — and col 4 the collation). An INTEGER-rowid pk has no such index (integers have
+/// no collation), so it returns `None`.
+pub(super) fn pk_column_with_non_binary_collation(
+    conn: &Connection,
+    table: &str,
+) -> rusqlite::Result<Option<String>> {
+    let mut pk_index = None;
+    conn.pragma(None, "index_list", table, |row| {
+        if row.get::<_, String>(3)? == "pk" {
+            pk_index = Some(row.get::<_, String>(1)?);
+        }
+        Ok(())
+    })?;
+    let Some(index) = pk_index else { return Ok(None) };
+    let mut offending = None;
+    conn.pragma(None, "index_xinfo", &index, |row| {
+        // index_xinfo columns: 0 seqno, 1 cid, 2 name (NULL for the rowid), 3 desc, 4 coll, 5 key.
+        let name: Option<String> = row.get(2)?;
+        let collation: String = row.get(4)?;
+        if let Some(name) = name
+            && !collation.eq_ignore_ascii_case("BINARY")
+            && offending.is_none()
+        {
+            offending = Some(name);
+        }
+        Ok(())
+    })?;
+    Ok(offending)
+}
+
+/// The name of the first trigger on `table`, if any (`sqlite_master` type='trigger'). A trigger can
+/// mutate the row (or other rows) from local/derived state, so the SAME received op could fold to
+/// different physical results on two devices — divergence the whole-row fold can't detect.
+pub(super) fn table_trigger(conn: &Connection, table: &str) -> rusqlite::Result<Option<String>> {
+    let mut stmt =
+        conn.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?1")?;
+    let mut rows = stmt.query([table])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(row.get(0)?)),
+        None => Ok(None),
+    }
+}
+
+/// Whether any OTHER table declares a foreign key REFERENCING `table` (an inbound reference). Scans
+/// every base table's `PRAGMA foreign_key_list` (col 2 is the referenced table).
+pub(super) fn table_is_referenced_by_foreign_key(
+    conn: &Connection,
+    table: &str,
+) -> rusqlite::Result<bool> {
+    let mut tables = Vec::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            tables.push(row?);
+        }
+    }
+    for other in tables {
+        if other == table {
+            continue;
+        }
+        let mut references = false;
+        conn.pragma(None, "foreign_key_list", &other, |row| {
+            // foreign_key_list columns: 0 id, 1 seq, 2 table (the referenced table), 3 from, 4 to.
+            if row.get::<_, String>(2)? == table {
+                references = true;
+            }
+            Ok(())
+        })?;
+        if references {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+pub(super) fn physical_column_info(
+    conn: &Connection,
+    table: &str,
+) -> rusqlite::Result<Vec<PhysicalColumn>> {
+    let mut cols = Vec::new();
+    conn.pragma(None, "table_info", table, |row| {
+        // PRAGMA table_info columns: 0 cid, 1 name, 2 type, 3 notnull, 4 dflt_value, 5 pk.
+        cols.push(PhysicalColumn {
+            name: row.get::<_, String>(1)?,
+            decl_type: row.get::<_, String>(2)?.to_ascii_uppercase(),
+            not_null: row.get::<_, i64>(3)? != 0,
+            default_sql: row.get::<_, Option<String>>(4)?,
+            pk_position: row.get::<_, i64>(5)?,
+        });
+        Ok(())
+    })?;
+    Ok(cols)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `lex_sql` without the char spans, which only `check_constraints` needs.
+    fn toks(sql: &str) -> Vec<SqlToken> {
+        lex_sql(sql).into_iter().map(|(token, ..)| token).collect()
+    }
+
+    #[test]
+    fn constraint_scanning_reads_sql_lexically_not_textually() {
+        // Every case here is one a raw-text scan gets WRONG, in both directions.
+        // Asserted through `read_table_ddl`, the live consumer of the lexer.
+        let bodies = |sql: &str| {
+            let conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(sql).unwrap();
+            read_table_ddl(&conn, "t")
+                .unwrap()
+                .checks
+                .into_iter()
+                .map(|c| c.body)
+                .collect::<Vec<_>>()
+        };
+        let mentions = |sql: &str, column: &str| {
+            bodies(sql).iter().any(|body| {
+                lex_sql(body).iter().any(
+                    |(t, ..)| matches!(t, SqlToken::Word(w) | SqlToken::Ident(w) if w == column),
+                )
+            })
+        };
+
+        // A parenthesis inside a literal must not end the constraint early. Textually the body
+        // stops at the quote, hiding `count` — a FALSE NEGATIVE on the unsafe shape.
+        assert!(
+            mentions(
+                "CREATE TABLE t(a TEXT, later TEXT, count INT, CHECK(later <> ')' OR count = 0)) \
+                 STRICT;",
+                "count"
+            ),
+            "a paren inside a string literal is not structure"
+        );
+
+        // A literal that spells a constraint is not one — a FALSE POSITIVE textually.
+        assert!(
+            bodies("CREATE TABLE t(a TEXT DEFAULT 'CHECK(later=count)', later TEXT) STRICT;")
+                .is_empty(),
+            "`CHECK(` inside a string is inert"
+        );
+        // Likewise a comment.
+        assert!(
+            bodies("CREATE TABLE t(\n -- CHECK(later=count)\n a TEXT, later TEXT) STRICT;")
+                .is_empty(),
+            "`CHECK(` inside a comment is inert"
+        );
+        assert!(
+            bodies("CREATE TABLE t(/* CHECK(later=count) */ a TEXT, later TEXT) STRICT;")
+                .is_empty(),
+            "`CHECK(` inside a block comment is inert"
+        );
+
+        // A column name spelled inside a literal is not a reference to that column.
+        assert!(
+            !mentions(
+                "CREATE TABLE t(note TEXT, later TEXT, CHECK(note <> 'later')) STRICT;",
+                "later"
+            ),
+            "text that happens to equal a column name is not a column reference"
+        );
+
+        // `CHECK` as part of an identifier is not the keyword.
+        assert!(
+            bodies("CREATE TABLE t(checksum TEXT, later TEXT) STRICT;").is_empty(),
+            "`CHECK` inside a longer identifier is not a constraint"
+        );
+
+        // Whole-identifier matching, and quoted identifiers still count as references.
+        assert!(
+            !mentions(
+                "CREATE TABLE t(account_id TEXT, later TEXT, CHECK(account_id <> '')) STRICT;",
+                "count"
+            ),
+            "`count` must not match inside `account_id`"
+        );
+        assert!(
+            mentions(
+                "CREATE TABLE t(\"odd name\" TEXT, later TEXT, CHECK(\"odd name\" <> '')) STRICT;",
+                "odd name"
+            ),
+            "a quoted identifier is a real reference"
+        );
+
+        // Nested parentheses keep the whole body.
+        assert!(
+            mentions(
+                "CREATE TABLE t(a INT, later INT, count INT, CHECK(later > (count + 1))) STRICT;",
+                "count"
+            ),
+            "a nested group stays inside the body"
+        );
+    }
+    #[test]
+    fn a_literal_is_never_read_as_a_column_reference() {
+        // `X'ff'` is a blob literal, not a reference to a column named `x` — and `x` is a plausible
+        // column name, so lexing its leading character as a word would refuse a legitimate schema.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t(x BLOB, later BLOB DEFAULT X'00', CHECK(later != X'ff')) STRICT;",
+        )
+        .unwrap();
+        let checks = read_table_ddl(&conn, "t")
+            .unwrap()
+            .checks
+            .into_iter()
+            .map(|c| c.body)
+            .collect::<Vec<_>>();
+        assert_eq!(checks.len(), 1);
+        let tokens = toks(&checks[0]);
+        assert!(
+            tokens.contains(&SqlToken::Word("later".to_string())),
+            "the constrained column lexes as a word"
+        );
+        assert!(
+            !tokens.contains(&SqlToken::Word("x".to_string())),
+            "the `x` of a blob literal is not an identifier: {tokens:?}"
+        );
+
+        // Numbers likewise: an identifier cannot begin with a digit.
+        assert!(!toks("1e2 + 0x1f").iter().any(|t| matches!(t, SqlToken::Word(_))));
+
+        // Case folding follows SQLite, which is ASCII-only. `to_lowercase()` is full Unicode and
+        // would fold characters SQLite keeps distinct — U+212A KELVIN SIGN lowercases to `k`.
+        assert_eq!(
+            toks("\u{212A}"),
+            vec![SqlToken::Word("\u{212A}".to_string())],
+            "Unicode folding must not apply — SQLite folds ASCII only"
+        );
+        assert_eq!(
+            toks("COUNT"),
+            vec![SqlToken::Word("count".to_string())],
+            "ASCII folding must apply"
+        );
+    }
+    #[test]
+    fn lexing_survives_multibyte_and_unterminated_input() {
+        // The old textual matcher advanced by BYTES, so a rejected match adjacent to a multi-byte
+        // identifier could slice mid-character and panic. Characters throughout now.
+        let tokens = toks("CHECK(\"éx\" >= 0 AND é = 1)");
+        assert!(
+            tokens.contains(&SqlToken::Ident("éx".to_string()))
+                && tokens.contains(&SqlToken::Word("é".to_string())),
+            "multi-byte identifiers lex as whole tokens: {tokens:?}"
+        );
+        assert!(!tokens.contains(&SqlToken::Word("e".to_string())), "`é` is not `e`");
+
+        // Truncated input must terminate rather than run off the end.
+        for sql in ["CHECK('unterminated", "CHECK(\"unterminated", "/* unterminated", "CHECK((("] {
+            let _ = toks(sql);
+        }
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -55,12 +55,25 @@ pub(crate) enum PendingReason {
     /// applying the known subset would leave a row NO device ever authored, and publishing that row
     /// lets the producer re-author the hole at a winning lamport (see [`super::apply`]).
     UnknownColumn,
-    /// The op omits a column this registry requires — an OLDER producer, whose complete row under
-    /// its narrower spec is a partial after-image under ours. Whole-row LWW needs the full
-    /// after-image, so nothing is written. Unlike a broken producer this is a version gap, and it
-    /// is redeemed from the SENDER's side: #1002's declared column defaults rebuild the missing
-    /// cells into a complete row, at which point the replay lands it.
+    /// The op was authored against a NEWER synced column set than this binary knows. We cannot know
+    /// what a later spec means — and the op may name columns we lack — so nothing is written until
+    /// a binary that understands it replays the entry.
+    NewerSpecVersion,
+    /// The op omits a column its OWN claimed version was obliged to carry. Whole-row LWW needs the
+    /// full after-image, so nothing is written.
+    ///
+    /// Since #1002 this no longer means "an older producer": an op that genuinely predates a column
+    /// is completed from that column's declared default and applies inline, never reaching here.
+    /// What remains is a BROKEN or mis-stamped producer, which under additive-only evolution no
+    /// future binary can redeem on its own — the sender has to fix its bug and author again (a new
+    /// entry; redelivery of this one short-circuits on `entry_exists`). It parks rather than
+    /// quarantining because a forgotten `spec_version` bump is the likeliest cause and parking is
+    /// what keeps that operator error recoverable, but do not expect the entry itself to clear.
     PartialAfterImage,
+    /// The op carries a cell for a column introduced AFTER the version it claims — self-
+    /// contradictory, so the stamp cannot be trusted to decide what the op predates. The one half
+    /// of the advisory version a receiver can check against its own registry.
+    MisstampedSpecVersion,
     /// The op-kind is outside this binary's row-op vocabulary.
     UnknownOpKind,
     /// The op bytes do not decode at all.
@@ -413,6 +426,45 @@ pub(crate) fn clear_entry_pending(
     Ok(())
 }
 
+/// The op of the entry that currently WINS a row — located by the clock's `(device, lamport)`,
+/// which `table_sync_entries` is UNIQUE on within a stream, so at most one entry can match.
+///
+/// The clock stores the fingerprint as lowercase hex while the entry log stores raw bytes; the
+/// fingerprint type round-trips between them, and an unparseable value simply resolves to nothing.
+/// Returns `None` when the entry is absent or its payload no longer decodes to a known op.
+pub(crate) fn winning_entry_op(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device_hex: &str,
+    lamport: u64,
+) -> anyhow::Result<Option<RowOp>> {
+    let Ok(device) = device_hex.parse::<DeviceFingerprint>() else {
+        return Ok(None);
+    };
+    let signed_bytes: Option<Vec<u8>> = tx
+        .query_row(
+            "SELECT signed_bytes FROM table_sync_entries
+              WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport = ?3",
+            params![
+                stream.to_bytes().as_slice(),
+                device.to_bytes().as_slice(),
+                i64::try_from(lamport)?
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(signed_bytes) = signed_bytes else {
+        return Ok(None);
+    };
+    let Ok(signed) = entry::decode_signed(&signed_bytes) else {
+        return Ok(None);
+    };
+    Ok(match row_op::decode(&signed.entry.op_bytes) {
+        Ok(DecodedRowOp::Known(op)) => Some(op),
+        _ => None,
+    })
+}
+
 /// One retained-but-unprojected entry, with everything replay needs except its apply context (which
 /// comes from [`stream_context`], since the stream id hashes that away).
 pub(crate) struct PendingEntry {
@@ -546,7 +598,11 @@ mod tests {
     }
 
     fn op(id: &str) -> RowOp {
-        RowOp::Remove { table: "t".to_string(), pk: vec![TypedValue::Text(id.to_string())] }
+        RowOp::Remove {
+            spec_version: 1,
+            table: "t".to_string(),
+            pk: vec![TypedValue::Text(id.to_string())],
+        }
     }
 
     #[test]


### PR DESCRIPTION
A table-sync `Upsert` carries a full after-image but never said **which synced column set it was authored against**, so a receiver could not tell an older producer's complete row from a newer producer's partial one and had to treat both conservatively. That left two costs, which this closes.

- **Older-to-newer replication was frozen.** An older producer's complete row is a partial after-image under a wider spec, so it parked — and only the sender could fix that, so it parked forever.
- **A column-set change left an authoring dead zone.** The anti-echo hash covers a column set, so afterwards nothing refreshed a pre-existing row's hash except a *winning* apply, and a row that never authors never wins. Even a genuine local edit produced nothing.

## The wire

`spec_version` becomes element 2 of both payloads — `Upsert [table, spec_version, pk, cells]`, `Remove [table, spec_version, pk]`. The envelope domain stays `rag-rat/table-op/1`: `SYNCABLE_TABLES` is empty and there is no transport, so no released binary has ever produced or consumed a table op, and bumping would assert a compatibility generation that never existed. Golden vectors are re-pinned, and `Remove` gains one — a round-trip is invariant under any symmetric format change, so half the wire was unpinned.

## The acceptance rule

**Newer** parks; **equal** is a strict full after-image; **older** has the columns it predates filled from their declared defaults.

The fill window is **per column**. `ColumnSpec::added` records the version that introduced a column, and one is filled only for ops predating *that* version — keyed on the spec's current version instead, a table at its third version would default a column the op's own version already had, resetting it for every receiver under whole-row LWW. An op naming a column its claimed version could not have known is self-contradictory and parks; that is the half of an advisory stamp a receiver can check against its own registry.

Whole-row semantics are preserved deliberately: an older producer's winning op resets a newer column to its default everywhere, which is what a whole-row write from a device that does not know the column *means*. `Remove` stays version-agnostic — it carries only the pk, so gating it would make a row deleted after a column change permanently undeletable.

## Settling a stale row

A row published under an older column set is settled by projecting its winning entry and **comparing**: equal restamps the publication record, different is a proven local edit and is authored, unresolvable is left alone. Re-applying the winner would write nothing (its clock equals the row's, so it never beats it), and bypassing the clock to force it would overwrite the edits this detects. The winner lookup verifies the entry it finds is *this row's* op rather than trusting `(stream, device, lamport)` to identify it.

`ApplyOutcome::Superseded` separates "landed but outranked" from "applied". Receivers treat them alike, but a locally-authored op takes the stream's maximum lamport plus one and so cannot lose while the row's bookkeeping belongs to that stream — losing proves the two have come apart, and reading it as settlement re-signs the same delta on every pass.

## Schema V095

`sync_published_rows.spec_version` replaces the store-global projector version, which was too coarse: registering an unrelated table would mark every table's rows incomparable. The table is rebuilt by rename-and-copy rather than dropped, so the migration cannot lose publication state if it is ever reached with rows present — `produce_row_ops` finds a locally-deleted row by its surviving published record.

## Evolution is enforced, not documented

`PROJECTOR_GENERATIONS` records the registry as of each projector version, with the live registry required to equal the last entry. A registry change can only be made green by appending, and the version *is* the number of generations — so the bump that lets parked entries replay cannot be omitted. Comparing consecutive generations then makes the additive-only rule checkable, where a single binary has no history to check against: a table or column that disappears, a primary key, scope or repo column that moves, a column that changes type or introduction tuple, and a new column that is not fillable for the previous spec are all rejected.

## Registry lint

A declared default must equal the column's SQL default, or a row backfilled by the migration and one rebuilt from an older op differ at the same clock.

A column's constraints must accept the default and depend on nothing else. That is decided by rebuilding the column alone in a scratch database — under the real table's name, STRICTness and verbatim DDL — and attempting the applier's insert, so collation, affinity and CHECK truth are SQLite's rather than reproduced. Which constraints involve the column is likewise SQLite's answer, from offering the body one world holding only that column and another holding every other.

What a probe cannot see is refused: the implicit rowid, clock keywords, `LIKE`/`GLOB` (connection state under `PRAGMA case_sensitive_like`), and any function not known to depend only on its arguments — an allowlist, because `SQLITE_DETERMINISTIC` means "within this build" and a build-varying function satisfies it. Generated columns are refused outright: absent from `PRAGMA table_info`, they can be classified neither synced nor local, yet reach the synced columns through their expression.

`schema_facts.rs` holds the reading of `PRAGMA` output and `sqlite_master`, including the small SQL lexer that makes constraint reading trustworthy; `registry.rs` stays spec and lint policy.

## Tests

Mixed-version convergence in both directions; an older op applying with defaults filled and a three-version spec distinguishing the per-column window; a newer op parking then replaying; `Remove` crossing a skew unimpeded; a stale row edited being authored and an untouched one restamped; the unsent-edit guard in all three of its verdicts; the losing self-apply; every generation invariant; and the lint's default, constraint and per-device rules, including the SQLite boundary it relies on pinned in both directions.

Follow-ups filed: #1017, #1018, #1019, #1020.

Closes #1002. Part of #892.