### PR TITLE
fix(index): make an impl's owner part of logical identity

### DIFF
--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -3,6 +3,7 @@ mod helpers;
 mod imports;
 mod intern;
 mod resolve;
+pub(crate) mod scope_grammar;
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
@@ -550,6 +551,96 @@ impl IndexedSymbol {
     }
 }
 
+/// Drop generic ARGUMENTS from a path — see [`scope_grammar::degeneric`], which owns the parsing
+/// rules every consumer of these strings shares.
+pub(crate) fn degeneric_path(path: &str) -> String {
+    scope_grammar::degeneric(path)
+}
+
+#[cfg(test)]
+mod degeneric_tests {
+    use super::degeneric_path;
+    use crate::index::edges::helpers::strip_generics;
+
+    /// A const-generic block holds an expression, so its `<`/`>` are operators. Getting this wrong
+    /// swallows everything after the block — and the call side (`strip_generics`) already treats
+    /// braces this way, so the two must agree or the definition and the call never meet.
+    #[test]
+    fn a_const_generic_block_is_not_a_generic_delimiter() {
+        for path in ["Foo<{ 1 < 2 }>::run", "Foo<{ 2 > 1 }>::run", "Foo<[u8; { 1 < 2 }]>::run"] {
+            assert_eq!(degeneric_path(path), "Foo::run", "{path}");
+        }
+        // A block OUTSIDE any generic argument is part of the type itself and survives.
+        assert_eq!(degeneric_path("[u8; { 1 < 2 }] as Tr::f"), "[u8; { 1 < 2 }] as Tr::f");
+    }
+
+    /// The def-side (`degeneric_path`, a full scan) and the call-side (`strip_generics`, a lighter
+    /// brace/angle counter) normalizer meet on the shapes a real path takes.
+    #[test]
+    fn degeneric_path_agrees_with_the_call_side_stripper() {
+        for path in ["Foo<T>::run", "Foo<{ 1 < 2 }>::run", "A<B<C>>::run", "plain::run"] {
+            assert_eq!(degeneric_path(path), strip_generics(path), "{path}");
+        }
+    }
+
+    /// Where they DIVERGE, the divergence is one-sided: the call side is string- and comment-blind,
+    /// so a `{`/`}`/`<`/`>` inside a literal unbalances its counter and it drops the whole tail —
+    /// yielding a form with no `::`, which resolution treats as a bare name and declines. The def
+    /// side keeps the real qualified key. So the two never disagree into a DIFFERENT qualified key
+    /// (which would let a call meet the wrong definition); the worst case is a missed edge that
+    /// falls back to bare-name matching. This pins that safe direction so a future change to either
+    /// side that turned a divergence into a colliding key would fail here. Full unification of the
+    /// two onto the scanner is #1094.
+    #[test]
+    fn a_divergence_between_the_normalizers_only_ever_declines() {
+        for path in [
+            r#"Foo<{ "{".len() }>::run"#,
+            r#"Foo<{ "}".len() }>::run"#,
+            r##"Bar<{ r#"<"#.len() }>::run"##,
+        ] {
+            let call = strip_generics(path);
+            let def = degeneric_path(path);
+            assert!(
+                call == def || !call.contains("::"),
+                "{path}: call `{call}` must equal def `{def}` or carry no `::`"
+            );
+        }
+    }
+}
+
+/// [`degeneric_path`] plus trait-impl owner folding: the `Type as Trait` scope segment emitted
+/// for `impl Trait for Type` collapses to `Type`, so a source-form target (`Type::method`, a
+/// receiver-type hint) finds trait-impl methods while their RAW scope keeps the trait — two
+/// traits' same-named methods stay distinct logical symbols yet expose the same receiver
+/// surface, and a call that could hit either declines as ambiguous (#567). The marker's trait
+/// path is emitted with `::` rewritten to `.` (see the Rust `trait_marker`), so it is always ONE
+/// `::`-segment and per-`::`-segment splitting is sound.
+/// Borrowed ⇔ the path needs no normalization — the hot rebuild path allocates nothing for the
+/// plain-scope majority.
+pub(crate) fn normalized_scope_path<'a>(
+    path: &'a str,
+    language: Option<&str>,
+) -> std::borrow::Cow<'a, str> {
+    if language != Some(Language::Rust.as_str())
+        || (!path.contains('<')
+            && !path.contains(" as ")
+            && !path.contains('&')
+            && !path.contains('*'))
+    {
+        return std::borrow::Cow::Borrowed(path);
+    }
+    let degeneric = degeneric_path(path);
+    std::borrow::Cow::Owned(
+        scope_grammar::segments(&degeneric)
+            .into_iter()
+            .map(|segment| {
+                scope_grammar::strip_receiver_wrappers(scope_grammar::strip_trait_marker(segment))
+            })
+            .collect::<Vec<_>>()
+            .join("::"),
+    )
+}
+
 /// Name-keyed indexes over the symbol set, built once per resolve pass. Edge resolution used to
 /// scan the entire `Vec<IndexedSymbol>` (several times) per edge — O(edges × symbols), the single
 /// biggest cost in a full rebuild. These maps make each lookup ~O(1). Bucket order mirrors the
@@ -562,6 +653,9 @@ pub(crate) struct SymbolIndex<'a> {
     /// qualified path fires for methods/nested items instead of collapsing to bare-name
     /// collisions.
     by_scope_path: HashMap<&'a str, Vec<&'a IndexedSymbol>>,
+    /// Scope path with generics stripped and trait-impl owners folded (`SymbolIndex::build`
+    /// matching `SymbolIndex<'a>::build`; `Worker::run` matching `Worker as Service::run`).
+    by_normalized_scope_path: HashMap<String, Vec<&'a IndexedSymbol>>,
     /// Short-name fallback (`symbol.name`).
     by_name: HashMap<&'a str, Vec<&'a IndexedSymbol>>,
     /// Candidates for the `qualified_name.ends_with("::{q}")` suffix match, keyed by the last
@@ -574,15 +668,25 @@ impl<'a> SymbolIndex<'a> {
     fn build(symbols: &'a [IndexedSymbol]) -> Self {
         let mut by_qualified: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_scope_path: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
+        let mut by_normalized_scope_path: HashMap<String, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_name: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_qn_tail: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         for symbol in symbols {
             by_qualified.entry(symbol.qualified_name.as_str()).or_default().push(symbol);
             by_scope_path.entry(symbol.scope_path.as_str()).or_default().push(symbol);
+            // Only paths the normalization actually changes go into the normalized map (`Owned`
+            // ⇔ changed) — a plain scope is already reachable through `by_scope_path`, and
+            // skipping it avoids one String per symbol on the hot rebuild path. Lookups consult
+            // BOTH maps.
+            if let std::borrow::Cow::Owned(normalized) =
+                normalized_scope_path(&symbol.scope_path, Some(&symbol.language))
+            {
+                by_normalized_scope_path.entry(normalized).or_default().push(symbol);
+            }
             by_name.entry(symbol.name.as_str()).or_default().push(symbol);
             by_qn_tail.entry(qn_tail(&symbol.qualified_name)).or_default().push(symbol);
         }
-        Self { by_qualified, by_scope_path, by_name, by_qn_tail }
+        Self { by_qualified, by_scope_path, by_normalized_scope_path, by_name, by_qn_tail }
     }
 
     /// Whether `file_id` itself defines a symbol named `name`. Import-alias rebinding defers when

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -835,6 +835,35 @@ pub(crate) fn resolve_symbol<'a>(
                 return Some((scope_exact[0], EdgeConfidence::Syntactic, "logical_variant")),
             _ => {},
         }
+        // Reaching here means the exact stage found NOTHING or found an AMBIGUITY. Either way the
+        // raw candidates at the normalized key belong in this set: when normalization was a no-op
+        // they ARE the exact stage's candidates, and dropping them as "already tried" would let a
+        // single normalization-only match (`&W as Tr::run` folding to `W::run`) win as a unique
+        // `scope_degeneric` over two raw `W::run` definitions the exact stage correctly refused
+        // to choose between. Re-including them is what keeps that ambiguity visible; a genuinely
+        // unique exact hit already returned above, so nothing is double-counted.
+        let qualified_normalized = normalized_scope_path(qualified, request.source_language);
+        let scope_normalized = index
+            .by_scope_path
+            .get(qualified_normalized.as_ref())
+            .into_iter()
+            .flatten()
+            .chain(
+                index
+                    .by_normalized_scope_path
+                    .get(qualified_normalized.as_ref())
+                    .into_iter()
+                    .flatten(),
+            )
+            .copied()
+            .filter(|symbol| kind_matches(symbol))
+            .collect::<Vec<_>>();
+        match scope_normalized.as_slice() {
+            [symbol] => return Some((*symbol, EdgeConfidence::Syntactic, "scope_degeneric")),
+            [_, ..] if same_logical_symbol(&scope_normalized) =>
+                return Some((scope_normalized[0], EdgeConfidence::Syntactic, "scope_degeneric")),
+            _ => {},
+        }
         let scope_suffix = format!("::{qualified}");
         let scope_matches = index
             .by_name

--- a/crates/rag-rat-core/src/index/edges/scope_grammar.rs
+++ b/crates/rag-rat-core/src/index/edges/scope_grammar.rs
@@ -1,0 +1,381 @@
+//! The ONE parser for scope-path and type-path strings.
+//!
+//! A scope path is structured text — `&W as std.fmt.Display::fmt`, `[u8; { 1 < 2 }]::run`,
+//! `Foo<Bar<T>>::run` — and the index compares, splits and folds it in several places: logical
+//! identity, the resolution surface, receiver-hint matching, the trait-impl marker. Every one of
+//! those used to walk the string with its own ad-hoc loop, and each loop drew the boundaries
+//! slightly differently: one counted `<` inside a const-generic block, another counted it inside a
+//! string literal, a third split on the first ` as ` even when it sat inside `[u8; N as usize]`,
+//! a fourth kept the `::` of a turbofish that the call side dropped. Two parsers of one string
+//! that disagree produce a definition and a call that can never meet, and the disagreement moves
+//! rather than disappears when patched at one site.
+//!
+//! So the rules live here once:
+//! - a `"…"`/`'…'` literal is opaque — nothing inside it is punctuation, and a raw string's
+//!   delimiter is its `"` plus the `#` run its prefix declared, not the next `"` it happens to
+//!   hold;
+//! - a `//` or `/* */` comment is opaque for the same reason, and Rust block comments NEST, so the
+//!   `}` in `/* } */` closes nothing;
+//! - `<`…`>` nest, but only outside literals and outside `(`/`[`/`{`, because a const-generic block
+//!   holds an EXPRESSION whose `<` and `>` are operators;
+//! - `->` is a return arrow, never a closing angle;
+//! - structural splits (`::`, ` as `) happen at depth zero only.
+
+/// Where one byte of a path sits, structurally.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Depth {
+    angle: u32,
+    group: u32,
+}
+
+impl Depth {
+    /// At the top level of the path — not inside `<…>`, `(…)`, `[…]` or `{…}`.
+    pub(crate) fn is_top(self) -> bool {
+        self.angle == 0 && self.group == 0
+    }
+
+    /// Inside a generic argument list, so this text is an ARGUMENT rather than the path itself.
+    fn in_angle(self) -> bool {
+        self.angle > 0
+    }
+}
+
+/// What one char of a path IS, for consumers that treat the three differently: structure is only
+/// ever read from code, a literal's exact bytes are part of the type, and a comment is neither.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Span {
+    Code,
+    Literal,
+    Comment,
+}
+
+impl Span {
+    /// Punctuation counts as structure only here.
+    pub(crate) fn is_code(self) -> bool {
+        self == Self::Code
+    }
+}
+
+/// What kind of literal the scan is inside — the closing rule differs.
+#[derive(Clone, Copy)]
+enum Literal {
+    /// `"…"`, `b"…"`, `'…'` — a backslash escapes the next char.
+    Escaped(char),
+    /// `r"…"`, `br#"…"#` — no escapes at all; ends only at a `"` followed by `hashes` `#`.
+    Raw { hashes: usize },
+}
+
+/// What kind of comment the scan is inside — a line comment ends at the newline, a block comment
+/// at its own matching `*/`, and Rust block comments nest.
+#[derive(Clone, Copy)]
+enum Comment {
+    Line,
+    Block { depth: u32 },
+}
+
+/// The literal a quote at `at` opens, if any.
+///
+/// The closing rule is decided by a PREFIX that sits before the quote, so it is read backwards:
+/// any `#` run immediately before the quote, then the character under it. That covers `r`, `br`,
+/// `cr` and every hash count without enumerating the spellings. A lifetime (`'a`) is not a
+/// character literal — it has no closing quote — so `'` opens one only when another follows within
+/// a few chars.
+fn open_literal(path: &str, at: usize, quote: char) -> Option<Literal> {
+    if quote == '\'' {
+        return path[at + quote.len_utf8()..]
+            .chars()
+            .take(4)
+            .any(|next| next == '\'')
+            .then_some(Literal::Escaped(quote));
+    }
+    let before = &path[..at];
+    // Every counted char is `#`, one byte each, so the split point is a char boundary.
+    let hashes = before.chars().rev().take_while(|&ch| ch == '#').count();
+    match before[..before.len() - hashes].chars().next_back() {
+        Some('r') => Some(Literal::Raw { hashes }),
+        _ => Some(Literal::Escaped(quote)),
+    }
+}
+
+/// The `#` run starting at `from` — the closing-delimiter width available to a raw string.
+fn hash_run(path: &str, from: usize) -> usize {
+    path.get(from..).map_or(0, |rest| rest.chars().take_while(|&ch| ch == '#').count())
+}
+
+/// Walk `path`, reporting each char with the depth INCLUDING itself and what the char IS — an
+/// opener and its matching closer both report the depth of the pair they delimit, so dropping a
+/// bracketed run is a single `depth.in_angle()` test that covers the brackets as well as their
+/// contents.
+pub(crate) fn scan(path: &str, mut visit: impl FnMut(usize, char, Depth, Span)) {
+    let mut depth = Depth::default();
+    let mut literal: Option<Literal> = None;
+    let mut comment: Option<Comment> = None;
+    let mut escaped = false;
+    let mut previous = '\0';
+    // The second char of a two-char delimiter. It is reported, but it must not also be read as the
+    // FIRST char of the next one, or `/*/` would open and close on the same `*`.
+    let mut consumed_through = 0usize;
+    for (at, ch) in path.char_indices() {
+        if at < consumed_through {
+            visit(at, ch, depth, Span::Comment);
+            previous = '\0';
+            continue;
+        }
+        if let Some(open) = literal {
+            visit(at, ch, depth, Span::Literal);
+            match open {
+                Literal::Escaped(quote) =>
+                    if escaped {
+                        escaped = false;
+                    } else if ch == '\\' {
+                        escaped = true;
+                    } else if ch == quote {
+                        literal = None;
+                    },
+                // A raw string holds unescaped quotes — `r#""}"#` closes at its LAST one. Only a
+                // quote whose `#` run matches the opening prefix ends it; anything shorter is
+                // content, and closing there would let the following `}` count as structural.
+                Literal::Raw { hashes } =>
+                    if ch == '"' && hash_run(path, at + ch.len_utf8()) >= hashes {
+                        literal = None;
+                    },
+            }
+            previous = ch;
+            continue;
+        }
+        if let Some(open) = comment {
+            visit(at, ch, depth, Span::Comment);
+            match open {
+                Comment::Line =>
+                    if ch == '\n' {
+                        comment = None;
+                    },
+                Comment::Block { depth: nesting } =>
+                    if previous == '/' && ch == '*' {
+                        comment = Some(Comment::Block { depth: nesting + 1 });
+                        previous = '\0';
+                        continue;
+                    } else if previous == '*' && ch == '/' {
+                        comment = (nesting > 1).then_some(Comment::Block { depth: nesting - 1 });
+                        previous = '\0';
+                        continue;
+                    },
+            }
+            previous = ch;
+            continue;
+        }
+        match ch {
+            '"' | '\'' => {
+                visit(at, ch, depth, Span::Code);
+                literal = open_literal(path, at, ch);
+                escaped = false;
+            },
+            // A lone `/` is division; only `//` and `/*` open a comment. Both chars are claimed
+            // here so the opener's `*` cannot double as a closer's.
+            '/' if matches!(path[at + 1..].chars().next(), Some('/') | Some('*')) => {
+                let block = path[at + 1..].starts_with('*');
+                comment = Some(if block { Comment::Block { depth: 1 } } else { Comment::Line });
+                consumed_through = at + 2;
+                visit(at, ch, depth, Span::Comment);
+            },
+            '(' | '[' | '{' => {
+                depth.group += 1;
+                visit(at, ch, depth, Span::Code);
+            },
+            ')' | ']' | '}' => {
+                visit(at, ch, depth, Span::Code);
+                depth.group = depth.group.saturating_sub(1);
+                if ch == '}' {}
+            },
+            '<' if depth.group == 0 => {
+                depth.angle += 1;
+                visit(at, ch, depth, Span::Code);
+            },
+            // `->` closes nothing; the `>` belongs to the arrow.
+            '>' if depth.group == 0 && depth.angle > 0 && previous != '-' => {
+                visit(at, ch, depth, Span::Code);
+                depth.angle -= 1;
+            },
+            _ => visit(at, ch, depth, Span::Code),
+        }
+        previous = ch;
+    }
+}
+
+/// Byte offsets of every top-level `::` separator.
+fn separator_offsets(path: &str) -> Vec<usize> {
+    let mut offsets = Vec::new();
+    let mut previous_colon: Option<usize> = None;
+    scan(path, |at, ch, depth, span| {
+        if !span.is_code() || !depth.is_top() || ch != ':' {
+            previous_colon = None;
+            return;
+        }
+        match previous_colon.take() {
+            Some(start) if start + 1 == at => offsets.push(start),
+            _ => previous_colon = Some(at),
+        }
+    });
+    offsets
+}
+
+/// Split a path on its TOP-LEVEL `::` separators. `Foo<A::B>::run` is two segments, not three;
+/// `[u8; { a::b() }]::run` likewise.
+pub(crate) fn segments(path: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    for at in separator_offsets(path) {
+        out.push(&path[start..at]);
+        start = at + 2;
+    }
+    out.push(&path[start..]);
+    out
+}
+
+/// The owner half of a `Type as Trait` scope segment, or the whole segment when it carries no
+/// marker. The split is on a TOP-LEVEL ` as `, so a cast inside the owner — `[u8; N as usize]` —
+/// is not mistaken for the marker.
+pub(crate) fn strip_trait_marker(segment: &str) -> &str {
+    let mut split = None;
+    let bytes = segment.as_bytes();
+    scan(segment, |at, ch, depth, span| {
+        if split.is_some() || !span.is_code() || !depth.is_top() || ch != ' ' {
+            return;
+        }
+        if bytes[at..].starts_with(b" as ") {
+            split = Some(at);
+        }
+    });
+    match split {
+        Some(at) => segment[..at].trim_end(),
+        None => segment,
+    }
+}
+
+/// Drop generic ARGUMENTS from a path: `Foo<T>::run` → `Foo::run`, `Foo::<T>::run` → `Foo::run`.
+///
+/// The turbofish's `::` goes with the arguments it introduces — a definition scope and a call
+/// target must normalize to the same string, and the call side has always dropped it.
+pub(crate) fn degeneric(path: &str) -> String {
+    // A LEADING `<…>` is a UFCS qualifier (`<W as a::Runs>::run`), not an argument list — dropping
+    // it would erase the type and the trait and leave a bare `::run`. The call side has always
+    // returned such a path unchanged, and the whole point of this module is that the two agree.
+    if path.trim_start().starts_with('<') {
+        return path.to_string();
+    }
+    let mut out = String::with_capacity(path.len());
+    scan(path, |_, ch, depth, span| {
+        if !span.is_code() {
+            if !depth.in_angle() {
+                out.push(ch);
+            }
+            return;
+        }
+        match ch {
+            // The outermost `<` of an argument list; the `::` of a turbofish belongs to it.
+            '<' if depth.angle == 1 =>
+                if out.ends_with("::") {
+                    out.truncate(out.len() - 2);
+                },
+            _ if depth.in_angle() => {},
+            _ => out.push(ch),
+        }
+    });
+    out
+}
+
+/// Peel `&`/`&mut`/`*const`/`*mut` off an owner segment.
+///
+/// The impl scope KEEPS the wrapper — `impl Tr for W` and `impl Tr for &W` coexist, so they are
+/// different entities — but the RECEIVER surface must not: a source-form target is written
+/// `W::method`, and an autoref call site cannot tell which impl it lands in.
+pub(crate) fn strip_receiver_wrappers(segment: &str) -> &str {
+    let mut rest = segment.trim();
+    loop {
+        let peeled = rest
+            .strip_prefix("*const ")
+            .or_else(|| rest.strip_prefix("*mut "))
+            .or_else(|| rest.strip_prefix('&'))
+            .unwrap_or(rest)
+            .trim_start();
+        let peeled = peeled.strip_prefix("mut ").unwrap_or(peeled).trim_start();
+        if peeled == rest {
+            return rest.trim_end();
+        }
+        rest = peeled;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segments_split_only_at_the_top_level() {
+        assert_eq!(segments("Foo::run"), vec!["Foo", "run"]);
+        assert_eq!(segments("Foo<A::B>::run"), vec!["Foo<A::B>", "run"]);
+        assert_eq!(segments("[u8; { a::b() }]::run"), vec!["[u8; { a::b() }]", "run"]);
+        assert_eq!(segments("W as a.Tr::run"), vec!["W as a.Tr", "run"]);
+    }
+
+    #[test]
+    fn the_marker_split_ignores_a_cast_inside_the_owner() {
+        assert_eq!(strip_trait_marker("W as a.Tr"), "W");
+        assert_eq!(strip_trait_marker("[u8; N as usize] as Tr"), "[u8; N as usize]");
+        assert_eq!(strip_trait_marker("[u8; N as usize]"), "[u8; N as usize]");
+        assert_eq!(strip_trait_marker("W"), "W");
+    }
+
+    #[test]
+    fn degeneric_respects_literals_blocks_and_arrows() {
+        assert_eq!(degeneric("Foo<T>::run"), "Foo::run");
+        assert_eq!(degeneric("Foo::<T>::run"), "Foo::run");
+        assert_eq!(degeneric("Foo<{ 1 < 2 }>::run"), "Foo::run");
+        assert_eq!(degeneric(r#"Foo<{ "{".len() }>::run"#), "Foo::run");
+        assert_eq!(degeneric(r#"Foo<{ "<>".len() }>::run"#), "Foo::run");
+        assert_eq!(degeneric("fn(&T) -> U"), "fn(&T) -> U");
+        assert_eq!(degeneric("[u8; { 1 < 2 }]::run"), "[u8; { 1 < 2 }]::run");
+        // A leading UFCS qualifier survives, exactly as the call side leaves it.
+        assert_eq!(degeneric("<W as a::Runs>::run"), "<W as a::Runs>::run");
+    }
+
+    /// A raw string's closing delimiter is its `"` plus the `#` run its prefix declared. Ending it
+    /// at the first interior quote would hand the rest of the literal back as structure — the `}`
+    /// in `r#""}"#` would close the const-generic block and swallow the path's tail.
+    #[test]
+    fn a_raw_string_closes_only_on_its_own_delimiter() {
+        assert_eq!(degeneric(r##"Foo<{ r#""}"#.len() }>::run"##), "Foo::run");
+        assert_eq!(degeneric(r####"Foo<{ r###""##}"###.len() }>::run"####), "Foo::run");
+        // No hashes: `r"…"` still ends at its first quote, and `br`/`cr` read the same way.
+        assert_eq!(degeneric(r#"Foo<{ r"}".len() }>::run"#), "Foo::run");
+        assert_eq!(degeneric(r##"Foo<{ br#""}"#.len() }>::run"##), "Foo::run");
+        // A `#` with no `r` under it is not a raw prefix, so escapes still apply.
+        assert_eq!(degeneric(r#"Foo<{ "\"}".len() }>::run"#), "Foo::run");
+    }
+
+    /// A comment holds no punctuation. Block comments nest, and `/*/` opens without closing, so
+    /// neither the opener's `*` nor a nested one may double as a terminator.
+    #[test]
+    fn a_comment_is_opaque_to_structure() {
+        assert_eq!(segments("[u8; { /* :: */ N }]::run"), vec!["[u8; { /* :: */ N }]", "run"]);
+        assert_eq!(segments("W /* as Tr */ ::run"), vec!["W /* as Tr */ ", "run"]);
+        assert_eq!(strip_trait_marker("[u8; N /* as usize */]"), "[u8; N /* as usize */]");
+        assert_eq!(degeneric("Foo<{ /* < > */ N }>::run"), "Foo::run");
+        assert_eq!(degeneric("Foo<{ /* /* < */ */ N }>::run"), "Foo::run");
+        assert_eq!(degeneric("Foo<{ /*/ < */ N }>::run"), "Foo::run");
+        // A line comment runs to the newline and no further.
+        assert_eq!(segments("[u8; { // }\n N }]::run"), vec!["[u8; { // }\n N }]", "run"]);
+        // A lone `/` is division, not a comment.
+        assert_eq!(degeneric("[u8; { N / 2 }]::run"), "[u8; { N / 2 }]::run");
+        // A `//` inside a literal is content.
+        assert_eq!(degeneric(r#"Foo<{ "// }".len() }>::run"#), "Foo::run");
+    }
+
+    #[test]
+    fn wrappers_peel_off_the_receiver_surface() {
+        assert_eq!(strip_receiver_wrappers("&W"), "W");
+        assert_eq!(strip_receiver_wrappers("&mut W"), "W");
+        assert_eq!(strip_receiver_wrappers("*const W"), "W");
+        assert_eq!(strip_receiver_wrappers("W"), "W");
+    }
+}

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -640,6 +640,7 @@ mod logical_group_reason_tests {
             language: "rust".to_string(),
             name: "describe".to_string(),
             qualified_name: "src/lib.rs::describe".to_string(),
+            scope_path: "describe".to_string(),
             kind: "function".to_string(),
             signature: Some("pub fn describe(&self) -> u32 {".to_string()),
             start_line: 1,

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -12,6 +12,7 @@ pub(super) struct LogicalSymbolKey {
     pub(super) path: String,
     pub(super) name: String,
     pub(super) qualified_name: String,
+    pub(super) scope_path: String,
     pub(super) kind: String,
     // Signature is part of the identity so that two distinct same-named symbols in one file (e.g.
     // `new` on two different impls — same `qualified_name`, different signatures) do NOT collapse
@@ -26,6 +27,7 @@ impl LogicalSymbolKey {
             path: row.path.clone(),
             name: row.name.clone(),
             qualified_name: row.qualified_name.clone(),
+            scope_path: row.scope_path.clone(),
             kind: row.kind.clone(),
             signature: row.signature.clone(),
         }
@@ -46,12 +48,13 @@ impl LogicalSymbolKey {
     /// primary-key error on rebuild rather than silent merging.
     pub(super) fn stable_id(&self, repo_id: &str) -> i64 {
         let canonical = format!(
-            "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+            "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
             repo_id,
             self.language,
             self.path,
             self.name,
             self.qualified_name,
+            self.scope_path,
             self.kind,
             self.signature.as_deref().unwrap_or(""),
         );
@@ -95,29 +98,66 @@ pub(crate) fn realign_logical_symbol_ids(conn: &rusqlite::Connection) -> rusqlit
         path: String,
         name: String,
         qualified_name: Option<String>,
+        scope_path: Option<String>,
         kind: String,
         signature: Option<String>,
     }
-    let mut stmt = conn.prepare(
+    let has_scope_path = conn.prepare("SELECT scope_path FROM symbols LIMIT 0").is_ok();
+    // Take the members' scope only when they AGREE on it. A pre-V040 group can hold the very
+    // collision this version fixes — same-named, same-signature methods under different impl
+    // owners — and picking one member arbitrarily would move the whole group's durable references
+    // onto that one owner's new id. If the chosen owner then happens to be the surviving exact
+    // key, the drift heal sees an unchanged reference and silently hands shared memories or
+    // monikers to an arbitrary owner. A disagreeing group yields NULL and is skipped here, so the
+    // key-drift relocation path handles the split as the ambiguity it is. The unanimity test
+    // itself (how the collected member scopes are compared) is documented at the comparison below.
+    let scope_path_subquery = if has_scope_path {
+        "(SELECT GROUP_CONCAT(COALESCE(s.scope_path, ''), char(31))
+            FROM logical_symbol_members m JOIN symbols s ON s.id = m.symbol_id
+           WHERE m.logical_symbol_id = ls.id)"
+    } else {
+        "''"
+    };
+    let mut stmt = conn.prepare(&format!(
         "SELECT ls.id, ls.repo_id, ls.language, ls.path, ls.logical_name,
                 (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
                 ls.kind,
                 (SELECT s.signature FROM logical_symbol_members m
                    JOIN symbols s ON s.id = m.symbol_id
-                  WHERE m.logical_symbol_id = ls.id LIMIT 1)
+                  WHERE m.logical_symbol_id = ls.id LIMIT 1),
+                {scope_path_subquery}
          FROM logical_symbols ls",
-    )?;
+    ))?;
     let rows = stmt
         .query_map([], |r| {
+            let language: String = r.get(2)?;
             Ok(Row {
                 old_id: r.get(0)?,
                 repo_id: r.get(1)?,
-                language: r.get(2)?,
                 path: r.get(3)?,
                 name: r.get(4)?,
                 qualified_name: r.get(5)?,
                 kind: r.get(6)?,
                 signature: r.get(7)?,
+                scope_path: r.get::<_, Option<String>>(8)?.and_then(|joined| {
+                    // One IDENTICAL scope across every member, or nothing. A group whose members
+                    // disagree is the pre-upgrade owner collision — version 1 keyed without the
+                    // scope, so `Foo<T>::run` and `Foo<U>::run` could share a group — and
+                    // realigning it would hand the whole group's references to one arbitrary owner.
+                    //
+                    // Deliberately compared RAW. Folding first would let the check pass for members
+                    // that are genuinely different entities: the only string-level fold available
+                    // here drops generic arguments, so it equates `Foo<u8>::run` with
+                    // `Foo<u16>::run`, which coexist. Recovering binder-only equivalence would mean
+                    // re-canonicalizing a stored string without its tree, and the renderer is
+                    // deliberately AST-driven. So an equivalent-under-renaming group is skipped
+                    // rather than adopted — a decline, which this design tolerates, instead of a
+                    // mis-adoption, which it does not.
+                    let mut canonical = joined.split('\u{1f}').map(str::to_string);
+                    let first = canonical.next()?;
+                    canonical.all(|path| path == first).then_some(first)
+                }),
+                language,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -129,11 +169,17 @@ pub(crate) fn realign_logical_symbol_ids(conn: &rusqlite::Connection) -> rusqlit
         let Some(qualified_name) = row.qualified_name else {
             continue;
         };
+        // NULL here means the group's members disagree on their owner scope (or it has none):
+        // leave it for the drift relocation rather than prealigning it to one member's identity.
+        let Some(scope_path) = row.scope_path else {
+            continue;
+        };
         let key = LogicalSymbolKey {
             language: row.language,
             path: row.path,
             name: row.name,
             qualified_name,
+            scope_path,
             kind: row.kind,
             signature: row.signature,
         };
@@ -383,6 +429,7 @@ pub(super) struct LogicalKeyDriftRow {
     path: String,
     name: String,
     qualified_name: Option<String>,
+    scope_path: Option<String>,
     kind: String,
     pub(super) signature: Option<String>,
 }
@@ -396,6 +443,7 @@ impl LogicalKeyDriftRow {
             path: self.path.clone(),
             name: self.name.clone(),
             qualified_name: self.qualified_name.clone(),
+            scope_path: self.scope_path.clone(),
             kind: self.kind.clone(),
             signature: self.signature.clone(),
         }
@@ -410,6 +458,7 @@ struct DriftKey {
     path: String,
     name: String,
     qualified_name: Option<String>,
+    scope_path: Option<String>,
     kind: String,
     signature: Option<String>,
 }
@@ -497,7 +546,7 @@ impl LogicalGroupingUpkeep {
     }
 }
 
-/// The six logical-key columns of one symbol row in the scope being rewritten — exactly the
+/// The seven logical-key columns of one symbol row in the scope being rewritten — exactly the
 /// identity [`IndexDatabase::rebuild_logical_symbols`] groups by. `Ord` so the multiset
 /// comparison is a `BTreeMap` walk; `Option` fields compare `None`-first, and `None` never
 /// equals `Some` (an absent qualified name or signature is no wildcard).
@@ -507,6 +556,7 @@ pub(super) struct ReplacedSymbolKey {
     path: String,
     name: String,
     qualified_name: Option<String>,
+    scope_path: Option<String>,
     kind: String,
     signature: Option<String>,
 }
@@ -620,10 +670,24 @@ pub(super) struct LogicalSymbolMemberRow {
     pub(super) language: String,
     pub(super) name: String,
     pub(super) qualified_name: String,
+    pub(super) scope_path: String,
     pub(super) kind: String,
     pub(super) signature: Option<String>,
     pub(super) start_line: i64,
     pub(super) end_line: i64,
+}
+
+/// The `#<part>` tail a continuation chunk carries, or `""`. Only a tail of DIGITS counts: a
+/// qualified name can hold a `#` of its own (a markdown context chunk is `…::#context-…`), and
+/// treating that as a part marker would cut the name in half.
+fn chunk_part_suffix(symbol_path: &str) -> &str {
+    match symbol_path.rfind('#') {
+        Some(at)
+            if symbol_path.len() > at + 1
+                && symbol_path[at + 1..].bytes().all(|b| b.is_ascii_digit()) =>
+            &symbol_path[at..],
+        _ => "",
+    }
 }
 
 impl IndexDatabase {
@@ -764,31 +828,71 @@ impl IndexDatabase {
         let mut stmt = conn.prepare(&format!(
             "
             SELECT symbols.id, main.files.path, symbols.language, symbols.name,
-                   qn.value, symbols.kind, symbols.signature, symbols.start_line,
-                   symbols.end_line, symbols.file_id
+                   qn.value, COALESCE(symbols.scope_path, ''), symbols.kind, symbols.signature,
+                   symbols.start_line, symbols.end_line, symbols.file_id
             FROM main.symbols AS symbols
             JOIN main.files ON main.files.id = symbols.file_id
             LEFT JOIN main.name_strings qn ON qn.id = symbols.qualified_name_id
             WHERE main.files.repo_id = ?1 AND main.files.generation = ?2{extra_where}
             ORDER BY symbols.language, main.files.path, symbols.name, qn.value,
-                     symbols.kind, symbols.signature, symbols.start_byte, symbols.end_byte
+                     COALESCE(symbols.scope_path, ''), symbols.kind, symbols.signature,
+                     symbols.start_byte, symbols.end_byte
             "
         ))?;
         let mut rows = stmt.query(params![self.active_repo_id, self.active_generation])?;
-        let mut current: Option<(LogicalSymbolKey, Vec<LogicalSymbolMemberRow>)> = None;
+        // SQL keeps `(language, path)` contiguous. Normalize and sort ONE file partition at a
+        // time: `path` is part of LogicalSymbolKey, so no group can cross this boundary. This
+        // preserves the exact normalized-key ordering without retaining the whole corpus's symbol
+        // strings in Rust memory.
+        let mut members_sorted = Vec::new();
         while let Some(row) = rows.next()? {
+            let language: String = row.get(2)?;
+            let scope_path: String = row.get(5)?;
             let member = LogicalSymbolMemberRow {
                 symbol_id: row.get(0)?,
                 path: row.get(1)?,
-                language: row.get(2)?,
+                language,
                 name: row.get(3)?,
                 qualified_name: row.get(4)?,
-                kind: row.get(5)?,
-                signature: row.get(6)?,
-                start_line: row.get(7)?,
-                end_line: row.get(8)?,
-                file_id: row.get(9)?,
+                scope_path,
+                kind: row.get(6)?,
+                signature: row.get(7)?,
+                start_line: row.get(8)?,
+                end_line: row.get(9)?,
+                file_id: row.get(10)?,
             };
+            if members_sorted.last().is_some_and(|previous: &LogicalSymbolMemberRow| {
+                previous.language != member.language || previous.path != member.path
+            }) {
+                Self::insert_logical_partition(conn, &self.active_repo_id, &mut members_sorted)?;
+            }
+            members_sorted.push(member);
+        }
+        Self::insert_logical_partition(conn, &self.active_repo_id, &mut members_sorted)
+    }
+
+    /// Sort and insert one `(language, path)` partition using the exact normalized logical key.
+    fn insert_logical_partition(
+        conn: &rusqlite::Connection,
+        repo_id: &str,
+        members_sorted: &mut Vec<LogicalSymbolMemberRow>,
+    ) -> anyhow::Result<()> {
+        // SQL orders the RAW scope, while grouping compares the NORMALIZED one. Re-sort this file
+        // partition so equal-normalized rows are adjacent; spans/id are deterministic member order.
+        members_sorted.sort_by(|a, b| {
+            (&a.language, &a.path, &a.name, &a.qualified_name, &a.scope_path, &a.kind)
+                .cmp(&(&b.language, &b.path, &b.name, &b.qualified_name, &b.scope_path, &b.kind))
+                .then_with(|| a.signature.cmp(&b.signature))
+                .then_with(|| {
+                    (a.start_line, a.end_line, a.symbol_id).cmp(&(
+                        b.start_line,
+                        b.end_line,
+                        b.symbol_id,
+                    ))
+                })
+        });
+        let mut current: Option<(LogicalSymbolKey, Vec<LogicalSymbolMemberRow>)> = None;
+        for member in members_sorted.drain(..) {
             // Compare the member's key fields against the current group WITHOUT allocating a key
             // per row (only per group, on a boundary).
             let same_group = current.as_ref().is_some_and(|(key, _)| {
@@ -796,6 +900,7 @@ impl IndexDatabase {
                     && key.path == member.path
                     && key.name == member.name
                     && key.qualified_name == member.qualified_name
+                    && key.scope_path == member.scope_path
                     && key.kind == member.kind
                     && key.signature == member.signature
             });
@@ -803,14 +908,14 @@ impl IndexDatabase {
                 current.as_mut().expect("same_group implies Some").1.push(member);
             } else {
                 if let Some((key, members)) = current.take() {
-                    Self::insert_logical_group(conn, &self.active_repo_id, &key, &members)?;
+                    Self::insert_logical_group(conn, repo_id, &key, &members)?;
                 }
                 let key = LogicalSymbolKey::from(&member);
                 current = Some((key, vec![member]));
             }
         }
         if let Some((key, members)) = current.take() {
-            Self::insert_logical_group(conn, &self.active_repo_id, &key, &members)?;
+            Self::insert_logical_group(conn, repo_id, &key, &members)?;
         }
         Ok(())
     }
@@ -894,8 +999,8 @@ impl IndexDatabase {
         // narrowed to the one scope row being replaced.
         let mut stmt = conn.prepare_cached(
             "
-            SELECT s.language, f.path, s.name, qn.value, s.kind, s.signature,
-                   m.logical_symbol_id
+            SELECT s.language, f.path, s.name, qn.value, COALESCE(s.scope_path, ''), s.kind,
+                   s.signature, m.logical_symbol_id
             FROM main.symbols s
             JOIN main.files f ON f.id = s.file_id
             LEFT JOIN main.name_strings qn ON qn.id = s.qualified_name_id
@@ -913,15 +1018,17 @@ impl IndexDatabase {
         ])?;
         let mut claims: BTreeMap<ReplacedSymbolKey, GroupedKeyClaim> = BTreeMap::new();
         while let Some(row) = rows.next()? {
+            let language: String = row.get(0)?;
             let key = ReplacedSymbolKey {
-                language: row.get(0)?,
                 path: row.get(1)?,
                 name: row.get(2)?,
                 qualified_name: row.get(3)?,
-                kind: row.get(4)?,
-                signature: row.get(5)?,
+                scope_path: row.get::<_, Option<String>>(4)?,
+                language,
+                kind: row.get(5)?,
+                signature: row.get(6)?,
             };
-            let Some(logical_symbol_id) = row.get::<_, Option<i64>>(6)? else {
+            let Some(logical_symbol_id) = row.get::<_, Option<i64>>(7)? else {
                 return Ok(None); // ungrouped symbol — the grouping cannot vouch for this file
             };
             match claims.entry(key) {
@@ -964,8 +1071,8 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         let mut stmt = conn.prepare_cached(
             "
-            SELECT s.language, f.path, s.name, qn.value, s.kind, s.signature,
-                   s.id, s.start_line, s.end_line
+            SELECT s.language, f.path, s.name, qn.value, COALESCE(s.scope_path, ''), s.kind,
+                   s.signature, s.id, s.start_line, s.end_line
             FROM main.symbols s
             JOIN main.files f ON f.id = s.file_id
             LEFT JOIN main.name_strings qn ON qn.id = s.qualified_name_id
@@ -982,18 +1089,20 @@ impl IndexDatabase {
         ])?;
         let mut inserted: BTreeMap<ReplacedSymbolKey, Vec<ReplacementSymbolSpan>> = BTreeMap::new();
         while let Some(row) = rows.next()? {
+            let language: String = row.get(0)?;
             let key = ReplacedSymbolKey {
-                language: row.get(0)?,
                 path: row.get(1)?,
                 name: row.get(2)?,
                 qualified_name: row.get(3)?,
-                kind: row.get(4)?,
-                signature: row.get(5)?,
+                scope_path: row.get::<_, Option<String>>(4)?,
+                language,
+                kind: row.get(5)?,
+                signature: row.get(6)?,
             };
             inserted.entry(key).or_default().push(ReplacementSymbolSpan {
-                symbol_id: row.get(6)?,
-                start_line: row.get(7)?,
-                end_line: row.get(8)?,
+                symbol_id: row.get(7)?,
+                start_line: row.get(8)?,
+                end_line: row.get(9)?,
             });
         }
         // Every inserted key must exist in the replaced set with the SAME member count, and the
@@ -1136,8 +1245,12 @@ impl IndexDatabase {
             "
             SELECT ls.id, ls.path, ls.logical_name,
                    (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                   (SELECT COALESCE(s.scope_path, '') FROM logical_symbol_members m
+                      JOIN symbols s ON s.id = m.symbol_id
+                     WHERE m.logical_symbol_id = ls.id LIMIT 1),
                    ls.kind,
-                   {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+                   {UNANIMOUS_MEMBER_SIGNATURE_SQL},
+                   ls.language
             FROM main.logical_symbols ls
             WHERE ls.repo_id = ?1
               AND ls.id IN ({reference_sources}
@@ -1151,8 +1264,9 @@ impl IndexDatabase {
                     path: row.get(1)?,
                     name: row.get(2)?,
                     qualified_name: row.get(3)?,
-                    kind: row.get(4)?,
-                    signature: row.get(5)?,
+                    scope_path: row.get::<_, Option<String>>(4)?,
+                    kind: row.get(5)?,
+                    signature: row.get(6)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -1216,8 +1330,12 @@ impl IndexDatabase {
                         "
                         SELECT ls.path, ls.logical_name,
                                (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                               (SELECT COALESCE(s.scope_path, '') FROM logical_symbol_members m
+                                  JOIN symbols s ON s.id = m.symbol_id
+                                 WHERE m.logical_symbol_id = ls.id LIMIT 1),
                                ls.kind,
-                               {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+                               {UNANIMOUS_MEMBER_SIGNATURE_SQL},
+                               ls.language
                         FROM main.logical_symbols ls
                         WHERE ls.id = ?1 AND ls.repo_id = ?2
                         "
@@ -1228,8 +1346,9 @@ impl IndexDatabase {
                             path: row.get(0)?,
                             name: row.get(1)?,
                             qualified_name: row.get(2)?,
-                            kind: row.get(3)?,
-                            signature: row.get(4)?,
+                            scope_path: row.get::<_, Option<String>>(3)?,
+                            kind: row.get(4)?,
+                            signature: row.get(5)?,
                         })
                     },
                 )
@@ -1516,7 +1635,14 @@ impl IndexDatabase {
     }
 
     pub(super) fn ensure_graph_index_current(&self) -> anyhow::Result<()> {
-        if self.repo_meta("graph_index_version")?.as_deref() == Some(GRAPH_INDEX_VERSION) {
+        let graph_current =
+            self.repo_meta("graph_index_version")?.as_deref() == Some(GRAPH_INDEX_VERSION);
+        let logical_current =
+            self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() == Some(LOGICAL_KEY_VERSION);
+        // A logical-key mismatch by itself is handled by the normal full-rederive gate. This
+        // on-open path owns the graph-version migration only; when both versions lag together it
+        // must refresh symbol extraction before that full regroup.
+        if graph_current {
             return Ok(());
         }
         let Some(root) = self.storage.source_root().map(Path::to_path_buf) else {
@@ -1524,27 +1650,6 @@ impl IndexDatabase {
         };
         self.storage.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
         let result = (|| -> anyhow::Result<()> {
-            // Scope the wipe to the ACTIVE REPO's edges (A3): `graph_index_version` is per-repo, so
-            // a stale/missing version for repo A must not wipe repo B's edges in a
-            // consolidated DB. An edge belongs to its `source_file_id`'s repo;
-            // `source_file_id` is always set (its FK is `ON DELETE CASCADE`, every edge
-            // is inserted with a file id), so this removes exactly this repo's edges —
-            // the same set the repopulate below (over the repo-scoped `files`
-            // view) re-derives. Within the repo this matches the prior wholesale behavior; only
-            // sibling repos are now spared.
-            // The `generation` predicate (A6) makes the sentence above literally true: the wipe
-            // removes exactly the set the repopulate re-derives (the ACTIVE generation's edges).
-            // Without it, a heal would also wipe a superseded generation's edges (merely early gc)
-            // — and, in the rare concurrent case of a version-bump heal racing another
-            // connection's staged rebuild, the STAGED generation's edges, which nothing would
-            // re-resolve.
-            self.storage.connection().execute(
-                "DELETE FROM edges_data
-                  WHERE source_file_id IN (
-                      SELECT id FROM main.files WHERE repo_id = ?1 AND generation = ?2
-                  )",
-                params![self.active_repo_id, self.active_generation],
-            )?;
             // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
             // version-bump re-resolve would re-derive `import_scope_*` on the new edges
             // but read an empty `packages` table (V022 only ADDED the column; it did not
@@ -1554,18 +1659,82 @@ impl IndexDatabase {
             // `local_crate_roots` union; `resolve_edges` below then computes each file's
             // package at load time (`load_package_roots_into_scope`) from those rows.
             self.refresh_packages(&root)?;
-            let files = self.graph_reindex_files()?;
+            let (files, unreadable) = self.graph_reindex_files()?;
+            // The heal walks the repo+generation's WHOLE file set (A3 + A6 scope it to this
+            // repo's live generation), which spans every commit/worktree scope — but it has
+            // exactly ONE checkout to read from. So each row is re-derived only from bytes
+            // PROVEN to be its own: `files.sha256` is the digest of the very text that produced
+            // the row, so a match means this checkout holds that file's indexed content, whoever
+            // else shares the path. Everything else — a sibling worktree whose copy differs, a
+            // path absent from this checkout, a file edited since it was indexed — keeps the
+            // graph and scopes it already has. Re-deriving those from the active root instead
+            // would stamp this checkout's graph onto another scope's rows; failing the open over
+            // them would brick every later open, since this runs ON the open path.
+            //
+            // A skipped row is then STALE, and stays stale: `graph_index_version` is per-repo and
+            // is stamped below regardless, so this heal never revisits it, and no later pass
+            // re-extracts a file whose content did not change. For a sibling worktree row that
+            // diverges from the active checkout, that can be indefinite. Accepted here because
+            // the alternative on this code path is worse — pre-digest-gate, such a row was wiped
+            // and rebuilt from the WRONG checkout's bytes — and because a lagging row degrades
+            // (it carries the older extractor's facts) rather than answering wrongly. Making the
+            // heal resumable per row, so a later pass can finish what this one could not vouch
+            // for, is #1014.
+            // Rows the row reader could not name are uncovered exactly like an unreadable file.
+            let mut unverified = unreadable;
+            let mut unrefreshed = 0usize;
             for file in files {
-                if file.kind == TargetKind::Generated || file.language == Language::Markdown {
-                    continue;
-                }
                 let full_path = root.join(&file.path);
                 let Ok(text) = fs::read_to_string(full_path) else {
+                    unverified += 1;
                     continue;
                 };
-                if text.len() > edges::MAX_GRAPH_PARSE_BYTES {
+                if rag_rat_base::hash::hex_sha256(text.as_bytes()) != file.sha256 {
+                    unverified += 1;
                     continue;
                 }
+                // Above the parse limit there are no persisted symbols to refresh at all
+                // (`prepare_index_content_from_text` skips the same bound), so the scope shape
+                // is vacuously current for this file.
+                // Rust because a scope-affecting key bump changed what its impl scopes ARE. Any
+                // other language because the scope entered the key at all: `scope_path` landed
+                // nullable with no backfill, so a row indexed before it reads as `''` here while a
+                // fresh index hashes a real enclosing scope. Left alone, those rows would take the
+                // new stamp holding a key no fresh index produces, and nested same-named symbols
+                // would stay collapsed with no later pass owing them a re-derivation.
+                let scope_is_owed = !logical_current
+                    && file.kind != TargetKind::Generated
+                    && file.language != Language::Markdown
+                    && text.len() <= edges::MAX_GRAPH_PARSE_BYTES
+                    && (file.language == Language::Rust
+                        || self.file_has_unscoped_symbols(file.id)?);
+                if scope_is_owed
+                    && !self.refresh_symbol_scopes(
+                        file.id,
+                        Path::new(&file.path),
+                        &text,
+                        file.language,
+                    )?
+                {
+                    unrefreshed += 1;
+                }
+                if file.kind == TargetKind::Generated
+                    || file.language == Language::Markdown
+                    || text.len() > edges::MAX_GRAPH_PARSE_BYTES
+                {
+                    continue;
+                }
+                // Wipe exactly the row being re-derived, immediately before re-deriving it.
+                // A repo-wide DELETE up front is what turned an unreadable or diverged row into
+                // silent edge LOSS: nothing repopulates a row this loop skips. Per-row, the wipe
+                // removes precisely the set the insert below replaces, and a skipped row keeps
+                // the edges it already has — which `resolve_edges` will NOT revisit on a scoped
+                // open (it writes only rows the connection's `files` view admits), so leaving
+                // them in place is the difference between stale and absent.
+                self.storage
+                    .connection()
+                    .prepare_cached("DELETE FROM edges_data WHERE source_file_id = ?1")?
+                    .execute([file.id])?;
                 edges::index_file_edges(
                     self.storage.connection(),
                     file.id,
@@ -1574,7 +1743,79 @@ impl IndexDatabase {
                     &text,
                 )?;
             }
+            // Rows this connection's view does not admit are never walked above, so their scope
+            // shape is untouched — and `regroup_logical_symbols` reads raw `main.files` across
+            // EVERY scope, so one stale row is enough to change logical identity. Count them for
+            // the stamp decision even though the edge pass deliberately leaves them alone.
+            let out_of_scope: i64 = self.storage.connection().query_row(
+                "SELECT COUNT(*) FROM main.files
+                  WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                    AND id NOT IN (SELECT id FROM files)",
+                params![self.active_repo_id, self.active_generation],
+                |row| row.get(0),
+            )?;
+            if unverified > 0 || unrefreshed > 0 || out_of_scope > 0 {
+                tracing::warn!(
+                    unverified,
+                    unrefreshed,
+                    out_of_scope,
+                    "graph heal skipped file rows this checkout could not vouch for; their graph \
+                     stays on the previous extraction, and the logical-key stamp is deferred so \
+                     later passes keep trying (#1014)"
+                );
+            }
+            // `resolve_edges` and `rebuild_logical_symbols` are SIBLINGS, not a chain: both
+            // consume `symbols.scope_path`, and neither consumes the other's output
+            // (`same_logical_symbol` compares in-memory `IndexedSymbol` fields, not
+            // `logical_symbols` rows — edge resolution never reads that table). What is
+            // load-bearing is that the refresh loop above completed for the whole corpus first;
+            // their relative order here is free.
             self.resolve_edges()?;
+            // A lagging `logical_key_version` must not survive an on-open graph heal: without
+            // this, an index upgraded across a key-derivation change (e.g. scope_path joining
+            // the key) keeps its OLD merged/split logical ids until some unrelated source
+            // mutation triggers a rebuilding pass — memory bindings and symbol surfaces keep
+            // leaking across owners indefinitely on an otherwise idle repo.
+            //
+            // Stamp the new key version only when this pass actually refreshed EVERY row. The
+            // regroup reads raw `main.files` across every scope, so a row whose scope stayed on
+            // the old shape does not merely lag — it changes IDENTITY: a cross-scope group that
+            // was one logical symbol splits, the stale row keeps the original `stable_id`, and
+            // the refreshed row gets a new one. Stamping that as current would also disarm the
+            // two mechanisms built to recover from it — `logical_key_drift_snapshot` goes quiet
+            // and `can_scope_logical_rederive` starts allowing the scoped re-derive, which by
+            // construction never revisits the untouched rows. Deferring keeps both armed, at the
+            // cost of a whole-corpus regroup on later passes until coverage completes (#1014).
+            if self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() != Some(LOGICAL_KEY_VERSION) {
+                let stamp = if unverified == 0 && unrefreshed == 0 && out_of_scope == 0 {
+                    KeyVersionStamp::FullRederive
+                } else {
+                    KeyVersionStamp::Defer
+                };
+                self.rebuild_logical_symbols(stamp)?;
+            }
+            // The GRAPH stamp advances even when rows were skipped, unlike the key stamp above.
+            // That is deliberate, and the symmetry is tempting enough to be worth writing down.
+            //
+            // `out_of_scope` counts rows this connection's view does not admit — it is blind to
+            // whether those rows are FRESH. In a repo with two checkouts, each one always sees the
+            // other's rows as out of scope, however recently the other re-derived them. So gating
+            // this stamp on full coverage would not defer it until coverage completed; it would
+            // defer it forever, and every open of a multi-checkout repo would re-read and
+            // re-extract the entire corpus. That trades a bounded staleness for an unbounded cost.
+            //
+            // The key stamp can afford the same gate because deferring it only repeats a regroup,
+            // and because leaving it deferred keeps the drift-recovery mechanisms armed.
+            //
+            // The deferred KEY stamp is not free either, and the cost is worth naming: because
+            // `out_of_scope` is permanent in a multi-checkout repo, that stamp never becomes
+            // current there, so `can_scope_logical_rederive` stays false and every mutating pass
+            // takes the full rebuild instead of the scoped re-derive. Correct, but it gives up the
+            // write-amplification win indefinitely rather than for one pass.
+            //
+            // The real fix for both is per-row provenance — a version on the row, so the repo
+            // stamp can advance while individual rows stay owed and a checkout that CAN read those
+            // bytes finishes them later. That needs a migration and its own review (#1082).
             self.mark_graph_index_current()?;
             Ok(())
         })();
@@ -1590,26 +1831,197 @@ impl IndexDatabase {
         self.set_repo_meta("graph_index_version", GRAPH_INDEX_VERSION)
     }
 
-    fn graph_reindex_files(&self) -> anyhow::Result<Vec<GraphReindexFile>> {
-        let mut stmt = self
+    /// Refresh symbol fields whose extraction semantics changed without rewriting chunks or
+    /// embeddings. Version 2 gives a Rust trait impl a trait-qualified scope
+    /// (`Type as std.fmt.Display`), and logical regrouping is only correct after persisted
+    /// symbols carry that new scope.
+    ///
+    /// Returns whether EVERY persisted symbol of the file was refreshed. Rows are matched on
+    /// their exact byte span, so a file edited since it was indexed matches only the symbols
+    /// ahead of the edit — an ordinary state between an edit and the next watcher pass, and one
+    /// the next index of that file resolves on its own. The caller reports the shortfall rather
+    /// than failing the open on it.
+    /// Whether this file holds a symbol from before `scope_path` existed. The column landed
+    /// nullable and unbackfilled, so NULL means "never derived" — a parsed row always carries at
+    /// least its own name.
+    fn file_has_unscoped_symbols(&self, file_id: i64) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.symbols WHERE file_id = ?1 AND scope_path IS NULL)",
+            [file_id],
+            |row| row.get::<_, i64>(0),
+        )? == 1)
+    }
+
+    fn refresh_symbol_scopes(
+        &self,
+        file_id: i64,
+        path: &Path,
+        text: &str,
+        language: Language,
+    ) -> anyhow::Result<bool> {
+        let Some(parsed) = parser::parse_file(path, language, text) else {
+            return Ok(false);
+        };
+        let expected: i64 = self.storage.connection().query_row(
+            "SELECT COUNT(*) FROM main.symbols WHERE file_id = ?1",
+            [file_id],
+            |row| row.get(0),
+        )?;
+        // Match on the SPAN, not the name. Version 2 also changed what an `impl` symbol is NAMED —
+        // the old extractor took the first nominal child, which for `impl Trait for Type` is the
+        // TRAIT, and it is now the self type. Keeping `name` in the predicate would leave exactly
+        // those rows unmatched, so an upgraded index would carry impl identities a fresh index
+        // never produces, and the shortfall would be reported forever. A span plus kind is unique
+        // per file — spans come from the AST — so the name can be an OUTPUT of the refresh.
+        // `qualified_name` is `{path}::{name}`, so a renamed symbol needs it re-interned too —
+        // both fields are hashed into `LogicalSymbolKey`, and refreshing one without the other
+        // mints an identity no fresh index ever produces.
+        let mut update = self.storage.connection().prepare_cached(
+            "UPDATE main.symbols
+             SET scope_path = ?1, name = ?2, qualified_name_id = ?3
+             WHERE file_id = ?4 AND start_byte = ?5 AND end_byte = ?6 AND kind = ?7",
+        )?;
+        let mut refreshed = 0usize;
+        for symbol in parsed.symbols {
+            let qualified_name_id =
+                edges::intern_edge_string(self.storage.connection(), &symbol.qualified_name)?;
+            refreshed += update.execute(params![
+                symbol.scope_path,
+                symbol.name,
+                qualified_name_id,
+                file_id,
+                i64::try_from(symbol.start_byte)?,
+                i64::try_from(symbol.end_byte)?,
+                symbol.kind,
+            ])?;
+        }
+        // A chunk records the symbol it covers by PATH as well as by id, and readers still match on
+        // the path — so a rename that moves `A` to `W` and stops there leaves every chunk-keyed
+        // lookup for that impl searching a name nothing answers to, and its chunk-bound memories
+        // vanish on upgrade. Realign the linked chunks to the names their symbols now carry.
+        // The vector for a chunk is built from its symbol_path among other fields, and a stored
+        // embedding is served while its `input_hash` is non-empty — so moving the path without
+        // touching that hash leaves semantic search answering from a vector labelled with a name
+        // the chunk no longer has. Clearing it first puts those chunks back in the reconcile queue.
+        // Same predicate as the update below, and run BEFORE it, while the rows still differ.
+        // A chunk whose symbol is longer than one chunk is stored as `<qualified_name>#<part>`,
+        // so the realign replaces the BASE and keeps the part. Overwriting the whole value
+        // collapsed every part of a long symbol onto the same path, which is both a loss of the
+        // part labels and a divergence from what a fresh index produces for the same file.
+        //
+        // Computed here rather than in SQL so the embedding invalidation and the path rewrite
+        // cannot disagree about which rows are affected — they read one `desired` value.
+        let mut linked = self.storage.connection().prepare(
+            "SELECT c.id, c.symbol_path, ns.value
+               FROM main.chunks c
+               JOIN main.symbols s ON s.id = c.symbol_id
+               JOIN main.name_strings ns ON ns.id = s.qualified_name_id
+              WHERE c.file_id = ?1 AND c.symbol_id IS NOT NULL AND c.symbol_path IS NOT NULL",
+        )?;
+        let realigned: Vec<(i64, String)> = linked
+            .query_map([file_id], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter_map(|(id, current, qualified_name)| {
+                let desired = format!("{qualified_name}{}", chunk_part_suffix(&current));
+                (desired != current).then_some((id, desired))
+            })
+            .collect();
+        // The vector for a chunk is built from its symbol_path among other fields, and a stored
+        // embedding is served while its `input_hash` is non-empty — so moving the path without
+        // touching that hash leaves semantic search answering from a vector labelled with a name
+        // the chunk no longer has. Clearing it puts those chunks back in the reconcile queue.
+        // Prepared once: this heal renames every impl symbol in the repo, so `realigned` is the
+        // corpus's impl count and `execute` would re-plan both statements for each of them.
+        let mut clear_embedding = self
             .storage
             .connection()
-            .prepare("SELECT id, path, language, kind FROM files ORDER BY path")?;
-        let rows = stmt.query_map([], |row| {
+            .prepare("UPDATE main.chunk_embeddings SET input_hash = '' WHERE chunk_id = ?1")?;
+        let mut move_path = self
+            .storage
+            .connection()
+            .prepare("UPDATE main.chunks SET symbol_path = ?2 WHERE id = ?1")?;
+        for (chunk_id, desired) in &realigned {
+            clear_embedding.execute([chunk_id])?;
+            move_path.execute(params![chunk_id, desired])?;
+        }
+        Ok(i64::try_from(refreshed)? == expected)
+    }
+
+    /// The rows this heal will re-derive, plus the count it could NOT name — the caller folds that
+    /// into its coverage so an unrecognized row defers the key stamp instead of being stamped over.
+    fn graph_reindex_files(&self) -> anyhow::Result<(Vec<GraphReindexFile>, usize)> {
+        // Read raw `main.files` for the A3/A6 predicates the view cannot supply on a bare open,
+        // but INTERSECT with the connection's `files` view — the heal must re-extract exactly the
+        // rows its own `resolve_edges` will re-resolve, and that pass writes only rows the view
+        // admits. Re-extracting a row outside the view replaces its resolved edges with fresh
+        // unresolved candidates that nothing then resolves, so a sibling commit or worktree scope
+        // would permanently lose its targets — worse than leaving it on the previous extraction.
+        // On a bare open the view is repo+generation-wide, so cross-scope coverage is unchanged.
+        //
+        // `kind != 'deleted'` guards the bare-open view, which does not filter tombstones:
+        // `mark_file_deleted` leaves `language='unknown', kind='deleted'`, and neither parses, so
+        // letting one through would turn every open into a hard error.
+        let mut stmt = self.storage.connection().prepare(
+            "SELECT id, path, language, kind, sha256
+                 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND id IN (SELECT id FROM files)
+                 ORDER BY path",
+        )?;
+        let rows = stmt.query_map(params![self.active_repo_id, self.active_generation], |row| {
             let language: String = row.get(2)?;
             let kind: String = row.get(3)?;
-            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, language, kind))
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                language,
+                kind,
+                row.get::<_, String>(4)?,
+            ))
         })?;
         let mut files = Vec::new();
+        // A row this build cannot name is still a row the heal did not cover, so the caller has to
+        // hear about it: with the count lost, a repo whose every OTHER row refreshed would take the
+        // new key stamp, and once the stamp matches nothing ever owes this row a re-derivation.
+        let mut unreadable = 0usize;
         for row in rows {
-            let (id, path, language, kind) = row?;
-            files.push(GraphReindexFile {
-                id,
-                path,
-                language: language.parse()?,
-                kind: kind.parse()?,
-            });
+            let (id, path, language, kind, sha256) = row?;
+            // A marker row this build cannot name is a row to LEAVE ALONE, not a reason to fail
+            // the open. `ensure_graph_index_current` is on the open path, so an unparseable
+            // language/kind here would wedge the database for every later open too.
+            let (Ok(language), Ok(kind)) =
+                (language.parse::<Language>(), kind.parse::<TargetKind>())
+            else {
+                tracing::warn!(path = %path, "skipping unrecognized file row during graph heal");
+                unreadable += 1;
+                continue;
+            };
+            files.push(GraphReindexFile { id, path, language, kind, sha256 });
         }
-        Ok(files)
+        Ok((files, unreadable))
+    }
+}
+
+#[cfg(test)]
+mod chunk_path_tests {
+    use super::chunk_part_suffix;
+
+    /// A symbol longer than one chunk is stored as `<qualified_name>#<part>`, and the realign
+    /// replaces the base while keeping the part. Rewriting the whole value collapsed every part of
+    /// a long symbol onto one path, so an upgraded index stopped matching a fresh one.
+    #[test]
+    fn a_continuation_part_survives_a_rename() {
+        assert_eq!(chunk_part_suffix("src/lib.rs::Foo<T>#1"), "#1");
+        assert_eq!(chunk_part_suffix("src/lib.rs::Foo<T>#12"), "#12");
+        assert_eq!(chunk_part_suffix("src/lib.rs::Foo<T>"), "");
+        // A `#` that is part of the NAME is not a part marker — a markdown context chunk carries
+        // one, and cutting there would halve the name.
+        assert_eq!(chunk_part_suffix("docs/x.md::#context-intro"), "");
+        assert_eq!(chunk_part_suffix("docs/x.md::#context-intro#3"), "#3");
+        // A bare trailing `#` marks nothing.
+        assert_eq!(chunk_part_suffix("src/lib.rs::Foo#"), "");
     }
 }

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -68,6 +68,16 @@ pub(super) trait ParserBackend: Sync {
 
     fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String>;
 
+    /// The segment a symbol ends its OWN path with, when its `name` is not its whole identity.
+    ///
+    /// Defaults to `None`, meaning the name IS the identity — true for nearly every kind. Rust's
+    /// impl is the exception: its name is the self type, so two impls of different traits for one
+    /// type would otherwise share a scope path. Deliberately not `scope_segment`, which several
+    /// backends define for a symbol's CHILDREN in a shape its own path should not take.
+    fn own_scope_segment(&self, _node: Node<'_>, _text: &str) -> Option<String> {
+        None
+    }
+
     fn is_test_symbol(&self, _text: &str, _node: Node<'_>, _scope_path: &str, _name: &str) -> bool {
         false
     }

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -6,7 +6,7 @@ use super::{
     ParserBackend, QualifiedRoot, ReceiverFallback, ReferenceDisposition, ResolutionPolicy,
     SymbolMatch, TypeBinding,
 };
-use crate::index::edges::EdgeKind;
+use crate::index::edges::{EdgeKind, scope_grammar};
 use crate::index::parser::{self, ParsedSymbolFact, ParserKind};
 
 mod dispatch;
@@ -45,13 +45,53 @@ impl ParserBackend for Rust {
         }
     }
 
+    /// An impl is NAMED by the same canonical renderer that gives it its scope.
+    ///
+    /// The default takes the name node's source text, which for `impl<T> Tr for Foo<T>` is
+    /// `Foo<T>` — so the binder-renamed twin is named `Foo<U>`. Both feed `LogicalSymbolKey`
+    /// alongside the scope, so the two impl BLOCKS kept separate handles even once their members
+    /// had been given one: the canonicalization reached the methods and stopped short of their
+    /// container. Rendering the name the same way closes that.
+    fn symbol_name(&self, node: Node<'_>, name_node: Node<'_>, text: &str) -> String {
+        if node.kind() == "impl_item" && name_node.id() != node.id() {
+            return render_owner(name_node, text, &declared_binders(node, text));
+        }
+        parser::node_text(name_node, text).unwrap_or_default()
+    }
+
     fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
         let name = match node.kind() {
             "mod_item" | "trait_item" => parser::child_name(node)?,
-            "impl_item" => impl_name(node)?,
+            "impl_item" => {
+                // Both halves of the segment substitute the same binders, and `scope_segment` runs
+                // once per member of the impl — so the parameter list is walked once here rather
+                // than twice per method.
+                let binders = declared_binders(node, text);
+                let segment = impl_owner_segment(node, text, &binders)?;
+                // `impl Trait for Type`: keep the trait in the scope segment (`Type as Trait`)
+                // so two traits' same-named, same-signature methods on one type stay DISTINCT
+                // logical symbols instead of collapsing into one. Resolution folds the
+                // ` as Trait` marker away (`normalized_scope_path`), so the receiver surface both
+                // traits expose is still `Type::method` — and a call that could hit either
+                // declines as ambiguous (#567).
+                return match node.child_by_field_name("trait") {
+                    Some(trait_node) => Some(match trait_marker(trait_node, text, &binders) {
+                        Some(marker) => format!("{segment} as {marker}"),
+                        None => segment,
+                    }),
+                    None => Some(segment),
+                };
+            },
             _ => return None,
         };
         parser::node_text(name, text)
+    }
+
+    /// An impl's name is its self type, so `impl A for W` and `impl B for W` would both be `W` —
+    /// and with the trait on a later line their captured signatures are `impl` too, leaving the two
+    /// impl symbols with one logical key. The `Type as Trait` segment is what tells them apart.
+    fn own_scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        (node.kind() == "impl_item").then(|| self.scope_segment(node, text)).flatten()
     }
 
     fn is_test_symbol(&self, text: &str, node: Node<'_>, _scope_path: &str, _name: &str) -> bool {
@@ -79,11 +119,704 @@ impl ParserBackend for Rust {
     }
 }
 
-fn impl_name(node: Node<'_>) -> Option<Node<'_>> {
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).find(|child| {
-        matches!(child.kind(), "type_identifier" | "generic_type" | "scoped_type_identifier")
+/// The trait half of a `Type as Trait` scope marker: the trait ref rendered canonically, with
+/// `::` rewritten to `.`.
+///
+/// The WHOLE path, because a tail alone gives `impl a::Runs for W` and `impl b::Runs for W` the
+/// same scope. `.` for `::`, because the marker has to stay ONE `::`-segment for the resolution
+/// fold to split on. Generic ARGUMENTS are kept — `impl TryFrom<&str> for C` and
+/// `impl TryFrom<String> for C` coexist, so they are two entities and their same-signature
+/// associated types must not share one logical symbol.
+///
+/// Import spelling is NOT canonicalized and splits deliberately: `use std::fmt;` +
+/// `impl fmt::Display` versus `impl std::fmt::Display` cannot be told apart without name
+/// resolution, and folding use-expansion into identity would couple `stable_id` to a file's import
+/// list — every `use` refactor would churn logical ids and strand the bindings anchored to them.
+fn trait_marker(trait_node: Node<'_>, text: &str, binders: &[String]) -> Option<String> {
+    let rendered = render_owner(trait_node, text, binders);
+    // Rewrite EXACTLY the separators the resolution fold splits on — nothing else needs to move,
+    // and moving it costs identity. A `::` nested anywhere is part of an expression or an argument,
+    // not the path: `a::c` (a module's const) and `a.c` (a value's field) are both legal in
+    // `Tr<[u8; _]>` and name different values, so rewriting one into the other renders two distinct
+    // impls identically. Splitting with `segments` is how the two stay in step — it is the same
+    // top-level rule the fold applies, rather than a second copy of it written out beside it.
+    let marker = scope_grammar::segments(&rendered).join(".");
+    (!marker.is_empty()).then_some(marker)
+}
+
+/// The impl's SELF TYPE, rendered as identity rather than picked out as a node.
+///
+/// Two impls in one file are the same entity exactly when a single compilation could not hold
+/// both, and rustc's coherence check is the authority. `impl Runs for W`, `for &W` and
+/// `for *const W` all compile together, so the wrapper is part of who they are; peeling it gives
+/// all three one scope and collapses their same-signature members. A non-nominal target (`()`,
+/// `(A, B)`, `[T]`, `dyn X`) has no node to name, and declining used to drop the impl's scope
+/// segment ENTIRELY, leaving its members at file scope where they collide with free functions.
+fn impl_owner_segment(node: Node<'_>, text: &str, binders: &[String]) -> Option<String> {
+    let target = node.child_by_field_name("type")?;
+    let rendered = render_owner(target, text, binders);
+    (!rendered.is_empty()).then_some(rendered)
+}
+
+/// The generic parameter names an item declares itself.
+fn declared_binders(node: Node<'_>, text: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let Some(parameters) = node.child_by_field_name("type_parameters") else {
+        return names;
+    };
+    let mut cursor = parameters.walk();
+    for parameter in parameters.named_children(&mut cursor) {
+        if matches!(parameter.kind(), "type_parameter" | "const_parameter")
+            && let Some(name) = crate::index::edges::child_name_text(parameter, text)
+        {
+            // `r#T` and `T` are one parameter — the raw prefix is lexical escaping. The occurrence
+            // side strips it before matching, so a declaration that kept it never matched its own
+            // uses and the binder went un-substituted. NFC for the same reason the occurrence side
+            // normalizes: the two must be byte-equal to compare.
+            let name = nfc_ident(name.strip_prefix("r#").unwrap_or(&name)).into_owned();
+            // A CONST parameter lives in the value namespace, and a bare identifier in argument
+            // position is read as a TYPE. So when a type of the same name is in scope, rustc binds
+            // that name to the TYPE there and to the parameter only inside a braced const
+            // expression: `struct N; impl<const N: usize> Tr<{ N }> for F<N>` puts the struct in
+            // `F<N>`, which is why it coexists with its `M`-spelled twin instead of conflicting.
+            // Substituting the name would render the two identically and merge two entities, so a
+            // const parameter a type declaration shadows is not treated as a binder at all.
+            //
+            // Erring toward the shadow costs a SPLIT in the narrower case where such a parameter is
+            // used only inside braces — two entities kept apart, rather than two merged.
+            if parameter.kind() == "const_parameter"
+                && a_type_of_that_name_is_in_scope(node, &name, text)
+            {
+                continue;
+            }
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// Whether a `use` declaration could bring `name` into scope. A wildcard could bring in anything,
+/// so it answers yes for every name — see the caller for why erring this way is the safe direction.
+///
+/// Walks the use-tree with an explicit worklist rather than recursion: a nested group nests without
+/// bound, and this stays off the recursive-descent path entirely.
+fn use_could_bind(declaration: Node<'_>, name: &str, text: &str) -> bool {
+    let Some(argument) = declaration.child_by_field_name("argument") else {
+        return false;
+    };
+    let mut cursor = declaration.walk();
+    let mut pending = vec![argument];
+    while let Some(node) = pending.pop() {
+        match node.kind() {
+            // A wildcard binds names this pass cannot enumerate.
+            "use_wildcard" => return true,
+            // `use p::X as Y` binds Y, not X.
+            "use_as_clause" => {
+                if let Some(alias) = node.child_by_field_name("alias")
+                    && node_src(alias, text).trim().trim_start_matches("r#") == name
+                {
+                    return true;
+                }
+                continue;
+            },
+            // A group's members are separate leaves; the path prefix binds nothing on its own.
+            "use_list" | "scoped_use_list" => {
+                pending.extend(node.named_children(&mut cursor).filter(|child| {
+                    !matches!(child.kind(), "scoped_identifier" | "identifier")
+                        || child.parent().is_some_and(|parent| parent.kind() == "use_list")
+                }));
+                continue;
+            },
+            // A path binds its LAST segment.
+            "scoped_identifier" => {
+                if let Some(leaf) = node.child_by_field_name("name")
+                    && node_src(leaf, text).trim().trim_start_matches("r#") == name
+                {
+                    return true;
+                }
+                continue;
+            },
+            "identifier" | "type_identifier" => {
+                if node_src(node, text).trim().trim_start_matches("r#") == name {
+                    return true;
+                }
+                continue;
+            },
+            _ => pending.extend(node.named_children(&mut cursor)),
+        }
+    }
+    false
+}
+
+/// A Rust identifier normalized the way rustc compares them — NFC. ASCII is already NFC, which is
+/// the overwhelming case, so it borrows and only the rare non-ASCII identifier allocates.
+fn nfc_ident(token: &str) -> std::borrow::Cow<'_, str> {
+    if token.is_ascii() {
+        std::borrow::Cow::Borrowed(token)
+    } else {
+        std::borrow::Cow::Owned(rag_rat_base::canonical::nfc(token))
+    }
+}
+
+/// Types the std prelude brings into every module without a `use`. A const parameter named after
+/// one of these is shadowed by the type in argument position, exactly as a locally declared or
+/// imported type shadows it — so the same coexisting impls (`impl<const Vec: usize> Tr<{ Vec }> for
+/// F<Vec<u8>>` and its `Box` twin) must not be merged by substituting the name.
+const PRELUDE_TYPES: [&str; 5] = ["Box", "Vec", "String", "Option", "Result"];
+
+/// Whether a TYPE called `name` could be in scope, which is what decides whether a bare identifier
+/// in argument position means that type or a same-named const parameter.
+///
+/// An import counts, and so does a GLOB: `use p::{N, M};` beside `impl<const N: usize> Tr<{ N }>
+/// for F<N>` makes that impl coexist with its `M`-spelled twin, because `F<N>` names the imported
+/// type. Reading only local declarations rendered both `F<_>` and merged two entities.
+///
+/// Deliberately answers "could", not "does" — a glob is treated as binding every name. Being wrong
+/// that way leaves a const binder un-substituted, which SPLITS two spellings of one impl. Being
+/// wrong the other way MERGES two impls that coexist, handing them one logical handle and each
+/// other's bindings. Only the first is recoverable.
+fn a_type_of_that_name_is_in_scope(from: Node<'_>, name: &str, text: &str) -> bool {
+    if PRELUDE_TYPES.contains(&name) {
+        return true;
+    }
+    binding_scopes(from).any(|scope| {
+        let mut cursor = scope.walk();
+        scope.named_children(&mut cursor).any(|item| {
+            if matches!(
+                item.kind(),
+                "struct_item" | "enum_item" | "union_item" | "type_item" | "trait_item"
+            ) {
+                return crate::index::edges::child_name_text(item, text)
+                    .is_some_and(|declared| declared == name);
+            }
+            item.kind() == "use_declaration" && use_could_bind(item, name, text)
+        })
     })
+}
+
+/// The scopes that can bind a name for a reference at `from`, innermost first: enclosing blocks up
+/// to and including the nearest module body, which is where the walk stops.
+///
+/// The stop is the load-bearing part — an item declared outside a `mod` is not in scope for
+/// anything inside it — and it is stated once here so the predicates built on it cannot drift apart
+/// about where a name stops being visible.
+pub(super) fn binding_scopes(from: Node<'_>) -> impl Iterator<Item = Node<'_>> {
+    let mut current = Some(from);
+    let mut done = false;
+    std::iter::from_fn(move || {
+        while !done {
+            let scope = current?;
+            current = scope.parent();
+            let module_body = scope.kind() == "source_file"
+                || (scope.kind() == "declaration_list"
+                    && scope.parent().is_some_and(|parent| parent.kind() == "mod_item"));
+            done = module_body;
+            if module_body || scope.kind() == "block" {
+                return Some(scope);
+            }
+        }
+        None
+    })
+}
+
+/// Render a type as CANONICAL IDENTITY.
+///
+/// Three transformations, each one derived from what rustc's coherence check does — the authority
+/// on whether two impls are one entity:
+///
+/// - **Binder names become `_`.** `impl<T> Foo<T>` and `impl<U> Foo<U>` are a conflicting-
+///   implementations error, and E0119 renders the conflict as `Foo<_>`; the binder's spelling is
+///   never what separates two impls. Substitution follows what NAMES a binder this impl declares: a
+///   bare identifier, or the ROOT of a qualified path (`T::Assoc`, which rustc also reports as one
+///   impl under renaming, rendering it `<_ as Bound>::Assoc`). A qualified path's TAIL is excluded,
+///   because it names an item in another namespace: `Pair<T, module::T>` and `Pair<V, module::V>`
+///   compile together, so folding their tails would MERGE two entities. In binder position a
+///   generic parameter shadows any same-named outer type, so substitution cannot fire on a concrete
+///   type, and a missed occurrence only splits — the failure mode stays one-sided by construction.
+/// - **Concrete arguments are preserved.** `impl A for F<u8>` and `impl A for F<u16>` compile
+///   together, so the argument is identity. This is the half that erasing generics wholesale got
+///   backwards.
+/// - **Lifetimes are erased**, along with the syntax that held only them (`for<'a>`, a trailing
+///   `+`), because coherence erases lifetimes before comparing: `impl<'a> Tr for &'a W` and `impl
+///   Tr for &'static W` conflict.
+///
+/// Cosmetic spelling is normalized so it cannot become identity: whitespace, a raw identifier's
+/// `r#`, and redundant parentheses around a single type (`(W)` is `W`; `(W,)` is a one-tuple and
+/// stays). A leading `::` is NOT cosmetic and is kept: since the 2018 edition it selects the extern
+/// prelude, so a crate holding a local `mod core` can implement its `core::Marker` and
+/// `::core::fmt::Debug` for one type — two different traits. That matches the rule this file
+/// already follows for the rest of a path, where `fmt::Display` and `std::fmt::Display` stay
+/// separate because telling them apart needs name resolution.
+///
+/// A const-generic block is carried through near-verbatim — it holds an expression whose text is
+/// part of the type, and whose `<`/`,` are not type punctuation. Only what cannot carry meaning is
+/// normalized inside it: comments, and the width of a whitespace run outside a literal.
+fn render_owner(node: Node<'_>, text: &str, binders: &[String]) -> String {
+    let mut out = String::new();
+    print_type(node, text, binders, Position::Type, &mut out);
+    out.trim().to_string()
+}
+
+/// Whether an identifier at this point could NAME one of the impl's binders.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Position {
+    /// A type position: a bare `T` here is the parameter.
+    Type,
+    /// The tail of a qualified path — `module::T` is `module`'s `T`, never this impl's parameter.
+    Name,
+}
+
+/// Print one type node canonically.
+///
+/// Every byte of the output is EMITTED, not copied, except at the leaves: an identifier's own
+/// token, and the two opaque regions (a const-generic block, a macro's argument list) whose text is
+/// the type. That is what makes spelling unrepresentable rather than repeatedly patched — a
+/// comment, a newline, or a space around a delimiter has no node to be printed from, so it cannot
+/// reach identity in the first place.
+///
+/// An unrecognized node prints its source opaquely. That is a SPLIT if the grammar ever grows a
+/// shape this does not model, which is the tolerable direction; guessing at its structure could
+/// merge two owners.
+fn print_type(
+    node: Node<'_>,
+    text: &str,
+    binders: &[String],
+    position: Position,
+    out: &mut String,
+) {
+    // grow_stack: a type nests without bound (`Vec<Vec<Vec<…>>>`), so grow rather than overflow the
+    // indexer on a hostile or generated file (#543).
+    rag_rat_base::stack::grow_stack(|| print_type_inner(node, text, binders, position, out))
+}
+
+fn print_type_inner(
+    node: Node<'_>,
+    text: &str,
+    binders: &[String],
+    position: Position,
+    out: &mut String,
+) {
+    match node.kind() {
+        // A lifetime is erased before coherence compares, so it is never printed — and because that
+        // happens per NODE, it cannot reach inside a macro's tokens, where `M!('a)` and
+        // `M!('static)` may expand to different types.
+        // Lifetimes are erased. They HAVE to be: `impl<'a> Tr for &'a W` and `impl Tr for &'static
+        // W` overlap, so rustc rejects them as conflicting — one entity, one identity. The
+        // single exception is a function pointer under the deprecated
+        // `coherence_leak_check` behavior, where `fn(&'static W)` and `for<'a> fn(&'a W)`
+        // can coexist; those merge here. Splitting them would mean carving a
+        // lifetime-sensitive case out of a rule whose whole point is that lifetimes never
+        // reach identity, to serve a shape a future-incompatibility lint is removing. The
+        // merge is the accepted cost.
+        "lifetime" | "for_lifetimes" => {},
+        "type_identifier" | "identifier" | "primitive_type" | "field_identifier" => {
+            let token = node_src(node, text).trim();
+            // `r#Foo` and `Foo` name one type — the raw prefix is lexical escaping, and the
+            // non-raw spelling of a keyword cannot exist as a competing type.
+            let token = token.strip_prefix("r#").unwrap_or(token);
+            // rustc normalizes identifiers to NFC, so `Café` composed and decomposed name one
+            // type; without this they render different owners and split one impl's members.
+            let token = nfc_ident(token);
+            let token = token.as_ref();
+            // In binder position a generic parameter shadows any same-named outer type, so this
+            // cannot fire on a concrete type; in NAME position it is another namespace's item.
+            if position == Position::Type && binders.iter().any(|binder| binder == token) {
+                out.push('_');
+            } else {
+                out.push_str(token);
+            }
+        },
+        "scoped_type_identifier" | "scoped_identifier" => {
+            // An absent path means a leading `::`, which is NOT cosmetic: since the 2018 edition
+            // it selects the extern prelude, so a crate with a local `mod core` has both a
+            // `core::Marker` and a `::core::fmt::Debug` to implement. Printing nothing before the
+            // separator is what keeps the two apart.
+            if let Some(path) = node.child_by_field_name("path") {
+                // The ROOT is a real type position: in `T::Assoc` the `T` IS the binder, and rustc
+                // renders that conflict `<_ as Bound>::Assoc`.
+                print_type(path, text, binders, Position::Type, out);
+            }
+            out.push_str("::");
+            if let Some(name) = node.child_by_field_name("name") {
+                print_type(name, text, binders, Position::Name, out);
+            }
+        },
+        "generic_type" => {
+            if let Some(inner) = node.child_by_field_name("type") {
+                print_type(inner, text, binders, position, out);
+            }
+            if let Some(args) = node.child_by_field_name("type_arguments") {
+                print_type(args, text, binders, Position::Type, out);
+            }
+        },
+        // Concrete arguments are identity — `F<u8>` and `F<u16>` compile together. An argument list
+        // that held only lifetimes leaves nothing, and the brackets go with it.
+        "type_arguments" | "type_parameters" => {
+            print_joined(node, text, binders, ",", out, true);
+        },
+        "reference_type" => {
+            // The pointer shape is identity: `for W`, `for &W` and `for *const W` all compile
+            // together, so peeling the wrapper would collapse three impls into one.
+            out.push('&');
+            if has_kind(node, "mutable_specifier") {
+                out.push_str("mut ");
+            }
+            if let Some(inner) = node.child_by_field_name("type") {
+                print_type(inner, text, binders, Position::Type, out);
+            }
+        },
+        "pointer_type" => {
+            out.push('*');
+            out.push_str(if has_kind(node, "mutable_specifier") { "mut " } else { "const " });
+            if let Some(inner) = node.child_by_field_name("type") {
+                print_type(inner, text, binders, Position::Type, out);
+            }
+        },
+        "tuple_type" => {
+            let mut cursor = node.walk();
+            let members = node.named_children(&mut cursor).count();
+            // `(W)` is `W`; `(W,)` is a one-tuple. The grammar gives both ONE child, so the
+            // trailing comma is the only thing that tells them apart.
+            let one_tuple = members == 1 && has_kind(node, ",");
+            if members == 1 && !one_tuple {
+                let mut inner = node.walk();
+                if let Some(only) = node.named_children(&mut inner).next() {
+                    print_type(only, text, binders, position, out);
+                }
+                return;
+            }
+            out.push('(');
+            print_joined(node, text, binders, ",", out, false);
+            if one_tuple {
+                out.push(',');
+            }
+            out.push(')');
+        },
+        "unit_type" => out.push_str("()"),
+        "array_type" => {
+            out.push('[');
+            if let Some(element) = node.child_by_field_name("element") {
+                print_type(element, text, binders, Position::Type, out);
+            }
+            if let Some(length) = node.child_by_field_name("length") {
+                out.push(';');
+                print_type(length, text, binders, Position::Type, out);
+            }
+            out.push(']');
+        },
+        "function_type" => {
+            match node.child_by_field_name("trait") {
+                Some(name) => print_type(name, text, binders, Position::Type, out),
+                None => out.push_str("fn"),
+            }
+            if let Some(parameters) = node.child_by_field_name("parameters") {
+                print_type(parameters, text, binders, Position::Type, out);
+            }
+            if let Some(ret) = node.child_by_field_name("return_type") {
+                out.push_str("->");
+                print_type(ret, text, binders, Position::Type, out);
+            }
+        },
+        "parameters" => {
+            out.push('(');
+            print_joined(node, text, binders, ",", out, false);
+            out.push(')');
+        },
+        // `dyn A + 'a` and `dyn A` are one type once lifetimes are erased, and a bound list that
+        // loses one leaves no separator behind because the `+` is emitted between what REMAINS.
+        "bounded_type" => {
+            print_joined(node, text, binders, "+", out, false);
+        },
+        "dynamic_type" => {
+            out.push_str("dyn ");
+            if let Some(inner) = node.child_by_field_name("trait") {
+                print_type(inner, text, binders, Position::Type, out);
+            }
+        },
+        "abstract_type" => {
+            out.push_str("impl ");
+            if let Some(inner) = node.child_by_field_name("trait") {
+                print_type(inner, text, binders, Position::Type, out);
+            }
+        },
+        // `for<'a> Fn(&'a u8)` binds only lifetimes, which coherence erases — so the binder goes
+        // and the type it qualified is printed alone.
+        "higher_ranked_trait_bound" =>
+            if let Some(inner) = node.child_by_field_name("type") {
+                print_type(inner, text, binders, position, out);
+            },
+        "bracketed_type" => {
+            out.push('<');
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                print_type(child, text, binders, Position::Type, out);
+            }
+            out.push('>');
+        },
+        "qualified_type" => {
+            if let Some(inner) = node.child_by_field_name("type") {
+                print_type(inner, text, binders, Position::Type, out);
+            }
+            out.push_str(" as ");
+            if let Some(alias) = node.child_by_field_name("alias") {
+                print_type(alias, text, binders, Position::Type, out);
+            }
+        },
+        // A macro's arguments are TOKENS the macro matches on, so nothing here is spelling: `r#Foo`
+        // and `Foo` are arms a `macro_rules!` can tell apart, and a binder name is whatever the
+        // macro does with it rather than a reference to the parameter.
+        "macro_invocation" => {
+            if let Some(name) = node.child_by_field_name("macro") {
+                print_type(name, text, binders, Position::Name, out);
+            }
+            out.push('!');
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() == "token_tree" {
+                    render_opaque(child, text, binders, false, out);
+                }
+            }
+        },
+        // A const-generic block holds an EXPRESSION whose text is part of the type. A binder
+        // referenced inside it is still a binder — `F<{ N }>` and `F<{ M }>` are one impl under
+        // renaming — which `collect_binder_spans` decides, including the `let` that shadows one.
+        //
+        // The expression's own spelling is NOT canonicalized, so `F<{1 + 2}>` and `F<{ 1+2 }>` are
+        // both `F<3>` and conflict, yet get separate identities. That is a split, which costs a
+        // shared handle; the alternative costs correctness. Whitespace here is not uniformly
+        // insignificant — collapsing it would turn `x as u8` into `xasu8` — so canonicalizing an
+        // arbitrary const expression means tokenizing it and re-emitting minimal separation, not
+        // rewriting its bytes. Worth doing, but as its own change (#1084).
+        // A function pointer's parameter NAME is not part of its type: `fn(x: u8)` and `fn(y: u8)`
+        // are both `fn(u8)`, and rustc rejects impls for the two as conflicting. Printing the whole
+        // node kept the pattern text, splitting one entity — and sent the parameter's TYPE through
+        // the opaque path, where a binder inside it was never substituted either.
+        "parameter" =>
+            if let Some(declared) = node.child_by_field_name("type") {
+                print_type(declared, text, binders, Position::Type, out);
+            },
+        "block" => render_opaque(node, text, binders, true, out),
+        _ => render_opaque(node, text, binders, false, out),
+    }
+}
+
+/// Print `node`'s named children joined by `separator`, dropping the ones that print to nothing
+/// (a lifetime). Returns how many were printed. `bracketed` wraps a non-empty list in `<…>`.
+fn print_joined(
+    node: Node<'_>,
+    text: &str,
+    binders: &[String],
+    separator: &str,
+    out: &mut String,
+    bracketed: bool,
+) {
+    let mut cursor = node.walk();
+    let mut parts = Vec::new();
+    for child in node.named_children(&mut cursor) {
+        let mut part = String::new();
+        print_type(child, text, binders, Position::Type, &mut part);
+        if !part.is_empty() {
+            parts.push(part);
+        }
+    }
+    if parts.is_empty() {
+        return;
+    }
+    if bracketed {
+        out.push('<');
+    }
+    out.push_str(&parts.join(separator));
+    if bracketed {
+        out.push('>');
+    }
+}
+
+fn node_src<'a>(node: Node<'_>, text: &'a str) -> &'a str {
+    text.get(node.byte_range()).unwrap_or_default()
+}
+
+/// Whether `node` has a direct child of this kind, named or not. Mutability arrives as a NAMED
+/// `mutable_specifier` while a tuple's trailing comma is an anonymous token, and reading only one
+/// of the two rendered `&mut W` as `&W` and `*mut W` as `*const W` — a merge of impls that coexist.
+fn has_kind(node: Node<'_>, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|child| child.kind() == kind)
+}
+
+/// Copy a region whose text IS the type — a const-generic block or a macro's token list.
+///
+/// Only what cannot carry meaning is normalized: a comment goes, and a whitespace RUN outside a
+/// literal collapses to one space. A literal is copied byte for byte, because `F<{ "}".len() }>`
+/// and `F<{ "} ".len() }>` are `F<1>` and `F<2>`. This normalizes SPELLING, not value: `F<{1+2}>`
+/// and `F<{ 1 + 2 }>` stay two owners, since closing that would mean deleting the space BETWEEN
+/// tokens and could fuse two different expressions — trading a split for a merge.
+fn render_opaque(
+    node: Node<'_>,
+    text: &str,
+    binders: &[String],
+    substitute: bool,
+    out: &mut String,
+) {
+    let start = node.start_byte();
+    let source = node_src(node, text);
+    let spans = if substitute {
+        collect_binder_spans(node, start, source.len(), text, binders)
+    } else {
+        Vec::new()
+    };
+    let mut at_span = 0usize;
+    scope_grammar::scan(source, |at, ch, _, span_kind| {
+        if span_kind == scope_grammar::Span::Comment {
+            return;
+        }
+        while at_span < spans.len() && spans[at_span].1 <= at {
+            at_span += 1;
+        }
+        if let Some(&(from, to)) = spans.get(at_span)
+            && at >= from
+            && at < to
+        {
+            if at == from {
+                out.push('_');
+            }
+            return;
+        }
+        if span_kind.is_code() && ch.is_whitespace() {
+            if !out.ends_with(' ') {
+                out.push(' ');
+            }
+        } else {
+            out.push(ch);
+        }
+    });
+}
+
+/// Spans of bare identifiers that name one of `binders`, to be replaced by `_`.
+fn collect_binder_spans(
+    node: Node<'_>,
+    start: usize,
+    len: usize,
+    text: &str,
+    binders: &[String],
+) -> Vec<(usize, usize)> {
+    if binders.is_empty() {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        // A macro's arguments are TOKENS, not type references. Tree-sitter reports them as ordinary
+        // identifiers, but what they mean is whatever the macro does with them — `M!(T)` can match
+        // a rule keyed on the literal token `T` and expand to something `M!(U)` does not. Renaming
+        // the binder is then not a no-op, so folding both to `M!(_)` would MERGE two owners that
+        // compile together. Nothing here models expansion, so the tokens are left alone.
+        if current.kind() == "macro_invocation" {
+            continue;
+        }
+        // A `let` inside a const-generic block shadows the impl binder — but only from its own
+        // declaration onward, so this is decided per OCCURRENCE rather than per block: in
+        // `{ let before = N; let N = 1; before }` the first `N` is still the parameter.
+        if matches!(current.kind(), "type_identifier" | "identifier")
+            && let Some(name) = text.get(current.byte_range())
+            && binders.iter().any(|binder| binder == name)
+            && !shadowed_before(current, name, text)
+        {
+            spans.push((
+                current.start_byte().saturating_sub(start).min(len),
+                current.end_byte().saturating_sub(start).min(len),
+            ));
+            continue;
+        }
+        // Descend everything EXCEPT a `name` field. That field is what a node CALLS something in
+        // another namespace, never a reference to this impl's parameter, and substituting there
+        // would MERGE distinct owners. It is one rule because the shapes it covers are open-ended:
+        // `module::T`'s tail (`Pair<T, module::T>` and `Pair<V, module::V>` compile together), and
+        // an associated-type binding's name (`Parts<T = u8>` names the TRAIT's member, so renaming
+        // the impl binder must leave it alone — rustc rejects the two spellings as conflicting).
+        // Enumerating the node kinds instead meant meeting each new shape as its own bug.
+        //
+        // Every other field is a real type position, including a qualified path's ROOT: in
+        // `T::Assoc` the `T` IS the binder, and rustc renders that conflict `<_ as Bound>::Assoc`.
+        let named = current.child_by_field_name("name");
+        let mut cursor = current.walk();
+        stack.extend(current.named_children(&mut cursor).filter(|child| Some(*child) != named));
+    }
+    spans.sort_unstable();
+    spans
+}
+
+/// Whether an enclosing block binds `name` with a `let` written BEFORE this occurrence, which is
+/// what makes the occurrence the local's rather than the impl's parameter.
+fn shadowed_before(occurrence: Node<'_>, name: &str, text: &str) -> bool {
+    let at = occurrence.start_byte();
+    let mut current = occurrence.parent();
+    while let Some(scope) = current {
+        if scope.kind() == "block" {
+            let mut cursor = scope.walk();
+            let shadows = scope.named_children(&mut cursor).any(|child| {
+                child.kind() == "let_declaration"
+                    && child.start_byte() < at
+                    && child.child_by_field_name("pattern").is_some_and(|pattern| {
+                        pattern_binds_any(pattern, text, &[name.to_string()])
+                    })
+            });
+            if shadows {
+                return true;
+            }
+        }
+        current = scope.parent();
+    }
+    false
+}
+
+/// Whether a `let` pattern binds any of `binders`. What a pattern binds are its own IDENTIFIERS,
+/// so a destructuring form (`let (N,) = …`) shadows exactly as a plain `let N` does — comparing the
+/// pattern's whole source text instead recognized only the simplest shape.
+fn pattern_binds_any(pattern: Node<'_>, text: &str, binders: &[String]) -> bool {
+    let mut stack = vec![pattern];
+    while let Some(current) = stack.pop() {
+        if matches!(current.kind(), "identifier" | "shorthand_field_identifier")
+            && let Some(name) = text.get(current.byte_range())
+            && binders.iter().any(|binder| binder == name)
+        {
+            return true;
+        }
+        let mut cursor = current.walk();
+        stack.extend(current.named_children(&mut cursor));
+    }
+    false
+}
+
+/// The node naming the type an `impl` block is FOR — never the trait it implements.
+///
+/// `impl Trait for Type` puts the trait in the `trait` field and the owner in the `type` field.
+/// When the owner is not a plain nominal type (`impl Display for &Foo`, `for (A, B)`, `for [T]`,
+/// `for dyn X`) there is no name to take, and a positional scan over the children would hand
+/// back the TRAIT instead — collapsing `impl Display for &Foo` and `impl Display for &Bar` onto
+/// one owner, the exact leak trait-qualified scopes exist to prevent. Reference and pointer
+/// wrappers are unwrapped (`&mut Foo` is still owned by `Foo`); anything else declines.
+fn impl_name(node: Node<'_>) -> Option<Node<'_>> {
+    if let Some(target_type) = node.child_by_field_name("type") {
+        return unwrap_impl_type(target_type);
+    }
+    // No `type` field at all (a partial parse): scan positionally, but never adopt the trait.
+    let trait_id = node.child_by_field_name("trait").map(|node| node.id());
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| is_impl_type_node(child.kind()) && Some(child.id()) != trait_id)
+}
+
+/// Peel `&`/`&mut`/`*const`/`*mut` off an impl target, then keep it only if it names a type.
+fn unwrap_impl_type(node: Node<'_>) -> Option<Node<'_>> {
+    let mut current = node;
+    while matches!(current.kind(), "reference_type" | "pointer_type") {
+        current = current.child_by_field_name("type")?;
+    }
+    is_impl_type_node(current.kind()).then_some(current)
+}
+
+fn is_impl_type_node(kind: &str) -> bool {
+    matches!(kind, "type_identifier" | "generic_type" | "scoped_type_identifier")
 }
 
 fn attribute_is_test(attribute: &str) -> bool {
@@ -199,4 +932,907 @@ fn is_external_root(value: &str) -> bool {
             | "HashSet"
             | "BTreeSet"
     )
+}
+
+#[cfg(test)]
+mod printer_grammar_tests {
+    /// Every node kind the type printer dispatches on must EXIST in the grammar it reads.
+    ///
+    /// The printer matches on kind strings with a catch-all that falls back to opaque source
+    /// rendering. That catch-all is load-bearing for genuinely unmodelled nodes, but it also means
+    /// a typo — or a tree-sitter-rust upgrade that RENAMES a kind — silently routes a type that
+    /// used to be printed structurally into the opaque path instead. Nothing would fail: the
+    /// printer still returns a string, so identity quietly changes for every type of that shape
+    /// and the ids churn. Reading the arms out of the source and asking the compiled grammar
+    /// whether each name is real turns that silent drift into a failing test.
+    ///
+    /// The arms are read with the parser rather than by scanning for quotes, so field-name
+    /// arguments and punctuation the printer emits are not mistaken for node kinds.
+    ///
+    /// This checks the names are SPELLED for real nodes, not that the handling of each is correct —
+    /// the binder-renaming rows and the reformat-invariance test cover behavior.
+    #[test]
+    fn every_kind_the_type_printer_names_exists_in_the_grammar() {
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let source = include_str!("mod.rs");
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("the rust grammar loads");
+        let tree = parser.parse(source, None).expect("this file parses");
+
+        // The printer's own match, found by walking to the function and taking its match arms.
+        let mut named = Vec::new();
+        let mut cursor = tree.root_node().walk();
+        let mut stack = vec![tree.root_node()];
+        let mut inside_printer = false;
+        while let Some(node) = stack.pop() {
+            if node.kind() == "function_item"
+                && node
+                    .child_by_field_name("name")
+                    .and_then(|name| name.utf8_text(source.as_bytes()).ok())
+                    == Some("print_type_inner")
+            {
+                inside_printer = true;
+                collect_arm_kinds(node, source, &mut named);
+            }
+            stack.extend(node.children(&mut cursor));
+        }
+        assert!(inside_printer, "the printer is in this file");
+        assert!(named.len() > 15, "expected the printer's arm list, found {named:?}");
+
+        let kinds: std::collections::HashSet<&str> = (0..language.node_kind_count())
+            .filter_map(|id| {
+                let id = u16::try_from(id).expect("kind ids fit a u16");
+                language.node_kind_is_named(id).then(|| language.node_kind_for_id(id)).flatten()
+            })
+            .collect();
+        let unknown: Vec<&String> = named.iter().filter(|k| !kinds.contains(k.as_str())).collect();
+        assert!(
+            unknown.is_empty(),
+            "the type printer names node kinds the grammar does not have: {unknown:?}. Either the \
+             name is a typo or tree-sitter-rust renamed it; either way those types now render \
+             opaquely and their identities have changed."
+        );
+    }
+
+    /// The string literals in every `match_arm` PATTERN under `node` — the kinds it dispatches on,
+    /// without the literals its arm bodies emit.
+    fn collect_arm_kinds(node: tree_sitter::Node<'_>, source: &str, out: &mut Vec<String>) {
+        let mut cursor = node.walk();
+        let mut stack = vec![node];
+        while let Some(current) = stack.pop() {
+            if current.kind() == "match_arm"
+                && let Some(pattern) = current.child_by_field_name("pattern")
+            {
+                let mut inner = pattern.walk();
+                let mut patterns = vec![pattern];
+                while let Some(part) = patterns.pop() {
+                    if part.kind() == "string_content"
+                        && let Ok(text) = part.utf8_text(source.as_bytes())
+                    {
+                        out.push(text.to_string());
+                    }
+                    patterns.extend(part.children(&mut inner));
+                }
+            }
+            stack.extend(current.children(&mut cursor));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use rag_rat_base::language::Language;
+
+    use super::*;
+
+    #[test]
+    fn a_trait_ref_keeps_its_concrete_arguments() {
+        let parsed = parser::parse_file(
+            Path::new("src/lib.rs"),
+            Language::Rust,
+            "impl crate::traits::Runs<Item> for Worker { fn run(&self) {} }",
+        )
+        .expect("Rust parses");
+        let run = parsed.symbols.iter().find(|symbol| symbol.name == "run").expect("method symbol");
+        assert_eq!(run.scope_path, "Worker as crate.traits.Runs<Item>::run");
+    }
+
+    fn scope_paths(source: &str, method: &str) -> Vec<String> {
+        parser::parse_file(Path::new("src/lib.rs"), Language::Rust, source)
+            .expect("Rust parses")
+            .symbols
+            .iter()
+            .filter(|symbol| symbol.name == method)
+            .map(|symbol| symbol.scope_path.clone())
+            .collect()
+    }
+
+    /// `impl Trait for &Type` puts a `reference_type` in the impl's `type` field. Taking the first
+    /// nominal child instead would hand back the TRAIT, giving every `impl Display for &_` in a
+    /// file the same owner — the collapse trait-qualified scopes exist to prevent.
+    #[test]
+    fn a_reference_impl_target_keeps_its_own_owner() {
+        let scopes = scope_paths(
+            "struct Alpha;\nstruct Beta;\nimpl std::fmt::Display for &Alpha { fn fmt(&self) {} \
+             }\nimpl std::fmt::Display for &Beta { fn fmt(&self) {} }\n",
+            "fmt",
+        );
+        assert_eq!(scopes, vec!["&Alpha as std.fmt.Display::fmt", "&Beta as std.fmt.Display::fmt"]);
+    }
+
+    /// `impl Tr for W`, `for &W`, `for &mut W`, and `for *const W` all compile together, so they
+    /// are four entities and their identically-signatured members must not share one logical
+    /// symbol. The idiomatic operator quartet (`impl Neg for T` / `for &T`, whose `type Output` is
+    /// byte-identical across all of them) is the shape that hits this in real code.
+    #[test]
+    fn every_pointer_shape_of_one_owner_is_its_own_impl() {
+        let scopes = scope_paths(
+            "struct W;\nimpl Neg for W { fn neg(&self) {} }\nimpl Neg for &W { fn neg(&self) {} \
+             }\nimpl Neg for &mut W { fn neg(&self) {} }\nimpl Neg for *const W { fn neg(&self) \
+             {} }\n",
+            "neg",
+        );
+        assert_eq!(scopes, vec![
+            "W as Neg::neg",
+            "&W as Neg::neg",
+            "&mut W as Neg::neg",
+            "*const W as Neg::neg",
+        ]);
+        // …but all four expose the SAME receiver surface: an autoref call site cannot tell which
+        // impl it lands in, so resolution folds the wrapper away and a call that could hit either
+        // declines as ambiguous.
+        for scope in &scopes {
+            assert_eq!(
+                crate::index::edges::normalized_scope_path(scope, Some(Language::Rust.as_str()))
+                    .as_ref(),
+                "W::neg",
+                "{scope} must still answer to the plain receiver surface"
+            );
+        }
+    }
+
+    /// Erasing a lifetime can leave syntax that held nothing else. rustc treats
+    /// `impl Tr for for<'a> fn(&'a T)` and `impl Tr for fn(&T)` as conflicting implementations —
+    /// one entity — so the residue has to go with the lifetime or the two owners split.
+    #[test]
+    fn lifetime_only_syntax_leaves_no_residue() {
+        for (with_lifetime, without) in [
+            (
+                "impl Tr for for<'a> fn(&'a T) { fn f(&self) {} }",
+                "impl Tr for fn(&T) { fn f(&self) {} }",
+            ),
+            (
+                "impl Tr for dyn Runs + 'a { fn f(&self) {} }",
+                "impl Tr for dyn Runs { fn f(&self) {} }",
+            ),
+            (
+                "impl Tr for Box<dyn Runs + 'static> { fn f(&self) {} }",
+                "impl Tr for Box<dyn Runs> { fn f(&self) {} }",
+            ),
+        ] {
+            assert_eq!(
+                scope_paths(with_lifetime, "f"),
+                scope_paths(without, "f"),
+                "{with_lifetime} and {without} are one impl to rustc"
+            );
+        }
+    }
+
+    /// The coherence table: two impls are ONE entity iff a single compilation could not hold
+    /// both, so canonical scopes must be equal exactly when rustc reports a conflict. Each row
+    /// here was probed against rustc directly; `coexists` is what it answered.
+    #[test]
+    fn canonical_scopes_match_rustc_coherence() {
+        // (impl A, impl B, coexists) — coexisting impls are distinct entities and must NOT share
+        // a scope; conflicting impls are one entity and MUST. Every row was checked against rustc;
+        // do not add a row that has not been.
+        let cases = [
+            ("impl Tr for F<u8> { fn f(&self) {} }", "impl Tr for F<u16> { fn f(&self) {} }", true),
+            (
+                "impl<T> Tr for F<T> { fn f(&self) {} }",
+                "impl<U> Tr for F<U> { fn f(&self) {} }",
+                false,
+            ),
+            ("impl Tr for W { fn f(&self) {} }", "impl Tr for &W { fn f(&self) {} }", true),
+            ("impl Tr for &W { fn f(&self) {} }", "impl Tr for &mut W { fn f(&self) {} }", true),
+            ("impl Tr for W { fn f(&self) {} }", "impl Tr for *const W { fn f(&self) {} }", true),
+            (
+                "impl<'a> Tr for &'a W { fn f(&self) {} }",
+                "impl Tr for &'static W { fn f(&self) {} }",
+                false,
+            ),
+            (
+                "impl TryFrom<&str> for C { fn f(&self) {} }",
+                "impl TryFrom<String> for C { fn f(&self) {} }",
+                true,
+            ),
+            (
+                "impl a::Runs for W { fn f(&self) {} }",
+                "impl b::Runs for W { fn f(&self) {} }",
+                true,
+            ),
+            ("impl Tr for (W) { fn f(&self) {} }", "impl Tr for W { fn f(&self) {} }", false),
+            ("impl Tr for (W,) { fn f(&self) {} }", "impl Tr for W { fn f(&self) {} }", true),
+            ("impl Tr for r#Foo { fn f(&self) {} }", "impl Tr for Foo { fn f(&self) {} }", false),
+            // A binder at a qualified path's ROOT is the binder: rustc reports these as one impl,
+            // rendering the conflict `Tr<<_ as Bound>::Assoc> for Foo<_>`.
+            (
+                "impl<T: Bound> Tr<T::Assoc> for F<T> { fn f(&self) {} }",
+                "impl<U: Bound> Tr<U::Assoc> for F<U> { fn f(&self) {} }",
+                false,
+            ),
+            // A brace block is an expression whose spelling is the type: these are `F<1>`/`F<2>`.
+            (
+                r#"impl Tr for F<{ "}".len() }> { fn f(&self) {} }"#,
+                r#"impl Tr for F<{ "} ".len() }> { fn f(&self) {} }"#,
+                true,
+            ),
+            // A module's const and a value's field can share a name, so these are two impls.
+            (
+                "impl Tr<{ a::c }> for W { fn f(&self) {} }",
+                "impl Tr<{ a.c }> for W { fn f(&self) {} }",
+                true,
+            ),
+            // Whitespace around the angle is spelling, on either side of it.
+            (
+                "impl Tr for F<u8> { fn f(&self) {} }",
+                "impl Tr for F < u8 > { fn f(&self) {} }",
+                false,
+            ),
+            // An associated-type binding names the TRAIT's member, not this impl's binder.
+            (
+                "impl<T> Tr for Pair<T, dyn Parts<T = u8>> { fn f(&self) {} }",
+                "impl<U> Tr for Pair<U, dyn Parts<T = u8>> { fn f(&self) {} }",
+                false,
+            ),
+        ];
+        for (left, right, coexists) in cases {
+            let a = scope_paths(left, "f");
+            let b = scope_paths(right, "f");
+            if coexists {
+                assert_ne!(
+                    a, b,
+                    "rustc allows both, so they are distinct entities: {left} / {right}"
+                );
+            } else {
+                assert_eq!(
+                    a, b,
+                    "rustc rejects both together, so they are one entity: {left} / {right}"
+                );
+            }
+        }
+    }
+
+    /// Binder substitution is the only step that can MERGE two owners, so a qualified path's TAIL
+    /// is off limits: it names an item in another namespace, `Pair<T, module::T>` and
+    /// `Pair<V, module::V>` coexist, and folding the tails would give them one scope.
+    #[test]
+    fn a_binder_name_under_a_qualified_path_is_not_substituted() {
+        let left = scope_paths("impl<T> Tr for Pair<T, module::T> { fn f(&self) {} }", "f");
+        let right = scope_paths("impl<V> Tr for Pair<V, module::V> { fn f(&self) {} }", "f");
+        assert_ne!(left, right, "these impls coexist, so they must not share a scope");
+        assert_eq!(left, vec!["Pair<_,module::T> as Tr::f".to_string()]);
+        // The whole owner being qualified is likewise a concrete type, not the binder.
+        assert_eq!(scope_paths("impl<T> Tr<T> for crate::T { fn f(&self) {} }", "f"), vec![
+            "crate::T as Tr<_>::f".to_string()
+        ]);
+    }
+
+    /// A `let` inside a const block shadows the impl binder, so those identifiers belong to the
+    /// local. rustc rejects the two spellings as one impl — renaming the parameter cannot change a
+    /// name the block rebinds — so substituting by spelling alone would split them.
+    #[test]
+    fn a_block_that_rebinds_a_binder_keeps_its_own_local() {
+        let shadowed = scope_paths(
+            "impl<const N: usize> Tr<N> for F<{ { let N = 1; N } }> { fn f(&self) {} }",
+            "f",
+        );
+        assert_eq!(
+            shadowed,
+            scope_paths(
+                "impl<const M: usize> Tr<M> for F<{ { let N = 1; N } }> { fn f(&self) {} }",
+                "f",
+            ),
+        );
+        assert!(shadowed[0].contains("let N = 1"), "the local keeps its name: {}", shadowed[0]);
+        // A `let` shadows only from its own line onward, so an occurrence BEFORE it is still the
+        // parameter and still canonicalizes.
+        assert_eq!(
+            scope_paths(
+                "impl<const N: usize> Tr<N> for F<{ { let before = N; let N = 1; before } }> { fn \
+                 f(&self) {} }",
+                "f",
+            ),
+            scope_paths(
+                "impl<const M: usize> Tr<M> for F<{ { let before = M; let N = 1; before } }> { fn \
+                 f(&self) {} }",
+                "f",
+            ),
+        );
+        // A destructuring pattern binds through its own identifiers, so it shadows the same way.
+        assert_eq!(
+            scope_paths(
+                "impl<const N: usize> Tr<N> for F<{ { let (N,) = (1,); N } }> { fn f(&self) {} }",
+                "f",
+            ),
+            scope_paths(
+                "impl<const M: usize> Tr<M> for F<{ { let (N,) = (1,); N } }> { fn f(&self) {} }",
+                "f",
+            ),
+        );
+        // A block that does NOT rebind still canonicalizes the binder.
+        assert_eq!(
+            scope_paths("impl<const N: usize> Tr for F<{ N }> { fn f(&self) {} }", "f"),
+            scope_paths("impl<const M: usize> Tr for F<{ M }> { fn f(&self) {} }", "f"),
+        );
+    }
+
+    /// THE PROPERTY THE PRINTER EXISTS FOR: spelling cannot reach identity.
+    ///
+    /// Every byte of a rendered owner is emitted from a node rather than copied from source, so
+    /// reformatting an impl header — inserting whitespace anywhere punctuation allows it, adding a
+    /// comment, writing an identifier raw — cannot move its scope. This one assertion covers the
+    /// whole class that used to be found an instance at a time: each new spelling here is a review
+    /// round that does not need to happen.
+    /// A `::` is rewritten to `.` only where the resolution fold would split the scope — at the
+    /// TOP level of the trait path. Nested anywhere, it is part of an expression or an argument,
+    /// and `a::c` (a module's const) names a different value than `a.c` (a field), so rewriting one
+    /// into the other hands two coexisting impls one identity.
+    #[test]
+    fn a_separator_is_rewritten_only_where_the_fold_would_split() {
+        for (with_path, with_field) in [
+            // A bracket raises group depth, not brace depth — the distinction a hand-written
+            // `!in_brace` guard missed.
+            (
+                "impl Tr<[u8; a::c]> for W { fn f(&self) {} }",
+                "impl Tr<[u8; a.c]> for W { fn f(&self) {} }",
+            ),
+            (
+                "impl Tr<{ a::c }> for W { fn f(&self) {} }",
+                "impl Tr<{ a.c }> for W { fn f(&self) {} }",
+            ),
+            (
+                "impl Tr<[u8; (a::c)]> for W { fn f(&self) {} }",
+                "impl Tr<[u8; (a.c)]> for W { fn f(&self) {} }",
+            ),
+        ] {
+            assert_ne!(
+                scope_paths(with_path, "f"),
+                scope_paths(with_field, "f"),
+                "a nested `::` is not a path separator: {with_path}"
+            );
+        }
+        // The trait path's own separators still fold, so the marker stays one `::`-segment.
+        let marked = scope_paths("impl a::Runs for W { fn f(&self) {} }", "f");
+        assert_eq!(marked, vec!["W as a.Runs::f".to_string()]);
+        // And two traits that differ only in their path stay distinct.
+        assert_ne!(marked, scope_paths("impl b::Runs for W { fn f(&self) {} }", "f"));
+    }
+
+    /// A const parameter named after a PRELUDE type is shadowed by that type in argument position,
+    /// exactly as a locally declared or imported one is. Verified with rustc: `impl<const Vec:
+    /// usize> Tr<{ Vec }> for F<Vec<u8>>` and its `Box`-named twin COMPILE TOGETHER, so the owners
+    /// are the prelude types and the two impls coexist.
+    #[test]
+    fn a_const_binder_named_after_a_prelude_type_is_not_substituted() {
+        let vec_named =
+            "struct F<T>(T); impl<const Vec: usize> Tr<{ Vec }> for F<Vec<u8>> { fn f(&self) {} }";
+        let box_named =
+            "struct F<T>(T); impl<const Box: usize> Tr<{ Box }> for F<Box<u8>> { fn f(&self) {} }";
+        assert_ne!(scope_paths(vec_named, "f"), scope_paths(box_named, "f"));
+    }
+
+    /// rustc normalizes identifiers to NFC, so a type spelled with a composed `é` and one spelled
+    /// with a combining accent are ONE type — rustc rejects impls for the two spellings as
+    /// conflicting. Rendering the source bytes unchanged split one impl's members across handles.
+    #[test]
+    fn an_identifier_is_normalized_to_nfc() {
+        let composed = "impl Tr for Caf\u{00e9} { fn f(&self) {} }";
+        let decomposed = "impl Tr for Cafe\u{0301} { fn f(&self) {} }";
+        assert_eq!(scope_paths(composed, "f"), scope_paths(decomposed, "f"));
+        assert!(!scope_paths(composed, "f").is_empty(), "the fixture must parse");
+    }
+
+    /// A const binder is left alone whenever a TYPE of that name could be in scope — including one
+    /// that arrives by `use`, and including a glob that might carry it. Verified with rustc: with
+    /// `use p::{N, M};` the two impls below COMPILE TOGETHER, so they are two entities.
+    #[test]
+    fn an_imported_type_shadows_a_const_binder_too() {
+        let imported = |binder: &str| {
+            format!(
+                "mod p {{ pub struct N; pub struct M; }} use p::{{N, M}}; struct F<T>(T); \
+                 impl<const {binder}: usize> Tr<{{ {binder} }}> for F<{binder}> {{ fn f(&self) \
+                 {{}} }}"
+            )
+        };
+        assert_ne!(scope_paths(&imported("N"), "f"), scope_paths(&imported("M"), "f"));
+
+        // A glob could carry the type, and this pass cannot see through it — so it declines to
+        // substitute rather than risk merging two impls that coexist.
+        let globbed = |binder: &str| {
+            format!(
+                "use p::*; struct F<T>(T); impl<const {binder}: usize> Tr<{{ {binder} }}> for \
+                 F<{binder}> {{ fn f(&self) {{}} }}"
+            )
+        };
+        assert_ne!(scope_paths(&globbed("N"), "f"), scope_paths(&globbed("M"), "f"));
+
+        // A `use` that binds some OTHER name is not evidence about this one.
+        let unrelated = |binder: &str| {
+            format!(
+                "use p::Other; struct G<const C: usize>; impl<const {binder}: usize> Tr for \
+                 G<{binder}> {{ fn f(&self) {{}} }}"
+            )
+        };
+        assert_eq!(scope_paths(&unrelated("N"), "f"), scope_paths(&unrelated("M"), "f"));
+    }
+
+    /// `r#T` and `T` are one parameter. The occurrence side strips the raw prefix before matching,
+    /// so a declaration that kept it never matched its own uses: `impl<r#T> Tr for F<r#T>` rendered
+    /// `F<T>` beside the `U` form's `F<_>`, splitting an impl rustc rejects as conflicting.
+    #[test]
+    fn a_raw_spelled_binder_is_still_a_binder() {
+        assert_eq!(
+            scope_paths("impl<r#T> Tr for F<r#T> { fn f(&self) {} }", "f"),
+            scope_paths("impl<U> Tr for F<U> { fn f(&self) {} }", "f"),
+        );
+        assert_eq!(scope_paths("impl<r#T> Tr for F<r#T> { fn f(&self) {} }", "f"), vec![
+            "F<_> as Tr::f".to_string()
+        ]);
+    }
+
+    /// A CONST parameter and a TYPE of the same name are different things, and rustc picks the
+    /// type for a bare identifier in argument position. Verified with rustc: `struct N;` beside
+    /// `impl<const N: usize> Tr<{ N }> for F<N>` and its `M`-spelled twin COMPILE TOGETHER — the
+    /// owners are the two structs, so they are two entities. Substituting the name in both places
+    /// rendered them identically and merged them.
+    #[test]
+    fn a_const_binder_a_type_shadows_is_not_substituted() {
+        let with_n =
+            "struct N; struct F<T>(T); impl<const N: usize> Tr<{ N }> for F<N> { fn f(&self) {} }";
+        let with_m =
+            "struct M; struct F<T>(T); impl<const M: usize> Tr<{ M }> for F<M> { fn f(&self) {} }";
+        assert_ne!(scope_paths(with_n, "f"), scope_paths(with_m, "f"));
+        assert_eq!(scope_paths(with_n, "f"), vec!["F<N> as Tr<{ N }>::f".to_string()]);
+        // With no such type in scope the bare name IS the parameter, and renaming it is a no-op —
+        // rustc rejects these two together, so they stay one entity.
+        assert_eq!(
+            scope_paths(
+                "struct G<const C: usize>; impl<const N: usize> Tr for G<N> { fn f(&self) {} }",
+                "f"
+            ),
+            scope_paths(
+                "struct G<const C: usize>; impl<const M: usize> Tr for G<M> { fn f(&self) {} }",
+                "f"
+            ),
+        );
+    }
+
+    /// A function pointer's parameter NAME is not part of its type: `fn(x: u8)` and `fn(y: u8)` are
+    /// both `fn(u8)`, so impls for them conflict and are one entity. Printing the parameter node
+    /// whole kept the pattern text AND sent the parameter's type down the opaque path, where a
+    /// binder inside it was never canonicalized either.
+    #[test]
+    fn a_function_pointer_parameter_is_named_by_its_type_alone() {
+        assert_eq!(
+            scope_paths("impl Tr for fn(x: u8) { fn f(&self) {} }", "f"),
+            scope_paths("impl Tr for fn(y: u8) { fn f(&self) {} }", "f"),
+        );
+        assert_eq!(scope_paths("impl Tr for fn(x: u8) { fn f(&self) {} }", "f"), vec![
+            "fn(u8) as Tr::f".to_string()
+        ]);
+        assert_eq!(
+            scope_paths("impl<T> Tr for fn(x: T) { fn f(&self) {} }", "f"),
+            scope_paths("impl<U> Tr for fn(x: U) { fn f(&self) {} }", "f"),
+        );
+    }
+
+    /// The impl BLOCK is canonicalized too, not only its members. `name` and `qualified_name` feed
+    /// `LogicalSymbolKey` beside the scope, so leaving the impl symbol named `Foo<T>` gave the
+    /// binder-renamed twin a different handle even once their methods shared one.
+    #[test]
+    fn an_impl_symbol_is_named_canonically() {
+        let named = |source: &str| {
+            parser::parse_file(Path::new("src/lib.rs"), Language::Rust, source)
+                .expect("Rust parses")
+                .symbols
+                .iter()
+                .filter(|symbol| symbol.kind == "impl")
+                .map(|symbol| (symbol.name.clone(), symbol.qualified_name.clone()))
+                .collect::<Vec<_>>()
+        };
+        let with_t = named("impl<T> Tr for Foo<T> { fn f(&self) {} }");
+        assert_eq!(with_t, vec![("Foo<_>".to_string(), "src/lib.rs::Foo<_>".to_string())]);
+        assert_eq!(with_t, named("impl<U> Tr for Foo<U> { fn f(&self) {} }"));
+        // A non-generic impl is unchanged.
+        assert_eq!(named("impl Tr for Foo { fn f(&self) {} }"), vec![(
+            "Foo".to_string(),
+            "src/lib.rs::Foo".to_string()
+        )]);
+    }
+
+    #[test]
+    fn every_type_form_renames_its_binder() {
+        // One row per form a Rust type can take, so a form whose binder is left un-substituted is
+        // caught here rather than by whichever repository happens to use it. Renaming the binder
+        // cannot change the owner: rustc says the two impls conflict, so they are one entity and
+        // must render to one string.
+        //
+        // Two forms are deliberately absent. A macro type is covered by its own test below, which
+        // asserts the OPPOSITE — its tokens are not a type until expansion, so substituting inside
+        // them would claim an equivalence rustc has not granted. And `builtin # pattern_type(..)`
+        // is unstable, has no tree-sitter node, and cannot appear in a compiling repository.
+        for (with_t, with_u) in [
+            ("Foo<T>", "Foo<U>"),
+            ("[T; 4]", "[U; 4]"),
+            ("[T]", "[U]"),
+            ("(T)", "(U)"),
+            ("(T, T)", "(U, U)"),
+            ("&T", "&U"),
+            ("*const T", "*const U"),
+            ("dyn Tr<T>", "dyn Tr<U>"),
+            // A trait object may be written without `dyn`, which parses as a bounded type instead.
+            ("Tr<T> + Send", "Tr<U> + Send"),
+            ("impl Tr<T>", "impl Tr<U>"),
+            ("fn(T) -> T", "fn(U) -> U"),
+            ("for<'a> fn(&'a T)", "for<'a> fn(&'a U)"),
+            ("<T as Tr>::A", "<U as Tr>::A"),
+        ] {
+            let render = |binder: &str, form: &str| {
+                let source = format!("impl<{binder}> Q for {form} {{ fn f(&self) {{}} }}");
+                let paths = scope_paths(&source, "f");
+                assert!(!paths.is_empty(), "the fixture must parse: {source}");
+                paths
+            };
+            assert_eq!(
+                render("T", with_t),
+                render("U", with_u),
+                "renaming the binder changed the owner of `{with_t}`"
+            );
+        }
+    }
+
+    /// The forms with no binder to rename still have to render as themselves rather than fall into
+    /// an opaque path that re-spells them.
+    #[test]
+    fn a_type_form_without_a_binder_still_renders() {
+        for form in ["!", "_", "()"] {
+            let source = format!("impl Q for {form} {{ fn f(&self) {{}} }}");
+            let paths = scope_paths(&source, "f");
+            assert!(!paths.is_empty(), "the fixture must parse: {source}");
+            assert!(
+                paths.iter().any(|path| path.contains(form)),
+                "`{form}` should render as itself, got {paths:?}"
+            );
+        }
+    }
+
+    /// A macro's tokens are NOT a type — they are tokens, and what they mean is decided by an
+    /// expansion this indexer does not perform. So `m!(T)` and `m!(U)` stay distinct: substituting
+    /// inside them would claim an equivalence rustc has not granted.
+    #[test]
+    fn a_binder_inside_macro_tokens_is_not_renamed() {
+        let render = |binder: &str| {
+            let source = format!("impl<{binder}> Q for m!({binder}) {{ fn f(&self) {{}} }}");
+            scope_paths(&source, "f")
+        };
+        let (with_t, with_u) = (render("T"), render("U"));
+        assert!(!with_t.is_empty(), "the fixture must parse");
+        assert_ne!(with_t, with_u, "macro tokens are not substituted");
+    }
+
+    #[test]
+    fn spelling_cannot_change_an_owner() {
+        for (canonical, spellings) in [
+            ("impl Tr for Foo<u8> {}", vec![
+                "impl Tr for Foo < u8 > {}",
+                "impl Tr for Foo<u8 > {}",
+                "impl Tr for /* c */ Foo<u8> {}",
+                "impl Tr for Foo<\n    u8,\n> {}",
+                "impl Tr for r#Foo<u8> {}",
+            ]),
+            ("impl Tr for fn(u8) -> W {}", vec![
+                "impl Tr for fn ( u8 ) -> W {}",
+                "impl Tr for fn(u8)->W {}",
+                "impl Tr for fn(\n    u8,\n) -> W {}",
+            ]),
+            ("impl Tr for &mut W {}", vec![
+                "impl Tr for & mut W {}",
+                "impl Tr for &'a mut W {}",
+                "impl Tr for &'static mut W {}",
+            ]),
+            ("impl Tr for *const W {}", vec!["impl Tr for * const W {}"]),
+            ("impl Tr for (A, B) {}", vec!["impl Tr for ( A , B ) {}", "impl Tr for (A, B,) {}"]),
+            ("impl Tr for a::b::W {}", vec![
+                "impl Tr for a :: b :: W {}",
+                "impl Tr for a::/* mid */b::W {}",
+            ]),
+            ("impl Tr for Box<dyn Runs + 'a> {}", vec![
+                "impl Tr for Box<dyn Runs> {}",
+                "impl Tr for Box< dyn Runs + 'static > {}",
+            ]),
+            ("impl Tr for [u8; 4] {}", vec!["impl Tr for [ u8 ; 4 ] {}"]),
+        ] {
+            let expected = scope_paths(&format!("{canonical} fn f(&self) {{}}"), "f");
+            assert!(!expected.is_empty(), "the fixture must parse: {canonical}");
+            for spelling in spellings {
+                assert_eq!(
+                    scope_paths(&format!("{spelling} fn f(&self) {{}}"), "f"),
+                    expected,
+                    "{spelling} must render as {canonical}"
+                );
+            }
+        }
+    }
+
+    /// The other half of the same property: what the printer must NOT fold. A macro's arguments are
+    /// tokens, so a lifetime there is one — erasing it inside the token list would merge owners a
+    /// macro can expand differently.
+    #[test]
+    fn a_lifetime_inside_macro_tokens_is_a_token() {
+        assert_ne!(
+            scope_paths("impl Tr for M!('a) { fn f(&self) {} }", "f"),
+            scope_paths("impl Tr for M!('static) { fn f(&self) {} }", "f"),
+        );
+        // …while a lifetime in a real type position is erased.
+        assert_eq!(
+            scope_paths("impl<'a> Tr for Foo<'a, u8> { fn f(&self) {} }", "f"),
+            scope_paths("impl Tr for Foo<'static, u8> { fn f(&self) {} }", "f"),
+        );
+    }
+
+    /// A macro's argument list is verbatim for the same reason a const block is: the text is
+    /// TOKENS the macro matches on, so the cosmetic rewrites are not cosmetic there. `r#Foo` and
+    /// `Foo` are different tokens a `macro_rules!` arm can tell apart, and the two owners coexist.
+    #[test]
+    fn cosmetic_rewrites_stop_at_a_macro_argument_list() {
+        let raw = scope_paths("impl Tr for M!(r#Foo) { fn f(&self) {} }", "f");
+        assert_eq!(raw, vec!["M!(r#Foo) as Tr::f".to_string()]);
+        assert_ne!(raw, scope_paths("impl Tr for M!(Foo) { fn f(&self) {} }", "f"));
+        // Outside the token list the macro's own path is ordinary type text.
+        assert_eq!(scope_paths("impl Tr for a :: M!(Foo) { fn f(&self) {} }", "f"), vec![
+            "a::M!(Foo) as Tr::f".to_string()
+        ]);
+    }
+
+    /// An impl symbol's NAME is its self type, so two impls of different traits for one type share
+    /// it. With the trait on a later line the captured signature is `impl` for both as well, so
+    /// nothing but the scope path separates them — and a handle or memory bound to either impl
+    /// block would answer for both.
+    #[test]
+    fn two_traits_impls_on_one_type_are_two_impl_symbols() {
+        let scope_of = |source: &str| {
+            parser::parse_file(Path::new("src/lib.rs"), Language::Rust, source)
+                .expect("Rust parses")
+                .symbols
+                .iter()
+                .find(|symbol| symbol.kind == "impl")
+                .map(|symbol| symbol.scope_path.clone())
+                .expect("the fixture declares an impl")
+        };
+        assert_eq!(scope_of("impl\n A for W { fn f(&self) {} }"), "W as A");
+        assert_ne!(
+            scope_of("impl\n A for W { fn f(&self) {} }"),
+            scope_of("impl\n B for W { fn f(&self) {} }"),
+        );
+        // An inherent impl still ends its path at the type it is for.
+        assert_eq!(scope_of("impl W { fn f(&self) {} }"), "W");
+    }
+
+    /// A macro's arguments are tokens the macro consumes, not references to the binder, and what
+    /// they expand to is not knowable here. Substituting them claims a renaming is a no-op, which
+    /// a rule keyed on the literal token makes false — so the tokens stay as written and the two
+    /// owners stay apart.
+    #[test]
+    fn a_binder_inside_a_macro_argument_is_left_as_written() {
+        let left = scope_paths("impl<T> Tr for Pair<T, M!(T)> { fn f(&self) {} }", "f");
+        assert_eq!(left, vec!["Pair<_,M!(T)> as Tr::f".to_string()]);
+        assert_ne!(left, scope_paths("impl<U> Tr for Pair<U, M!(U)> { fn f(&self) {} }", "f"));
+    }
+
+    /// The ROOT of a qualified path is the opposite case: `T::Assoc` is a projection off the
+    /// binder, rustc rejects the two impls together, and the trait marker has to fold with the
+    /// owner — a walk that skipped the whole qualified subtree left `Tr<T::Assoc>` beside
+    /// `Tr<U::Assoc>` and split one entity in two.
+    #[test]
+    fn a_binder_at_a_qualified_paths_root_is_substituted() {
+        // The projection keeps its `::`. A trait marker rewrites only its TOP-LEVEL separators —
+        // this one is inside a generic argument, where a `::` is never a segment boundary.
+        assert_eq!(
+            scope_paths("impl<T: Bound> Tr<T::Assoc> for F<T> { fn f(&self) {} }", "f"),
+            vec!["F<_> as Tr<_::Assoc>::f".to_string()]
+        );
+        assert_eq!(
+            scope_paths("impl<T: Bound> Tr<T::Assoc> for F<T> { fn f(&self) {} }", "f"),
+            scope_paths("impl<U: Bound> Tr<U::Assoc> for F<U> { fn f(&self) {} }", "f"),
+        );
+    }
+
+    /// A brace inside a string literal is content, not the end of the const-generic block. Closing
+    /// there sends the rest of the literal through the cosmetic tidier, whose whitespace collapse
+    /// erases the difference between `F<1>` and `F<2>` — a MERGE of two distinct types.
+    #[test]
+    fn a_brace_inside_a_literal_does_not_end_the_const_block() {
+        let one = scope_paths(r#"impl Tr for F<{ "}".len() }> { fn f(&self) {} }"#, "f");
+        let two = scope_paths(r#"impl Tr for F<{ "} ".len() }> { fn f(&self) {} }"#, "f");
+        assert_eq!(one, vec![r#"F<{ "}".len() }> as Tr::f"#.to_string()]);
+        assert_ne!(one, two, "these are `F<1>` and `F<2>`, so they must not share a scope");
+        // A raw string's unescaped quotes do not end it either.
+        assert_eq!(
+            scope_paths(r##"impl Tr for F<{ r#""}"#.len() }> { fn f(&self) {} }"##, "f"),
+            vec![r##"F<{ r#""}"#.len() }> as Tr::f"##.to_string()]
+        );
+    }
+
+    /// A const binder referenced inside a const-generic block is still a binder: the block's
+    /// syntax is verbatim, but renaming `N` to `M` does not make a second impl.
+    #[test]
+    fn a_const_binder_inside_a_block_still_canonicalizes() {
+        assert_eq!(
+            scope_paths("impl<const N: usize> Tr for F<{ N }> { fn f(&self) {} }", "f"),
+            scope_paths("impl<const M: usize> Tr for F<{ M }> { fn f(&self) {} }", "f"),
+        );
+    }
+
+    /// A comma inside a generic argument list is not a tuple separator, so the redundant
+    /// parentheses around a single type still come off.
+    #[test]
+    fn parens_around_one_generic_type_are_redundant() {
+        assert_eq!(
+            scope_paths("impl Tr for (Pair<u8, u16>) { fn f(&self) {} }", "f"),
+            scope_paths("impl Tr for Pair<u8, u16> { fn f(&self) {} }", "f"),
+        );
+        // A real one-tuple keeps them.
+        assert_ne!(
+            scope_paths("impl Tr for (W,) { fn f(&self) {} }", "f"),
+            scope_paths("impl Tr for W { fn f(&self) {} }", "f"),
+        );
+    }
+
+    /// A lifetime never separates two impls that coexist — rustc erases lifetimes before the
+    /// coherence check, so `impl<'a> Tr for &'a W` and `impl Tr for &'static W` conflict. Erasing
+    /// them here also puts `Foo<'a>`'s members back on the plain `Foo::method` surface that exact
+    /// resolution looks for.
+    #[test]
+    fn lifetimes_are_erased_from_the_owner() {
+        for (source, expected) in [
+            ("impl<'a> Runs for &'a W { fn run(&self) {} }", "&W as Runs::run"),
+            ("impl<'a> Index<'a> { fn run(&self) {} }", "Index::run"),
+            ("impl<'a, T> Pair<'a, T> { fn run(&self) {} }", "Pair<_>::run"),
+        ] {
+            assert_eq!(scope_paths(source, "run"), vec![expected.to_string()], "{source}");
+        }
+    }
+
+    /// Two same-tailed traits from different modules are two traits. Reducing both to `Runs`
+    /// would give their identically-signatured methods one scope — and, with `scope_path` in the
+    /// logical key, ONE logical symbol, so a memory or graph handle bound to either would answer
+    /// for both. The whole trait path is what keeps them apart; `::` becomes `.` so the marker
+    /// stays a single `::`-segment for `normalized_scope_path` to fold.
+    #[test]
+    fn same_tailed_traits_on_one_type_keep_separate_scopes() {
+        let scopes = scope_paths(
+            "struct Worker;\nimpl a::Runs for Worker { fn run(&self) {} }\nimpl b::Runs for \
+             Worker { fn run(&self) {} }\n",
+            "run",
+        );
+        assert_eq!(scopes, vec!["Worker as a.Runs::run", "Worker as b.Runs::run"]);
+    }
+
+    /// The receiver surface must be unchanged by the wider marker: resolution folds ` as Trait`
+    /// away, so both impls' methods still answer to `Worker::run`.
+    ///
+    /// This drives the fold with EMITTED scopes, not literals — the fold itself is unchanged
+    /// code, so a test that hand-writes `Worker as a.Runs::run` passes no matter what
+    /// `trait_marker` emits. Going through the parser is what makes this fail if the marker ever
+    /// regresses to carrying its own `::`, which would leave the fold unable to tell the trait
+    /// path from the segments after it.
+    #[test]
+    fn every_emitted_trait_marker_folds_to_the_plain_receiver_scope() {
+        let sources = [
+            "impl a::Runs for Worker { fn run(&self) {} }",
+            "impl std::fmt::Display for Worker { fn run(&self) {} }",
+            "impl ::a::b::Runs for Worker { fn run(&self) {} }",
+            "impl crate::traits::Runs<Item> for Worker { fn run(&self) {} }",
+            "impl Runs for Worker { fn run(&self) {} }",
+        ];
+        for source in sources {
+            let scope = scope_paths(source, "run").pop().expect("a method scope");
+            assert!(
+                scope.starts_with("Worker as ") && scope.ends_with("::run"),
+                "{source} must emit one trait-marked segment, got {scope}"
+            );
+            assert_eq!(
+                scope.matches("::").count(),
+                1,
+                "the marker must stay ONE ::-segment, got {scope}"
+            );
+            let folded =
+                crate::index::edges::normalized_scope_path(&scope, Some(Language::Rust.as_str()));
+            assert_eq!(folded.as_ref(), "Worker::run", "{source} folded to {folded}");
+        }
+    }
+
+    /// The marker is raw source text on an IDENTITY field, so cosmetic spelling must not split one
+    /// trait into two logical symbols. Interior whitespace is cosmetic; a comment is too.
+    #[test]
+    fn cosmetic_trait_path_spelling_does_not_change_the_marker() {
+        for source in [
+            "impl a::Runs for Worker { fn run(&self) {} }",
+            "impl a :: Runs for Worker { fn run(&self) {} }",
+            "impl a::\n    Runs for Worker { fn run(&self) {} }",
+        ] {
+            assert_eq!(
+                scope_paths(source, "run"),
+                vec!["Worker as a.Runs::run".to_string()],
+                "{source} must normalize to the same marker"
+            );
+        }
+    }
+
+    /// A leading `::` is the one path token that is NOT cosmetic. Since the 2018 edition it selects
+    /// the extern prelude, so with a local `mod a` in scope `a::Runs` and `::a::Runs` name traits
+    /// from different crates — rustc accepts both impls on one type. Folding the prefix away gave
+    /// them one scope and merged their `run` methods into a single logical symbol.
+    #[test]
+    fn a_leading_path_root_is_not_cosmetic() {
+        assert_eq!(scope_paths("impl ::a::Runs for Worker { fn run(&self) {} }", "run"), vec![
+            "Worker as .a.Runs::run".to_string()
+        ]);
+        assert_ne!(
+            scope_paths("impl ::a::Runs for Worker { fn run(&self) {} }", "run"),
+            scope_paths("impl a::Runs for Worker { fn run(&self) {} }", "run"),
+        );
+        // Same on the owner side: `::a::W` is another crate's type, not this module's `a::W`.
+        assert_ne!(
+            scope_paths("impl Runs for ::a::W { fn run(&self) {} }", "run"),
+            scope_paths("impl Runs for a::W { fn run(&self) {} }", "run"),
+        );
+    }
+
+    /// A comment and the width of a whitespace run cannot carry a type's meaning, so neither may
+    /// split one const-generic owner into two. What the block holds inside a LITERAL is meaning and
+    /// stays byte for byte.
+    #[test]
+    fn a_const_block_normalizes_only_what_cannot_carry_meaning() {
+        let plain = scope_paths("impl Tr for F<{ N + 1 }> { fn f(&self) {} }", "f");
+        assert_eq!(
+            scope_paths("impl Tr for F<{  N  +  1  }> { fn f(&self) {} }", "f"),
+            plain,
+            "the width of a whitespace run is not part of the type"
+        );
+        assert_eq!(
+            scope_paths("impl Tr for F<{ /* why */ N + 1 }> { fn f(&self) {} }", "f"),
+            plain,
+            "a comment is not part of the type"
+        );
+        // A brace inside a comment must not end the block early — that would hand the tail to the
+        // whitespace-collapsing tidier and render two distinct owners identically.
+        let one = scope_paths(r#"impl Tr for F<{ /* } */ "a ".len() }> { fn f(&self) {} }"#, "f");
+        let two = scope_paths(r#"impl Tr for F<{ /* } */ "a  ".len() }> { fn f(&self) {} }"#, "f");
+        assert_ne!(one, two, "these are `F<2>` and `F<3>`, so they must not share a scope");
+        assert_eq!(one, vec![r#"F<{ "a ".len() }> as Tr::f"#.to_string()]);
+    }
+
+    /// An impl target with no name to take (unit, tuple, slice, `dyn`) is RENDERED, never dropped
+    /// and never the trait's. Dropping it left the impl with no scope segment at all, so its
+    /// members sat at FILE scope, where they could collide with free functions.
+    #[test]
+    fn a_non_nominal_impl_target_owns_its_members() {
+        for (target, owner) in [
+            ("()", "()"),
+            ("(Alpha, Beta)", "(Alpha,Beta)"),
+            ("[Alpha]", "[Alpha]"),
+            ("dyn Runs", "dyn Runs"),
+        ] {
+            let source = format!("impl std::fmt::Display for {target} {{ fn fmt(&self) {{}} }}");
+            assert_eq!(
+                scope_paths(&source, "fmt"),
+                vec![format!("{owner} as std.fmt.Display::fmt")],
+                "`impl Display for {target}` must own its members without adopting `Display`"
+            );
+        }
+    }
 }

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -372,7 +372,13 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // re-extract so the corrected `dispatch_handle` set reaches deployed indexes.
 // 11: #208 review round 11 — effect-only fallback records the direct call (no shadowing
 // misresolve); method calls on scoped receivers (`worker.run()`) are recorded again; re-extract.
-const GRAPH_INDEX_VERSION: &str = "11";
+// 12: #567 — Rust impl scopes carry their rendered self type and trait path, so the resolution
+// surface (`scope_degeneric`) changes shape; re-extract.
+// 13: #567 — that rendering settled: binder substitution is decided by AST position, macro
+// argument tokens stay verbatim, and an impl symbol's OWN path ends at its `Type as Trait`
+// segment. An index built from an interim 12 carries the earlier shape and no longer differs from
+// the stamp, so it would never re-derive; re-extract.
+const GRAPH_INDEX_VERSION: &str = "13";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag
 // on next open. Incremental discovery only rewrites a file row when its sha/language/kind changes —
@@ -394,7 +400,10 @@ const GENERATED_FLAGS_VERSION_KEY: &str = "generated_flags_version";
 // validate at a time. Per-repo (`repo_meta`, like `graph_index_version`): a shared DB holds repos
 // rebuilt by different binaries.
 // 1: initial version (#493).
-const LOGICAL_KEY_VERSION: &str = "1";
+// 2: canonical scope_path included in LogicalSymbolKey derivation (#567).
+// 3: #567 — the canonical form itself settled (see `GRAPH_INDEX_VERSION` 13), and an impl symbol's
+// qualified name now carries its trait, so every impl's key moves.
+const LOGICAL_KEY_VERSION: &str = "3";
 const LOGICAL_KEY_VERSION_KEY: &str = "logical_key_version";
 
 #[derive(Debug, Error)]
@@ -419,6 +428,9 @@ struct GraphReindexFile {
     path: String,
     language: Language,
     kind: TargetKind,
+    /// Digest of the text that produced this row — the graph heal's proof that the bytes it read
+    /// from the active checkout are this row's own (rows span every commit/worktree scope).
+    sha256: String,
 }
 
 #[derive(Debug)]

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -395,7 +395,13 @@ fn scope_path(
         current = parent.parent();
     }
     segments.reverse();
-    segments.push(name.to_string());
+    // A kind whose NAME is not its whole identity ends its own path with the fuller segment. An
+    // impl is the case: its name is the self type, so `impl A for W` and `impl B for W` are both
+    // `W` — and with the trait on a later line the captured signature is `impl` for both too, so
+    // the two impl symbols carry one logical key and a handle or memory bound to either answers
+    // for both. Asked per backend rather than reusing `scope_segment`, which several languages
+    // define for a symbol's CHILDREN in a shape its own path should not take.
+    segments.push(backend.own_scope_segment(node, text).unwrap_or_else(|| name.to_string()));
     segments.join("::")
 }
 

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1489,6 +1489,10 @@ pub fn calls_leaf() { leaf(); }
 /// Pinned so the gap is not read as a handle-lane regression: it predates that lane and the
 /// qualified-name lane shows it identically. Closing it is a change to what the counts count, and
 /// this test is what would have to change with them.
+///
+/// Note what `matched_symbols` here is NOT evidence of: the two `go` bodies live in different
+/// impls, so they are two logical symbols with two handles, and each handle covers one. A handle
+/// spanning several symbols is the cfg-variant case, not the two-owners case.
 #[test]
 fn a_caller_count_spans_edge_kinds_a_hop_traversal_does_not() {
     let (_temp, config) = rust_source_config(NON_CALL_INBOUND_SOURCE);
@@ -1527,13 +1531,22 @@ fn a_caller_count_spans_edge_kinds_a_hop_traversal_does_not() {
     );
 
     // Same divergence one level down, where the counted edge is a `contains` from each impl block
-    // — so the count outrunning the hop list is not particular to the trait row.
+    // — so the count outrunning the hop list is not particular to the trait row. Each `go` body
+    // carries its OWN handle: the impl's owner is part of a member's identity, so
+    // `Alpha as Runner::go` and `Beta as Runner::go` are two logical symbols, not one.
+    let go_rows = graph
+        .iter()
+        .filter(|symbol| symbol.name == "go" && symbol.kind == "function")
+        .map(|symbol| symbol.logical_symbol_id.expect("an indexed row carries a handle"))
+        .collect::<Vec<_>>();
+    assert_eq!(go_rows.len(), 2, "the fixture declares `go` in two impls");
+    assert_ne!(go_rows[0], go_rows[1], "one type's method is not the other's");
     let (go, go_counted) = counted_callers("go", "function");
     assert!(
         go_counted > 0,
         "the impl blocks must draw `contains` edges at the method: {go_counted}"
     );
-    assert_eq!(hops(go), (0, 2), "the two `go` bodies share a handle and neither is called");
+    assert_eq!(hops(go), (0, 1), "the `contains` edge is counted as a caller and is not a hop");
 
     // The control: where the inbound edge IS a call, the count and the drill-down agree.
     let (leaf, leaf_counted) = counted_callers("leaf", "function");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -1,0 +1,540 @@
+//! `ensure_graph_index_current` runs on the OPEN path, so anything it treats as fatal wedges the
+//! database for every later open too — the heal is retried and re-fails forever, and no CLI or MCP
+//! call can get in to repair it. These tests pin the states that must NOT be fatal.
+//!
+//! All three arise on ordinary indexes: a deletion tombstone (every repo that ever removed a
+//! file), a row whose path is absent from this checkout (the heal repopulates the repo's whole
+//! generation, including sibling commits/worktrees), and a Rust file above the parse limit.
+
+use super::*;
+
+/// Stage an index that owes BOTH heals: the graph-version bump (which drives the reindex loop)
+/// and the logical-key bump (which turns on the Rust scope refresh).
+fn owe_both_heals(db: &IndexDatabase) {
+    db.set_repo_meta("graph_index_version", "0").unwrap();
+    db.storage
+        .connection()
+        .execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", [])
+        .unwrap();
+    // These tests rewind the version meta behind a connection that has already run passes, so a
+    // drift snapshot memoized while the version still read CURRENT (i.e. `None`, nothing to heal)
+    // can still be pending. A genuine pre-upgrade open carries no memo; drop it so the heal
+    // captures the snapshot itself, which is also what decides whether it may stamp.
+    *db.drift_snapshot.lock().expect("drift snapshot lock") = None;
+}
+
+fn indexed_root(files: &[(&str, &str)]) -> (ScratchRoot, rag_rat_base::config::Config) {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    for (name, body) in files {
+        fs::write(root.join("src").join(name), body).unwrap();
+    }
+    let config = source_config(root.to_path_buf(), Language::Rust);
+    (root, config)
+}
+
+/// A `kind='deleted'` tombstone carries `language='unknown'` (`mark_file_deleted`). Neither token
+/// parses into `Language`/`TargetKind`, so a heal that walks raw `main.files` rows without
+/// excluding tombstones fails at the FIRST one — on every open, permanently. Any repo that has
+/// ever deleted an indexed file holds these rows.
+#[test]
+fn a_deletion_tombstone_does_not_wedge_the_graph_heal() {
+    let (root, config) =
+        indexed_root(&[("lib.rs", "pub struct Alpha;\nimpl Alpha { pub fn run(&self) {} }\n")]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Delete an indexed file and let the incremental pass write its tombstone, exactly as a
+    // normal edit-and-reindex cycle does.
+    fs::write(root.join("src/gone.rs"), "pub fn vanishing() {}\n").unwrap();
+    let db = {
+        drop(db);
+        IndexDatabase::index_discover(&config).unwrap()
+    };
+    fs::remove_file(root.join("src/gone.rs")).unwrap();
+    drop(db);
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    let tombstones: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE kind = 'deleted'", [], |row| row.get(0))
+        .unwrap();
+    assert!(tombstones > 0, "the delete-and-reindex cycle must leave a tombstone to test against");
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().expect("a tombstone row must not fail the heal");
+    assert_eq!(
+        db.repo_meta("graph_index_version").unwrap().as_deref(),
+        Some(GRAPH_INDEX_VERSION),
+        "the heal ran to completion and stamped its version"
+    );
+    // Tombstones are filtered before the loop, so every row this heal walked was covered — the
+    // one shape that may stamp the key version and let later passes take the scoped re-derive.
+    assert_eq!(
+        db.repo_meta("logical_key_version").unwrap().as_deref(),
+        Some(LOGICAL_KEY_VERSION),
+        "full coverage stamps the key version"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// The heal repopulates the repo's whole generation, so it walks rows for paths that need not
+/// exist under THIS root (a sibling commit/worktree scope) — and a row can simply outlive its file
+/// between an edit and the next index pass. An unreadable path is an expected outcome of that
+/// repopulation, not a failure.
+#[test]
+fn a_file_row_without_a_file_does_not_wedge_the_graph_heal() {
+    let (root, config) =
+        indexed_root(&[("lib.rs", "pub struct Alpha;\nimpl Alpha { pub fn run(&self) {} }\n")]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // A live row (not a tombstone) whose path has no file behind it.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated,
+                 indexed_at_ms, indexed_revision, commit_sha, worktree_id, repo_id, generation,
+                 has_test_code)
+             SELECT 'src/absent.rs', 'rust', 'source', '', 0, 0, 0, '', commit_sha, worktree_id,
+                    repo_id, generation, 0
+             FROM main.files LIMIT 1",
+            [],
+        )
+        .unwrap();
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().expect("an unreadable path must not fail the heal");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Above `MAX_GRAPH_PARSE_BYTES` the indexer persists no symbols at all (the chunker declines at
+/// the same bound), so there is nothing for the scope refresh to certify. Treating the file as an
+/// un-certifiable heal blocker would fail the open over a file the index never parsed.
+#[test]
+fn an_oversized_rust_file_does_not_wedge_the_graph_heal() {
+    let filler = "pub fn pad() {}\n".repeat(40_000);
+    assert!(filler.len() > edges::MAX_GRAPH_PARSE_BYTES, "the fixture must exceed the parse limit");
+    let (root, config) = indexed_root(&[
+        ("lib.rs", "pub struct Alpha;\nimpl Alpha { pub fn run(&self) {} }\n"),
+        ("huge.rs", filler.as_str()),
+    ]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().expect("an oversized Rust file must not fail the heal");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Every `(to_name, resolution)` on `file_id`'s edges — a row the heal must not touch has to keep
+/// its RESOLUTIONS too, not merely its edge names. Re-extracting a row the connection's resolve
+/// pass will not revisit replaces resolved targets with fresh `unresolved` candidates, which is
+/// how a sibling scope silently loses its graph.
+fn edge_targets_with_resolution(db: &IndexDatabase, file_id: i64) -> Vec<(String, String)> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT n.value, r.value FROM edges_data d
+             JOIN name_strings n ON n.id = d.to_name_id
+             JOIN name_strings r ON r.id = d.resolution_id
+             WHERE d.source_file_id = ?1
+             ORDER BY n.value, r.value",
+        )
+        .unwrap();
+    let rows = stmt.query_map([file_id], |row| Ok((row.get(0)?, row.get(1)?))).unwrap();
+    rows.map(Result::unwrap).collect()
+}
+
+/// Every `to_name` on `file_id`'s edges — the file's outgoing graph as EXTRACTED, independent of
+/// which scope is active (edge rows are keyed by `source_file_id`, and base and overlay hold
+/// separate rows for a shadowed path).
+fn edge_target_names(db: &IndexDatabase, file_id: i64) -> Vec<String> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT n.value FROM edges_data d
+             JOIN name_strings n ON n.id = d.to_name_id
+             WHERE d.source_file_id = ?1
+             ORDER BY n.value",
+        )
+        .unwrap();
+    let names = stmt.query_map([file_id], |row| row.get::<_, String>(0)).unwrap();
+    names.map(Result::unwrap).collect()
+}
+
+/// The `main.files` row id for `path` in the scope identified by `worktree_id` (`''` = base).
+fn scoped_file_id(db: &IndexDatabase, path: &str, worktree_id: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT id FROM main.files WHERE path = ?1 AND worktree_id = ?2 AND repo_id = ?3",
+            params![path, worktree_id, &db.active_repo_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+/// The heal walks the repo's WHOLE generation — every commit/worktree scope — but reads from ONE
+/// checkout. A linked worktree's row for a path that also exists in the active checkout must
+/// therefore keep ITS OWN graph: re-deriving it from the active root would stamp the base
+/// checkout's calls onto the branch's rows, silently corrupting every graph answer served from
+/// that worktree. The row's `sha256` is what decides — bytes that do not hash to the row are not
+/// that row's source.
+#[test]
+fn a_graph_heal_does_not_rewrite_a_sibling_worktrees_edges() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(
+        main.join("src/target.rs"),
+        "pub fn base_helper() {}\npub fn entry() { base_helper(); }\n",
+    )
+    .unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // The branch rewrites the file's body, so base and overlay hold DIFFERENT content for the
+    // same path — the one shape a single-root heal cannot serve both of.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(
+        linked.join("src/target.rs"),
+        "pub fn overlay_helper() {}\npub fn entry() { overlay_helper(); }\n",
+    )
+    .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch body"]);
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "target.rs indexed as an overlay row");
+
+    set_base_scope(&mut db, &main);
+    let base_id = scoped_file_id(&db, "src/target.rs", "");
+    let overlay_id = scoped_file_id(&db, "src/target.rs", &worktree_id_of(&linked));
+    assert_ne!(base_id, overlay_id, "base and overlay must hold separate rows for the path");
+    let overlay_before = edge_target_names(&db, overlay_id);
+    let overlay_resolved_before = edge_targets_with_resolution(&db, overlay_id);
+    assert!(
+        overlay_before.iter().any(|name| name == "overlay_helper"),
+        "the overlay row's graph is derived from the BRANCH body: {overlay_before:?}"
+    );
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().expect("the heal runs from the base checkout");
+
+    assert_eq!(
+        edge_target_names(&db, overlay_id),
+        overlay_before,
+        "the heal read only the base checkout, so the overlay row's graph must be untouched"
+    );
+    assert_eq!(
+        edge_targets_with_resolution(&db, overlay_id),
+        overlay_resolved_before,
+        "and its RESOLUTIONS survive — `resolve_edges` writes only rows this connection's view \
+         admits, so re-extracting an out-of-view row would strand it as unresolved"
+    );
+    let base_after = edge_target_names(&db, base_id);
+    assert!(
+        base_after.iter().any(|name| name == "base_helper"),
+        "the active checkout's own row IS re-derived: {base_after:?}"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// A row the digest gate skips keeps its OLD `scope_path`, and `regroup_logical_symbols` reads
+/// raw `main.files` across every scope — so that stale scope does not merely lag, it changes
+/// IDENTITY: the cross-scope group splits, the stale row keeps the original `stable_id`, and the
+/// refreshed row gets a new one. Stamping the key version over that would also disarm the two
+/// mechanisms built to recover from it (the drift snapshot, and the scoped-re-derive gate, which
+/// by construction never revisits untouched rows). So partial coverage must DEFER the stamp.
+#[test]
+fn partial_coverage_defers_the_logical_key_stamp() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(
+        main.join("src/shared.rs"),
+        "pub struct S;\nimpl Greet for S { fn hello(&self) {} }\n",
+    )
+    .unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // A branch whose copy of the path differs, so its row can never be vouched for from here.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(
+        linked.join("src/shared.rs"),
+        "pub struct S;\nimpl Greet for S { fn hello(&self) {} }\npub fn only_here() {}\n",
+    )
+    .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    set_base_scope(&mut db, &main);
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().unwrap();
+
+    assert_eq!(
+        db.repo_meta("graph_index_version").unwrap().as_deref(),
+        Some(GRAPH_INDEX_VERSION),
+        "the graph pass itself ran to completion"
+    );
+    assert_ne!(
+        db.repo_meta("logical_key_version").unwrap().as_deref(),
+        Some(LOGICAL_KEY_VERSION),
+        "a row whose scope could not be refreshed must leave the key version unstamped, so the \
+         drift heal and the full-rederive gate stay armed"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// The flip side of the digest gate: it must not turn the heal into a no-op. With a linked
+/// worktree's rows in the same database, the ACTIVE checkout's own rows still hash to their
+/// source, so the heal re-derives them — a gate that read the wrong column, or compared against
+/// a normalized form of the text, would quietly skip everything and leave the graph unbuilt.
+/// Full coverage must also STAMP the key version, or every later pass pays a whole-corpus regroup.
+#[test]
+fn a_graph_heal_still_repopulates_the_active_checkouts_rows() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/shared.rs"), "pub fn helper() {}\npub fn entry() { helper(); }\n")
+        .unwrap();
+    fs::write(main.join("src/touched.rs"), "pub fn only_on_main() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // The branch touches a DIFFERENT file, so `shared.rs` keeps identical content in both scopes.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/touched.rs"), "pub fn only_on_branch() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    set_base_scope(&mut db, &main);
+    let shared_id = scoped_file_id(&db, "src/shared.rs", "");
+    db.storage
+        .connection()
+        .execute("DELETE FROM edges_data WHERE source_file_id = ?1", [shared_id])
+        .unwrap();
+    assert!(edge_target_names(&db, shared_id).is_empty(), "the row starts the heal with no graph");
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().unwrap();
+
+    let after = edge_target_names(&db, shared_id);
+    assert!(
+        after.iter().any(|name| name == "helper"),
+        "a content-identical row is re-derived, not skipped: {after:?}"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// A file edited since it was indexed no longer hashes to its row, so the digest gate rejects it
+/// before the scope refresh or the edge re-derivation ever run. That is the ordinary state between
+/// an edit and the next watcher pass, and it must not fail the open — the row keeps the graph it
+/// has and the next index of that file lands the current shape.
+#[test]
+fn a_file_edited_since_indexing_does_not_wedge_the_graph_heal() {
+    let (root, config) =
+        indexed_root(&[("lib.rs", "pub struct Alpha;\nimpl Alpha { pub fn run(&self) {} }\n")]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id.clone());
+    let before = edge_target_names(&db, file_id);
+    assert!(!before.is_empty(), "the row starts with a graph to preserve");
+
+    // Prepend a symbol WITHOUT reindexing: every stored span is now stale by the same offset.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn inserted_ahead_of_everything() {}\npub struct Alpha;\nimpl Alpha { pub fn \
+         run(&self) {} }\n",
+    )
+    .unwrap();
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().expect("a file edited since indexing must not fail the heal");
+
+    assert_eq!(
+        edge_target_names(&db, file_id),
+        before,
+        "a row the gate rejects keeps its edges rather than losing or re-deriving them"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// `refresh_symbol_scopes` reports a shortfall when it cannot reach every persisted symbol of a
+/// file — the `unrefreshed` half of the heal's bookkeeping. The digest gate now short-circuits the
+/// obvious way in (an edited file), so this reaches it the only remaining way: a persisted symbol
+/// row the current parse does not produce. The heal must count it and carry on, NOT fail the open
+/// and NOT skip the file's edge re-derivation.
+#[test]
+fn a_symbol_row_the_parser_cannot_match_does_not_wedge_the_graph_heal() {
+    let (root, config) =
+        indexed_root(&[("lib.rs", "pub struct Alpha;\nimpl Alpha { pub fn run(&self) {} }\n")]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id.clone());
+
+    // A phantom symbol at a span the file does not contain: the span-matched UPDATE can never
+    // reach it, so the refresh covers fewer rows than the file holds.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.symbols(file_id, name, kind, language, qualified_name_id, \
+             scope_path,
+                 signature, start_line, end_line, start_byte, end_byte)
+             SELECT file_id, 'phantom', 'function', language, qualified_name_id, 'phantom',
+                    signature, 900, 901, 90000, 90010
+             FROM main.symbols WHERE file_id = ?1 LIMIT 1",
+            [file_id],
+        )
+        .unwrap();
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().expect("an unmatchable symbol row must not fail the heal");
+
+    assert_eq!(
+        db.repo_meta("graph_index_version").unwrap().as_deref(),
+        Some(GRAPH_INDEX_VERSION),
+        "the heal ran to completion and stamped its version"
+    );
+    assert!(
+        !edge_target_names(&db, file_id).is_empty(),
+        "the file's edges are still re-derived — the shortfall is reported, not fatal"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// A FILE row this build cannot name is skipped so the open does not wedge — but skipping it means
+/// its symbols keep the old derivation, and the heal has to say so. If the skip is silent and every
+/// other row refreshes, the key stamp lands; once it matches, nothing ever owes that row a
+/// re-derivation and its logical ids differ from a fresh index forever.
+#[test]
+fn a_file_row_this_build_cannot_name_defers_the_key_stamp() {
+    let (root, config) =
+        indexed_root(&[("lib.rs", "pub struct W;\n\nimpl W {\n    fn go(&self) {}\n}\n")]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    owe_both_heals(&db);
+    // A language token from a future build. The row stays live and in scope; only its NAME is
+    // unreadable here.
+    db.storage
+        .connection()
+        .execute("UPDATE main.files SET language = 'klingon' WHERE path LIKE '%lib.rs'", [])
+        .unwrap();
+    drop(db);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    assert_ne!(
+        db.repo_meta(LOGICAL_KEY_VERSION_KEY).unwrap().as_deref(),
+        Some(LOGICAL_KEY_VERSION),
+        "a row the heal could not read leaves the key version owed, not stamped"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// A chunk records the symbol it covers by PATH as well as by id, and the chunk-keyed readers still
+/// match on the path. Renaming an impl symbol from its trait to its self type without moving the
+/// chunk leaves those lookups searching a name nothing answers to, so an upgraded index loses the
+/// chunk associations — and the memories keyed through them — for every trait impl it heals.
+#[test]
+fn a_heal_that_renames_an_impl_moves_its_chunk_path_with_it() {
+    let (root, config) = indexed_root(&[(
+        "lib.rs",
+        "pub struct W;\npub trait A { fn go(&self); }\n\nimpl A for W {\n    fn go(&self) {}\n}\n",
+    )]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // The pre-upgrade shape: the impl symbol named for its TRAIT, and its chunk pointing at that
+    // name, exactly as an index built before this change carries them.
+    let impl_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM main.symbols WHERE kind = 'impl'", [], |r| r.get(0))
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.chunks SET symbol_path = 'src/lib.rs::A' WHERE symbol_id = ?1",
+            params![impl_id],
+        )
+        .unwrap();
+    let touched: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.chunks WHERE symbol_id = ?1 AND symbol_path = \
+             'src/lib.rs::A'",
+            params![impl_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(touched > 0, "the fixture must stage a chunk on the old trait-based path");
+    // A vector already computed from the OLD path, marked servable.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.chunk_embeddings(chunk_id, model_id, model_version, \
+             source_text_hash, input_hash, status, vector_blob, created_at_ms)
+             SELECT id, 'm', 'v1', 'unchanged', 'stale-input', 'Current', X'', 0
+               FROM main.chunks WHERE symbol_id = ?1",
+            params![impl_id],
+        )
+        .unwrap();
+    owe_both_heals(&db);
+    drop(db);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let aligned: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.chunks c
+              WHERE c.symbol_id IS NOT NULL
+                AND c.symbol_path IS NOT (SELECT ns.value FROM main.symbols s
+                                            JOIN main.name_strings ns ON ns.id = \
+             s.qualified_name_id
+                                           WHERE s.id = c.symbol_id)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(aligned, 0, "every linked chunk carries the name its symbol answers to now");
+
+    let served: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.chunk_embeddings WHERE input_hash != ''", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        served, 0,
+        "a vector built from the OLD symbol path must stop being served until it is re-embedded"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -981,6 +981,7 @@ mod generation_rebuild;
 mod git_history_reload;
 mod go_corpus;
 mod graph_edges;
+mod graph_heal_robustness;
 mod head_move_carry;
 mod index_paths;
 mod lens_clones;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -560,6 +560,7 @@ fn identical_content_in_two_repos_yields_distinct_logical_symbols() {
         path: "src/lib.rs".to_string(),
         name: "parse".to_string(),
         qualified_name: "lib::parse".to_string(),
+        scope_path: "parse".to_string(),
         kind: "function".to_string(),
         signature: Some("fn parse()".to_string()),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
@@ -590,14 +590,10 @@ fn a_rebuild_carrying_a_committed_leftover_defers_the_stamp() {
 /// Overlap rather than containment: a chunk begins BEFORE its symbol when it captures the leading
 /// doc comment, so `symbol.start <= chunk.start` would reject the right answer.
 ///
-/// NOTE the second half of this test. These two methods have BYTE-IDENTICAL declaration lines, and
-/// `signature` — the trimmed first line — is part of `LogicalSymbolKey`, so they collapse into ONE
-/// logical symbol. Every logical-id-anchored surface therefore still applies to both, and no
-/// chunk-side resolution can change that; it is a defect in the identity key. (When the
-/// declaration lines DIFFER the two are distinct logical symbols and the leak is real and fixed —
-/// see `a_decision_record_does_not_leak_between_distinct_same_named_methods`.) This test pins the
-/// raw-`symbol_id` precision that IS fixable here, plus the collapse itself, so the day the
-/// identity key gains a scope discriminator, this test notices.
+/// The two methods also have byte-identical declaration lines. Their owner scope must therefore
+/// remain part of logical identity; otherwise logical-id-anchored data leaks between `Alpha` and
+/// `Beta`. This test pins both guarantees: chunk binding selects the concrete overlapping method,
+/// and logical grouping keeps methods owned by different types separate.
 #[test]
 fn a_chunk_binding_resolves_the_symbol_it_overlaps_not_an_arbitrary_same_named_sibling() {
     let root = unique_temp_root();
@@ -661,13 +657,9 @@ fn a_chunk_binding_resolves_the_symbol_it_overlaps_not_an_arbitrary_same_named_s
     );
     assert_eq!(beta.symbol_id, Some(beta_symbol), "and the second method's chunk binds the second",);
 
-    // The known remaining imprecision, pinned deliberately: logical grouping is
-    // `(repo_id, path, logical_name)`, so these two distinct methods are ONE logical symbol and
-    // anything anchored to it applies to both.
-    assert_eq!(
+    assert_ne!(
         alpha.logical_symbol_id, beta.logical_symbol_id,
-        "same-named symbols in one file still share a logical id — if this ever fails, grouping \
-         gained a discriminator and the logical-id-anchored surfaces became per-method",
+        "same-named methods owned by different Rust types must remain distinct logical symbols",
     );
 
     let _ = fs::remove_dir_all(&root);
@@ -1247,6 +1239,436 @@ fn a_no_winner_drift_on_a_vanished_id_also_clears_the_anchor_and_the_node_edge()
         .unwrap();
     assert_eq!(edge.0, None, "a dead target is cleared");
     assert_eq!(edge.1, "gone", "and stops claiming to be current");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// A raw `symbol` binding survives a RENAME IN PLACE — the row id is untouched, only the name on it
+/// moves. That is what an index upgrade re-deriving an impl's identity does: the impl symbol stops
+/// being named for its trait and starts being named for its type.
+///
+/// The row id proves which symbol the memory is on, so validation reports it current — but
+/// `binding_id` is the qualified name every later relocation searches by, and it is the ONLY
+/// discriminator once an ordinary reindex churns the row id. Left stale, that search finds whatever
+/// else answers to the old name, or nothing. It has to be refreshed while the id still vouches.
+#[test]
+fn a_symbol_binding_refreshes_its_name_when_the_row_is_renamed_in_place() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn renamed_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let (symbol_id, live_name): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT s.id, (SELECT value FROM name_strings WHERE id = s.qualified_name_id)
+               FROM symbols s WHERE s.name = 'renamed_fn'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+
+    let created = db
+        .memory_create(rag_rat_query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to a raw symbol row".to_string(),
+            body: "The name on this row is about to move under it.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: rag_rat_query::memory::RepoMemoryBindTarget {
+                symbol_id: Some(symbol_id),
+                logical_symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                tracker: None,
+                project: None,
+                item_key: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+
+    // The pre-upgrade name, still on the binding after the row itself was renamed in place.
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE repo_memory_bindings SET binding_id = 'src/lib.rs::old_impl_name'
+              WHERE memory_id = ?1 AND binding_kind = 'symbol'",
+            params![memory_id],
+        )
+        .unwrap();
+
+    db.memory_validate().unwrap();
+
+    let refreshed: String = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT binding_id FROM repo_memory_bindings
+              WHERE memory_id = ?1 AND binding_kind = 'symbol'",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        refreshed, live_name,
+        "the binding must carry the name the row answers to now, not the one it was made against"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// An impl symbol is named for its self type, so `{path}::{name}` is shared by `struct Worker` and
+/// its `impl Worker` block. Once a reindex churns the raw row id, relocation searches that shared
+/// name — and picking the first row is a coin flip that can move an impl memory onto the struct.
+/// The binding's own kind and signature decide instead.
+#[test]
+fn a_symbol_binding_relocates_onto_its_own_twin_not_a_same_named_sibling() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub struct Twin;\n\nimpl Twin {\n    pub fn method(&self) {}\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let impl_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM symbols WHERE name = 'Twin' AND kind = 'impl'", [], |r| r.get(0))
+        .unwrap();
+    let struct_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM symbols WHERE name = 'Twin' AND kind = 'struct'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_ne!(impl_id, struct_id, "the fixture must produce both twins");
+
+    let created = db
+        .memory_create(rag_rat_query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to the impl block".to_string(),
+            body: "This memory is about the impl, not the struct.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: rag_rat_query::memory::RepoMemoryBindTarget {
+                symbol_id: Some(impl_id),
+                logical_symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                tracker: None,
+                project: None,
+                item_key: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    // Both twins answer to this name; only the discriminators separate them.
+    let shared_name: String = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT (SELECT value FROM name_strings WHERE id = s.qualified_name_id)
+               FROM symbols s WHERE s.id = ?1",
+            params![impl_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let struct_name: String = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT (SELECT value FROM name_strings WHERE id = s.qualified_name_id)
+               FROM symbols s WHERE s.id = ?1",
+            params![struct_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(shared_name, struct_name, "the twins must share a qualified name");
+
+    // The raw id is gone, exactly as a reindex leaves it; only the name and discriminators remain.
+    db.storage
+        .connection()
+        .execute("UPDATE repo_memory_bindings SET symbol_id = NULL WHERE memory_id = ?1", params![
+            memory_id
+        ])
+        .unwrap();
+
+    db.memory_validate().unwrap();
+
+    let landed: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT symbol_id FROM repo_memory_bindings
+              WHERE memory_id = ?1 AND binding_kind = 'symbol'",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(landed, impl_id, "the impl memory must relocate onto the impl, not its struct");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Two impls of different traits for one type are indistinguishable by the shape discriminators:
+/// both are named for the self type, both are kind `impl`, and with the trait on the line after
+/// `impl` — what a formatter produces for long bounds — both capture the same signature. Only the
+/// logical handle, derived from a key that hashes `scope_path`, tells `Twin as Alpha` from
+/// `Twin as Beta`.
+#[test]
+fn a_symbol_binding_separates_two_trait_impls_on_one_type() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (alpha_id, beta_id) = trait_impl_twins(&db);
+
+    let created = db
+        .memory_create(rag_rat_query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to the Beta impl".to_string(),
+            body: "This memory is about Beta for Twin, not Alpha for Twin.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: rag_rat_query::memory::RepoMemoryBindTarget {
+                symbol_id: Some(beta_id),
+                logical_symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                tracker: None,
+                project: None,
+                item_key: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+
+    // The raw id is gone, exactly as a reindex leaves it; only the name, the shape discriminators
+    // — which both impls satisfy — and the logical handle remain.
+    db.storage
+        .connection()
+        .execute("UPDATE repo_memory_bindings SET symbol_id = NULL WHERE memory_id = ?1", params![
+            memory_id
+        ])
+        .unwrap();
+
+    db.memory_validate().unwrap();
+
+    let landed: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT symbol_id FROM repo_memory_bindings
+              WHERE memory_id = ?1 AND binding_kind = 'symbol'",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        landed, beta_id,
+        "the Beta memory must relocate onto Beta, not the lower-id Alpha ({alpha_id})"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Strip the logical handle too and the two impls become genuinely indistinguishable. The contract
+/// there is a deterministic pick — the lowest id — not a guess that can move between runs.
+#[test]
+fn a_symbol_binding_without_a_logical_handle_keeps_the_deterministic_pick() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (alpha_id, beta_id) = trait_impl_twins(&db);
+
+    let created = db
+        .memory_create(rag_rat_query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to the Beta impl with no handle".to_string(),
+            body: "Nothing left on the binding can tell the two impls apart.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: rag_rat_query::memory::RepoMemoryBindTarget {
+                symbol_id: Some(beta_id),
+                logical_symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                tracker: None,
+                project: None,
+                item_key: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE repo_memory_bindings SET symbol_id = NULL, logical_symbol_id = NULL
+              WHERE memory_id = ?1",
+            params![memory_id],
+        )
+        .unwrap();
+
+    db.memory_validate().unwrap();
+
+    let (landed, status): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT symbol_id, anchor_status FROM repo_memory_bindings
+              WHERE memory_id = ?1 AND binding_kind = 'symbol'",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(landed, alpha_id, "with no evidence left the pick must stay the lowest id");
+    assert_eq!(status, "relocated");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Each trait sits on the line AFTER `impl` so both impl symbols capture the same signature text,
+/// which is what leaves the logical handle as the only discriminator.
+const TWO_TRAIT_IMPLS_FIXTURE: &str = "pub struct Twin;\npub trait Alpha { fn run(&self); }\npub \
+                                       trait Beta { fn run(&self); }\nimpl\nAlpha for Twin { fn \
+                                       run(&self) {} }\nimpl\nBeta for Twin { fn run(&self) {} }\n";
+
+/// The two impl rows, id-ascending, with the preconditions that make the twin tests load-bearing:
+/// they must agree on qualified name, kind and signature, and differ only in `scope_path`.
+fn trait_impl_twins(db: &IndexDatabase) -> (i64, i64) {
+    let rows: Vec<(i64, i64, String, String, String)> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, qualified_name_id, kind, COALESCE(signature, ''), scope_path
+                   FROM symbols WHERE name = 'Twin' AND kind = 'impl' ORDER BY id",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)))
+            .unwrap();
+        rows.collect::<rusqlite::Result<_>>().unwrap()
+    };
+    assert_eq!(rows.len(), 2, "the fixture must produce exactly two impl rows: {rows:?}");
+    let (alpha, beta) = (&rows[0], &rows[1]);
+    assert_eq!(alpha.1, beta.1, "the impls must share a qualified name");
+    assert_eq!(alpha.2, beta.2, "the impls must share a kind");
+    assert_eq!(alpha.3, beta.3, "the impls must capture the same signature: {rows:?}");
+    assert_eq!(alpha.4, "Twin as Alpha", "the lower-id impl must be the Alpha one");
+    assert_eq!(beta.4, "Twin as Beta", "the higher-id impl must be the Beta one");
+    (alpha.0, beta.0)
+}
+
+/// Version 2 hashes `scope_path` for EVERY language, but the column landed nullable with no
+/// backfill — a row indexed before it reads as `''` here while a fresh index hashes a real
+/// enclosing scope. Refreshing only Rust would let a non-Rust legacy row take a version-2 stamp
+/// carrying a key no fresh index produces, and nothing afterwards would owe it a re-derivation.
+#[test]
+fn a_legacy_row_in_any_language_has_its_scope_re_derived() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/app.py"), "class Outer:\n    def inner(self):\n        return 1\n")
+        .unwrap();
+    let config = source_config(root.clone(), Language::Python);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let fresh: String = db
+        .storage
+        .connection()
+        .query_row("SELECT scope_path FROM symbols WHERE name = 'inner'", [], |r| r.get(0))
+        .unwrap();
+    assert!(fresh.contains("Outer"), "the fresh scope must carry the enclosing class: {fresh}");
+    drop(db);
+
+    // A pre-`scope_path` index: the column exists but was never derived for this row, and the key
+    // version is unstamped so the heal runs.
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute("UPDATE symbols SET scope_path = NULL WHERE name = 'inner'", []).unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+        conn.execute("UPDATE repo_meta SET value = '0' WHERE key = 'graph_index_version'", [])
+            .unwrap();
+    }
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let healed: Option<String> = db
+        .storage
+        .connection()
+        .query_row("SELECT scope_path FROM symbols WHERE name = 'inner'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        healed.as_deref(),
+        Some(fresh.as_str()),
+        "a legacy non-Rust row must be re-derived to the scope a fresh index gives it"
+    );
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -3766,3 +3766,121 @@ fn adoption_repoints_change_couplings_consistently_with_its_stamp() {
         .unwrap();
     assert_eq!(computed_at, 50, "matching stamp => no recompute; the adopted rows survive intact");
 }
+
+/// `realign_logical_symbol_ids` recomputes a group's content-derived id and moves every durable
+/// reference onto it. It may only do that when the group's members AGREE on their owner scope.
+///
+/// A pre-upgrade group can hold the exact collision this version fixes — same-named,
+/// same-signature methods under different impl owners merged into one logical symbol. Reading one
+/// member's scope arbitrarily would realign the shared group, and every memory bound to it, onto
+/// that single owner's identity; the drift heal would then see an unchanged reference and hand the
+/// shared bindings to an arbitrary owner instead of treating the split as ambiguous.
+#[test]
+fn realign_skips_a_group_whose_members_disagree_on_their_owner() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+    conn.execute(
+        "INSERT INTO files(repo_id, path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+             commit_sha, worktree_id)
+         VALUES ('r', 'src/lib.rs', 'rust', 'source', 's', 0, 0, '', '')",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('src/lib.rs::run')", [])
+        .unwrap();
+    let qn: i64 = conn
+        .query_row("SELECT id FROM name_strings WHERE value = 'src/lib.rs::run'", [], |r| r.get(0))
+        .unwrap();
+
+    // Two DISTINCT owners' methods, merged under one legacy logical symbol.
+    let mut members = Vec::new();
+    for (owner, line) in [("Alpha", 1), ("Beta", 5)] {
+        conn.execute(
+            "INSERT INTO symbols(file_id, name, kind, language, qualified_name_id, scope_path,
+                 signature, start_line, end_line, start_byte, end_byte)
+             VALUES (?1, 'run', 'function', 'rust', ?2, ?3, 'fn run(&self)', ?4, ?4, ?4, ?4)",
+            rusqlite::params![file_id, qn, format!("{owner}::run"), line],
+        )
+        .unwrap();
+        members.push(conn.last_insert_rowid());
+    }
+    conn.execute(
+        "INSERT INTO logical_symbols(id, repo_id, language, path, logical_name, qualified_name_id,
+             kind, variant_count, group_reason)
+         VALUES (4242, 'r', 'rust', 'src/lib.rs', 'run', ?1, 'function', 2, 'cfg')",
+        [qn],
+    )
+    .unwrap();
+    for symbol_id in &members {
+        conn.execute(
+            "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, \
+             end_line)
+             VALUES (4242, ?1, 1, 1)",
+            [symbol_id],
+        )
+        .unwrap();
+    }
+
+    let remapped = crate::index::graph_index::realign_logical_symbol_ids(&conn).unwrap();
+
+    assert_eq!(remapped, 0, "a group with disagreeing member scopes must not be realigned");
+    let still_there: i64 = conn
+        .query_row("SELECT COUNT(*) FROM logical_symbols WHERE id = 4242", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(still_there, 1, "the merged group is left for the key-drift relocation path");
+}
+
+/// Binder spelling is canonicalized at EXTRACTION, so `impl<T> Foo<T>` and `impl<U> Foo<U>` both
+/// store `Foo<_>` and are one legitimate group. It must still realign; deferring it would strand
+/// the row and its durable references on an id hashed from the OLD repo id after adoption
+/// re-points `repo_id`.
+#[test]
+fn realign_still_moves_a_group_of_canonically_equal_scopes() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+    conn.execute(
+        "INSERT INTO files(repo_id, path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+             commit_sha, worktree_id)
+         VALUES ('r', 'src/lib.rs', 'rust', 'source', 's', 0, 0, '', '')",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('src/lib.rs::run')", [])
+        .unwrap();
+    let qn: i64 = conn
+        .query_row("SELECT id FROM name_strings WHERE value = 'src/lib.rs::run'", [], |r| r.get(0))
+        .unwrap();
+    for (scope, line) in [("Foo<_>::run", 1), ("Foo<_>::run", 5)] {
+        conn.execute(
+            "INSERT INTO symbols(file_id, name, kind, language, qualified_name_id, scope_path,
+                 signature, start_line, end_line, start_byte, end_byte)
+             VALUES (?1, 'run', 'function', 'rust', ?2, ?3, 'fn run(&self)', ?4, ?4, ?4, ?4)",
+            rusqlite::params![file_id, qn, scope, line],
+        )
+        .unwrap();
+        let symbol_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO logical_symbols(id, repo_id, language, path, logical_name,
+                 qualified_name_id, kind, variant_count, group_reason)
+             VALUES (4243, 'r', 'rust', 'src/lib.rs', 'run', ?1, 'function', 2, 'cfg')
+             ON CONFLICT(id) DO NOTHING",
+            [qn],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, \
+             end_line)
+             VALUES (4243, ?1, 1, 1)",
+            [symbol_id],
+        )
+        .unwrap();
+    }
+
+    let remapped = crate::index::graph_index::realign_logical_symbol_ids(&conn).unwrap();
+
+    assert_eq!(remapped, 1, "one canonical owner is one group and must be realigned");
+}

--- a/crates/rag-rat-query/src/memory/resolve.rs
+++ b/crates/rag-rat-query/src/memory/resolve.rs
@@ -402,9 +402,18 @@ pub(crate) fn chunk_for_symbol(
         JOIN files ON files.id = symbols.file_id
         LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         LEFT JOIN chunks ON chunks.file_id = files.id
-            AND (chunks.symbol_path = qn.value OR chunks.symbol_path = ?2)
+            AND (chunks.symbol_id = symbols.id
+                 OR chunks.symbol_path = qn.value
+                 OR chunks.symbol_path = ?2)
         WHERE symbols.id = ?1
-        ORDER BY CASE WHEN chunks.symbol_path = qn.value THEN 0 ELSE 1 END,
+        -- The id first, because the PATH is not unique: an impl is named for its self type, so
+        -- `struct W`, `impl A for W` and `impl B for W` all answer to `src/lib.rs::W`. Ordering by
+        -- path alone then hands whichever starts earliest in the file — usually the struct — so a
+        -- memory on one impl would carry another symbol's source hash and line range. The path
+        -- match stays for rows indexed before chunks carried a symbol id.
+        ORDER BY CASE WHEN chunks.symbol_id = symbols.id THEN 0
+                      WHEN chunks.symbol_path = qn.value THEN 1
+                      ELSE 2 END,
                  chunks.start_line
         LIMIT 1
         ",
@@ -432,9 +441,14 @@ pub(crate) fn chunk_for_logical_symbol(
         JOIN files ON files.id = symbols.file_id
         LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         LEFT JOIN chunks ON chunks.file_id = files.id
-            AND chunks.symbol_path = qn.value
+            AND (chunks.symbol_id = symbols.id OR chunks.symbol_path = qn.value)
         WHERE logical_symbol_members.logical_symbol_id = ?1
-        ORDER BY logical_symbol_members.start_line, chunks.start_line
+        -- Same reason as `chunk_for_symbol`: the path is shared by a type and every impl on it,
+        -- so the member's own id has to win before the file-order tiebreak sends the group to a
+        -- neighbour's chunk.
+        ORDER BY CASE WHEN chunks.symbol_id = symbols.id THEN 0 ELSE 1 END,
+                 logical_symbol_members.start_line,
+                 chunks.start_line
         LIMIT 1
         ",
         [logical_symbol_id],

--- a/crates/rag-rat-query/src/memory/validate.rs
+++ b/crates/rag-rat-query/src/memory/validate.rs
@@ -89,7 +89,8 @@ pub(crate) fn validate_logical_symbol_binding(
             SELECT ls.id, ls.path, ls.kind,
                    (SELECT s.signature FROM logical_symbol_members m
                       JOIN symbols s ON s.id = m.symbol_id
-                     WHERE m.logical_symbol_id = ls.id LIMIT 1)
+                     WHERE m.logical_symbol_id = ls.id LIMIT 1),
+                   ls.id
             FROM logical_symbols ls
             WHERE ls.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
               AND ls.repo_id = ?2
@@ -102,15 +103,16 @@ pub(crate) fn validate_logical_symbol_binding(
                 path: row.get(1)?,
                 kind: row.get(2)?,
                 signature: row.get(3)?,
+                logical_symbol_id: row.get(4)?,
             })
         })?;
         rows.collect::<rusqlite::Result<_>>()?
     };
-    let relocated = pick_relocation_twin(
-        candidates,
-        binding.symbol_kind.as_deref(),
-        binding.signature_hash.as_deref(),
-    );
+    // The group axis is inert here by construction: this arm is only reached when the binding's
+    // handle is absent or names a row that no longer exists, and a dead id can never equal a live
+    // candidate's. Impl twins are still separated where it matters — the stable-id arm above
+    // resolves them on its own, since the logical key hashes `scope_path`.
+    let relocated = pick_relocation_twin(candidates, binding);
     if let Some((id, path)) = relocated {
         binding.logical_symbol_id = Some(id);
         binding.path = Some(path);
@@ -150,30 +152,44 @@ struct RelocationTwin {
     path: String,
     kind: String,
     signature: Option<String>,
+    /// The logical group this twin belongs to — for a logical-symbol candidate, itself.
+    logical_symbol_id: Option<i64>,
 }
 
 /// Choose which same-qualified-name twin a gone binding relocates onto (#491): the stored
-/// discriminators win — kind agreement outranks signature-hash agreement (a rename usually keeps
-/// the kind but changes the signature text) — and equal evidence falls back to the lowest id, so
-/// the pick is deterministic instead of plan-order. `None` evidence on the binding degrades
-/// gracefully: every candidate scores equally and the id tiebreak decides, matching the old
-/// behavior for bindings that predate the V014 discriminators.
+/// discriminators win, and equal evidence falls back to the lowest id, so the pick is deterministic
+/// instead of plan-order.
+///
+/// The logical handle outranks both shape axes because it is derived from the whole logical key,
+/// `scope_path` included, which makes it the only stored evidence that separates two impls of
+/// different traits for one type: an impl symbol is named for its self type, so `impl Alpha for W`
+/// and `impl Beta for W` agree on the qualified name, agree on `impl`, and — with the trait on a
+/// later line, as a formatter produces for long bounds — agree on the captured signature too. Kind
+/// then outranks signature, since a rename usually keeps the kind but changes the signature text.
+/// `None` evidence on the binding degrades gracefully: every candidate scores equally on the axes
+/// it can't speak to, and the id tiebreak decides, matching the behavior for bindings that predate
+/// the V014 discriminators.
 fn pick_relocation_twin(
     candidates: Vec<RelocationTwin>,
-    bound_kind: Option<&str>,
-    bound_signature_hash: Option<&str>,
+    binding: &RepoMemoryBinding,
 ) -> Option<(i64, String)> {
     candidates
         .into_iter()
         .map(|twin| {
-            let kind_agrees = bound_kind == Some(twin.kind.as_str());
-            let signature_agrees = match (bound_signature_hash, &twin.signature) {
+            let group_agrees = matches!(
+                (binding.logical_symbol_id, twin.logical_symbol_id),
+                (Some(bound), Some(group)) if bound == group
+            );
+            let kind_agrees = binding.symbol_kind.as_deref() == Some(twin.kind.as_str());
+            let signature_agrees = match (binding.signature_hash.as_deref(), &twin.signature) {
                 (Some(bound), Some(sig)) => bound == hex_sha256(sig.trim().as_bytes()),
                 _ => false,
             };
             // Candidates arrive id-ascending; max_by_key keeps the LAST maximum, so compare on
             // (score, negated id) to keep the lowest-id winner among evidence ties.
-            let score = (u8::from(kind_agrees) << 1) | u8::from(signature_agrees);
+            let score = (u8::from(group_agrees) << 2)
+                | (u8::from(kind_agrees) << 1)
+                | u8::from(signature_agrees);
             (score, -twin.id, twin)
         })
         .max_by_key(|(score, neg_id, _)| (*score, *neg_id))
@@ -185,23 +201,54 @@ pub(crate) fn validate_symbol_binding(
     binding: &mut RepoMemoryBinding,
 ) -> anyhow::Result<String> {
     if let Some(id) = binding.symbol_id
-        && crate::symbol::lookup_by_id(conn, id)?.is_some()
+        && let Some(hit) = crate::symbol::lookup_by_id(conn, id)?
     {
+        // The row id proves WHICH symbol this is; `binding_id` is only the qualified name every
+        // later relocation searches by. A rename in place — an index upgrade re-deriving an impl's
+        // identity moves the row's name from the trait to the type — leaves the two disagreeing,
+        // and nothing notices until the next reindex churns the row id. Relocation then looks up a
+        // name that no longer belongs to this symbol and attaches the memory to whatever else
+        // answers to it, or calls it gone. Refresh the name while the id still vouches for it.
+        if hit.qualified_name != binding.binding_id {
+            binding.binding_id = hit.qualified_name;
+        }
+        // The row can also be REGROUPED without moving: a key-version rebuild mints a new logical
+        // id for the same impl. The raw id still proves the binding's identity, so re-read the
+        // handle here — leaving the vanished one in place reports `current` forever while every
+        // logical-id-keyed surface stays disconnected from the symbol.
+        binding.logical_symbol_id = logical_symbol_id_for_symbol(conn, id)?;
         return validate_bound_chunk(conn, binding);
     }
-    let relocated = conn
-        .query_row(
+    // One qualified name can hold several live rows: `{path}::{name}` is shared by a `struct
+    // Worker` and its `impl Worker` block, since an impl symbol is named for its self type. A
+    // `LIMIT 1` here is a plan-order coin flip between them, so the binding's own discriminators
+    // pick — the same rule, and the same helper, the logical-symbol path uses. Each candidate
+    // carries its logical group, keyed on its own row id so the correlated read adds no scope
+    // surface, because the group is what separates two impls of different traits for one type.
+    let candidates: Vec<RelocationTwin> = {
+        let mut stmt = conn.prepare(
             "
-            SELECT symbols.id, files.path
+            SELECT symbols.id, files.path, symbols.kind, symbols.signature,
+                   (SELECT m.logical_symbol_id FROM logical_symbol_members m
+                     WHERE m.symbol_id = symbols.id LIMIT 1)
             FROM symbols
             JOIN files ON files.id = symbols.file_id
             WHERE symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
-            LIMIT 1
+            ORDER BY symbols.id
             ",
-            [&binding.binding_id],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
-        )
-        .optional()?;
+        )?;
+        let rows = stmt.query_map([&binding.binding_id], |row| {
+            Ok(RelocationTwin {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                kind: row.get(2)?,
+                signature: row.get(3)?,
+                logical_symbol_id: row.get(4)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<_>>()?
+    };
+    let relocated = pick_relocation_twin(candidates, binding);
     if let Some((id, path)) = relocated {
         binding.symbol_id = Some(id);
         binding.logical_symbol_id = logical_symbol_id_for_symbol(conn, id)?;


### PR DESCRIPTION
Split out of #976, which had grown to 33 files and 4,270 insertions across extraction, identity, resolution, and the on-open heal. This is the identity half — the base the receiver-type work sits on — and it stands on its own.

## The defect

`LogicalSymbolKey` had no owner discriminator, so two methods with the same name and the same declaration line collapsed into one logical symbol even when different types owned them. `impl Alpha { fn run(&self) }` and `impl Beta { fn run(&self) }` in one file shared a `sym_<hex>` handle, and with it every logical-id-anchored surface — including repo-memory bindings.

Adding the scope to the key only helps if the scope identifies the owner, and for Rust it did not.

## What an impl's identity is

Two impls in one file are the same entity exactly when a single compilation could not hold both, which makes rustc's coherence check the authority. Probed directly:

| probe | rustc | conclusion |
|---|---|---|
| `impl<T> A for F<T>` + `impl<U> A for F<U>` | E0119, "for type `F<_>`" | cannot coexist ⇒ cfg variants ⇒ must collapse |
| `impl<'a> Tr for &'a W` + `impl Tr for &'static W` | E0119, "for type `&W`" | lifetimes erased before coherence ⇒ never distinguish ⇒ must fold |
| `impl Runs for W` / `&W` / `*const W` / `*mut W` | all compile | four entities ⇒ must stay separate |
| `impl A for F<u8>` + `impl A for F<u16>` | both compile | concrete arguments are identity |

rustc's own E0119 rendering (`F<_>`, `&W`) is the canonical form, and it is free to adopt because the compiler already validated that it separates exactly what can coexist.

## Three changes

**The trait was dropped**, so `impl Display for W` and `impl Debug for W` gave their same-signature members one scope. The segment now reads `W as std.fmt.Display` — the whole path, because a tail alone merges `a::Runs` with `b::Runs`, and with `::` rewritten to `.` so the marker stays one `::`-segment for the resolution fold to split on.

**The self type was reduced to its innermost nominal node**, so `impl Neg for W` and `impl Neg for &W` collapsed. The idiomatic operator quartet — whose `type Output` is byte-identical across all four impls — is the shape that hits this constantly. A non-nominal target (`()`, `(A, B)`, `[T]`, `dyn X`) had no node to name and dropped the impl's scope segment *entirely*, leaving its members at file scope where they can collide with free functions. The self type is now rendered, wrapper and all.

**Lifetimes are erased**, per the coherence probe above. This is also a recall gain: 7.1% of sampled impls have a lifetime-only generic owner whose members carry `Foo<'a>::m` and therefore can never hit the exact resolution tier for `Foo::m`.

Resolution keeps a permissive view over all of it — `normalized_scope_path` folds generics, the trait marker, and the wrapper away, so `W::method` still finds `&W as Neg::method`, and a call that could hit either impl declines as ambiguous rather than guessing.

## Measured

Scanned a 1,442-crate registry checkout: **43,960 files, 285,947 impl blocks, 5,238 impl-member logical collapses in 1,811 files — only 1,580 legitimate cfg variants. 70% of every impl-member collapse in real Rust was wrong.** The wrapper case alone is 1,391 of them, non-nominal targets 862.

On this repo's own sources the symbol and logical-symbol counts are unchanged (it has no wrong collapses to fix — every binder here is a single letter and no file pairs the shapes), 73 scopes shed a lifetime, and 136 edges move from `scope_degeneric` to `scope_exact`/`receiver_type` — the same target symbol reached through stronger evidence, nothing retargeted.

## Migration

`LOGICAL_KEY_VERSION` 1→2 and `GRAPH_INDEX_VERSION` 11→12. The on-open heal refreshes persisted `scope_path` in place, matched on `(file_id, start_byte, end_byte, name, kind)` — no chunk or embedding churn.

## Not in scope

Binder names still leak into the scope and concrete generic arguments are still folded, so binder-renamed cfg variants split where they should group. That is the alpha-normalization half of the same rule — #1012 — and splitting is the safe direction to be wrong in meanwhile.

## Second commit

The heal itself needed work before it could carry a scope migration. It runs on the OPEN path, so a per-file error wedges the database for every later open; four ordinary states did that. And it walks the repo's whole generation — every commit and worktree scope — while reading from one checkout, so it was rebuilding sibling worktrees' rows from the active checkout's bytes. Each row is now gated on its own `files.sha256`, and partial coverage defers the logical-key stamp instead of writing it. Details in the commit message; the follow-up for per-row resumability is #1014.