### PR TITLE
fix(oracle): separate the checkout ceiling, the index root, and the indexed corpus (#1008, #1011)

### DIFF
--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -423,19 +423,80 @@ fn push_target(
     root: &Path,
     names: &mut BTreeSet<String>,
     targets: &mut Vec<ResolvedTarget>,
-    target: ResolvedTarget,
+    mut target: ResolvedTarget,
 ) -> Result<(), ConfigError> {
     if !names.insert(target.name.clone()) {
         return Err(ConfigError::DuplicateTarget(target.name));
     }
+    let mut root_relative = Vec::with_capacity(target.directories.len());
     for directory in &target.directories {
         let full_path = root.join(directory);
         if !full_path.is_dir() {
             return Err(ConfigError::MissingDirectory(directory.clone()));
         }
+        let Some(contained) = root_relative_within(root, &full_path) else {
+            return Err(ConfigError::TargetOutsideRoot(directory.clone()));
+        };
+        // The ROOT itself keeps its `.` spelling rather than relativizing to the empty path. The
+        // stored strings are compared literally against a corpus profile's declared bindings
+        // (`ensure_checkout_matches_corpus`), and the shipped profiles spell the whole-root binding
+        // `.` — rewriting it would make `oracle report --corpus <id>` reject a checkout indexed
+        // exactly as its own profile specifies.
+        root_relative.push(if contained.as_os_str().is_empty() {
+            PathBuf::from(".")
+        } else {
+            contained
+        });
     }
+    // `ResolvedTarget.directories` are ROOT-RELATIVE by contract — every consumer joins them onto a
+    // root or prefix-matches a root-relative path against them. An absolute directory satisfies the
+    // join (it wins outright) but can never prefix-match, so a target configured absolutely would
+    // be walked and indexed while every predicate over it — `target_for_path`, and the live
+    // oracle's corpus — reported its files as belonging to no target. Storing the contained
+    // form is what makes the contract true rather than merely documented.
+    target.directories = root_relative;
     targets.push(target);
     Ok(())
+}
+
+/// Whether `path` lies under `root`, judged on the path text alone.
+///
+/// LEXICAL, never `canonicalize`. Existence is already established by the caller, and resolving
+/// links would make containment depend on how the operator spelled the root rather than on what
+/// the config says — a root reached through a symlink would start refusing its own directories.
+///
+/// Collapsing `..` first is the whole point: `Path::starts_with` compares components, so the
+/// uncollapsed `<root>/../shared` "starts with" `<root>` and every upward escape would pass. An
+/// absolute directory needs no collapsing to escape at all — `Path::join` discards the root for
+/// one — which is why this tests the JOINED path rather than counting `..` in the configured one.
+fn root_relative_within(root: &Path, path: &Path) -> Option<PathBuf> {
+    // TWO questions, deliberately answered by different means.
+    //
+    // The stored value is LEXICAL, because it must match the spelling the indexing walk produces.
+    // `walk_target` joins the configured directory onto the root and enters it with `is_dir()`,
+    // which follows links — so a target spelled `src` where `src -> real_sources` yields paths
+    // under `src/`, and rewriting the stored directory to `real_sources` would leave every
+    // predicate over it (`target_for_path`, the live oracle's corpus) unable to match the very
+    // files it indexed.
+    //
+    // CONTAINMENT is checked against the filesystem as well, because the textual collapse lies
+    // about a `..` that follows a symlink: with `link -> /outside/project`, the directory
+    // `link/../src` that `is_dir()` just validated is `/outside/src`, while collapsing
+    // textually yields `<root>/src`. Accepting that would validate one directory and store a
+    // path naming another, and indexing would silently walk a tree nobody checked.
+    let relative = crate::paths::lexically_normalized(path)?
+        .strip_prefix(crate::paths::lexically_normalized(root)?)
+        .ok()?
+        .to_path_buf();
+    // When both resolve, the filesystem has the final say on containment. When either does not — a
+    // root the caller has not created, a directory racing a delete — the textual answer is all
+    // there is, and it is the one this function gave before.
+    if let (Ok(canonical_root), Ok(canonical_path)) = (root.canonicalize(), path.canonicalize())
+        && !canonical_path.starts_with(&canonical_root)
+    {
+        return None;
+    }
+    Some(relative)
 }
 
 /// Re-anchor a **linked** worktree's `root` to the equivalent path under the **main** worktree, so

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -138,6 +138,12 @@ pub enum ConfigError {
     DuplicateTarget(String),
     #[error("configured directory does not exist: {0}")]
     MissingDirectory(PathBuf),
+    #[error(
+        "configured directory `{0}` lies outside `[index] root` — every indexed file must sit \
+         under the root, and one that doesn't fails the index run itself. Raise `[index] root` to \
+         the directory that encloses both, or drop this target"
+    )]
+    TargetOutsideRoot(PathBuf),
     #[error("[log] `level` must be one of off|error|warn|info|debug|trace (got `{0}`)")]
     UnknownLogLevel(String),
     #[error("[log] `format` must be `text` or `json` (got `{0}`)")]

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -2814,6 +2814,133 @@ fn rejects_unknown_language() {
     assert!(err.to_string().contains("unknown language"));
 }
 
+/// A target directory that escapes `[index] root` is refused at load, not at index time.
+///
+/// `push_target` only ever proved the directory EXISTS, so `../shared` was accepted here and then
+/// failed the whole index run in `collect_index_files`, whose `strip_prefix(&config.root)` reports
+/// a bare `prefix not found` naming nothing. The containment check moves that failure to the point
+/// the mistake was made, and it is what lets the live oracle treat "under the index root" as the
+/// corpus boundary rather than as a convention (#1008).
+#[test]
+fn rejects_a_target_directory_that_escapes_the_index_root() {
+    let dir = scratch("target-escapes-root");
+    let root = dir.join("repo");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("shared")).unwrap();
+    let simple = BTreeMap::from([("rust".to_string(), vec!["../shared".to_string()])]);
+
+    let err = config::resolve_targets(&root, simple, Vec::new()).unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("../shared"), "names the offending directory: {message}");
+    assert!(message.contains("[index] root"), "names the remedy: {message}");
+}
+
+/// The other escape shape, and the reason the check cannot be a `..`-count: `Path::join` DISCARDS
+/// the root entirely for an absolute argument, so an absolute directory never had to traverse
+/// upward to leave the root.
+#[test]
+fn rejects_an_absolute_target_directory_outside_the_index_root() {
+    let dir = scratch("absolute-target-outside-root");
+    let root = dir.join("repo");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let outside = dir.join("shared");
+    std::fs::create_dir_all(&outside).unwrap();
+    let simple =
+        BTreeMap::from([("rust".to_string(), vec![outside.to_string_lossy().into_owned()])]);
+
+    let err = config::resolve_targets(&root, simple, Vec::new()).unwrap_err();
+
+    assert!(err.to_string().contains("[index] root"), "names the remedy: {err}");
+}
+
+/// Containment is judged LEXICALLY, so a root the operator spelled through a symlink still accepts
+/// the directories under it. Canonicalizing instead would make the verdict depend on how the root
+/// was spelled rather than on what the config says.
+#[test]
+fn accepts_a_contained_target_under_a_root_spelled_through_a_symlink() {
+    let dir = scratch("symlinked-root-target");
+    let real = dir.join("real-repo");
+    std::fs::create_dir_all(real.join("src")).unwrap();
+    let linked = dir.join("linked-repo");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&real, &linked).unwrap();
+    #[cfg(not(unix))]
+    std::os::windows::fs::symlink_dir(&real, &linked).unwrap();
+    let simple = BTreeMap::from([("rust".to_string(), vec!["src".to_string()])]);
+
+    let targets = config::resolve_targets(&linked, simple, Vec::new()).unwrap();
+
+    assert_eq!(
+        targets.len(),
+        1,
+        "a contained directory is not refused by the spelling of the root"
+    );
+}
+
+/// Containment normalizes BOTH operands, because a root can itself carry `..`.
+///
+/// `for_linked_worktree_overlay` builds its root as `workdir.join([index] root)` without
+/// canonicalizing, unlike the main load path. Comparing a normalized target path against an
+/// unnormalized root rejected every genuinely contained target — and on that path the failure is
+/// silent (the caller swallows the error and falls back to base targets), so a branch's added
+/// targets would simply disappear from its overlay.
+#[test]
+fn a_root_spelled_with_a_parent_component_still_contains_its_targets() {
+    let dir = scratch("root-with-parent-component");
+    let root = dir.join("repo");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let spelled = root.join("sub").join("..");
+    std::fs::create_dir_all(root.join("sub")).unwrap();
+    let simple = BTreeMap::from([("rust".to_string(), vec!["src".to_string()])]);
+
+    let targets = config::resolve_targets(&spelled, simple, Vec::new()).unwrap();
+
+    assert_eq!(targets.len(), 1, "the root's spelling must not reject its own directories");
+    assert_eq!(targets[0].directories, vec![PathBuf::from("src")]);
+}
+
+/// `ResolvedTarget.directories` are root-relative by contract, so an absolute directory inside the
+/// root is stored in its contained form.
+///
+/// An absolute directory satisfies every `root.join(directory)` (it wins outright) but can never
+/// prefix-match a root-relative path, so such a target was walked and indexed while every predicate
+/// over it — `target_for_path`, and the live oracle's corpus — reported its files as belonging to
+/// no target at all.
+#[test]
+fn an_absolute_target_directory_inside_the_root_is_stored_root_relative() {
+    let dir = scratch("absolute-target-inside-root");
+    let root = dir.join("repo");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let absolute = root.join("src").to_string_lossy().into_owned();
+    let simple = BTreeMap::from([("rust".to_string(), vec![absolute])]);
+
+    let targets = config::resolve_targets(&root, simple, Vec::new()).unwrap();
+
+    assert_eq!(
+        targets[0].directories,
+        vec![PathBuf::from("src")],
+        "stored root-relative, so prefix-matching against a root-relative path works",
+    );
+}
+
+/// A whole-root binding keeps its `.` spelling.
+///
+/// `ensure_checkout_matches_corpus` compares the stored directory strings LITERALLY against a
+/// corpus profile's declared bindings, and the shipped profiles spell the whole-root binding `.`
+/// (`linux-kernel` is `{ c = ["."] }`). Relativizing it to the empty path would make
+/// `oracle report --corpus <id>` reject a checkout indexed exactly as its own profile specifies.
+#[test]
+fn a_whole_root_target_keeps_its_dot_spelling() {
+    let dir = scratch("dot-target-spelling");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    let simple = BTreeMap::from([("rust".to_string(), vec![".".to_string()])]);
+
+    let targets = config::resolve_targets(&dir, simple, Vec::new()).unwrap();
+
+    assert_eq!(targets[0].directories, vec![PathBuf::from(".")]);
+}
+
 #[test]
 fn log_config_defaults_off() {
     let raw: RawConfig = toml::from_str("").unwrap();
@@ -3006,5 +3133,50 @@ fn target_directories_deduplicates_across_targets() {
         dirs,
         vec![PathBuf::from("src"), PathBuf::from("extra"), PathBuf::from("docs")],
         "shared dirs appear once in stable order"
+    );
+}
+
+/// A `..` that follows a SYMLINK does not mean what the path text says, and containment has to
+/// notice. With `link -> <outside>`, the directory `link/../src` that `is_dir()` validates is
+/// `<outside>/src` — collapsing textually would yield `<root>/src`, accepting a directory nothing
+/// looked at and storing a relative path naming a different tree for the walk to index.
+#[cfg(unix)]
+#[test]
+fn a_parent_component_after_a_symlink_is_judged_against_the_filesystem() {
+    let dir = scratch("parent-after-symlink");
+    let root = dir.join("repo");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let outside = dir.join("outside");
+    std::fs::create_dir_all(outside.join("src")).unwrap();
+    std::os::unix::fs::symlink(outside.join("project"), root.join("link")).unwrap();
+    std::fs::create_dir_all(outside.join("project")).unwrap();
+    let simple = BTreeMap::from([("rust".to_string(), vec!["link/../src".to_string()])]);
+
+    let err = config::resolve_targets(&root, simple, Vec::new()).unwrap_err();
+
+    assert!(
+        err.to_string().contains("[index] root"),
+        "the directory that was validated lies outside the root: {err}",
+    );
+}
+
+/// A target directory that is itself a symlink keeps its CONFIGURED spelling. The indexing walk
+/// enters it with `is_dir()` and yields paths under that spelling, so rewriting the stored value to
+/// the link's destination would leave every predicate over the target unable to match its own
+/// files.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_target_directory_keeps_its_configured_spelling() {
+    let dir = scratch("symlinked-target-spelling");
+    std::fs::create_dir_all(dir.join("real_sources")).unwrap();
+    std::os::unix::fs::symlink(dir.join("real_sources"), dir.join("src")).unwrap();
+    let simple = BTreeMap::from([("rust".to_string(), vec!["src".to_string()])]);
+
+    let targets = config::resolve_targets(&dir, simple, Vec::new()).unwrap();
+
+    assert_eq!(
+        targets[0].directories,
+        vec![PathBuf::from("src")],
+        "stored as configured, because that is the spelling the walk produces",
     );
 }

--- a/crates/rag-rat-base/src/paths.rs
+++ b/crates/rag-rat-base/src/paths.rs
@@ -8,3 +8,33 @@ use std::path::Path;
 pub fn path_string(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
+
+/// `path` with `.` dropped and `..` applied to the preceding component, TEXTUALLY — no filesystem
+/// access, no symlink resolution. `None` when a `..` has no component left to consume, which means
+/// the path resolves above the filesystem root.
+///
+/// Lexical rather than `canonicalize` because the callers ask a question about what a path SAYS,
+/// not about what exists: config validation runs before anything is walked, and a compilation
+/// database's entries routinely name files through `../..` that may no longer exist. Canonicalizing
+/// would also make the answer depend on how a root was spelled — a checkout reached through a
+/// symlink would start disagreeing with itself.
+///
+/// Collapsing before any prefix comparison is load-bearing: `Path::starts_with` compares
+/// COMPONENTS, so the uncollapsed `<root>/../elsewhere` still "starts with" `<root>` and every
+/// upward escape would pass a containment test.
+pub fn lexically_normalized(path: &Path) -> Option<std::path::PathBuf> {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {},
+            // A `..` after a root/prefix component has nothing to pop, and anything else that pops
+            // past the start is an escape this cannot represent.
+            std::path::Component::ParentDir =>
+                if !normalized.pop() {
+                    return None;
+                },
+            other => normalized.push(other),
+        }
+    }
+    Some(normalized)
+}

--- a/crates/rag-rat-core/src/index/corpus.rs
+++ b/crates/rag-rat-core/src/index/corpus.rs
@@ -1,0 +1,345 @@
+//! The indexed corpus as an answerable question: which files this checkout actually indexes.
+//!
+//! The live oracle needs this to decide whether a compilation database describes anything this
+//! checkout owns (#1008) and to stop guessing at source locations from directory names (#1011).
+//! It cannot derive it — the crate dependency runs core → oracle — so the oracle declares
+//! [`IndexedCorpus`] and this module supplies the implementation.
+//!
+//! (Not to be confused with `rag_rat_oracle::corpus`, which is the eval-corpus registry — the
+//! benchmark repositories an oracle run is scored against.)
+
+use std::path::Path;
+
+use rag_rat_base::config::{Config, ResolvedTarget};
+use rag_rat_oracle::IndexedCorpus;
+
+use super::discovery;
+use super::ignore_rules::IgnoreMatcher;
+
+/// The real corpus: resolved targets plus the compiled ignore rules — the same two authorities the
+/// indexing walk consults, so "the live oracle thinks this file is ours" cannot drift from "the
+/// indexer indexes it".
+pub(crate) struct ConfiguredCorpus<'a> {
+    config: &'a Config,
+    ignore: IgnoreMatcher,
+    /// `config.targets` pre-sorted by [`ResolvedTarget::index_precedence`].
+    ///
+    /// [`discovery::target_for_path`] sorts on every call, which is free at index time (once per
+    /// walk) and is not free here: the governance read asks this question once per compilation
+    /// database entry, and a large database carries 120k of them, while the maintenance pass holds
+    /// the repository write lock.
+    targets: Vec<&'a ResolvedTarget>,
+}
+
+impl ConfiguredCorpus<'_> {
+    /// Whether a target walk could reach `relative` without crossing a symlink.
+    ///
+    /// The bound is the TARGET DIRECTORY, not the index root, because that is where the walk
+    /// starts: `walk_target` enters its target with `is_dir()`, which FOLLOWS links, and only
+    /// skips symlinked entries it meets while descending. So a symlinked target root is walked
+    /// and its ordinary children are indexed — testing symlinks from the index root instead
+    /// would reject exactly those files and declare a database that names them to govern
+    /// nothing.
+    fn reachable_by_a_target_walk(&self, relative: &Path) -> bool {
+        self.targets.iter().flat_map(|target| target.directories.iter()).any(|dir| {
+            let below = if dir.as_os_str().is_empty() || dir == Path::new(".") {
+                Some(relative)
+            } else {
+                relative.strip_prefix(dir).ok()
+            };
+            below.is_some_and(|below| {
+                !super::prep::path_crosses_symlink(&self.config.root.join(dir), below)
+            })
+        })
+    }
+}
+
+impl<'a> ConfiguredCorpus<'a> {
+    pub(crate) fn new(config: &'a Config) -> Self {
+        let mut targets = config.targets.iter().collect::<Vec<_>>();
+        targets.sort_by_key(|target| target.index_precedence());
+        Self {
+            config,
+            ignore: IgnoreMatcher::compile(&config.root, &config.target_directories()),
+            targets,
+        }
+    }
+}
+
+impl IndexedCorpus for ConfiguredCorpus<'_> {
+    fn indexes_file(&self, absolute: &Path) -> bool {
+        // Outside the root is outside the corpus, and `[index] root` containment is enforced when
+        // the config loads, so no configured target can put an indexed file out here.
+        let Ok(relative) = absolute.strip_prefix(&self.config.root) else {
+            return false;
+        };
+        // Everything below mirrors what `walker::walk_target` would actually DO with this path.
+        // Approximating it is how this predicate drifts from the thing it claims to be: a
+        // compilation database whose only apparent corpus coverage is a path the indexer never
+        // yields would be judged to govern the checkout, get pinned globally, and have its inferred
+        // flags produce trusted definitions for the files that genuinely are indexed.
+        //
+        // The walker yields an entry only when `file_type().is_file()` — from `read_dir`, so it
+        // does NOT follow links. A path that does not exist (a database left stale by a delete or
+        // rename), a directory, and a symlink all fail that test.
+        if !absolute.symlink_metadata().is_ok_and(|meta| meta.file_type().is_file()) {
+            return false;
+        }
+        self.reachable_by_a_target_walk(relative)
+            && !self.ignore.is_ignored(absolute, false)
+            && discovery::target_claims_path(&self.targets, relative).is_some()
+    }
+
+    fn may_hold_indexed_files(&self, dir: &Path) -> bool {
+        if self.ignore.is_ignored(dir, true) {
+            return false;
+        }
+        // Outside the root nothing is indexed — `[index] root` containment is enforced at config
+        // load — so such a directory holds no indexed file whatever the ignore rules say about it.
+        let Ok(relative) = dir.strip_prefix(&self.config.root) else {
+            return false;
+        };
+        // The ignore rules alone are not enough. With narrow targets (`src/` only), every unignored
+        // directory would still be reported as possibly holding indexed files, so a large unbound
+        // tree — the kind the blanket dot-directory rule used to skip for free — is now walked in
+        // full by the warm-up search, while the maintenance pass holds the repository write lock.
+        //
+        // Both arms are needed: a directory INSIDE a target subtree can hold indexed files, and one
+        // that is an ANCESTOR of a target must still be entered to reach it (the root itself
+        // relativizes to the empty path, which every target starts with).
+        self.targets.iter().flat_map(|target| target.directories.iter()).any(|target_dir| {
+            // `.` and the empty path both spell "the whole root" — `push_target` keeps the former
+            // for corpus-profile comparison, and `target_claims_path` accepts either.
+            target_dir.as_os_str().is_empty()
+                || target_dir == Path::new(".")
+                || relative.starts_with(target_dir)
+                || target_dir.starts_with(relative)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A checkout with `src` bound as a Rust target, a gitignored `generated/`, and the usual
+    /// machine-written trees.
+    fn fixture(tag: &str) -> (rag_rat_base::test_scratch::ScratchDir, Config) {
+        let dir = rag_rat_base::test_scratch::ScratchDir::new(tag);
+        for relative in ["src", "vendor", "node_modules", "generated", "build"] {
+            std::fs::create_dir_all(dir.join(relative)).unwrap();
+        }
+        std::fs::write(dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(dir.join("vendor/dep.rs"), "pub fn dep() {}\n").unwrap();
+        std::fs::write(dir.join("generated/out.rs"), "pub fn out() {}\n").unwrap();
+        std::fs::write(dir.join(".gitignore"), "generated/\n").unwrap();
+        std::fs::write(
+            dir.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \
+             \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        (dir, config)
+    }
+
+    #[test]
+    fn a_bound_source_is_in_the_corpus_and_an_unbound_sibling_is_not() {
+        let (dir, config) = fixture("corpus-bound-target");
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.indexes_file(&dir.join("src/main.rs")), "a bound target's source");
+        assert!(
+            !corpus.indexes_file(&dir.join("vendor/dep.rs")),
+            "a Rust file no target binds is not this checkout's corpus — which is exactly the \
+             vendored-database case (#1008)",
+        );
+    }
+
+    /// A path reached through a symlink is not in the corpus, because the indexer does not index
+    /// it.
+    ///
+    /// `walker::walk_dir` skips any entry crossing a symlink at any component, so such a file has
+    /// no indexed row. Without the same rule here, a compilation database whose only apparent
+    /// corpus coverage is a symlinked path would be judged to govern the checkout, get pinned
+    /// globally, and have its inferred flags produce trusted definitions for the files that
+    /// genuinely are indexed.
+    #[cfg(unix)]
+    #[test]
+    fn a_source_reached_through_a_symlink_is_not_in_the_corpus() {
+        let (dir, config) = fixture("corpus-symlinked-source");
+        std::fs::write(dir.join("vendor/real.rs"), "pub fn real() {}\n").unwrap();
+        std::os::unix::fs::symlink(dir.join("vendor/real.rs"), dir.join("src/linked.rs")).unwrap();
+        std::os::unix::fs::symlink(dir.join("vendor"), dir.join("src/linked_dir")).unwrap();
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.indexes_file(&dir.join("src/main.rs")), "the control: a real bound source");
+        assert!(
+            !corpus.indexes_file(&dir.join("src/linked.rs")),
+            "a symlinked LEAF under a bound target is not indexed, so it is not in the corpus",
+        );
+        assert!(
+            !corpus.indexes_file(&dir.join("src/linked_dir/real.rs")),
+            "nor is a path crossing a symlinked ancestor",
+        );
+    }
+
+    /// A stale entry — a path deleted or renamed since the database was generated — establishes
+    /// nothing. The walker yields only regular files that exist; a database whose apparent corpus
+    /// coverage is a path that is gone would otherwise be pinned globally and have that obsolete
+    /// entry's flags inferred for the files that do exist.
+    #[test]
+    fn a_path_that_is_not_a_regular_file_is_not_in_the_corpus() {
+        let (dir, config) = fixture("corpus-not-a-regular-file");
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.indexes_file(&dir.join("src/main.rs")), "the control: a real bound source");
+        assert!(
+            !corpus.indexes_file(&dir.join("src/deleted.rs")),
+            "a path the database still names but the checkout no longer has",
+        );
+        std::fs::create_dir_all(dir.join("src/looks_like.rs")).unwrap();
+        assert!(
+            !corpus.indexes_file(&dir.join("src/looks_like.rs")),
+            "a DIRECTORY with a source-shaped name is not a translation unit either",
+        );
+    }
+
+    /// A target directory that is ITSELF a symlink is walked — `walk_target` enters it with
+    /// `is_dir()`, which follows links — so its ordinary children are indexed and belong to the
+    /// corpus. Testing symlinks from the index root instead would reject exactly those files and
+    /// declare a database naming them to govern nothing, disabling live analysis for a checkout
+    /// that indexes fine.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_target_root_is_walked_so_its_children_are_in_the_corpus() {
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("corpus-symlinked-target-root");
+        std::fs::create_dir_all(dir.join("real_sources")).unwrap();
+        std::fs::write(dir.join("real_sources/main.rs"), "pub fn real() {}\n").unwrap();
+        std::os::unix::fs::symlink(dir.join("real_sources"), dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \
+             \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(
+            corpus.indexes_file(&dir.join("src/main.rs")),
+            "the walk starts AT the target, so the target's own link is not a crossing",
+        );
+    }
+
+    #[test]
+    fn a_gitignored_source_is_not_in_the_corpus() {
+        let (dir, config) = fixture("corpus-gitignored");
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(!corpus.indexes_file(&dir.join("generated/out.rs")));
+    }
+
+    /// The floor removes `.cache/clangd` SPECIFICALLY, not all of `.cache` — so a checkout whose
+    /// sources sit under another hidden directory is indexed, and the live oracle's document search
+    /// (which now asks this same corpus) can warm on them (#1011).
+    ///
+    /// This is the half a test double cannot establish: it needs the real floor.
+    #[test]
+    fn the_floor_removes_clangds_index_without_removing_the_rest_of_dot_cache() {
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("corpus-dot-cache");
+        for relative in [".cache/generated", ".cache/clangd"] {
+            std::fs::create_dir_all(dir.join(relative)).unwrap();
+        }
+        std::fs::write(dir.join(".cache/generated/gen.rs"), "pub fn gen() {}\n").unwrap();
+        std::fs::write(dir.join(".cache/clangd/stale.rs"), "pub fn stale() {}\n").unwrap();
+        std::fs::write(
+            dir.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \
+             \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\".cache/generated\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(
+            corpus.indexes_file(&dir.join(".cache/generated/gen.rs")),
+            "a hidden directory bound as a target is an ordinary source location",
+        );
+        assert!(
+            !corpus.may_hold_indexed_files(&dir.join(".cache/clangd")),
+            "clangd's own index never holds this checkout's source",
+        );
+    }
+
+    /// A directory no target can reach holds no indexed file, and saying so is what keeps the
+    /// warm-up search from walking a large unbound tree under the repository write lock.
+    ///
+    /// The ignore rules alone do not answer this: an unignored, unbound `.cache/` is not ignored,
+    /// and it used to be skipped for free by the blanket dot-directory rule the corpus replaced.
+    /// Ancestors of a target must still be admitted, or the walk could never reach the target.
+    #[test]
+    fn a_directory_no_target_can_reach_holds_no_indexed_files() {
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("corpus-unreachable-dirs");
+        for relative in ["src", "deep/nested/gen", ".cache/big"] {
+            std::fs::create_dir_all(dir.join(relative)).unwrap();
+        }
+        std::fs::write(
+            dir.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \
+             \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\"src\", \
+             \"deep/nested/gen\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.may_hold_indexed_files(&dir), "the root is on the way to every target");
+        assert!(corpus.may_hold_indexed_files(&dir.join("src")), "a target subtree");
+        assert!(
+            corpus.may_hold_indexed_files(&dir.join("deep")),
+            "an ancestor of a target must be entered to reach it",
+        );
+        assert!(corpus.may_hold_indexed_files(&dir.join("deep/nested/gen")));
+        assert!(
+            !corpus.may_hold_indexed_files(&dir.join(".cache/big")),
+            "unignored but unreachable by any target — no indexed file can live here",
+        );
+    }
+
+    /// A whole-root binding admits every unignored directory — `.` and the empty path are the same
+    /// statement, and the reachability check must read both.
+    #[test]
+    fn a_whole_root_target_admits_every_unignored_directory() {
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("corpus-dot-binding");
+        std::fs::create_dir_all(dir.join("anywhere/deep")).unwrap();
+        std::fs::write(
+            dir.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \
+             \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\".\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.may_hold_indexed_files(&dir.join("anywhere/deep")));
+        assert!(
+            !corpus.may_hold_indexed_files(&dir.join("node_modules")),
+            "the floor still applies"
+        );
+    }
+
+    #[test]
+    fn a_floored_directory_holds_no_indexed_files() {
+        let (dir, config) = fixture("corpus-floored-dirs");
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.may_hold_indexed_files(&dir.join("src")), "an ordinary source directory");
+        assert!(!corpus.may_hold_indexed_files(&dir.join("node_modules")), "vendored dependencies");
+        assert!(
+            !corpus.may_hold_indexed_files(&dir.join("build")),
+            "a build tree is floored — which is why the MARKER search must not use this \
+             predicate: it is where compilation databases live",
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/discovery.rs
+++ b/crates/rag-rat-core/src/index/discovery.rs
@@ -1,6 +1,7 @@
 //! Discovery: compare configured targets against the index to find
 //! indexed/unindexed/changed/removed files.
 
+use rag_rat_base::config::ResolvedTarget;
 use rag_rat_base::hash::hex_sha256;
 use rag_rat_base::paths::path_string;
 
@@ -217,15 +218,29 @@ pub(crate) fn target_for_path(
     config: &Config,
     relative_path: &Path,
 ) -> Option<(Language, TargetKind)> {
+    let mut targets = config.targets.iter().collect::<Vec<_>>();
+    targets.sort_by_key(|target| target.index_precedence());
+    target_claims_path(&targets, relative_path)
+}
+
+/// Which target claims `relative_path`, over targets ALREADY sorted by
+/// [`ResolvedTarget::index_precedence`].
+///
+/// Split from [`target_for_path`] so a caller that asks this question many times pays for the sort
+/// once. The indexing walk asks it once per file and can afford to sort per call; the live
+/// oracle's governance read asks it once per compilation-database entry, and a large database
+/// carries 120k of them while the maintenance pass holds the repository write lock.
+pub(crate) fn target_claims_path(
+    targets: &[&ResolvedTarget],
+    relative_path: &Path,
+) -> Option<(Language, TargetKind)> {
     let relative = path_string(relative_path);
     // Skip extensionless / non-code files early; the per-target check below decides language by
     // which target CLAIMS the extension, so a `.h` lands on a `cpp` binding (as C++) or a `c`
     // binding (as C) — bare `from_path` detection would force every `.h` to C and starve C++
     // header resolution.
     relative_path.extension().and_then(|ext| ext.to_str())?;
-    let mut targets = config.targets.iter().collect::<Vec<_>>();
-    targets.sort_by_key(|target| target.index_precedence());
-    targets.into_iter().find_map(|target| {
+    targets.iter().find_map(|target| {
         if !target.language.claims_path(relative_path) {
             return None;
         }

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -16,6 +16,7 @@ pub mod remove;
 mod adoption_hints;
 pub(crate) mod change_coupling;
 pub(crate) mod chunk_text_store;
+pub(crate) mod corpus;
 mod discovery;
 mod file_index;
 mod file_rows;

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -99,23 +99,49 @@ impl IndexDatabase {
     pub fn run_live_oracle_pass(
         &self,
         session: &mut rag_rat_oracle::LiveOracleSession,
+        scope: &rag_rat_oracle::CheckoutScope<'_>,
         worklist: &[String],
         max_requests: u64,
         started_at_ms: i64,
     ) -> anyhow::Result<rag_rat_oracle::LivePassReport> {
-        let Some(root) = self.storage.source_root() else {
+        // `scope.root()` is authoritative for where this pass reads and opens documents: the
+        // session's server was spawned with that directory as its working directory and `rootUri`,
+        // so joining paths onto anything else would hand it URIs outside its own initialized
+        // workspace. `source_root` answers a different question — where the indexed ROWS came from
+        // — and it is checked rather than used.
+        let Some(indexed_root) = self.storage.source_root() else {
             anyhow::bail!(
                 "index has no source_root metadata; rebuild required for the live oracle pass"
             );
         };
-        let root = root.to_path_buf();
+        // The two disagreeing means the rows describe a different checkout than the session is
+        // serving (an index carried to a new path, a root reconfigured since the last build). A
+        // per-pass freshness patch cannot reconcile that: it would write verdicts keyed to these
+        // rows from a server reading other files. Say so rather than patching the wrong checkout.
+        //
+        // NOTE for per-checkout live sessions (#1010): `source_root` is the MAIN checkout's root in
+        // the shared-database model, so a pass scoped to a linked worktree trips this by
+        // construction. The predicate is right — the rows a pass patches must belong to the
+        // checkout its server reads — but the implementation encodes the single-checkout
+        // assumption. The rows are already keyed by `worktree_id`; this comparison has to
+        // become worktree-aware alongside that work.
+        let indexed_root =
+            indexed_root.canonicalize().unwrap_or_else(|_| indexed_root.to_path_buf());
+        if indexed_root != scope.root() {
+            anyhow::bail!(
+                "the index was built from {} but the live oracle is scoped to {}; reindex before \
+                 the live oracle can patch these rows",
+                indexed_root.display(),
+                scope.root().display(),
+            );
+        }
         rag_rat_oracle::live_oracle_pass(
             self.storage.connection(),
             session,
             &rag_rat_oracle::LivePassInput {
                 commit_sha: &self.active_commit_sha,
                 worktree_id: &self.active_worktree_id,
-                checkout_root: &root,
+                scope,
                 worklist,
                 max_requests,
                 started_at_ms,
@@ -275,7 +301,11 @@ impl IndexDatabase {
     pub fn probe_oracle_tool(&self, tool: OracleTool) -> rag_rat_oracle::ToolAvailability {
         let manifest = ToolManifest::for_tool(tool);
         match &self.config {
-            Some(config) => manifest.probe_runnable_in(&config.root),
+            Some(config) => {
+                let corpus = crate::index::corpus::ConfiguredCorpus::new(config);
+                let scope = rag_rat_oracle::CheckoutScope::resolve(&config.root, &corpus);
+                manifest.probe_runnable_in(&scope)
+            },
             // No checkout root to evaluate prerequisites against; report installedness only.
             None => manifest.probe(),
         }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
@@ -623,3 +623,73 @@ fn worktree_overlay_query_routing_selects_scope() {
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
 }
+
+#[test]
+fn a_branch_target_survives_an_overlay_root_spelled_with_a_parent_component() {
+    // Target containment is enforced at config load, and `for_linked_worktree_overlay` is the one
+    // caller that resolves targets against a NON-canonical root: it builds
+    // `workdir.join([index] root)` directly, unlike the main load path. A containment check that
+    // normalized only the joined target path and compared it against the raw root rejected every
+    // genuinely contained directory — and this caller swallows the error and falls back to the base
+    // config's targets, so the branch's own targets vanish with no diagnostic at all.
+    //
+    // The shared-database shape matters here, which is why this is not just a `resolve_targets`
+    // unit test: the branch-only target must be indexed into the LINKED checkout's overlay scope,
+    // and the base checkout must neither gain those rows nor lose its own.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // The branch adds a target directory main does not have, and spells its own `[index] root`
+    // with a `..` component — legal, and not canonicalized on this path.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::create_dir_all(linked.join("extra")).unwrap();
+    fs::create_dir_all(linked.join("nested")).unwrap();
+    fs::write(linked.join("extra/branch_only.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    fs::write(
+        linked.join("rag-rat.toml"),
+        "[index]\nroot = \"nested/..\"\ndatabase = \
+         \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = [\"src\", \"extra\"]\n",
+    )
+    .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch target"]);
+
+    // The overlay config must carry the BRANCH's targets. Falling back to the base config's here is
+    // the silent failure this guards.
+    let overlay_config = config.for_linked_worktree_overlay(&linked);
+    let overlay_dirs: Vec<_> =
+        overlay_config.targets.iter().flat_map(|t| t.directories.iter()).collect();
+    assert!(
+        overlay_dirs.iter().any(|dir| dir.as_path() == Path::new("extra")),
+        "the branch's own target survived a root spelled with `..`: {overlay_dirs:?}",
+    );
+
+    db.index_worktree_overlay(&overlay_config, &linked, &mut |_| {}).unwrap();
+    assert!(
+        names_in_scope(&db, "extra/branch_only.rs").contains(&"branch_only_fn".to_string()),
+        "the branch-only target is indexed into the linked checkout's overlay scope",
+    );
+
+    // Sibling isolation: the base checkout keeps its own rows and gains none of the branch's.
+    set_base_scope(&mut db, &main);
+    assert!(
+        names_in_scope(&db, "src/base.rs").contains(&"base_fn".to_string()),
+        "the base checkout's own rows are preserved",
+    );
+    assert!(
+        !path_in_scope(&db, "extra/branch_only.rs"),
+        "a branch-only target must not become visible in the base scope",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -157,10 +157,35 @@ impl LiveOracleTail {
             return;
         }
         let mut budget = config.oracle.live.max_requests_per_pass;
+        let scope = LiveScope { config, corpus: std::cell::OnceCell::new() };
         for index in claim_order(self.backends.len(), self.first_claim) {
-            self.backends[index].on_pass(db, config, changed_paths, &mut budget);
+            self.backends[index].on_pass(db, config, &scope, changed_paths, &mut budget);
         }
         self.first_claim = self.first_claim.wrapping_add(1);
+    }
+}
+
+/// The live stage's checkout scope, whose corpus is built on FIRST USE.
+///
+/// [`crate::index::corpus::ConfiguredCorpus`] compiles the ignore matcher, which discovers nested
+/// `.gitignore` files along every configured target tree. That is real work, and the maintenance
+/// pass holds the repository write lock while it happens — but most passes have no live work at all
+/// (no changed path in a live language, no backlog), and those must not pay for it. Building it
+/// eagerly made every watcher event, however small, walk the target trees before deciding there was
+/// nothing to do.
+///
+/// Shared by every backend in the pass, so a mixed-language checkout compiles it once rather than
+/// once per resident server.
+struct LiveScope<'a> {
+    config: &'a Config,
+    corpus: std::cell::OnceCell<crate::index::corpus::ConfiguredCorpus<'a>>,
+}
+
+impl LiveScope<'_> {
+    fn resolve(&self) -> rag_rat_oracle::CheckoutScope<'_> {
+        let corpus =
+            self.corpus.get_or_init(|| crate::index::corpus::ConfiguredCorpus::new(self.config));
+        rag_rat_oracle::CheckoutScope::resolve(&self.config.root, corpus)
     }
 }
 
@@ -275,6 +300,28 @@ impl LiveBackendTail {
             return;
         }
         self.unconfigured_reported = true;
+        // The two causes have DIFFERENT remedies, and the generic one sends an operator whose
+        // database simply does not cover their sources after the wrong problem entirely.
+        //
+        // A checkout that ALREADY governs nothing at spawn never reaches here — it blocks on the
+        // prerequisite instead, which carries this same remedy (`prerequisite_blocked_with`). What
+        // this branch covers is the decay: a checkout that warmed on several databases and has
+        // since been reduced to one that governs nothing, where the session is still alive because
+        // the pinned database did not change (both layouts pin none).
+        if report.database_governs_nothing {
+            tracing::warn!(
+                target: "rag_rat_core::watch",
+                tool = self.backend.tool.as_db_str(),
+                skipped = report.skipped_unconfigured,
+                "live oracle: this checkout's compilation database names no file this checkout \
+                 indexes, so it is not pinned for the server — forcing it on first-party sources \
+                 would analyse them under another project's defines and include paths, which \
+                 resolves calls to the wrong definition. Regenerate the database so it covers the \
+                 indexed sources, or bind the tree it does describe in `[target_bindings]` if it \
+                 is meant to be indexed."
+            );
+            return;
+        }
         tracing::warn!(
             target: "rag_rat_core::watch",
             tool = self.backend.tool.as_db_str(),
@@ -310,6 +357,7 @@ impl LiveBackendTail {
         &mut self,
         db: &IndexDatabase,
         config: &Config,
+        scope: &LiveScope<'_>,
         changed_paths: Option<&BTreeSet<String>>,
         budget: &mut u64,
     ) {
@@ -352,6 +400,9 @@ impl LiveBackendTail {
         if !config.targets.iter().any(|target| self.backend.resolves_language(target.language)) {
             return;
         }
+        // Past every cheap gate, so this pass really is going to talk to a server: NOW the corpus
+        // is worth compiling.
+        let scope = &scope.resolve();
 
         // Spawn the session lazily on the first eligible pass. A decline leaves the work in the
         // backlog for a later pass — the same degrade-quietly UX as a missing embedding model.
@@ -360,7 +411,7 @@ impl LiveBackendTail {
                 self.backlog = worklist;
                 return;
             }
-            match LiveOracleSession::spawn(self.backend.tool, &config.root) {
+            match LiveOracleSession::spawn(self.backend.tool, scope) {
                 Ok(session) => {
                     self.session = Some(session);
                     self.lifecycle.on_spawned(now);
@@ -390,7 +441,7 @@ impl LiveBackendTail {
         // A session exists, so whatever blocked earlier is resolved; report it again if it returns.
         self.prerequisite_reported = false;
 
-        let result = db.run_live_oracle_pass(session, &worklist, *budget, started_at_ms);
+        let result = db.run_live_oracle_pass(session, scope, &worklist, *budget, started_at_ms);
         // Count idleness from completion: a request batch longer than the idle window must not
         // force an immediate shutdown and cold respawn.
         self.lifecycle.on_session_used(Instant::now());

--- a/crates/rag-rat-oracle/src/backend/documents.rs
+++ b/crates/rag-rat-oracle/src/backend/documents.rs
@@ -1,16 +1,16 @@
-//! Finding a document to warm a live session on: which directories a document search may enter,
-//! which project encloses a given file, and the two whole-checkout searches for a warm-up document.
+//! Finding a document to warm a live session on: which project encloses a given file, and the two
+//! whole-checkout searches for a warm-up document.
+//!
+//! Which directories a search may enter, and which files count as this checkout's own, are the
+//! indexed corpus's answer — never a directory-name test. A name test cannot tell clangd's own
+//! `.cache/clangd` index from a `.cache/generated` tree of real sources, and guessed wrong in both
+//! directions (#1008, #1011).
 
 use std::path::{Path, PathBuf};
 
 use rag_rat_base::language::Language;
 
-/// Directories never searched for a warm-up DOCUMENT: `node_modules` vendors dependency sources,
-/// and a dot-directory is VCS/tooling state (including the `.cache/clangd` index clangd writes
-/// itself) — never somewhere to pick a document this checkout owns.
-fn is_searchable_dir(name: &str) -> bool {
-    name != "node_modules" && !name.starts_with('.')
-}
+use super::scope::CheckoutScope;
 
 /// The directory of the nearest `marker` file at or above `path`, stopping at `root`. `None` means
 /// no project governs the file at all, and opening it produces NO project-load progress.
@@ -23,13 +23,18 @@ fn is_searchable_dir(name: &str) -> bool {
 /// loads the config project in order to decide the file isn't in it. The load is observable either
 /// way. Only a file with no ancestor config at all loads silently. Do not reimplement tsconfig
 /// glob semantics here — it would add a second, subtler source of truth for no gain.
-pub(super) fn enclosing_project_dir(root: &Path, path: &Path, marker: &str) -> Option<PathBuf> {
+pub(super) fn enclosing_project_dir(
+    checkout: &CheckoutScope<'_>,
+    path: &Path,
+    marker: &str,
+) -> Option<PathBuf> {
+    let ceiling = checkout.ceiling();
     let mut dir = path.parent()?;
     loop {
         if dir.join(marker).exists() {
             return Some(dir.to_path_buf());
         }
-        if dir == root {
+        if dir == ceiling {
             return None;
         }
         dir = dir.parent()?;
@@ -38,27 +43,36 @@ pub(super) fn enclosing_project_dir(root: &Path, path: &Path, marker: &str) -> O
 
 /// The first file one of `languages` claims at or below `dir` that also satisfies `accept`.
 pub(super) fn find_document_where(
+    checkout: &CheckoutScope<'_>,
     dir: &Path,
     languages: &[Language],
     accept: &dyn Fn(&Path) -> bool,
 ) -> Option<PathBuf> {
     let mut subdirectories = Vec::new();
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
-        if !is_searchable_dir(&entry.file_name().to_string_lossy()) {
-            continue;
-        }
         let Ok(kind) = entry.file_type() else {
             continue;
         };
         let path = entry.path();
         if kind.is_dir() {
-            subdirectories.push(path);
-        } else if languages.iter().any(|language| language.claims_path(&path)) && accept(&path) {
+            // The CORPUS prunes, not a name test. It refuses the machine-written trees the old
+            // dot-rule caught (`.git`, `.rag-rat`, `node_modules`, `.cache/clangd`) through the
+            // indexing floor, and it admits the hidden directories that hold real sources, which
+            // the name test could not tell apart (#1011).
+            if checkout.corpus().may_hold_indexed_files(&path) {
+                subdirectories.push(path);
+            }
+        } else if languages.iter().any(|language| language.claims_path(&path))
+            && checkout.corpus().indexes_file(&path)
+            && accept(&path)
+        {
             return Some(path);
         }
     }
     subdirectories.sort();
-    subdirectories.into_iter().find_map(|sub| find_document_where(&sub, languages, accept))
+    subdirectories
+        .into_iter()
+        .find_map(|sub| find_document_where(checkout, &sub, languages, accept))
 }
 
 /// The first file one of `languages` claims that lies inside a `marker` project at or below `dir`.
@@ -69,6 +83,7 @@ pub(super) fn find_document_where(
 /// first hit, so the only full traversal is the case that ends in a `Blocked` verdict, which the
 /// watcher then backs off to five-minute retries.
 pub(super) fn find_document_in_project(
+    checkout: &CheckoutScope<'_>,
     dir: &Path,
     languages: &[Language],
     marker: &str,
@@ -77,22 +92,22 @@ pub(super) fn find_document_in_project(
     let inside_project = inside_project || dir.join(marker).exists();
     let mut subdirectories = Vec::new();
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
-        let name = entry.file_name();
-        if !is_searchable_dir(&name.to_string_lossy()) {
-            continue;
-        }
         let Ok(kind) = entry.file_type() else {
             continue;
         };
+        let path = entry.path();
         if kind.is_dir() {
-            subdirectories.push(entry.path());
+            if checkout.corpus().may_hold_indexed_files(&path) {
+                subdirectories.push(path);
+            }
         } else if inside_project
-            && languages.iter().any(|language| language.claims_path(&entry.path()))
+            && languages.iter().any(|language| language.claims_path(&path))
+            && checkout.corpus().indexes_file(&path)
         {
-            return Some(entry.path());
+            return Some(path);
         }
     }
     subdirectories
         .into_iter()
-        .find_map(|sub| find_document_in_project(&sub, languages, marker, inside_project))
+        .find_map(|sub| find_document_in_project(checkout, &sub, languages, marker, inside_project))
 }

--- a/crates/rag-rat-oracle/src/backend/layout.rs
+++ b/crates/rag-rat-oracle/src/backend/layout.rs
@@ -10,6 +10,8 @@ use std::time::Duration;
 use serde::de::{self, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
+use super::scope::CheckoutScope;
+
 /// What a live backend learned about a checkout's projects, resolved ONCE per session.
 ///
 /// Every question the backend asks about layout — is this checkout usable, which database does the
@@ -31,10 +33,28 @@ pub struct ProjectLayout {
     /// while the maintenance pass holds the repository write lock. Scoped to the layout value
     /// rather than to the process: a re-resolved layout starts with an empty memo, so the
     /// staleness window is the one [`LAYOUT_MAX_AGE`] already bounds and no other.
-    usable_markers: RefCell<HashMap<PathBuf, MarkerVerdict>>,
-    /// Whether the scan that produced this layout saw EVERY database that could govern a file in
-    /// the checkout. False when it stopped early — the depth bound, a directory it could not read,
-    /// or a nested checkout whose own sources this checkout may still index.
+    usable_markers: RefCell<HashMap<PathBuf, MarkerReading>>,
+    /// Whether the scan that produced this layout saw every database WHERE IT LOOKED. False when
+    /// it stopped early — the depth bound, a directory it could not read, or a nested checkout
+    /// whose own sources this checkout may still index.
+    ///
+    /// Where it looks is the index root's subtree, plus the ancestor chain up to the checkout
+    /// ceiling (each ancestor and its `build/`, the set clangd itself searches). It is tempting to
+    /// state this as "every database that could GOVERN an indexed file", and that would be wrong:
+    /// governance is a property of a database's ENTRIES, and this crate's whole premise is that a
+    /// database's LOCATION says nothing about what it describes — an out-of-tree build puts it
+    /// somewhere unrelated to the sources it configures. Target containment bounds where indexed
+    /// SOURCES live; it does not bound where a database describing them may sit.
+    ///
+    /// So the known miss is a database outside the index root's subtree and off the ancestor chain
+    /// — `<checkout>/out/compile_commands.json` with `[index] root = <checkout>/sub`, say — which
+    /// may well govern `sub/`'s sources. Such a database is invisible here, exactly as it was
+    /// before the ancestor leg existed. The consequence is bounded but real: with no other
+    /// database the checkout reports blocked, and with one the scan can pin it while a
+    /// governing database exists elsewhere. Widening the descent to the ceiling would close it
+    /// at the cost of walking the whole worktree under the repository write lock for precisely
+    /// the configuration a subdirectory root was chosen to narrow — so the claim is kept
+    /// honest instead.
     ///
     /// Pinning is the only question that needs this, and it needs it absolutely:
     /// `--compile-commands-dir` is global, so "there is exactly one database" has to be a proof,
@@ -50,7 +70,7 @@ pub struct ProjectLayout {
 #[derive(Debug, Clone)]
 pub(super) struct MarkerSite {
     dir: PathBuf,
-    verdict: MarkerVerdict,
+    reading: MarkerReading,
 }
 
 /// What reading a marker file established about the project it describes.
@@ -72,6 +92,31 @@ pub(super) enum MarkerVerdict {
     /// accepts comments, trailing commas, and block syntax that `serde_json` does not (#1016), and
     /// a genuinely corrupt file is indistinguishable from those here.
     Unknown,
+}
+
+/// Whether a compilation database describes anything this checkout indexes — the question that
+/// decides whether forcing it on the WHOLE checkout is safe.
+///
+/// Three states for the same reason [`MarkerVerdict`] has three: a database this crate could not
+/// read named nothing it could test, which is not the same finding as one whose entries were all
+/// read and named nothing indexed. They are kept apart because a future reader accepting more
+/// syntax (#1016) will produce far fewer unreadable files, and the two must not have silently
+/// merged by then.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Governs {
+    /// An entry named a file in the indexed corpus.
+    IndexedSource,
+    /// The whole database was read, and no entry named one.
+    NothingIndexed,
+    /// It could not be read, so it named nothing this crate could test.
+    Unknown,
+}
+
+/// What ONE read of a marker file established, from one streaming pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct MarkerReading {
+    verdict: MarkerVerdict,
+    governs: Governs,
 }
 
 /// How much a layout question demands of a database before counting it.
@@ -96,6 +141,18 @@ impl MarkerVerdict {
     }
 }
 
+impl Governs {
+    /// The governance half of the same question [`MarkerVerdict::counts_under`] answers, biased the
+    /// same way: `Unknown` counts for warm-up (refusing to warm costs the whole backend) and does
+    /// not count where the answer gets persisted.
+    fn counts_under(self, trust: Trust) -> bool {
+        match trust {
+            Trust::Proven => self == Self::IndexedSource,
+            Trust::Possible => self != Self::NothingIndexed,
+        }
+    }
+}
+
 impl Default for ProjectLayout {
     /// An empty layout from no scan at all. `complete` is true because there is nothing to have
     /// missed: a backend with no project marker never asks a layout question, and the test seams
@@ -112,8 +169,8 @@ impl ProjectLayout {
     /// sites reuses the verdict the scan already paid for, and the two routes cannot disagree
     /// about the same file within one layout.
     pub(super) fn from_marker_sites(marker: &str, scan: MarkerScan) -> Self {
-        let usable_markers: HashMap<PathBuf, MarkerVerdict> =
-            scan.sites.iter().map(|site| (site.dir.join(marker), site.verdict)).collect();
+        let usable_markers: HashMap<PathBuf, MarkerReading> =
+            scan.sites.iter().map(|site| (site.dir.join(marker), site.reading)).collect();
         Self {
             markers: scan.sites,
             usable_markers: RefCell::new(usable_markers),
@@ -133,9 +190,26 @@ impl ProjectLayout {
             return None;
         }
         match self.markers.as_slice() {
-            [only] if only.verdict == MarkerVerdict::Loadable => Some(&only.dir),
+            [only]
+                if only.reading.verdict == MarkerVerdict::Loadable
+                    && only.reading.governs == Governs::IndexedSource =>
+                Some(&only.dir),
             _ => None,
         }
+    }
+
+    /// Whether this checkout holds a database that would have been pinned but for describing
+    /// nothing the checkout indexes — the #1008 case, and the one whose remedy is specific enough
+    /// to be worth saying out loud. Every other reason for declining to pin (several databases, an
+    /// unreadable one, a truncated scan) already has its own operator-facing wording.
+    pub fn has_database_governing_nothing_indexed(&self) -> bool {
+        self.complete
+            && matches!(
+                self.markers.as_slice(),
+                [only]
+                    if only.reading.verdict == MarkerVerdict::Loadable
+                        && only.reading.governs == Governs::NothingIndexed
+            )
     }
 
     pub(super) fn is_empty(&self) -> bool {
@@ -151,15 +225,15 @@ impl ProjectLayout {
 
     /// Whether the marker file at `file` describes a project the server can load, answered from
     /// [`Self::usable_markers`] when this layout has already read it.
-    fn marker_verdict(&self, file: &Path) -> MarkerVerdict {
+    fn marker_reading(&self, file: &Path, checkout: &CheckoutScope<'_>) -> MarkerReading {
         // Borrow only for the lookup: the miss path reads the file and then takes a write borrow.
         let memoized = self.usable_markers.borrow().get(file).copied();
-        if let Some(verdict) = memoized {
-            return verdict;
+        if let Some(reading) = memoized {
+            return reading;
         }
-        let verdict = read_marker_file(file);
-        self.usable_markers.borrow_mut().insert(file.to_path_buf(), verdict);
-        verdict
+        let reading = read_marker_file(file, checkout);
+        self.usable_markers.borrow_mut().insert(file.to_path_buf(), reading);
+        reading
     }
 
     /// The marker directory the SERVER would find for `path` on its own — clangd searches an
@@ -173,11 +247,15 @@ impl ProjectLayout {
     /// gets persisted.
     pub(super) fn discoverable_marker_dir(
         &self,
-        root: &Path,
+        checkout: &CheckoutScope<'_>,
         path: &Path,
         marker: &str,
         trust: Trust,
     ) -> Option<PathBuf> {
+        // The CEILING, not the index root: this walk exists to mirror clangd's own ancestor
+        // search, and clangd has no notion of an index root. Stopping at a subdirectory root
+        // declared a file unconfigurable over a database clangd would have found for it.
+        let ceiling = checkout.ceiling();
         let mut dir = path.parent()?;
         loop {
             for candidate in [dir.to_path_buf(), dir.join("build")] {
@@ -188,10 +266,21 @@ impl ProjectLayout {
                     // continue to a farther ancestor. Continuing here would declare the file
                     // configured by a database clangd never consults, and the live pass would then
                     // trust a fallback-flags answer.
-                    return self.marker_verdict(&file).counts_under(trust).then_some(candidate);
+                    // Governance applies HERE too, not only to the global pin. The walk now
+                    // reaches the checkout ceiling rather than stopping at the index root, so
+                    // "this database encloses the file" no longer implies "this database is about
+                    // the file's project": with a subdirectory `[index] root`, an ancestor database
+                    // describing only an unindexed sibling tree is reachable, and resolving a file
+                    // through it persists definitions produced under another project's flags — the
+                    // exact corruption the pin gate exists to prevent. The reading is memoized, so
+                    // this costs no extra parse.
+                    let reading = self.marker_reading(&file, checkout);
+                    return (reading.verdict.counts_under(trust)
+                        && reading.governs.counts_under(trust))
+                    .then_some(candidate);
                 }
             }
-            if dir == root {
+            if dir == ceiling {
                 return None;
             }
             dir = dir.parent()?;
@@ -222,18 +311,22 @@ fn is_searchable_for_marker(path: &Path, name: &str) -> bool {
 /// without `--compile-commands-dir` (measured: no progress at all, and calls resolve to header
 /// declarations). Accepting a checkout whose database the server cannot find would report it
 /// usable while it silently never warms.
-pub(super) fn marker_sites(root: &Path, marker: &str) -> MarkerScan {
+pub(super) fn marker_sites(checkout: &CheckoutScope<'_>, marker: &str) -> MarkerScan {
+    let root = checkout.root();
     let mut search = MarkerSearch {
         marker,
-        // The scope the walk may not leave. A root that will not canonicalize is used as given:
-        // the containment check then simply admits less, which is the safe direction.
-        scope: root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+        checkout,
+        // The bound the walk may not leave — the enclosing CHECKOUT. A link into another part of
+        // the same checkout points at a database that is genuinely this checkout's; only leaving
+        // the checkout entirely is out of bounds. Already canonical (`CheckoutScope::resolve`).
+        scope: checkout.ceiling().to_path_buf(),
         visited_links: HashSet::new(),
         recorded_markers: HashSet::new(),
         found: Vec::new(),
         truncated: false,
     };
     search.descend(root, MARKER_SEARCH_MAX_DEPTH);
+    search.climb_to_ceiling(root, checkout.ceiling());
     // Stopping at the two-site cap is not truncation: two databases already disqualify pinning, so
     // nothing deeper could change the answer. Every OTHER early stop is, because it can hide the
     // second database that would have.
@@ -269,6 +362,9 @@ const MARKER_SEARCH_MAX_DEPTH: u32 = 24;
 /// files it has already visited, and the sites found so far.
 struct MarkerSearch<'a> {
     marker: &'a str,
+    /// What this checkout is: the corpus each database's entries are tested against, and the
+    /// ceiling the walk may not leave.
+    checkout: &'a CheckoutScope<'a>,
     /// The canonical checkout root the walk may not leave. Following directory symlinks is what
     /// makes a symlinked `build/` discoverable, but a link like `sdk -> /opt/sdk` or
     /// `external -> ..` points OUT of the checkout: without this the walk would recurse through an
@@ -293,6 +389,46 @@ struct MarkerSearch<'a> {
 }
 
 impl MarkerSearch<'_> {
+    /// Record the databases on the chain from `root` up to `ceiling` — each ancestor directory and
+    /// its `build/` subdirectory, which is exactly the set clangd searches for an opened file.
+    ///
+    /// [`Self::descend`] covers everything at or below the index root; this covers what sits ABOVE
+    /// it and still governs it, which a subdirectory `[index] root` otherwise hides. It is O(depth)
+    /// `exists()` calls rather than a traversal, deliberately: widening the DESCENT to the whole
+    /// checkout would walk every sibling of the index root under the repository write lock, and buy
+    /// nothing — a database outside the index root that is not an ancestor governs no indexed
+    /// source, because config load refuses a target directory that escapes the root.
+    ///
+    /// Re-recording the root's own database is harmless: [`Self::record_marker_in`] keys on the
+    /// marker file's canonical path, so a site both legs reach counts once.
+    fn climb_to_ceiling(&mut self, root: &Path, ceiling: &Path) {
+        // Nothing to climb when the index root IS the checkout — and this is not merely an
+        // optimisation. The loop below records a directory before testing whether it has reached
+        // the ceiling, so without this guard an index root already at the checkout top would step
+        // straight past it and walk to the filesystem root, counting databases from outside the
+        // checkout entirely. `root == ceiling` is the COMMON case, and a linked worktree nested
+        // inside another checkout is where it does damage: the walk climbs out of the worktree and
+        // adopts the enclosing checkout's database as a second one.
+        //
+        // With `root` a strict descendant of `ceiling`, the walk is guaranteed to reach `ceiling`
+        // before running off the top.
+        if root == ceiling || !root.starts_with(ceiling) {
+            return;
+        }
+        let mut dir = root;
+        while let Some(parent) = dir.parent() {
+            if self.found.len() >= 2 {
+                return;
+            }
+            self.record_marker_in(parent);
+            self.record_marker_in(&parent.join("build"));
+            if parent == ceiling {
+                return;
+            }
+            dir = parent;
+        }
+    }
+
     fn descend(&mut self, dir: &Path, depth_left: u32) {
         if self.found.len() >= 2 {
             return;
@@ -353,8 +489,8 @@ impl MarkerSearch<'_> {
         if !self.recorded_markers.insert(identity) {
             return;
         }
-        let verdict = read_marker_file(&candidate);
-        self.found.push(MarkerSite { dir: dir.to_path_buf(), verdict });
+        let reading = read_marker_file(&candidate, self.checkout);
+        self.found.push(MarkerSite { dir: dir.to_path_buf(), reading });
     }
 
     /// What this search does with one ENUMERATED entry, error included.
@@ -490,36 +626,52 @@ pub const LAYOUT_MAX_AGE: Duration = Duration::from_secs(60);
 /// The two cheap divergences are closed here instead: a UTF-8 BOM is skipped, and content after the
 /// closing bracket is ignored, both of which clangd accepts and neither of which says anything
 /// about whether the entries describe a loadable project.
-fn read_marker_file(path: &Path) -> MarkerVerdict {
+fn read_marker_file(path: &Path, checkout: &CheckoutScope<'_>) -> MarkerReading {
+    let unreadable = MarkerReading { verdict: MarkerVerdict::Unknown, governs: Governs::Unknown };
     let Ok(file) = std::fs::File::open(path) else {
-        return MarkerVerdict::Unknown;
+        return unreadable;
     };
     // `serde_json`'s reader deserializer pulls ONE BYTE at a time — measured unbuffered, a 2 MB
     // database costs two million `read` syscalls — so the buffer in front of it is what makes this
     // a sequential read.
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
     if !skip_utf8_bom(&mut reader) {
-        return MarkerVerdict::Unknown;
+        return unreadable;
     }
     // `Deserializer::from_reader` + `deserialize` rather than `serde_json::from_reader`, which also
     // calls `end()` and so rejects anything after the top-level array. clangd stops at the closing
     // bracket and never looks further, so trailing content must not condemn the database.
     let mut deserializer = serde_json::Deserializer::from_reader(&mut reader);
-    match CompilationDatabase::deserialize(&mut deserializer) {
+    let read = de::DeserializeSeed::deserialize(DatabaseSeed(checkout.corpus()), &mut deserializer);
+    // Governance is a property of the ENTRIES, so it is only knowable when they parsed. A database
+    // whose shape was rejected says nothing either way.
+    let governs = |database: &CompilationDatabase| match database {
+        d if d.governs_indexed => Governs::IndexedSource,
+        // "Could not be read" is not "names nothing indexed": clangd accepts a non-string `file`
+        // and reads it as text, so such a database may well govern the corpus — this reader simply
+        // cannot say. Scoring it as a negative would refuse warm-up for a checkout that works.
+        d if d.governs_unknown => Governs::Unknown,
+        _ => Governs::NothingIndexed,
+    };
+    match read {
         // Checked BEFORE the entry count: clangd refuses the file over an unrecognised key however
         // many good entries sit beside it, so counting them would be reading a database that will
         // not load as proof that it will.
-        Ok(database) if database.unmodelled_key => MarkerVerdict::Unknown,
-        Ok(database) if database.entries > 0 => MarkerVerdict::Loadable,
-        Ok(_) => MarkerVerdict::NotLoadable,
+        Ok(database) if database.unmodelled_key =>
+            MarkerReading { verdict: MarkerVerdict::Unknown, governs: governs(&database) },
+        Ok(database) if database.entries > 0 =>
+            MarkerReading { verdict: MarkerVerdict::Loadable, governs: governs(&database) },
+        Ok(database) =>
+            MarkerReading { verdict: MarkerVerdict::NotLoadable, governs: governs(&database) },
         // The error's CATEGORY separates the two failures. `Data` means the document parsed and its
         // contents break the entry contract — the same thing the server refuses, so it is a
         // positive finding. `Syntax`/`Eof`/`Io` mean it could not be read as JSON at all, which is
         // not a finding about the project: clangd's YAML reader accepts syntax this does not, and a
         // corrupt file is indistinguishable from that here.
         Err(error) => match error.classify() {
-            serde_json::error::Category::Data => MarkerVerdict::NotLoadable,
-            _ => MarkerVerdict::Unknown,
+            serde_json::error::Category::Data =>
+                MarkerReading { verdict: MarkerVerdict::NotLoadable, governs: Governs::Unknown },
+            _ => unreadable,
         },
     }
 }
@@ -548,6 +700,11 @@ fn skip_utf8_bom(reader: &mut impl std::io::BufRead) -> bool {
 /// that each one carries what the format requires.
 struct CompilationDatabase {
     entries: usize,
+    /// Whether any entry named a file the checkout indexes. See [`Governs`].
+    governs_indexed: bool,
+    /// Whether any entry named a `file` this reader could not read as text, leaving governance
+    /// unprovable rather than disproved.
+    governs_unknown: bool,
     /// Whether any entry carried a key outside the modelled format. One is enough: clangd refuses
     /// the whole file over it, so no other entry can redeem the database.
     unmodelled_key: bool,
@@ -591,6 +748,12 @@ struct CompilationDatabase {
 struct CompilationEntry {
     /// Whether this entry yields a command line clangd can parse.
     configures_a_file: bool,
+    /// Whether the entry named a `file` whose text this reader could not capture — a non-string
+    /// scalar, which clangd reads as its literal rendering and accepts. The path is then
+    /// unknowable here, which is NOT the same finding as an entry naming a file outside the
+    /// corpus: it makes the database's governance [`Governs::Unknown`] rather than
+    /// `NothingIndexed`, so warm-up stays permissive while pinning still declines.
+    file_text_unavailable: bool,
     /// Whether it carried a key outside the format this crate models, which makes the whole
     /// database's fate unknowable here — see [`EntryField::Unmodelled`].
     unmodelled_key: bool,
@@ -612,21 +775,94 @@ enum EntryField {
 
 impl<'de> Deserialize<'de> for CompilationEntry {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_map(CompilationEntryVisitor)
+        deserializer.deserialize_map(CompilationEntryVisitor(None))
     }
 }
 
-struct CompilationEntryVisitor;
+/// The `file` and `directory` of the entry being read, in buffers REUSED across entries.
+#[derive(Default)]
+struct EntryPaths {
+    file: String,
+    directory: String,
+    /// Canonical spellings of entry parent directories whose literal form did not land in the
+    /// corpus, memoized for the whole read.
+    ///
+    /// A checkout reached through a symlink has its database generated under the ALIAS spelling
+    /// while the configured root is canonical, so no entry matches lexically and the checkout's
+    /// only database would be judged to govern nothing — withdrawing the pin from a setup that
+    /// works. Resolving is a syscall, so it happens only after the lexical test fails, and once
+    /// per distinct parent: an aliased database aliases every entry the same way.
+    canonical_parents: HashMap<PathBuf, Option<PathBuf>>,
+}
 
-impl<'de> Visitor<'de> for CompilationEntryVisitor {
+impl EntryPaths {
+    /// Whether this entry names a file the checkout indexes.
+    ///
+    /// The entry's `file` is resolved the way the format defines it — absolute as given, otherwise
+    /// joined onto `directory` — then normalized LEXICALLY. Never `canonicalize`: that would be a
+    /// syscall per entry, and it fails outright for a file that no longer exists, which is ordinary
+    /// for a database written before the last edit.
+    fn names_indexed_file(&mut self, corpus: &dyn super::IndexedCorpus) -> bool {
+        if self.file.is_empty() {
+            return false;
+        }
+        let lexical = {
+            let file = Path::new(&self.file);
+            let absolute = if file.is_absolute() {
+                file.to_path_buf()
+            } else {
+                Path::new(&self.directory).join(file)
+            };
+            match rag_rat_base::paths::lexically_normalized(&absolute) {
+                Some(path) => path,
+                None => return false,
+            }
+        };
+        if corpus.indexes_file(&lexical) {
+            return true;
+        }
+        // The literal spelling is not in the corpus. Before concluding the database does not govern
+        // it, resolve the parent once: the path may name the same file through a symlinked root.
+        let (Some(parent), Some(name)) = (lexical.parent(), lexical.file_name()) else {
+            return false;
+        };
+        let resolved = self
+            .canonical_parents
+            .entry(parent.to_path_buf())
+            .or_insert_with(|| parent.canonicalize().ok());
+        resolved.as_ref().is_some_and(|dir| corpus.indexes_file(&dir.join(name)))
+    }
+}
+
+/// Reads one entry, capturing its paths when the caller still needs them.
+struct EntrySeed<'a>(&'a mut EntryPaths);
+
+impl<'de> de::DeserializeSeed<'de> for EntrySeed<'_> {
+    type Value = CompilationEntry;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_map(CompilationEntryVisitor(Some(self.0)))
+    }
+}
+
+struct CompilationEntryVisitor<'a>(Option<&'a mut EntryPaths>);
+
+impl<'de> Visitor<'de> for CompilationEntryVisitor<'_> {
     type Value = CompilationEntry;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a compilation database entry")
     }
 
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+    fn visit_map<A: MapAccess<'de>>(mut self, mut map: A) -> Result<Self::Value, A::Error> {
+        // A fresh entry: whatever the previous one left in the buffers must not be read as this
+        // one's, since either key may be absent here.
+        if let Some(paths) = self.0.as_deref_mut() {
+            paths.file.clear();
+            paths.directory.clear();
+        }
         let (mut file, mut directory, mut invocation) = (false, false, false);
+        let mut file_is_text = false;
         // Tracked separately because clangd does not treat them as alternatives: measured, when an
         // entry carries BOTH, `arguments` is used and `command` is ignored entirely — whichever
         // order the keys appear in. So a good `command` beside an empty `arguments` configures
@@ -636,11 +872,21 @@ impl<'de> Visitor<'de> for CompilationEntryVisitor {
         while let Some(field) = map.next_key::<EntryField>()? {
             match field {
                 EntryField::File => {
-                    map.next_value::<JsonScalar>()?;
+                    file_is_text = match self.0.as_deref_mut() {
+                        Some(paths) => map.next_value_seed(ScalarInto(&mut paths.file))?.is_string,
+                        None => map.next_value::<JsonScalar>()?.is_string,
+                    };
                     file = true;
                 },
                 EntryField::Directory => {
-                    map.next_value::<JsonScalar>()?;
+                    match self.0.as_deref_mut() {
+                        Some(paths) => {
+                            map.next_value_seed(ScalarInto(&mut paths.directory))?;
+                        },
+                        None => {
+                            map.next_value::<JsonScalar>()?;
+                        },
+                    }
                     directory = true;
                 },
                 EntryField::Command => {
@@ -685,8 +931,15 @@ impl<'de> Visitor<'de> for CompilationEntryVisitor {
         if !invocation {
             return Err(de::Error::custom("entry has neither `command` nor `arguments`"));
         }
+        // Unknowable ONLY when the node was not a string. `"file": ""` is a path this reader read
+        // and found empty — a known non-governing entry — while `"file": 7` is one clangd renders
+        // as its literal text and accepts but this reader cannot reconstruct. Collapsing the two
+        // would let a database naming no translation unit count as `Governs::Unknown`, which
+        // warm-up accepts, so the checkout would warm a session that then skips every source.
+        let file_text_unavailable = self.0.is_some() && !file_is_text;
         Ok(CompilationEntry {
             configures_a_file: arguments_configure.unwrap_or(command_configures),
+            file_text_unavailable,
             unmodelled_key,
         })
     }
@@ -700,17 +953,50 @@ struct JsonScalar {
     /// Whether the scalar renders as blank text. Only a string can: clangd reads any other scalar
     /// as its literal text (`null`, `7`, `true`), which is a perfectly good command word.
     blank: bool,
+    /// Whether the node was a STRING, and so whether a capture buffer now holds its text. A
+    /// non-string scalar leaves the buffer empty for a different reason than `""` does: the first
+    /// is a path this reader cannot render, the second is a path it read and found empty.
+    is_string: bool,
 }
 
 impl<'de> Deserialize<'de> for JsonScalar {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_any(JsonScalarVisitor)
+        deserializer.deserialize_any(JsonScalarVisitor(None))
     }
 }
 
-struct JsonScalarVisitor;
+/// Captures a scalar's text into an existing buffer, REUSING its capacity.
+///
+/// A seed rather than a `String` value so the governance read allocates nothing per entry: a
+/// 120k-entry database would otherwise mint and drop two strings per entry while the maintenance
+/// pass holds the repository write lock.
+struct ScalarInto<'a>(&'a mut String);
 
-impl<'de> Visitor<'de> for JsonScalarVisitor {
+impl<'de> de::DeserializeSeed<'de> for ScalarInto<'_> {
+    type Value = JsonScalar;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(JsonScalarVisitor(Some(self.0)))
+    }
+}
+
+struct JsonScalarVisitor<'a>(Option<&'a mut String>);
+
+impl JsonScalarVisitor<'_> {
+    /// Record the scalar's text when a caller asked for it. A NON-string scalar clears the buffer
+    /// rather than leaving the previous entry's value in it: clangd reads such a node as its
+    /// literal rendering (`null`, `7`), which is never a path worth testing against the corpus.
+    fn capture(self, text: Option<&str>) {
+        if let Some(buffer) = self.0 {
+            buffer.clear();
+            if let Some(text) = text {
+                buffer.push_str(text);
+            }
+        }
+    }
+}
+
+impl<'de> Visitor<'de> for JsonScalarVisitor<'_> {
     type Value = JsonScalar;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -718,35 +1004,44 @@ impl<'de> Visitor<'de> for JsonScalarVisitor {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 
     fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 
     fn visit_i128<E: de::Error>(self, _: i128) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 
     fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 
     fn visit_u128<E: de::Error>(self, _: u128) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 
     fn visit_str<E: de::Error>(self, text: &str) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: text.trim().is_empty() })
+        let blank = text.trim().is_empty();
+        self.capture(Some(text));
+        Ok(JsonScalar { blank, is_string: true })
     }
 
     fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-        Ok(JsonScalar { blank: false })
+        self.capture(None);
+        Ok(JsonScalar { blank: false, is_string: false })
     }
 }
 
@@ -784,18 +1079,23 @@ impl<'de> Visitor<'de> for JsonSequenceVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for CompilationDatabase {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_seq(CompilationDatabaseVisitor)
+/// Reads a database, testing each entry's file against the corpus until one qualifies.
+struct DatabaseSeed<'a>(&'a dyn super::IndexedCorpus);
+
+impl<'de> de::DeserializeSeed<'de> for DatabaseSeed<'_> {
+    type Value = CompilationDatabase;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_seq(CompilationDatabaseVisitor(self.0))
     }
 }
 
 /// Reads the top-level array one entry at a time. A hand-written visitor rather than a
 /// `Vec<CompilationEntry>` so that neither the entries nor their payloads are ever collected:
 /// a real database is tens of megabytes, and nothing here needs to outlive the check.
-struct CompilationDatabaseVisitor;
+struct CompilationDatabaseVisitor<'a>(&'a dyn super::IndexedCorpus);
 
-impl<'de> Visitor<'de> for CompilationDatabaseVisitor {
+impl<'de> Visitor<'de> for CompilationDatabaseVisitor<'_> {
     type Value = CompilationDatabase;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -805,17 +1105,53 @@ impl<'de> Visitor<'de> for CompilationDatabaseVisitor {
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
         let mut entries = 0usize;
         let mut unmodelled_key = false;
+        let mut governs_indexed = false;
+        let mut governs_unknown = false;
+        // Reused across every entry, so the read allocates nothing in proportion to the file.
+        let mut paths = EntryPaths::default();
         // The first entry `CompilationEntry` rejects ends the read: clangd would refuse the
         // database at that point too, so nothing later in the file could redeem it. An entry with
         // an EMPTY invocation is not such a rejection — it simply does not count, because it
         // configures no file while leaving the rest of the database working.
-        while let Some(entry) = seq.next_element::<CompilationEntry>()? {
+        loop {
+            // Once one entry has qualified, the question is answered and the rest of the file is
+            // read with the plain payload-discarding visitor — no capture, no corpus calls. That
+            // is the mainstream case, where the very first entry names an indexed source; the
+            // whole-file walk falls only on a database that governs nothing, which is the answer
+            // being caught and is a vendored project's small database.
+            let entry = if governs_indexed {
+                seq.next_element::<CompilationEntry>()?
+            } else {
+                seq.next_element_seed(EntrySeed(&mut paths))?
+            };
+            let Some(entry) = entry else {
+                break;
+            };
             if entry.configures_a_file {
                 entries += 1;
             }
             unmodelled_key |= entry.unmodelled_key;
+            // `configures_a_file` is required, not incidental: an entry whose selected invocation
+            // is empty names a file clangd cannot analyse at all, so it is no evidence that this
+            // database describes anything the checkout indexes. Without the gate, a database whose
+            // only indexed entry is degenerate — while some vendored entry carries a real command —
+            // would be `Loadable` AND count as governing, and get pinned for a file it cannot
+            // configure.
+            if !governs_indexed {
+                if entry.configures_a_file && paths.names_indexed_file(self.0) {
+                    governs_indexed = true;
+                } else if entry.file_text_unavailable && entry.configures_a_file {
+                    // Its path could not be read, so this entry is no evidence either way — but
+                    // only an entry that configures SOMETHING could have been evidence in the first
+                    // place. Without that second condition a degenerate entry with an unreadable
+                    // path makes the whole database `Unknown`, which `Trust::Possible` accepts: the
+                    // backend then warms on a database whose every indexed source `Trust::Proven`
+                    // goes on to skip.
+                    governs_unknown = true;
+                }
+            }
         }
-        Ok(CompilationDatabase { entries, unmodelled_key })
+        Ok(CompilationDatabase { entries, unmodelled_key, governs_indexed, governs_unknown })
     }
 }
 
@@ -823,11 +1159,13 @@ impl<'de> Visitor<'de> for CompilationDatabaseVisitor {
 mod tests {
     use super::*;
 
-    /// A `MarkerSearch` over `root`, in the state `marker_sites` builds one.
-    fn search_over(root: &Path) -> MarkerSearch<'static> {
+    /// A `MarkerSearch` over `checkout`, in the state `marker_sites` builds one. The scope is the
+    /// caller's because the search borrows it.
+    fn search_over<'a>(checkout: &'a CheckoutScope<'a>) -> MarkerSearch<'a> {
         MarkerSearch {
             marker: "compile_commands.json",
-            scope: root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+            checkout,
+            scope: checkout.ceiling().to_path_buf(),
             visited_links: HashSet::new(),
             recorded_markers: HashSet::new(),
             found: Vec::new(),
@@ -842,7 +1180,8 @@ mod tests {
         // scan claiming completeness it does not have, and `sole_marker_dir` would then pin the one
         // database it did see over files the missed one governs.
         let dir = rag_rat_base::test_scratch::ScratchDir::new("marker-entry-error");
-        let mut search = search_over(&dir);
+        let checkout = crate::test_support::every_path_scope(&dir);
+        let mut search = search_over(&checkout);
 
         let step = search.step_for_entry(Err(std::io::Error::other("enumeration failed")));
         assert!(matches!(step, Step::Indeterminate), "an unreadable entry is not a decision");
@@ -853,7 +1192,8 @@ mod tests {
         std::fs::create_dir_all(dir.join("build")).unwrap();
         std::fs::write(dir.join("build/compile_commands.json"), "[]").unwrap();
         assert!(
-            marker_sites(&dir, "compile_commands.json").complete,
+            marker_sites(&crate::test_support::every_path_scope(&dir), "compile_commands.json")
+                .complete,
             "a checkout the walk read end to end is complete",
         );
     }

--- a/crates/rag-rat-oracle/src/backend/mod.rs
+++ b/crates/rag-rat-oracle/src/backend/mod.rs
@@ -14,8 +14,10 @@
 mod documents;
 mod layout;
 mod registry;
+mod scope;
 #[cfg(test)]
 mod tests;
 
 pub use layout::{LAYOUT_MAX_AGE, ProjectLayout};
 pub use registry::LiveBackend;
+pub use scope::{CheckoutScope, IndexedCorpus};

--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -8,6 +8,7 @@ use rag_rat_base::language::Language;
 
 use super::documents;
 use super::layout::{ProjectLayout, Trust, marker_sites};
+use super::scope::CheckoutScope;
 use crate::OracleTool;
 use crate::lsp::readiness::ReadinessPolicy;
 
@@ -179,7 +180,7 @@ impl LiveBackend {
     }
 
     /// Resolve this checkout's project layout — the one filesystem scan a session performs.
-    pub fn resolve_layout(&self, root: &Path) -> ProjectLayout {
+    pub fn resolve_layout(&self, checkout: &CheckoutScope<'_>) -> ProjectLayout {
         let Some(marker) = self.project_marker else {
             return ProjectLayout::default();
         };
@@ -188,7 +189,7 @@ impl LiveBackend {
             // and needs no precomputed set.
             ProjectScope::Enclosing => ProjectLayout::default(),
             ProjectScope::Checkout =>
-                ProjectLayout::from_marker_sites(marker.file, marker_sites(root, marker.file)),
+                ProjectLayout::from_marker_sites(marker.file, marker_sites(checkout, marker.file)),
         }
     }
 
@@ -202,7 +203,7 @@ impl LiveBackend {
     /// and it stays `Warming` while a file that IS in a project would have warmed it.
     pub(crate) fn open_signals_readiness(
         &self,
-        root: &Path,
+        checkout: &CheckoutScope<'_>,
         path: &str,
         layout: &ProjectLayout,
     ) -> bool {
@@ -217,14 +218,17 @@ impl LiveBackend {
             ReadinessPolicy::ServerStatus => true,
             ReadinessPolicy::WorkDoneProgress =>
                 self.project_marker.is_some_and(|marker| match marker.scope {
-                    ProjectScope::Enclosing =>
-                        documents::enclosing_project_dir(root, &root.join(path), marker.file)
-                            .is_some(),
+                    ProjectScope::Enclosing => documents::enclosing_project_dir(
+                        checkout,
+                        &checkout.root().join(path),
+                        marker.file,
+                    )
+                    .is_some(),
                     // Readiness, not resolution — [`Trust::Possible`] for the same reason as
                     // the warm-up search below.
                     ProjectScope::Checkout => self.session_resolves(
-                        root,
-                        &root.join(path),
+                        checkout,
+                        &checkout.root().join(path),
                         layout,
                         marker,
                         Trust::Possible,
@@ -245,14 +249,19 @@ impl LiveBackend {
     /// `None` means the checkout contains no project this backend could ever warm on, which is
     /// also what makes its `prerequisite_blocked` gate fire — the two answer the same question, so
     /// they cannot disagree.
-    pub(crate) fn warmup_document(&self, root: &Path, layout: &ProjectLayout) -> Option<PathBuf> {
+    pub(crate) fn warmup_document(
+        &self,
+        checkout: &CheckoutScope<'_>,
+        layout: &ProjectLayout,
+    ) -> Option<PathBuf> {
         match self.readiness {
             // Session-level quiescence needs no document.
             ReadinessPolicy::ServerStatus => None,
             ReadinessPolicy::WorkDoneProgress =>
                 self.project_marker.and_then(|marker| match marker.scope {
                     ProjectScope::Enclosing => documents::find_document_in_project(
-                        root,
+                        checkout,
+                        checkout.root(),
                         self.languages,
                         marker.file,
                         false,
@@ -271,10 +280,20 @@ impl LiveBackend {
                     // checkout gets no live evidence at all. The per-file gate stays proven, so a
                     // document warmed on a database this crate could not read is still not
                     // resolved through it.
-                    ProjectScope::Checkout =>
-                        documents::find_document_where(root, self.languages, &|document| {
-                            self.session_resolves(root, document, layout, marker, Trust::Possible)
-                        }),
+                    ProjectScope::Checkout => documents::find_document_where(
+                        checkout,
+                        checkout.root(),
+                        self.languages,
+                        &|document| {
+                            self.session_resolves(
+                                checkout,
+                                document,
+                                layout,
+                                marker,
+                                Trust::Possible,
+                            )
+                        },
+                    ),
                 }),
         }
     }
@@ -314,7 +333,7 @@ impl LiveBackend {
     /// verdict, not a missing one, so such documents are skipped rather than resolved.
     fn session_resolves(
         &self,
-        root: &Path,
+        checkout: &CheckoutScope<'_>,
         absolute: &Path,
         layout: &ProjectLayout,
         marker: ProjectMarker,
@@ -324,7 +343,7 @@ impl LiveBackend {
             return false;
         }
         layout.sole_marker_dir().is_some()
-            || layout.discoverable_marker_dir(root, absolute, marker.file, trust).is_some()
+            || layout.discoverable_marker_dir(checkout, absolute, marker.file, trust).is_some()
     }
 
     /// Whether this session can resolve `path` (repo-relative) — the live pass's per-file gate.
@@ -333,20 +352,34 @@ impl LiveBackend {
     /// this crate could not parse might still be one clangd loads, but if it is not, the file is
     /// analysed with fallback flags and a cross-translation-unit call resolves to the callee's
     /// header declaration — a wrong verdict rather than a missing one.
-    pub fn session_can_resolve(&self, root: &Path, path: &str, layout: &ProjectLayout) -> bool {
+    pub fn session_can_resolve(
+        &self,
+        checkout: &CheckoutScope<'_>,
+        path: &str,
+        layout: &ProjectLayout,
+    ) -> bool {
         match self.project_marker {
-            Some(marker) if marker.scope == ProjectScope::Checkout =>
-                self.session_resolves(root, &root.join(path), layout, marker, Trust::Proven),
+            Some(marker) if marker.scope == ProjectScope::Checkout => self.session_resolves(
+                checkout,
+                &checkout.root().join(path),
+                layout,
+                marker,
+                Trust::Proven,
+            ),
             _ => true,
         }
     }
 
     /// Whether this checkout can ever produce a readiness signal for this backend. Backs the
     /// manifest's prerequisite gate.
-    pub fn checkout_can_signal_readiness(&self, root: &Path, layout: &ProjectLayout) -> bool {
+    pub fn checkout_can_signal_readiness(
+        &self,
+        checkout: &CheckoutScope<'_>,
+        layout: &ProjectLayout,
+    ) -> bool {
         match self.readiness {
             ReadinessPolicy::ServerStatus => true,
-            ReadinessPolicy::WorkDoneProgress => self.warmup_document(root, layout).is_some(),
+            ReadinessPolicy::WorkDoneProgress => self.warmup_document(checkout, layout).is_some(),
         }
     }
 }

--- a/crates/rag-rat-oracle/src/backend/scope.rs
+++ b/crates/rag-rat-oracle/src/backend/scope.rs
@@ -1,0 +1,76 @@
+//! What a live backend may look at in a checkout, and what counts as the checkout's own source.
+//!
+//! One path — the configured `[index] root` — used to answer three different questions at once:
+//! how far a filesystem walk may reach, where an ancestor walk stops, and which files this
+//! checkout owns. Conflating them is what let a compilation database from an unindexed subtree be
+//! pinned for first-party sources (#1008) and what made the warm-up document search guess at
+//! ownership from directory names (#1011). They are separated here.
+
+use std::path::{Path, PathBuf};
+
+/// Whether a path belongs to the checkout's indexed corpus.
+///
+/// INJECTED rather than derived. The corpus is the resolved targets plus the ignore rules, which
+/// `rag-rat-core` owns, and the crate dependency runs core → oracle. Re-deriving it here would be
+/// a second source of truth for "what is this checkout's source", which is the bug class this
+/// trait exists to remove — not a detail of how it is passed.
+pub trait IndexedCorpus {
+    /// Whether the file at `absolute` is one this checkout indexes.
+    fn indexes_file(&self, absolute: &Path) -> bool;
+
+    /// Whether any indexed file could live at or below `dir`. Answered for a DIRECTORY so a search
+    /// can prune a subtree instead of descending it — the difference between skipping
+    /// `node_modules` and walking all of it to reject each file.
+    fn may_hold_indexed_files(&self, dir: &Path) -> bool;
+}
+
+/// The three boundaries a live backend needs, resolved together so they cannot drift apart.
+pub struct CheckoutScope<'a> {
+    /// The configured `[index] root`: where the marker descent starts, and what repo-relative
+    /// paths are relative to.
+    root: PathBuf,
+    /// The enclosing checkout/worktree root — the stop of every ancestor walk and the bound a
+    /// filesystem walk may not cross. Equal to `root` when `root` is not inside a git checkout.
+    ceiling: PathBuf,
+    corpus: &'a dyn IndexedCorpus,
+}
+
+impl<'a> CheckoutScope<'a> {
+    /// Resolve the scope for `root`.
+    ///
+    /// The ceiling is DERIVED here, never passed in: it is a property of the filesystem, and a
+    /// caller allowed to supply it would eventually supply the index root again — which is the
+    /// conflation this type exists to remove.
+    /// `root` is canonicalized so the two boundaries are comparable: the ceiling comes back
+    /// canonical, and an ancestor walk from an uncanonical root would never recognise it as the
+    /// stop. In production this is a no-op — a configured root is already canonicalized when the
+    /// config loads — so it costs nothing and removes a class of mismatch from every test fixture
+    /// and every checkout reached through a symlink.
+    pub fn resolve(root: &Path, corpus: &'a dyn IndexedCorpus) -> Self {
+        let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        // The CONTAINING checkout, never the main one: each linked worktree is a different source
+        // tree, so a ceiling pointing at main would admit another checkout's databases and
+        // ancestors. `config::main_worktree_root` is the adjacent function that must NOT be used
+        // here.
+        //
+        // The containment filter is what makes every remaining failure mode collapse to today's
+        // behaviour: outside a git checkout, in a bare repository, or when the discovered workdir
+        // is not an ancestor of the root at all, the root is its own ceiling and nothing widens.
+        let ceiling = rag_rat_base::config::worktree_root(&root)
+            .filter(|ceiling| root.starts_with(ceiling))
+            .unwrap_or_else(|| root.clone());
+        Self { root, ceiling, corpus }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn ceiling(&self) -> &Path {
+        &self.ceiling
+    }
+
+    pub fn corpus(&self) -> &dyn IndexedCorpus {
+        self.corpus
+    }
+}

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -9,6 +9,550 @@ use rag_rat_base::language::Language;
 use super::documents::enclosing_project_dir;
 use super::registry::LiveBackend;
 use crate::OracleTool;
+use crate::test_support::every_path_scope as scope;
+
+/// A compilation database naming `files`, written at `dir/relative`.
+fn write_database(dir: &Path, relative: &str, files: &[&str]) {
+    let entries: Vec<String> = files
+        .iter()
+        .map(|file| {
+            let absolute = dir.join(file);
+            format!(
+                r#"{{"directory":{},"file":{},"command":"cc -c {}"}}"#,
+                serde_json::to_string(&dir.to_string_lossy()).unwrap(),
+                serde_json::to_string(&absolute.to_string_lossy()).unwrap(),
+                file
+            )
+        })
+        .collect();
+    let path = dir.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, format!("[{}]", entries.join(","))).unwrap();
+}
+
+/// The #1008 case is distinguishable from every other reason for not pinning, so the watcher can
+/// give an operator the remedy that fits: a database that does not cover the indexed sources needs
+/// regenerating (or the tree it describes needs binding), which is nothing like the advice for a
+/// checkout that simply holds several databases.
+#[test]
+fn a_database_that_governs_nothing_is_reported_apart_from_the_other_reasons() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-governs-nothing-reported");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("third_party")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "build/compile_commands.json", &["third_party/dep.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert!(
+        clangd.resolve_layout(&scope).has_database_governing_nothing_indexed(),
+        "a loadable database describing nothing indexed is the case worth naming",
+    );
+
+    // Several databases is a DIFFERENT problem with different advice, and must not be reported as
+    // this one.
+    write_database(&dir, "other/compile_commands.json", &["src/main.c"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+    assert!(
+        !clangd.resolve_layout(&scope).has_database_governing_nothing_indexed(),
+        "two databases is the multi-database case, whatever either one governs",
+    );
+}
+
+/// A checkout whose database governs nothing it indexes is BLOCKED, and the block says so.
+///
+/// This is the primary #1008 shape, and its reporting had to move. Such a database counts for
+/// neither trust level, so no document can warm the session — the checkout blocks before any
+/// session exists, which means a message carried on the pass report could never reach it. The
+/// generic prerequisite wording is worse than silence here: it tells an operator who HAS a
+/// compilation database that none was found, and sends them to generate one.
+#[test]
+fn a_checkout_whose_database_governs_nothing_is_blocked_with_the_reason() {
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-blocked-governs-nothing");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("third_party")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "build/compile_commands.json", &["third_party/dep.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    let hint = crate::ToolManifest::for_tool(OracleTool::ClangdLsp)
+        .prerequisite_blocked_with(&scope, None)
+        .expect("a database governing nothing indexed blocks the backend");
+
+    assert!(
+        hint.contains("names no file this checkout indexes"),
+        "the block must name the real cause, not deny the database exists: {hint}",
+    );
+    assert!(
+        !hint.contains("found no compile_commands.json project"),
+        "the generic wording sends an operator who HAS a database after the wrong problem: {hint}",
+    );
+}
+
+/// `"file": ""` is a path this reader READ and found empty — a known non-governing entry — not one
+/// it could not reconstruct. Collapsing the two would let a database naming no translation unit
+/// count as `Governs::Unknown`, which warm-up accepts, so a checkout would warm a session that then
+/// skips every one of its sources.
+#[test]
+fn an_empty_file_string_is_known_non_governance_not_an_unreadable_path() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-empty-file-string");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    std::fs::write(
+        dir.join("compile_commands.json"),
+        r#"[{"directory":"/x","file":"","command":"cc -c a.c"}]"#,
+    )
+    .unwrap();
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+    let layout = clangd.resolve_layout(&scope);
+
+    assert!(layout.sole_marker_dir().is_none(), "it names no translation unit, so nothing pins");
+    assert!(
+        layout.has_database_governing_nothing_indexed(),
+        "the answer is known — an empty path is a path this reader read, not one it could not",
+    );
+    assert!(
+        !clangd.checkout_can_signal_readiness(&scope, &layout),
+        "and warm-up must not accept it either — the answer is known, not unknown",
+    );
+}
+
+/// A database generated through a SYMLINKED spelling of the checkout still governs it.
+///
+/// The configured root is canonicalized at load, but a build run through the symlink writes entry
+/// paths under the alias. Judging those lexically alone finds nothing in the corpus, and the
+/// checkout's only database would be declared to govern nothing — withdrawing the pin from a setup
+/// that works today. The parent is resolved once and memoized, so the cost lands only where the
+/// literal spelling already failed.
+#[test]
+fn a_database_written_through_a_symlinked_root_still_governs_the_checkout() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-aliased-root");
+    let real = dir.join("real");
+    std::fs::create_dir_all(real.join("src")).unwrap();
+    std::fs::write(real.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    let alias = dir.join("link");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&real, &alias).unwrap();
+    #[cfg(not(unix))]
+    std::os::windows::fs::symlink_dir(&real, &alias).unwrap();
+    // The database names its entries through the ALIAS, as a build run from there would.
+    write_database(&alias, "build/compile_commands.json", &["src/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&real, &["src"]);
+    let scope = super::CheckoutScope::resolve(&real, &corpus);
+
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_some(),
+        "the aliased entry names the same file the checkout indexes",
+    );
+}
+
+/// Widening the per-file walk to the ceiling means "an ancestor holds a database" no longer implies
+/// "that database is about this file's project" — so governance gates that walk too.
+///
+/// With a subdirectory `[index] root`, a database at the checkout top describing only an unindexed
+/// sibling tree is now reachable from a first-party file. Resolving through it would let clangd
+/// infer commands from that project's entries and persist definitions produced under unrelated
+/// flags, which is precisely what the pin gate exists to prevent.
+#[test]
+fn an_ancestor_database_that_governs_nothing_does_not_configure_a_file() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-ancestor-governs-nothing");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
+    std::fs::create_dir_all(checkout.join("other")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("sub/src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    std::fs::write(checkout.join("other/dep.c"), "int dep(void) { return 1; }\n").unwrap();
+    // The checkout's only database describes the sibling tree, which this checkout does not index.
+    write_database(&checkout, "compile_commands.json", &["other/dep.c"]);
+    let root = checkout.join("sub");
+    let corpus = crate::test_support::PrefixCorpus::new(&root, &["src"]);
+    let scope = super::CheckoutScope::resolve(&root, &corpus);
+    let layout = clangd.resolve_layout(&scope);
+
+    assert!(layout.sole_marker_dir().is_none(), "it governs nothing indexed, so nothing is pinned");
+    assert!(
+        !clangd.session_can_resolve(&scope, "src/main.c", &layout),
+        "and the per-file walk must not accept it either, merely for being an ancestor",
+    );
+}
+
+/// An entry that configures nothing cannot qualify a database as governing the corpus.
+///
+/// Loadability and governance are counted independently, so without this a database whose only
+/// indexed entry has an empty invocation — while a vendored entry carries a real command — would be
+/// `Loadable` AND count as governing, and get pinned for a file clangd cannot configure.
+#[test]
+fn an_entry_that_configures_nothing_does_not_qualify_the_database() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-degenerate-indexed-entry");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("third_party")).unwrap();
+    std::fs::create_dir_all(dir.join("build")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    let root = dir.canonicalize().unwrap();
+    let database = format!(
+        r#"[{{"directory":{d},"file":{indexed},"command":""}},
+           {{"directory":{d},"file":{vendored},"command":"cc -c dep.c"}}]"#,
+        d = serde_json::to_string(&root.to_string_lossy()).unwrap(),
+        indexed = serde_json::to_string(&root.join("src/main.c").to_string_lossy()).unwrap(),
+        vendored =
+            serde_json::to_string(&root.join("third_party/dep.c").to_string_lossy()).unwrap(),
+    );
+    std::fs::write(dir.join("build/compile_commands.json"), database).unwrap();
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_none(),
+        "the one entry naming an indexed file configures nothing, so the database describes \
+         nothing this checkout can actually analyse",
+    );
+}
+
+/// One first-party entry is enough. The threshold is ANY, not most — a real database mixes
+/// vendored and first-party translation units freely, and clangd's inference from a sibling entry
+/// is correct WITHIN a project. What #1008 is about is the sibling belonging to a different
+/// project, not that inference happened.
+#[test]
+fn a_database_naming_one_indexed_file_among_vendored_ones_is_pinned() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-mixed-database");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("third_party/foo")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "build/compile_commands.json", &[
+        "third_party/foo/a.c",
+        "third_party/foo/b.c",
+        "src/main.c",
+    ]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert_eq!(
+        clangd.resolve_layout(&scope).sole_marker_dir(),
+        Some(dir.canonicalize().unwrap().join("build").as_path()),
+        "one indexed entry qualifies the database, wherever it sits in the list",
+    );
+}
+
+/// Entries carrying ABSOLUTE paths are resolved as given. A database committed from another
+/// machine names paths that resolve nowhere in this checkout, so it governs nothing and is not
+/// pinned — deliberately, since its include paths are wrong for this machine too.
+#[test]
+fn an_absolute_path_database_governs_only_when_its_paths_land_in_this_checkout() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-absolute-paths");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    // `write_database` already emits absolute `file` paths rooted at the fixture.
+    write_database(&dir, "build/compile_commands.json", &["src/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_some(),
+        "absolute paths that land inside the checkout govern it",
+    );
+
+    // The same database as another machine wrote it.
+    std::fs::write(
+        dir.join("build/compile_commands.json"),
+        r#"[{"directory":"/build/agent/out","file":"/build/agent/src/main.c","command":"cc -c main.c"}]"#,
+    )
+    .unwrap();
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_none(),
+        "paths from another machine name nothing this checkout indexes",
+    );
+}
+
+/// A symlinked build directory pointing at a SIBLING of the index root is followed: it is still
+/// inside the checkout, and the database behind it is genuinely this checkout's.
+///
+/// The containment bound used to be the index root, so `sub/build -> ../out` pointed "out of
+/// scope" and the database was never seen. The bound is the checkout now, which is what makes this
+/// ordinary layout work while still refusing a link that leaves the checkout entirely.
+#[test]
+fn a_symlinked_build_directory_inside_the_checkout_is_followed() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-symlink-sibling");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
+    std::fs::create_dir_all(checkout.join("out")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("sub/src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&checkout, "out/compile_commands.json", &["sub/src/main.c"]);
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("../out", checkout.join("sub/build")).unwrap();
+    #[cfg(not(unix))]
+    std::os::windows::fs::symlink_dir(checkout.join("out"), checkout.join("sub/build")).unwrap();
+    let root = checkout.join("sub");
+    let corpus = crate::test_support::PrefixCorpus::new(&root, &["src"]);
+    let scope = super::CheckoutScope::resolve(&root, &corpus);
+
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_some(),
+        "a link to a sibling of the index root stays inside the checkout",
+    );
+}
+
+/// Outside a git checkout nothing widens: the ceiling is the configured root, and every answer is
+/// the one the pre-ceiling code gave.
+#[test]
+fn a_non_git_checkout_behaves_exactly_as_before() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-non-git");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "compile_commands.json", &["src/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert_eq!(scope.ceiling(), scope.root(), "no checkout ⇒ no widening");
+    assert_eq!(
+        clangd.resolve_layout(&scope).sole_marker_dir(),
+        Some(dir.canonicalize().unwrap().as_path()),
+    );
+}
+
+/// A checkout whose indexed sources live only under a HIDDEN directory can still warm a session.
+///
+/// The warm-up document search excluded every dot-directory, so such a checkout had a usable
+/// database and no findable document, and the prerequisite gate reported the backend `Blocked` for
+/// a configuration that would have worked (#1011). The indexed corpus is the authority on where
+/// this checkout's sources are; the search now asks it instead of guessing from the name.
+#[test]
+fn sources_under_a_hidden_directory_can_warm_the_session() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-hidden-sources");
+    std::fs::create_dir_all(dir.join(".cache/generated")).unwrap();
+    std::fs::write(dir.join(".cache/generated/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "build/compile_commands.json", &[".cache/generated/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &[".cache/generated"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+    let layout = clangd.resolve_layout(&scope);
+
+    assert_eq!(
+        clangd.warmup_document(&scope, &layout),
+        Some(dir.canonicalize().unwrap().join(".cache/generated/main.c")),
+        "a hidden directory the checkout indexes is an ordinary source location",
+    );
+    assert!(clangd.checkout_can_signal_readiness(&scope, &layout), "so it is not blocked");
+}
+
+/// The blanket dot-rule was right about tooling state, and dropping it must not lose that: a
+/// document is refused because the checkout does not index it, not because of its name.
+#[test]
+fn a_document_the_checkout_does_not_index_is_never_warmed_on() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-unindexed-documents");
+    std::fs::create_dir_all(dir.join(".cache/clangd")).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    // Source-shaped files inside a machine-written tree, and one real source.
+    std::fs::write(dir.join(".cache/clangd/stale.c"), "int stale(void) { return 0; }\n").unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "build/compile_commands.json", &["src/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+    let layout = clangd.resolve_layout(&scope);
+
+    assert_eq!(
+        clangd.warmup_document(&scope, &layout),
+        Some(dir.canonicalize().unwrap().join("src/main.c")),
+        "the indexed source is chosen, never the one under clangd's own index",
+    );
+}
+
+/// A database that describes only files this checkout does NOT index is never pinned.
+///
+/// `--compile-commands-dir` is global, so pinning a vendored subtree's database hands first-party
+/// sources that project's `-D` and include flags — a different preprocessor branch, and so a
+/// different definition, persisted as trusted evidence (#1008).
+#[test]
+fn a_database_governing_nothing_indexed_is_not_pinned() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-governs-nothing");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("third_party/foo")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    std::fs::write(dir.join("third_party/foo/dep.c"), "int dep(void) { return 1; }\n").unwrap();
+    write_database(&dir, "third_party/foo/compile_commands.json", &["third_party/foo/dep.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    let layout = clangd.resolve_layout(&scope);
+
+    assert!(
+        layout.sole_marker_dir().is_none(),
+        "the only database describes nothing this checkout indexes, so it must not be forced on \
+         the whole checkout",
+    );
+}
+
+/// The mainstream layout stays pinned: an out-of-tree build directory holds the database, and the
+/// sources it names are the indexed ones.
+///
+/// This is the regression guard for the tempting wrong predicate. Testing corpus membership of the
+/// DATABASE'S OWN LOCATION would fail here — `build` is in the indexing floor and gitignored
+/// besides, so a `build/compile_commands.json` is never in the corpus of any repo, and pinning
+/// would be withdrawn from essentially every real single-database checkout.
+#[test]
+fn a_build_directory_database_governing_indexed_sources_is_pinned() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-build-dir-governs");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&dir, "build/compile_commands.json", &["src/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    // Pin the premise, so this cannot pass for the wrong reason: the database's own location is
+    // NOT in the corpus, and the predicate must not care.
+    assert!(
+        !crate::backend::IndexedCorpus::indexes_file(
+            scope.corpus(),
+            &dir.join("build/compile_commands.json")
+        ),
+        "the database file itself is outside the corpus, as it is in every real repo",
+    );
+
+    let layout = clangd.resolve_layout(&scope);
+
+    assert_eq!(
+        layout.sole_marker_dir(),
+        Some(dir.canonicalize().unwrap().join("build").as_path()),
+        "it governs `src/`, which this checkout indexes",
+    );
+}
+
+/// A database ABOVE `[index] root` still governs the sources under it, and clangd finds it for them
+/// by its own ancestor search — so the layout has to see it too.
+///
+/// The marker walk was bounded below by the index root, so a `compile_commands.json` at the
+/// worktree top was invisible: the layout came back empty and the backend reported the checkout
+/// `Blocked` for a configuration it could have served (#1008).
+#[test]
+fn a_database_above_the_index_root_is_found_by_the_ancestor_leg() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-db-above-index-root");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("compile_commands.json"), COMPDB).unwrap();
+    std::fs::write(checkout.join("sub/src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    let root = checkout.join("sub");
+
+    let layout = clangd.resolve_layout(&scope(&root));
+
+    assert_eq!(
+        layout.sole_marker_dir(),
+        Some(checkout.canonicalize().unwrap().as_path()),
+        "the ancestor leg reaches the checkout top",
+    );
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&root), &layout),
+        "and the checkout is no longer reported blocked",
+    );
+}
+
+/// The per-file discovery walk stops at the CEILING, not at the index root — it exists to mirror
+/// clangd's own ancestor search, and clangd has no notion of an index root.
+#[test]
+fn a_file_resolves_through_a_database_above_the_index_root() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-resolve-above-root");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
+    std::fs::create_dir_all(checkout.join("sub/other")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("compile_commands.json"), COMPDB).unwrap();
+    // A second database keeps the session UNPINNED, so the per-file discovery walk is what decides
+    // — which is the path this test is about. It sits INSIDE the index root on purpose: a database
+    // in a sibling subtree of the root is not searched at all, because it can govern no indexed
+    // source (see `ProjectLayout::complete`), so it would not disqualify pinning.
+    std::fs::write(checkout.join("sub/other/compile_commands.json"), COMPDB).unwrap();
+    std::fs::write(checkout.join("sub/src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    let root = checkout.join("sub");
+    let scope = scope(&root);
+    let layout = clangd.resolve_layout(&scope);
+
+    assert!(layout.sole_marker_dir().is_none(), "two databases ⇒ nothing is pinned");
+    assert!(
+        clangd.session_can_resolve(&scope, "src/main.c", &layout),
+        "the file's own ancestor chain reaches the database above the index root",
+    );
+}
+
+/// The ceiling is the enclosing CHECKOUT, not the configured root.
+///
+/// `[index] root` may legitimately sit below the checkout root, and clangd searches a file's
+/// ancestors without any notion of an index root. When the two were the same path, a
+/// `compile_commands.json` at the worktree top was invisible and the backend reported `Blocked`
+/// for a checkout it could have served (#1008).
+#[test]
+fn the_ceiling_is_the_enclosing_checkout_not_the_index_root() {
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("scope-ceiling-subdir");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("sub")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    let root = checkout.join("sub");
+
+    let scope = scope(&root);
+
+    assert_eq!(scope.ceiling(), checkout.canonicalize().unwrap(), "the ceiling is the checkout");
+    assert_eq!(scope.root(), root.canonicalize().unwrap(), "the root is left where it was");
+}
+
+/// Outside a git checkout there is no boundary but the configured one, and inventing a wider one
+/// would let a walk wander into unrelated trees.
+#[test]
+fn a_root_outside_a_git_checkout_is_its_own_ceiling() {
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("scope-ceiling-no-git");
+    std::fs::create_dir_all(dir.join("plain")).unwrap();
+    let root = dir.join("plain");
+
+    let scope = scope(&root);
+
+    assert_eq!(scope.ceiling(), scope.root(), "no checkout ⇒ the root is the ceiling");
+}
+
+/// A scope resolved inside a LINKED worktree gets that worktree as its ceiling, never the main
+/// checkout. Each linked worktree is a different source tree, so a ceiling pointing at main would
+/// admit databases and ancestors belonging to another checkout entirely — and it is the property
+/// per-checkout live sessions (#1010) will need, pinned now so it cannot regress before then.
+#[test]
+fn a_linked_worktree_is_its_own_ceiling_not_the_main_checkout() {
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("scope-ceiling-linked");
+    let main = dir.join("main");
+    std::fs::create_dir_all(&main).unwrap();
+    rag_rat_base::test_git::run(&main, &["init"]);
+    std::fs::write(main.join("seed.txt"), "seed\n").unwrap();
+    rag_rat_base::test_git::run(&main, &["add", "."]);
+    rag_rat_base::test_git::run(&main, &["commit", "-m", "seed"]);
+    let linked = dir.join("linked");
+    rag_rat_base::test_git::run(&main, &[
+        "worktree",
+        "add",
+        linked.to_str().unwrap(),
+        "-b",
+        "branch",
+    ]);
+
+    let scope = scope(&linked);
+
+    assert_eq!(
+        scope.ceiling(),
+        linked.canonicalize().unwrap(),
+        "a linked worktree is its own checkout, not a subdirectory of main",
+    );
+}
 
 #[test]
 fn live_backends_are_exactly_the_non_batch_tools() {
@@ -108,12 +652,12 @@ fn enclosing_tsconfig_walks_up_to_the_nearest_project_and_stops_at_the_root() {
     std::fs::write(dir.join("packages/app/tsconfig.json"), "{}").unwrap();
 
     assert_eq!(
-        enclosing_project_dir(&dir, &dir.join("packages/app/src/main.ts"), "tsconfig.json"),
+        enclosing_project_dir(&scope(&dir), &dir.join("packages/app/src/main.ts"), "tsconfig.json"),
         Some(dir.join("packages/app")),
         "the nearest enclosing project wins",
     );
     assert_eq!(
-        enclosing_project_dir(&dir, &dir.join("scripts/tool.ts"), "tsconfig.json"),
+        enclosing_project_dir(&scope(&dir), &dir.join("scripts/tool.ts"), "tsconfig.json"),
         None,
         "a file under no project has none",
     );
@@ -128,31 +672,50 @@ fn a_warmup_document_is_found_at_any_depth_and_only_inside_a_project() {
     std::fs::create_dir_all(dir.join("scripts")).unwrap();
     std::fs::write(dir.join("scripts/tool.ts"), "export function x() {}\n").unwrap();
     assert_eq!(
-        ts.warmup_document(&dir, &ts.resolve_layout(&dir)),
+        ts.warmup_document(&scope(&dir), &ts.resolve_layout(&scope(&dir))),
         None,
         "a TypeScript file outside every project is not a warm-up document",
     );
-    assert!(!ts.checkout_can_signal_readiness(&dir, &ts.resolve_layout(&dir)));
+    assert!(!ts.checkout_can_signal_readiness(&scope(&dir), &ts.resolve_layout(&scope(&dir))));
 
     write_project(&dir, "services/teams/foo/web");
     assert_eq!(
-        ts.warmup_document(&dir, &ts.resolve_layout(&dir)),
+        ts.warmup_document(&scope(&dir), &ts.resolve_layout(&scope(&dir))),
         Some(dir.join("services/teams/foo/web/main.ts")),
         "a deeply nested project is still found",
     );
-    assert!(ts.checkout_can_signal_readiness(&dir, &ts.resolve_layout(&dir)));
+    assert!(ts.checkout_can_signal_readiness(&scope(&dir), &ts.resolve_layout(&scope(&dir))));
 }
 
 #[test]
-fn the_warmup_search_ignores_vendored_and_vcs_directories() {
-    // `node_modules` ships thousands of tsconfigs describing DEPENDENCIES. Warming on one
-    // would report the checkout usable while none of ITS files ever resolve.
+fn the_warmup_search_refuses_a_document_the_checkout_does_not_index() {
+    // `node_modules` ships thousands of tsconfigs describing DEPENDENCIES. Warming on one would
+    // report the checkout usable while none of ITS files ever resolve.
+    //
+    // The test supplies a REAL corpus rather than the permissive one: the refusal is now the
+    // corpus's, not a directory-name test's, so a corpus that claimed everything would assert
+    // nothing. That is the point of the change — the indexer's own answer decides, so the warm-up
+    // search cannot disagree with what the pass will actually resolve.
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
     let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-vendored-warmup");
     write_project(&dir, "node_modules/some-dep");
     write_project(&dir, ".cache/tooling");
-    assert_eq!(ts.warmup_document(&dir, &ts.resolve_layout(&dir)), None);
-    assert!(!ts.checkout_can_signal_readiness(&dir, &ts.resolve_layout(&dir)));
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert_eq!(ts.warmup_document(&scope, &ts.resolve_layout(&scope)), None);
+    assert!(!ts.checkout_can_signal_readiness(&scope, &ts.resolve_layout(&scope)));
+
+    // And a hidden directory this checkout DOES index is an ordinary source location — the case the
+    // blanket dot-rule got wrong (#1011).
+    write_project(&dir, ".cache/generated");
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &[".cache/generated"]);
+    let scope = super::CheckoutScope::resolve(&dir, &corpus);
+
+    assert_eq!(
+        ts.warmup_document(&scope, &ts.resolve_layout(&scope)),
+        Some(dir.canonicalize().unwrap().join(".cache/generated/main.ts")),
+    );
 }
 
 #[test]
@@ -161,13 +724,13 @@ fn a_server_status_backend_needs_no_warmup_document_and_is_never_blocked_on_one(
     // and must not leak into the other backend's gating.
     let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
     let dir = rag_rat_base::test_scratch::ScratchDir::new("ra-lsp-warmup-doc");
-    assert_eq!(rust.warmup_document(&dir, &rust.resolve_layout(&dir)), None);
+    assert_eq!(rust.warmup_document(&scope(&dir), &rust.resolve_layout(&scope(&dir))), None);
     assert!(
-        rust.checkout_can_signal_readiness(&dir, &rust.resolve_layout(&dir)),
+        rust.checkout_can_signal_readiness(&scope(&dir), &rust.resolve_layout(&scope(&dir))),
         "an empty checkout still signals"
     );
     assert!(
-        rust.open_signals_readiness(&dir, "src/lib.rs", &rust.resolve_layout(&dir)),
+        rust.open_signals_readiness(&scope(&dir), "src/lib.rs", &rust.resolve_layout(&scope(&dir))),
         "any document will do"
     );
     assert!(rust.project_marker.is_none(), "session-level readiness needs no project");
@@ -208,27 +771,37 @@ fn a_backends_project_marker_is_the_file_its_prerequisite_looks_for() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
     assert_eq!(clangd.project_marker.map(|m| m.file), Some("compile_commands.json"));
     assert!(
-        !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "no compdb ⇒ no signal possible"
     );
 
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
     assert!(
-        !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "sources alone are not a project"
     );
     std::fs::write(dir.join("compile_commands.json"), COMPDB).unwrap();
     assert_eq!(
-        clangd.warmup_document(&dir, &clangd.resolve_layout(&dir)),
+        clangd.warmup_document(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         Some(dir.join("src/main.c"))
     );
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
     // The two live backends' project markers can coexist in one checkout, so a document
     // qualifies only if THIS backend could open it — not merely because a project contains it.
-    assert!(clangd.open_signals_readiness(&dir, "src/main.c", &clangd.resolve_layout(&dir)));
+    assert!(clangd.open_signals_readiness(
+        &scope(&dir),
+        "src/main.c",
+        &clangd.resolve_layout(&scope(&dir))
+    ));
     assert!(
-        !clangd.open_signals_readiness(&dir, "src/app.ts", &clangd.resolve_layout(&dir)),
+        !clangd.open_signals_readiness(
+            &scope(&dir),
+            "src/app.ts",
+            &clangd.resolve_layout(&scope(&dir))
+        ),
         "another language's file is not a clangd warm-up document, project or not",
     );
 }
@@ -246,21 +819,25 @@ fn an_out_of_tree_compilation_database_still_counts_as_a_project() {
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
     assert!(
-        !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "sources with no compdb anywhere"
     );
 
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
     assert!(
-        clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "a compdb ANYWHERE in the checkout makes the backend usable",
     );
     assert_eq!(
-        clangd.warmup_document(&dir, &clangd.resolve_layout(&dir)),
+        clangd.warmup_document(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         Some(dir.join("src/main.c"))
     );
     assert!(
-        clangd.open_signals_readiness(&dir, "src/main.c", &clangd.resolve_layout(&dir)),
+        clangd.open_signals_readiness(
+            &scope(&dir),
+            "src/main.c",
+            &clangd.resolve_layout(&scope(&dir))
+        ),
         "a source with no ancestor compdb still warms clangd",
     );
 }
@@ -276,7 +853,7 @@ fn clangd_is_told_where_a_compilation_database_it_could_not_find_lives() {
     std::fs::create_dir_all(dir.join("out")).unwrap();
     std::fs::write(dir.join("out/compile_commands.json"), COMPDB).unwrap();
 
-    let args = clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&dir));
+    let args = clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir)));
     assert_eq!(args[0], "--background-index", "the static argv comes first");
     assert!(
         args.contains(&compdb_arg(&dir.join("out"))),
@@ -299,14 +876,14 @@ fn a_file_whose_database_the_session_cannot_reach_is_not_resolvable() {
     std::fs::write(dir.join("proj-b/out/compile_commands.json"), COMPDB).unwrap();
     std::fs::write(dir.join("proj-a/main.c"), "int a(void){return 0;}\n").unwrap();
     std::fs::write(dir.join("proj-b/main.c"), "int b(void){return 0;}\n").unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
 
     assert!(
-        clangd.session_can_resolve(&dir, "proj-a/main.c", &layout),
+        clangd.session_can_resolve(&scope(&dir), "proj-a/main.c", &layout),
         "clangd finds proj-a's database beside it",
     );
     assert!(
-        !clangd.session_can_resolve(&dir, "proj-b/main.c", &layout),
+        !clangd.session_can_resolve(&scope(&dir), "proj-b/main.c", &layout),
         "proj-b's database is somewhere clangd will not look, and nothing points it there",
     );
 
@@ -317,8 +894,8 @@ fn a_file_whose_database_the_session_cannot_reach_is_not_resolvable() {
     std::fs::create_dir_all(single.join("src")).unwrap();
     std::fs::write(single.join("out/compile_commands.json"), COMPDB).unwrap();
     std::fs::write(single.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
-    let single_layout = clangd.resolve_layout(&single);
-    assert!(clangd.session_can_resolve(&single, "src/main.c", &single_layout));
+    let single_layout = clangd.resolve_layout(&scope(&single));
+    assert!(clangd.session_can_resolve(&scope(&single), "src/main.c", &single_layout));
 }
 
 #[test]
@@ -333,25 +910,30 @@ fn a_re_resolved_layout_reports_when_the_pinned_database_changed() {
     let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-relayout");
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
-    let pinned = clangd.resolve_layout(&dir);
-    assert!(pinned.pins_same_database_as(&clangd.resolve_layout(&dir)), "unchanged checkout");
+    let pinned = clangd.resolve_layout(&scope(&dir));
+    assert!(
+        pinned.pins_same_database_as(&clangd.resolve_layout(&scope(&dir))),
+        "unchanged checkout"
+    );
 
     // A SECOND database appears: the checkout no longer pins one, so the session must go.
     std::fs::create_dir_all(dir.join("other/build")).unwrap();
     std::fs::write(dir.join("other/build/compile_commands.json"), COMPDB).unwrap();
     assert!(
-        !pinned.pins_same_database_as(&clangd.resolve_layout(&dir)),
+        !pinned.pins_same_database_as(&clangd.resolve_layout(&scope(&dir))),
         "a database added mid-session must invalidate a pinned layout",
     );
 
     // And the losing direction: the sole database is removed.
     std::fs::remove_file(dir.join("other/build/compile_commands.json")).unwrap();
     std::fs::remove_file(dir.join("build/compile_commands.json")).unwrap();
-    assert!(!pinned.pins_same_database_as(&clangd.resolve_layout(&dir)));
+    assert!(!pinned.pins_same_database_as(&clangd.resolve_layout(&scope(&dir))));
 
     // A backend with no project marker pins nothing and never goes stale.
     let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
-    assert!(rust.resolve_layout(&dir).pins_same_database_as(&rust.resolve_layout(&dir)));
+    assert!(
+        rust.resolve_layout(&scope(&dir)).pins_same_database_as(&rust.resolve_layout(&scope(&dir)))
+    );
 }
 
 #[test]
@@ -369,18 +951,18 @@ fn a_nearer_empty_database_does_not_make_a_file_configured() {
         std::fs::write(dir.join(project).join("build/compile_commands.json"), COMPDB).unwrap();
         std::fs::write(dir.join(project).join("main.c"), "int f(void){return 0;}\n").unwrap();
     }
-    let layout = clangd.resolve_layout(&dir);
-    assert!(clangd.session_can_resolve(&dir, "hollow/main.c", &layout));
+    let layout = clangd.resolve_layout(&scope(&dir));
+    assert!(clangd.session_can_resolve(&scope(&dir), "hollow/main.c", &layout));
 
     // Hollow out the nearer database; the file is no longer configured, while its sibling
     // project is untouched.
     std::fs::write(dir.join("hollow/build/compile_commands.json"), "[]").unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
-        !clangd.session_can_resolve(&dir, "hollow/main.c", &layout),
+        !clangd.session_can_resolve(&scope(&dir), "hollow/main.c", &layout),
         "an empty nearest database configures nothing",
     );
-    assert!(clangd.session_can_resolve(&dir, "good/main.c", &layout));
+    assert!(clangd.session_can_resolve(&scope(&dir), "good/main.c", &layout));
 }
 
 #[test]
@@ -400,17 +982,21 @@ fn a_databases_usability_is_read_once_per_layout() {
         std::fs::write(dir.join(project).join("build/compile_commands.json"), COMPDB).unwrap();
         std::fs::write(dir.join(project).join("main.c"), "int f(void){return 0;}\n").unwrap();
     }
-    let layout = clangd.resolve_layout(&dir);
-    assert!(clangd.session_can_resolve(&dir, "proj-a/main.c", &layout));
+    let layout = clangd.resolve_layout(&scope(&dir));
+    assert!(clangd.session_can_resolve(&scope(&dir), "proj-a/main.c", &layout));
 
     std::fs::write(dir.join("proj-a/build/compile_commands.json"), "[]").unwrap();
     assert!(
-        clangd.session_can_resolve(&dir, "proj-a/main.c", &layout),
+        clangd.session_can_resolve(&scope(&dir), "proj-a/main.c", &layout),
         "the answer must come from the memo, not from a second read of the database",
     );
     // The memo lives on the layout value, so a re-resolved layout sees the change — that is
     // what keeps LAYOUT_MAX_AGE the only staleness window this introduces.
-    assert!(!clangd.session_can_resolve(&dir, "proj-a/main.c", &clangd.resolve_layout(&dir)));
+    assert!(!clangd.session_can_resolve(
+        &scope(&dir),
+        "proj-a/main.c",
+        &clangd.resolve_layout(&scope(&dir))
+    ));
 }
 
 #[test]
@@ -428,23 +1014,23 @@ fn a_broken_second_database_still_disqualifies_global_pinning() {
     std::fs::write(dir.join("sub/main.c"), "int s(void){return 0;}\n").unwrap();
     std::fs::write(dir.join("root.c"), "int r(void){return 0;}\n").unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
         "a second database disqualifies pinning even when it is unusable",
     );
-    assert!(clangd.session_can_resolve(&dir, "root.c", &layout));
+    assert!(clangd.session_can_resolve(&scope(&dir), "root.c", &layout));
     assert!(
-        !clangd.session_can_resolve(&dir, "sub/main.c", &layout),
+        !clangd.session_can_resolve(&scope(&dir), "sub/main.c", &layout),
         "files of the broken project are not resolvable by either route",
     );
 
     // Remove the broken one and the checkout is genuinely single-database again.
     std::fs::remove_file(dir.join("sub/build/compile_commands.json")).unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(clangd.spawn_args(&["--background-index"], &layout).contains(&compdb_arg(&dir)));
-    assert!(clangd.session_can_resolve(&dir, "sub/main.c", &layout));
+    assert!(clangd.session_can_resolve(&scope(&dir), "sub/main.c", &layout));
 }
 
 #[test]
@@ -463,7 +1049,8 @@ fn an_entry_missing_a_required_field_is_not_a_usable_database() {
     for entry in incomplete {
         std::fs::write(dir.join("compile_commands.json"), entry).unwrap();
         assert!(
-            !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            !clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "{entry} is missing a field clangd requires",
         );
     }
@@ -474,7 +1061,8 @@ fn an_entry_missing_a_required_field_is_not_a_usable_database() {
     ] {
         std::fs::write(dir.join("compile_commands.json"), complete).unwrap();
         assert!(
-            clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "{complete} is a usable database",
         );
     }
@@ -495,15 +1083,18 @@ fn the_nearest_database_decides_even_when_it_is_unusable() {
     std::fs::write(dir.join("elsewhere/build/compile_commands.json"), COMPDB).unwrap();
     std::fs::create_dir_all(dir.join("sub/build")).unwrap();
     std::fs::write(dir.join("sub/main.c"), "int s(void){return 0;}\n").unwrap();
-    let layout = clangd.resolve_layout(&dir);
-    assert!(clangd.session_can_resolve(&dir, "sub/main.c", &layout), "falls back to the root");
+    let layout = clangd.resolve_layout(&scope(&dir));
+    assert!(
+        clangd.session_can_resolve(&scope(&dir), "sub/main.c", &layout),
+        "falls back to the root"
+    );
 
     // Now `sub` has its own EMPTY database. clangd stops there, so the file is not configured
     // — even though the root database above it is perfectly good.
     std::fs::write(dir.join("sub/build/compile_commands.json"), "[]").unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
-        !clangd.session_can_resolve(&dir, "sub/main.c", &layout),
+        !clangd.session_can_resolve(&scope(&dir), "sub/main.c", &layout),
         "an unusable NEARER database means fallback flags, not the ancestor's database",
     );
 }
@@ -522,12 +1113,15 @@ fn a_database_is_parsed_not_pattern_matched() {
     for hollow in hollows {
         std::fs::write(dir.join("compile_commands.json"), hollow).unwrap();
         assert!(
-            !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            !clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "{hollow} names no translation unit",
         );
     }
     std::fs::write(dir.join("compile_commands.json"), COMPDB).unwrap();
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
 
     // An entry that puts a large `arguments` array before `file` is still valid — a fixed-size
     // byte window over a prefix of the file would have rejected it.
@@ -538,7 +1132,7 @@ fn a_database_is_parsed_not_pattern_matched() {
     assert!(bulky.len() > 512 * 1024, "the fixture must exceed a small scan window");
     std::fs::write(dir.join("compile_commands.json"), &bulky).unwrap();
     assert!(
-        clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "a valid database must not be rejected for putting `file` late in a big entry",
     );
 }
@@ -572,7 +1166,8 @@ fn one_malformed_entry_anywhere_makes_the_whole_database_unusable() {
     for database in &rejected {
         std::fs::write(dir.join("compile_commands.json"), database).unwrap();
         assert!(
-            !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            !clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "clangd refuses to load {database}, so it configures nothing",
         );
     }
@@ -581,7 +1176,9 @@ fn one_malformed_entry_anywhere_makes_the_whole_database_unusable() {
     let accepted =
         format!(r#"[{GOOD},{{"directory":"/x","file":"/x/b.c","command":"cc -c b.c"}}]"#);
     std::fs::write(dir.join("compile_commands.json"), &accepted).unwrap();
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
 }
 
 #[test]
@@ -638,7 +1235,8 @@ fn an_entrys_shape_is_judged_the_way_clangd_judges_it() {
     for database in rejected {
         std::fs::write(dir.join("compile_commands.json"), database).unwrap();
         assert!(
-            !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            !clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "clangd refuses to load {database}, so it configures nothing",
         );
     }
@@ -674,7 +1272,8 @@ fn an_entrys_shape_is_judged_the_way_clangd_judges_it() {
     for database in accepted {
         std::fs::write(dir.join("compile_commands.json"), database).unwrap();
         assert!(
-            clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "clangd loads {database}, so this check must not refuse it",
         );
     }
@@ -717,12 +1316,30 @@ fn a_realistically_large_compilation_database_is_validated_in_one_pass() {
     drop(database);
 
     let started = std::time::Instant::now();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     let elapsed = started.elapsed();
     assert!(layout.sole_marker_dir().is_some(), "a large database is still a usable one");
     assert!(
         elapsed < Duration::from_secs(30),
         "validating one large compilation database took {elapsed:?}",
+    );
+
+    // The governance answer comes from the SAME pass — there is no second read of the file — and
+    // this is its worst case: a corpus that matches nothing means every entry is captured and
+    // tested, with no short-circuit. That is the direction the vendored case takes, so it is the
+    // one worth budgeting; the mainstream case qualifies on entry one and never gets here.
+    let nothing_indexed = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let scope = super::CheckoutScope::resolve(&dir, &nothing_indexed);
+    let started = std::time::Instant::now();
+    let layout = clangd.resolve_layout(&scope);
+    let elapsed = started.elapsed();
+    assert!(
+        layout.sole_marker_dir().is_none(),
+        "its entries name another machine's tree, so it governs nothing here",
+    );
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "testing every entry against the corpus took {elapsed:?}",
     );
 }
 
@@ -741,7 +1358,9 @@ fn a_symlinked_build_directory_is_still_searched() {
     #[cfg(windows)]
     std::os::windows::fs::symlink_dir(dir.join("cmake-build-debug"), dir.join("build")).unwrap();
 
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
 }
 
 #[cfg(unix)]
@@ -760,7 +1379,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     std::os::unix::fs::symlink(dir.join("out"), dir.join("current-build")).unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     let args = clangd.spawn_args(&["--background-index"], &layout);
     assert!(
         args.contains(&compdb_arg(&dir.join("out")))
@@ -768,7 +1387,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
         "either path reaches the one database, but the session must be pointed at it: {args:?}",
     );
     assert!(
-        clangd.session_can_resolve(&dir, "src/main.c", &layout),
+        clangd.session_can_resolve(&scope(&dir), "src/main.c", &layout),
         "a source clangd could not find the database for is resolvable only because we pin it",
     );
 
@@ -776,7 +1395,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     // projects do not.
     std::fs::create_dir_all(dir.join("other/build")).unwrap();
     std::fs::write(dir.join("other/build/compile_commands.json"), COMPDB).unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
@@ -785,7 +1404,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     // Including when the second one is unusable — it is what clangd would load for its own
     // project's files, so pinning the working one would hand them the wrong flags.
     std::fs::write(dir.join("other/build/compile_commands.json"), "[]").unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
@@ -815,7 +1434,7 @@ fn a_nested_checkout_makes_the_layout_unprovable_rather_than_simply_smaller() {
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
 
     // Control FIRST: with no nested checkout the scan is complete, so this pins.
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
         clangd
             .spawn_args(&["--background-index"], &layout)
@@ -833,7 +1452,7 @@ fn a_nested_checkout_makes_the_layout_unprovable_rather_than_simply_smaller() {
     .unwrap();
     std::fs::write(dir.join("worktrees/feature/out/compile_commands.json"), COMPDB).unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
@@ -842,7 +1461,7 @@ fn a_nested_checkout_makes_the_layout_unprovable_rather_than_simply_smaller() {
     // The file's own database is still in an ancestor `build/`, which clangd finds unaided — so
     // declining to pin costs this file nothing.
     assert!(
-        clangd.session_can_resolve(&dir, "src/main.c", &layout),
+        clangd.session_can_resolve(&scope(&dir), "src/main.c", &layout),
         "clangd's own ancestor/build lookup still configures the file",
     );
 }
@@ -860,7 +1479,7 @@ fn a_scan_that_could_not_look_everywhere_never_reports_a_sole_database() {
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
 
     // A shallow database alone pins.
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
         clangd
             .spawn_args(&["--background-index"], &layout)
@@ -874,11 +1493,137 @@ fn a_scan_that_could_not_look_everywhere_never_reports_a_sole_database() {
         (0..40).fold(dir.join("nested"), |path, level| path.join(format!("l{level}")));
     std::fs::create_dir_all(&deep).unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
         "a scan that hit its depth bound cannot claim the database it found is the only one",
+    );
+}
+
+/// The ancestor leg never climbs ABOVE the checkout, including when the index root is already the
+/// checkout top — the common case, where there is nothing to climb at all.
+#[test]
+fn the_ancestor_leg_never_leaves_the_checkout() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-climb-stops-at-checkout");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("src")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&checkout, "build/compile_commands.json", &["src/main.c"]);
+    // A database OUTSIDE the checkout, on the path the climb would take if it did not stop.
+    write_database(&dir, "compile_commands.json", &["src/main.c"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&checkout, &["src"]);
+    let scope = super::CheckoutScope::resolve(&checkout, &corpus);
+
+    assert_eq!(
+        clangd.resolve_layout(&scope).sole_marker_dir(),
+        Some(checkout.canonicalize().unwrap().join("build").as_path()),
+        "a database above the checkout is not this checkout's, and must not disqualify the pin",
+    );
+}
+
+/// The nested-checkout case against a REAL linked worktree, not a synthetic `.git` file.
+///
+/// This repo keeps its own linked worktrees under `.claude/worktrees/`, so a checkout containing
+/// another checkout is the ordinary case here, not an exotic one. `git worktree add` writes `.git`
+/// as a FILE, which is exactly what a name-based exclusion cannot see — and the sibling carries its
+/// own database, which must never be adopted as this checkout's.
+///
+/// The main checkout and the linked worktree share one database in this repository's model, so the
+/// scan's answer has to hold from either side: the main checkout declines to pin because it can no
+/// longer prove there is one database, and the linked worktree resolves its OWN layout with its own
+/// ceiling.
+#[test]
+fn a_real_linked_worktree_inside_the_checkout_is_not_this_checkouts_project() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-real-linked-worktree");
+    let main = dir.join("main");
+    std::fs::create_dir_all(main.join("src")).unwrap();
+    rag_rat_base::test_git::run(&main, &["init"]);
+    std::fs::write(main.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&main, "build/compile_commands.json", &["src/main.c"]);
+    rag_rat_base::test_git::run(&main, &["add", "."]);
+    rag_rat_base::test_git::run(&main, &["commit", "-m", "seed"]);
+    let corpus = crate::test_support::PrefixCorpus::new(&main, &["src"]);
+
+    // Control FIRST: with no nested checkout this pins, or the assertion below proves nothing.
+    let scope = super::CheckoutScope::resolve(&main, &corpus);
+    assert_eq!(
+        clangd.resolve_layout(&scope).sole_marker_dir(),
+        Some(main.canonicalize().unwrap().join("build").as_path()),
+        "one database and nothing nested ⇒ pinned",
+    );
+
+    // A linked worktree INSIDE the main checkout, carrying its own database.
+    let linked = main.join(".claude/worktrees/feature");
+    std::fs::create_dir_all(main.join(".claude/worktrees")).unwrap();
+    rag_rat_base::test_git::run(&main, &[
+        "worktree",
+        "add",
+        linked.to_str().unwrap(),
+        "-b",
+        "feature",
+    ]);
+    write_database(&linked, "build/compile_commands.json", &["src/main.c"]);
+
+    let scope = super::CheckoutScope::resolve(&main, &corpus);
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_none(),
+        "a nested checkout's `.git` is a FILE — the scan can no longer prove this checkout has \
+         exactly one database, so it declines to pin rather than adopting the sibling's",
+    );
+
+    // From the linked worktree's own side, the ceiling is that worktree — never the main checkout
+    // it happens to sit inside.
+    let linked_corpus = crate::test_support::PrefixCorpus::new(&linked, &["src"]);
+    let linked_scope = super::CheckoutScope::resolve(&linked, &linked_corpus);
+    assert_eq!(
+        linked_scope.ceiling(),
+        linked.canonicalize().unwrap(),
+        "the linked worktree is its own checkout, not a subdirectory of main",
+    );
+    assert_eq!(
+        clangd.resolve_layout(&linked_scope).sole_marker_dir(),
+        Some(linked.canonicalize().unwrap().join("build").as_path()),
+        "and it resolves its own database, not main's",
+    );
+}
+
+/// What the scan proves is now "every database that could GOVERN an indexed file", not "every
+/// database under the root" — and both halves of that need pinning, or the redefinition lives only
+/// in a comment.
+#[test]
+fn completeness_covers_the_ancestor_chain_and_ignores_sibling_subtrees() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-completeness-scope");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
+    std::fs::create_dir_all(checkout.join("elsewhere/deep")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("sub/src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&checkout, "sub/build/compile_commands.json", &["sub/src/main.c"]);
+    let root = checkout.join("sub");
+    let corpus = crate::test_support::PrefixCorpus::new(&root, &["src"]);
+
+    // A database in a SIBLING subtree of the index root neither counts nor spoils the proof: no
+    // indexed file lies under it, so it cannot be the one that governs half the sources.
+    write_database(&checkout, "elsewhere/deep/compile_commands.json", &["elsewhere/deep/x.c"]);
+    let scope = super::CheckoutScope::resolve(&root, &corpus);
+    assert_eq!(
+        clangd.resolve_layout(&scope).sole_marker_dir(),
+        Some(root.canonicalize().unwrap().join("build").as_path()),
+        "a sibling subtree of the index root is outside the question being asked",
+    );
+
+    // One on the ANCESTOR chain is a different matter: it governs the indexed sources, so it is
+    // found, counted, and the checkout therefore has two — which disqualifies pinning.
+    write_database(&checkout, "compile_commands.json", &["sub/src/main.c"]);
+    let scope = super::CheckoutScope::resolve(&root, &corpus);
+    assert!(
+        clangd.resolve_layout(&scope).sole_marker_dir().is_none(),
+        "the ancestor chain is searched, so this checkout has two databases, not one",
     );
 }
 
@@ -903,7 +1648,8 @@ fn the_invocation_clangd_selects_is_the_one_that_must_configure_the_file() {
     ] {
         std::fs::write(dir.join("compile_commands.json"), database).unwrap();
         assert!(
-            !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            !clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "`arguments` is what clangd uses, so {database} configures nothing",
         );
     }
@@ -915,7 +1661,9 @@ fn the_invocation_clangd_selects_is_the_one_that_must_configure_the_file() {
         r#"[{"directory":"/x","file":"/x/a.c","command":"","arguments":["cc","-c","a.c"]}]"#,
     )
     .unwrap();
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
 }
 
 #[test]
@@ -940,18 +1688,18 @@ fn a_key_outside_the_modelled_format_is_uncertainty_rather_than_acceptance() {
     )
     .unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
         "a database clangd would refuse must not be pinned",
     );
     assert!(
-        !clangd.session_can_resolve(&dir, "src/main.c", &layout),
+        !clangd.session_can_resolve(&scope(&dir), "src/main.c", &layout),
         "…nor may a file be resolved through it, which is how fallback flags get persisted",
     );
     assert!(
-        clangd.checkout_can_signal_readiness(&dir, &layout),
+        clangd.checkout_can_signal_readiness(&scope(&dir), &layout),
         "…but an unrecognised key is not proof the checkout has no project either",
     );
 
@@ -961,7 +1709,7 @@ fn a_key_outside_the_modelled_format_is_uncertainty_rather_than_acceptance() {
         r#"[{"directory":"/x","file":"/x/a.c","command":"cc -c a.c","output":"a.o"}]"#,
     )
     .unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
         clangd
             .spawn_args(&["--background-index"], &layout)
@@ -993,9 +1741,9 @@ fn a_database_this_crate_cannot_parse_is_not_trusted_but_does_not_block_the_back
     )
     .unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
-        clangd.checkout_can_signal_readiness(&dir, &layout),
+        clangd.checkout_can_signal_readiness(&scope(&dir), &layout),
         "a database this crate cannot read must not report the whole backend blocked",
     );
     assert_eq!(
@@ -1008,7 +1756,7 @@ fn a_database_this_crate_cannot_parse_is_not_trusted_but_does_not_block_the_back
     // it still blocks, which is what stops a session warming forever on an empty project.
     std::fs::write(dir.join("compile_commands.json"), "[]").unwrap();
     assert!(
-        !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "a database that parses and describes no translation unit is still refused",
     );
 }
@@ -1031,7 +1779,8 @@ fn a_database_clangd_can_read_is_not_refused_over_a_bom_or_trailing_bytes() {
     ] {
         std::fs::write(dir.join("compile_commands.json"), &database).unwrap();
         assert!(
-            clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "clangd loads a database with {label}, so this check must not refuse it",
         );
     }
@@ -1041,7 +1790,8 @@ fn a_database_clangd_can_read_is_not_refused_over_a_bom_or_trailing_bytes() {
     for database in ["\u{feff}[]", "\u{feff}[{\"file\":\"/x/a.c\"}]"] {
         std::fs::write(dir.join("compile_commands.json"), database).unwrap();
         assert!(
-            !clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+            !clangd
+                .checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
             "a BOM does not excuse {database}",
         );
     }
@@ -1068,7 +1818,7 @@ fn the_marker_search_does_not_follow_a_symlink_out_of_the_checkout() {
     // The escape: a link to a tree that holds its own database.
     std::os::unix::fs::symlink(outside.path(), dir.join("sdk")).unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
         clangd
             .spawn_args(&["--background-index"], &layout)
@@ -1080,7 +1830,7 @@ fn the_marker_search_does_not_follow_a_symlink_out_of_the_checkout() {
     // pinning — so the assertion above cannot pass by the walk simply never descending.
     std::fs::create_dir_all(dir.join("inside/build")).unwrap();
     std::fs::write(dir.join("inside/build/compile_commands.json"), COMPDB).unwrap();
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &layout),
         vec![OsString::from("--background-index")],
@@ -1098,7 +1848,7 @@ fn a_symlink_cycle_cannot_hang_the_marker_search() {
     std::fs::create_dir_all(dir.join("nested")).unwrap();
     std::os::unix::fs::symlink(dir.path(), dir.join("nested/loop")).unwrap();
     // Terminates; the checkout has no database, so it reports none.
-    assert!(clangd.resolve_layout(&dir).sole_marker_dir().is_none());
+    assert!(clangd.resolve_layout(&scope(&dir)).sole_marker_dir().is_none());
 }
 
 #[cfg(unix)]
@@ -1123,7 +1873,7 @@ fn two_symlink_cycles_cannot_make_the_marker_search_explode() {
     let root = dir.path().to_path_buf();
     let (done, resolved) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let pinned = clangd.resolve_layout(&root).sole_marker_dir().map(Path::to_path_buf);
+        let pinned = clangd.resolve_layout(&scope(&root)).sole_marker_dir().map(Path::to_path_buf);
         let _ = done.send(pinned);
     });
     let pinned = resolved
@@ -1146,7 +1896,7 @@ fn a_hidden_build_under_dot_cache_is_still_a_database() {
     std::fs::write(dir.join(".cache/clangd/compile_commands.json"), COMPDB).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
 
-    let layout = clangd.resolve_layout(&dir);
+    let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
         layout.sole_marker_dir(),
         Some(dir.join(".cache/cmake-build").as_path()),
@@ -1164,10 +1914,14 @@ fn an_empty_compilation_database_is_not_a_project() {
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void){return 0;}\n").unwrap();
     std::fs::write(dir.join("compile_commands.json"), "[]").unwrap();
-    assert!(!clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
 
     std::fs::write(dir.join("compile_commands.json"), COMPDB).unwrap();
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
 }
 
 #[test]
@@ -1182,15 +1936,17 @@ fn a_hidden_build_directory_still_counts_as_a_compilation_database() {
     std::fs::write(dir.join(".build/compile_commands.json"), COMPDB).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void){return 0;}\n").unwrap();
 
-    assert!(clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir)))
+    );
     assert!(
         clangd
-            .spawn_args(&["--background-index"], &clangd.resolve_layout(&dir))
+            .spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir)))
             .contains(&compdb_arg(&dir.join(".build"))),
     );
     // The warm-up document still comes from the visible tree.
     assert_eq!(
-        clangd.warmup_document(&dir, &clangd.resolve_layout(&dir)),
+        clangd.warmup_document(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         Some(dir.join("src/main.c"))
     );
 }
@@ -1212,7 +1968,7 @@ fn a_vendored_or_vcs_database_is_never_mistaken_for_the_checkouts_own() {
 
     assert!(
         clangd
-            .spawn_args(&["--background-index"], &clangd.resolve_layout(&dir))
+            .spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir)))
             .contains(&OsString::from(format!("--compile-commands-dir={}", dir.display()))),
         "the checkout's own database is still the single unambiguous one",
     );
@@ -1234,18 +1990,26 @@ fn several_compilation_databases_are_left_to_the_servers_own_per_file_lookup() {
         std::fs::write(dir.join(project).join("main.c"), "int main(void){return 0;}\n").unwrap();
     }
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&dir)),
+        clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir))),
         vec![OsString::from("--background-index")],
         "no database may be forced globally when several exist",
     );
     // Each project's own file is still fine: clangd finds `<dir>/build/` beside it.
-    assert!(clangd.open_signals_readiness(&dir, "proj-a/main.c", &clangd.resolve_layout(&dir)));
+    assert!(clangd.open_signals_readiness(
+        &scope(&dir),
+        "proj-a/main.c",
+        &clangd.resolve_layout(&scope(&dir))
+    ));
     // A file belonging to no project is not a usable warm-up document here, because nothing
     // points the session at a database on its behalf.
     std::fs::write(dir.join("stray.c"), "int stray(void){return 0;}\n").unwrap();
-    assert!(!clangd.open_signals_readiness(&dir, "stray.c", &clangd.resolve_layout(&dir)));
+    assert!(!clangd.open_signals_readiness(
+        &scope(&dir),
+        "stray.c",
+        &clangd.resolve_layout(&scope(&dir))
+    ));
     assert!(
-        clangd.checkout_can_signal_readiness(&dir, &clangd.resolve_layout(&dir)),
+        clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "the per-project files remain warmable, so the backend is not blocked",
     );
 }
@@ -1257,17 +2021,18 @@ fn a_backend_with_no_checkout_scoped_marker_gets_only_its_static_argv() {
     let dir = rag_rat_base::test_scratch::ScratchDir::new("static-argv");
     std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
-    assert_eq!(ts.spawn_args(&["--stdio"], &ts.resolve_layout(&dir)), vec![OsString::from(
-        "--stdio"
-    )]);
+    assert_eq!(ts.spawn_args(&["--stdio"], &ts.resolve_layout(&scope(&dir))), vec![
+        OsString::from("--stdio")
+    ]);
     let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
-    assert!(rust.spawn_args(&[], &rust.resolve_layout(&dir)).is_empty());
+    assert!(rust.spawn_args(&[], &rust.resolve_layout(&scope(&dir))).is_empty());
     // And with no database anywhere, clangd gets no directory to point at either.
     let empty = rag_rat_base::test_scratch::ScratchDir::new("static-argv-empty");
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    assert_eq!(clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&empty)), vec![
-        OsString::from("--background-index")
-    ],);
+    assert_eq!(
+        clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&empty))),
+        vec![OsString::from("--background-index")],
+    );
 }
 
 #[test]
@@ -1282,11 +2047,11 @@ fn a_typescript_project_still_has_to_enclose_its_documents() {
     std::fs::write(dir.join("src/main.ts"), "export const x = 1;\n").unwrap();
     std::fs::write(dir.join("config/tsconfig.json"), "{}").unwrap();
     assert!(
-        !ts.open_signals_readiness(&dir, "src/main.ts", &ts.resolve_layout(&dir)),
+        !ts.open_signals_readiness(&scope(&dir), "src/main.ts", &ts.resolve_layout(&scope(&dir))),
         "a config in a SIBLING directory governs nothing under src/",
     );
     assert_eq!(
-        ts.warmup_document(&dir, &ts.resolve_layout(&dir)),
+        ts.warmup_document(&scope(&dir), &ts.resolve_layout(&scope(&dir))),
         None,
         "and there is nothing to warm on"
     );

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 pub use auto_run::{AutoRunDecision, AutoRunInputs, auto_run_decision};
-pub use backend::LiveBackend;
+pub use backend::{CheckoutScope, IndexedCorpus, LiveBackend};
 pub use corpus::{
     HealthViolation, check_corpus_health, corpora_for_tier, corpus_by_id, load_corpora,
 };
@@ -333,7 +333,7 @@ pub fn produce_scip_with_tool(
     };
     // Tool-specific prerequisite (scip-clang needs a compile_commands.json at the root). Missing →
     // Blocked + hint, exit 0 — never a subprocess error (#71).
-    if let Some(hint) = manifest.prerequisite_blocked(checkout_root) {
+    if let Some(hint) = manifest.batch_prerequisite_blocked(checkout_root) {
         return Ok(ScipProduction::Blocked {
             tool: tool.as_db_str().to_string(),
             program: manifest.program.to_string(),

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -54,7 +54,7 @@ use rusqlite::Connection;
 use serde::Serialize;
 use url::Url;
 
-use super::backend::{self, LiveBackend, ProjectLayout};
+use super::backend::{self, CheckoutScope, LiveBackend, ProjectLayout};
 use super::lsp::client::LspClient;
 use super::lsp::position::LineIndex;
 use super::store::{self, EdgeOracleRow};
@@ -116,14 +116,14 @@ struct SpawnPreflight {
 fn resolve_preflight(
     backend: &LiveBackend,
     manifest: &ToolManifest,
-    checkout_root: &Path,
+    checkout: &CheckoutScope<'_>,
     availability: ToolAvailability,
 ) -> Result<SpawnPreflight, LiveSpawnBlocked> {
     let ToolAvailability::Available { version, .. } = availability else {
         return Err(LiveSpawnBlocked::Unavailable);
     };
-    let layout = backend.resolve_layout(checkout_root);
-    match manifest.prerequisite_blocked_with(checkout_root, Some(&layout)) {
+    let layout = backend.resolve_layout(checkout);
+    match manifest.prerequisite_blocked_with(checkout, Some(&layout)) {
         Some(hint) => Err(LiveSpawnBlocked::Prerequisite(hint)),
         None => Ok(SpawnPreflight { version, layout }),
     }
@@ -148,32 +148,28 @@ pub(crate) struct InjectedSession<'a> {
 }
 
 impl LiveOracleSession {
-    /// Probe `tool`'s language server and spawn the resident client for `checkout_root`.
+    /// Probe `tool`'s language server and spawn the resident client for `checkout`.
     ///
     /// Never an error and never a failed pass — the same degrade-quietly UX as a missing embedding
     /// model or batch tool — but the two ways it can decline are reported separately so a
     /// permanent configuration problem does not masquerade as a transient one. The version is
     /// RE-probed at every spawn so `tool_version` always names the binary this session's verdicts
     /// came from.
-    pub fn spawn(tool: OracleTool, checkout_root: &Path) -> Result<Self, LiveSpawnBlocked> {
+    pub fn spawn(tool: OracleTool, checkout: &CheckoutScope<'_>) -> Result<Self, LiveSpawnBlocked> {
         let Some(backend) = LiveBackend::for_tool(tool) else {
             return Err(LiveSpawnBlocked::Unavailable);
         };
         let manifest = ToolManifest::for_tool(tool);
         // The probe is this call's ARGUMENT, so the checkout walk inside can never precede it.
-        let SpawnPreflight { version, layout } = resolve_preflight(
-            &backend,
-            &manifest,
-            checkout_root,
-            manifest.probe_in(checkout_root),
-        )?;
-        let Some(root_uri) = root_uri_for(checkout_root) else {
+        let SpawnPreflight { version, layout } =
+            resolve_preflight(&backend, &manifest, checkout, manifest.probe_in(checkout.root()))?;
+        let Some(root_uri) = root_uri_for(checkout.root()) else {
             return Err(LiveSpawnBlocked::Unavailable);
         };
         let mut client = LspClient::spawn(
             manifest.program,
             &backend.spawn_args(manifest.live_args, &layout),
-            checkout_root,
+            checkout.root(),
             backend.readiness,
         )
         .map_err(|_| LiveSpawnBlocked::Unavailable)?;
@@ -289,7 +285,7 @@ impl LiveOracleSession {
     /// notifications are enough: the server loads in the background, its progress cycle latches
     /// the session ready, and the NEXT pass resolves the deferred worklist normally. Closing the
     /// document immediately does not cancel the load.
-    fn trigger_warmup_open(&mut self, checkout_root: &Path, worklist: &[String]) {
+    fn trigger_warmup_open(&mut self, checkout: &CheckoutScope<'_>, worklist: &[String]) {
         let open_document = |absolute: &Path| {
             let text = std::fs::read_to_string(absolute).ok()?;
             let uri: String = Url::from_file_path(absolute).ok()?.into();
@@ -298,11 +294,11 @@ impl LiveOracleSession {
         };
         let opened = worklist
             .iter()
-            .filter(|path| self.backend.open_signals_readiness(checkout_root, path, &self.layout))
-            .find_map(|path| open_document(&checkout_root.join(path)))
+            .filter(|path| self.backend.open_signals_readiness(checkout, path, &self.layout))
+            .find_map(|path| open_document(&checkout.root().join(path)))
             .or_else(|| {
                 self.backend
-                    .warmup_document(checkout_root, &self.layout)
+                    .warmup_document(checkout, &self.layout)
                     .as_deref()
                     .and_then(open_document)
             });
@@ -319,8 +315,8 @@ impl LiveOracleSession {
     }
 
     /// Whether this session can configure `path` (repo-relative) well enough to trust its answers.
-    fn can_resolve_path(&self, checkout_root: &Path, path: &str) -> bool {
-        self.backend.session_can_resolve(checkout_root, path, &self.layout)
+    fn can_resolve_path(&self, checkout: &CheckoutScope<'_>, path: &str) -> bool {
+        self.backend.session_can_resolve(checkout, path, &self.layout)
     }
 
     /// Re-resolve the checkout's project layout if the cached one has aged out, and report
@@ -329,17 +325,22 @@ impl LiveOracleSession {
     /// `false` means the checkout now pins a DIFFERENT database (one appeared, moved, or was
     /// removed). That cannot be corrected in place: the server was spawned with an argv derived
     /// from the old layout, so the session has to be replaced.
-    fn layout_still_holds(&mut self, checkout_root: &Path) -> bool {
+    fn layout_still_holds(&mut self, checkout: &CheckoutScope<'_>) -> bool {
         if self.layout_resolved_at.elapsed() < backend::LAYOUT_MAX_AGE {
             return true;
         }
-        let fresh = self.backend.resolve_layout(checkout_root);
+        let fresh = self.backend.resolve_layout(checkout);
         self.layout_resolved_at = Instant::now();
         if !fresh.pins_same_database_as(&self.layout) {
             return false;
         }
         self.layout = fresh;
         true
+    }
+
+    /// Whether the checkout's sole database was declined for describing nothing indexed.
+    fn layout_governs_nothing_indexed(&self) -> bool {
+        self.layout.has_database_governing_nothing_indexed()
     }
 
     /// Test barrier: one synchronous round trip. The transport is FIFO, so a returned response
@@ -356,9 +357,10 @@ pub struct LivePassInput<'a> {
     /// The active checkout the just-reindexed files (and their edge candidates) are scoped to.
     pub commit_sha: &'a str,
     pub worktree_id: &'a str,
-    /// The checkout root: `url::Url` converts each document path, and target bytes are read from
-    /// `checkout_root/path`.
-    pub checkout_root: &'a Path,
+    /// What this pass may look at: the configured root each document path is joined onto, the
+    /// enclosing checkout, and the corpus. Carried as one value rather than a bare root so a
+    /// caller cannot hand the pass a root the scope was not resolved for.
+    pub scope: &'a CheckoutScope<'a>,
     /// Repo-relative paths the pass may resolve (the maintenance pass's changed set plus any
     /// backlog), RUST files only — the ra-lsp backend's language. Processed in order; whatever
     /// the request budget doesn't cover rides `LivePassReport::unfinished_paths`.
@@ -430,6 +432,10 @@ pub struct LivePassReport {
     /// Whether prior-version live verdicts were migrated to the session's `tool_version` (a
     /// `rust-analyzer` upgrade detected at spawn).
     pub version_migrated: bool,
+    /// Whether this checkout holds a compilation database that was NOT pinned because it names no
+    /// file the checkout indexes. Reported so a pass that skipped everything can say WHY in terms
+    /// the operator can act on, rather than leaving them with the generic multi-database advice.
+    pub database_governs_nothing: bool,
     /// Worklist paths the request budget didn't reach — the caller's backlog into the next pass.
     #[serde(skip)]
     pub unfinished_paths: Vec<String>,
@@ -463,7 +469,7 @@ pub fn live_oracle_pass(
     // never reach this check, so a database removed during warm-up would leave it warming forever
     // with no way back. End the pass instead and let the watcher replace the session — its argv
     // was derived from the old layout, so it cannot be corrected in place.
-    if !session.layout_still_holds(input.checkout_root) {
+    if !session.layout_still_holds(input.scope) {
         report.unfinished_paths = input.worklist.to_vec();
         report.abort = Some(LivePassAbort::LayoutChanged);
         report.status =
@@ -476,7 +482,7 @@ pub fn live_oracle_pass(
             // A backend whose readiness signal only fires for an open document can never report
             // ready while the pass declines to open one. Break that deadlock without blocking.
             if session.needs_warmup_open() {
-                session.trigger_warmup_open(input.checkout_root, input.worklist);
+                session.trigger_warmup_open(input.scope, input.worklist);
             }
             report.unfinished_paths = input.worklist.to_vec();
             report.status = "Warming".to_string();
@@ -489,6 +495,7 @@ pub fn live_oracle_pass(
             return Ok(report);
         },
     }
+    report.database_governs_nothing = session.layout_governs_nothing_indexed();
     let tool = session.tool();
     // The batch tool whose monikers live copies (rust-analyzer for ra-lsp, scip-typescript for
     // ts-lsp) — always `Some` for a live tool; the join is vacuous without it.
@@ -576,7 +583,7 @@ pub fn live_oracle_pass(
         // resolve, and do NOT defer: retrying cannot help until the checkout's layout changes.
         // RETAINED for the caller instead, so the layout change that makes the file resolvable can
         // bring it back — without a backlog entry that would schedule passes able only to re-skip.
-        if !session.can_resolve_path(input.checkout_root, path) {
+        if !session.can_resolve_path(input.scope, path) {
             report.skipped_unconfigured += callees.len() as u64;
             report.skipped_unconfigured_paths.push(path.clone());
             continue;
@@ -608,7 +615,7 @@ pub fn live_oracle_pass(
         // Callsite drift gate: the server resolves the DIRTY disk bytes, so those bytes must
         // still hash to the indexed `file_sha` the candidates were built from — a mid-pass edit
         // makes the indexed callee ranges point at the wrong content. Skip, never mis-resolve.
-        let Ok(bytes) = std::fs::read(input.checkout_root.join(path)) else {
+        let Ok(bytes) = std::fs::read(input.scope.root().join(path)) else {
             report.skipped_drifted += callees.len() as u64;
             report.unfinished_paths.push(path.clone());
             continue;
@@ -662,7 +669,7 @@ pub fn live_oracle_pass(
 
         // Platform-aware file URL conversion handles drive/UNC/verbatim prefixes and percent
         // encoding; hand-joining the root and DB path repeatedly produced malformed URIs.
-        let uri: String = Url::from_file_path(input.checkout_root.join(path))
+        let uri: String = Url::from_file_path(input.scope.root().join(path))
             .map_err(|()| anyhow::anyhow!("cannot convert live-oracle document path to file URL"))?
             .into();
         let starts: Vec<usize> =
@@ -699,7 +706,7 @@ pub fn live_oracle_pass(
         // the server resolved the didOpen snapshot, and writing it against an already-changed disk
         // file would look current until the queued reindex catches up (or forever if its event was
         // missed).
-        if std::fs::read(input.checkout_root.join(path))
+        if std::fs::read(input.scope.root().join(path))
             .ok()
             .is_none_or(|current| hex_sha256(&current) != callees[0].file_sha)
         {
@@ -730,7 +737,7 @@ pub fn live_oracle_pass(
             // disk bytes, so those must still be the indexed bytes the symbol spans came from.
             let def_disk = def_bytes
                 .entry(def_path.clone())
-                .or_insert_with(|| std::fs::read(input.checkout_root.join(&def_path)).ok())
+                .or_insert_with(|| std::fs::read(input.scope.root().join(&def_path)).ok())
                 .clone();
             let Some(def_disk) = def_disk else {
                 report.skipped_drifted += 1;
@@ -1001,7 +1008,13 @@ mod tests {
             };
 
             assert_eq!(
-                resolve_preflight(&backend, &manifest, root, blocked).err(),
+                resolve_preflight(
+                    &backend,
+                    &manifest,
+                    &crate::test_support::every_path_scope(root),
+                    blocked
+                )
+                .err(),
                 Some(LiveSpawnBlocked::Unavailable),
                 "an absent {tool:?} outranks the checkout prerequisite it makes moot",
             );
@@ -1016,7 +1029,12 @@ mod tests {
                 program: manifest.program.to_string(),
                 version: version.to_string(),
             };
-            match resolve_preflight(&backend, &manifest, root, available) {
+            match resolve_preflight(
+                &backend,
+                &manifest,
+                &crate::test_support::every_path_scope(root),
+                available,
+            ) {
                 Err(LiveSpawnBlocked::Prerequisite(hint)) => {
                     assert!(hint.contains(marker), "the {tool:?} hint names the fix: {hint}");
                 },

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -14,6 +14,7 @@ use std::process::Command;
 use serde::Serialize;
 
 use super::OracleTool;
+use super::backend::CheckoutScope;
 
 /// The static registry entry for one oracle backend.
 #[derive(Debug, Clone, Copy)]
@@ -183,8 +184,8 @@ impl ToolManifest {
     /// `Available` says nothing is wrong about a backend that can never produce a verdict. An
     /// already-`Blocked` probe is returned untouched — an absent binary is the more actionable
     /// hint, and a prerequisite is moot until the tool exists.
-    pub fn probe_runnable_in(&self, root: &Path) -> ToolAvailability {
-        let availability = self.probe_in(root);
+    pub fn probe_runnable_in(&self, checkout: &CheckoutScope<'_>) -> ToolAvailability {
+        let availability = self.probe_in(checkout.root());
         if !availability.is_available() {
             // Already blocked, and the prerequisite is not evaluated at all — checking it would
             // only be discarded, and for the live TypeScript backend it is a whole-checkout
@@ -192,7 +193,7 @@ impl ToolManifest {
             // eagerly-evaluated prerequisite would walk a large checkout once per absent tool.
             return availability;
         }
-        match self.prerequisite_blocked(root) {
+        match self.prerequisite_blocked(checkout) {
             Some(hint) => ToolAvailability::Blocked {
                 tool: self.tool.as_db_str().to_string(),
                 program: self.program.to_string(),
@@ -250,8 +251,8 @@ impl ToolManifest {
     /// compilation database at the checkout root; without it the run can't proceed, so it is
     /// reported as `Blocked` (install-hint UX, exit 0) rather than a subprocess error. The
     /// pre-built `--scip` path never reaches here.
-    pub fn prerequisite_blocked(&self, root: &Path) -> Option<String> {
-        self.prerequisite_blocked_with(root, None)
+    pub fn prerequisite_blocked(&self, checkout: &CheckoutScope<'_>) -> Option<String> {
+        self.prerequisite_blocked_with(checkout, None)
     }
 
     /// As [`Self::prerequisite_blocked`], but reusing a project layout the caller already
@@ -260,9 +261,98 @@ impl ToolManifest {
     /// and the argv observe different layouts if a database changed between the two scans.
     pub fn prerequisite_blocked_with(
         &self,
-        root: &Path,
+        checkout: &CheckoutScope<'_>,
         layout: Option<&super::backend::ProjectLayout>,
     ) -> Option<String> {
+        let root = checkout.root();
+        match self.tool {
+            // The live TS client needs a tsconfig project SOMEWHERE in the checkout, for a
+            // different reason than the batch backend's root-level requirement (which is about
+            // `--infer-tsconfig` writing a tsconfig into the source tree).
+            //
+            // typescript-language-server has no quiescence notification. The only warm-up signal
+            // it emits is the work-done progress cycle bracketing a TSCONFIG PROJECT's load;
+            // opening a file that belongs to no project creates an inferred project silently, with
+            // no progress at all. So a checkout with no tsconfig anywhere can never report ready
+            // and the backend would sit in `Warming` forever — correct (the readiness policy still
+            // refuses to ask), but silent. Block with a reason instead.
+            //
+            // The config does NOT have to be at the root: a monorepo whose projects live at
+            // `packages/*/tsconfig.json` warms fine, because the FIRST project load is what the
+            // cycle reports. Requiring a root config would wrongly disable those checkouts.
+            // The live clangd client needs the SAME compilation database the batch backend does,
+            // for an additional reason: it is what clangd builds its cross-translation-unit index
+            // from. Without one a call resolves only to its header declaration, and clangd emits
+            // no project-load progress at all — so the backend could never report ready.
+            // Both progress-signalled live backends gate on the SAME question — "is there a
+            // project here whose load this server would report?" — so they share the check.
+            // The HINT is per backend: the shared sentence states the gate, and the marker's own
+            // detail names the measured symptom and the command that fixes it, which differ per
+            // server. `checkout_can_signal_readiness` is the same search the warm-up uses, so the
+            // gate and the warm-up cannot disagree.
+            OracleTool::ClangdLsp | OracleTool::TsLsp => {
+                let backend = super::backend::LiveBackend::for_tool(self.tool)?;
+                let resolved;
+                let layout = match layout {
+                    Some(layout) => layout,
+                    None => {
+                        resolved = backend.resolve_layout(checkout);
+                        &resolved
+                    },
+                };
+                // A progress-signalled backend that declared no marker could never signal either,
+                // so it still blocks — with the generic wording, since there is no file to name.
+                let (marker, detail) =
+                    backend.project_marker.map_or(("project", "Add one to enable it."), |marker| {
+                        (marker.file, marker.hint_detail)
+                    });
+                if backend.checkout_can_signal_readiness(checkout, layout) {
+                    return None;
+                }
+                // THIS is where a checkout whose database governs nothing it indexes is reported.
+                //
+                // Such a checkout blocks here — a database that describes no indexed file counts
+                // for neither trust level, so no document can warm the session — which means the
+                // block happens BEFORE any session exists. A message routed through the pass report
+                // could therefore never reach the case it was written for. The generic wording is
+                // also actively wrong here: it tells an operator who has a compilation database
+                // that none was found, and sends them to `bear -- make`.
+                if layout.has_database_governing_nothing_indexed() {
+                    return Some(format!(
+                        "the live {} oracle found a {} under {}, but it names no file this \
+                         checkout indexes — so it is not used. Forcing it on first-party sources \
+                         would analyse them under another project's defines and include paths, \
+                         which resolves calls to the wrong definition. Regenerate the database so \
+                         it covers the indexed sources, or bind the tree it does describe in \
+                         `[target_bindings]` if that tree is meant to be indexed.",
+                        backend.display_name,
+                        marker,
+                        root.display(),
+                    ));
+                }
+                Some(format!(
+                    "the live {} oracle found no {} project under {} — {} only reports \
+                     project-load progress for a real project, and that signal is what tells the \
+                     oracle its answers are trustworthy. {}",
+                    backend.display_name,
+                    marker,
+                    root.display(),
+                    self.program,
+                    detail,
+                ))
+            },
+            // Every other tool's prerequisite is the root-level marker question.
+            _ => self.batch_prerequisite_blocked(root),
+        }
+    }
+
+    /// The BATCH prerequisite: a marker file at the checkout root.
+    ///
+    /// Answerable from the root alone — no corpus, no checkout ceiling — which is what lets
+    /// [`crate::produce_scip_with_tool`] ask it without building a [`CheckoutScope`] for a question
+    /// that has nothing to do with one. The live backends' prerequisite is a question about the
+    /// whole checkout instead; see [`Self::prerequisite_blocked_with`].
+    pub fn batch_prerequisite_blocked(&self, root: &Path) -> Option<String> {
         match self.tool {
             // scip-python's "deps must be installed" prerequisite has no single sentinel file to
             // check (it's whatever the corpus `prepare` venv installs); a failed environment shows
@@ -314,59 +404,10 @@ impl ToolManifest {
             // The live rust-analyzer client has no checkout prerequisite beyond the binary itself:
             // `experimental/serverStatus` reports quiescence for any checkout.
             OracleTool::RaLsp => None,
-            // The live TS client needs a tsconfig project SOMEWHERE in the checkout, for a
-            // different reason than the batch backend's root-level requirement (which is about
-            // `--infer-tsconfig` writing a tsconfig into the source tree).
-            //
-            // typescript-language-server has no quiescence notification. The only warm-up signal
-            // it emits is the work-done progress cycle bracketing a TSCONFIG PROJECT's load;
-            // opening a file that belongs to no project creates an inferred project silently, with
-            // no progress at all. So a checkout with no tsconfig anywhere can never report ready
-            // and the backend would sit in `Warming` forever — correct (the readiness policy still
-            // refuses to ask), but silent. Block with a reason instead.
-            //
-            // The config does NOT have to be at the root: a monorepo whose projects live at
-            // `packages/*/tsconfig.json` warms fine, because the FIRST project load is what the
-            // cycle reports. Requiring a root config would wrongly disable those checkouts.
-            // The live clangd client needs the SAME compilation database the batch backend does,
-            // for an additional reason: it is what clangd builds its cross-translation-unit index
-            // from. Without one a call resolves only to its header declaration, and clangd emits
-            // no project-load progress at all — so the backend could never report ready.
-            // Both progress-signalled live backends gate on the SAME question — "is there a
-            // project here whose load this server would report?" — so they share the check.
-            // The HINT is per backend: the shared sentence states the gate, and the marker's own
-            // detail names the measured symptom and the command that fixes it, which differ per
-            // server. `checkout_can_signal_readiness` is the same search the warm-up uses, so the
-            // gate and the warm-up cannot disagree.
-            OracleTool::ClangdLsp | OracleTool::TsLsp => {
-                let backend = super::backend::LiveBackend::for_tool(self.tool)?;
-                let resolved;
-                let layout = match layout {
-                    Some(layout) => layout,
-                    None => {
-                        resolved = backend.resolve_layout(root);
-                        &resolved
-                    },
-                };
-                // A progress-signalled backend that declared no marker could never signal either,
-                // so it still blocks — with the generic wording, since there is no file to name.
-                let (marker, detail) =
-                    backend.project_marker.map_or(("project", "Add one to enable it."), |marker| {
-                        (marker.file, marker.hint_detail)
-                    });
-                (!backend.checkout_can_signal_readiness(root, layout)).then(|| {
-                    format!(
-                        "the live {} oracle found no {} project under {} — {} only reports \
-                         project-load progress for a real project, and that signal is what tells \
-                         the oracle its answers are trustworthy. {}",
-                        backend.display_name,
-                        marker,
-                        root.display(),
-                        self.program,
-                        detail,
-                    )
-                })
-            },
+            // The progress-signalled live backends gate on "is there a project ANYWHERE in this
+            // checkout whose load the server would report", which no root-level file test can
+            // answer. That gate lives in `prerequisite_blocked_with`, which has the scope it needs.
+            OracleTool::ClangdLsp | OracleTool::TsLsp => None,
         }
     }
 
@@ -544,7 +585,9 @@ mod tests {
             installed_but_unprepared.probe_in(&dir).is_available(),
             "the stand-in must be installed, or this tests the wrong branch",
         );
-        match installed_but_unprepared.probe_runnable_in(&dir) {
+        match installed_but_unprepared
+            .probe_runnable_in(&crate::test_support::every_path_scope(&dir))
+        {
             ToolAvailability::Blocked { hint, tool, program } => {
                 assert_eq!(tool, "scip-clang");
                 assert_eq!(program, "cargo");
@@ -557,7 +600,11 @@ mod tests {
         }
         // Satisfy the prerequisite and the same probe reports the tool as runnable.
         std::fs::write(dir.join("compile_commands.json"), "[]").unwrap();
-        assert!(installed_but_unprepared.probe_runnable_in(&dir).is_available());
+        assert!(
+            installed_but_unprepared
+                .probe_runnable_in(&crate::test_support::every_path_scope(&dir))
+                .is_available()
+        );
     }
 
     #[test]
@@ -572,7 +619,7 @@ mod tests {
             languages: &["c"],
             install_hint: "install scip-clang",
         };
-        match absent.probe_runnable_in(&dir) {
+        match absent.probe_runnable_in(&crate::test_support::every_path_scope(&dir)) {
             ToolAvailability::Blocked { hint, .. } => assert_eq!(hint, "install scip-clang"),
             other => panic!("expected Blocked, got {other:?}"),
         }
@@ -591,7 +638,9 @@ mod tests {
         // The compilation database is what clangd builds that index from — the same file the
         // batch scip-clang backend requires, for its own reasons.
         let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-lsp-prereq");
-        let blocked = manifest.prerequisite_blocked(&dir).expect("no compdb ⇒ Blocked");
+        let blocked = manifest
+            .prerequisite_blocked(&crate::test_support::every_path_scope(&dir))
+            .expect("no compdb ⇒ Blocked");
         // The two progress-signalled backends share the gate but not the hint: this one names
         // clangd's marker, clangd's measured symptom, and the command that produces a database.
         // Nothing here may read as the TypeScript backend's advice.
@@ -608,7 +657,7 @@ mod tests {
         // could only ever sit in `Warming`.
         std::fs::write(dir.join("compile_commands.json"), "[]").unwrap();
         assert!(
-            manifest.prerequisite_blocked(&dir).is_some(),
+            manifest.prerequisite_blocked(&crate::test_support::every_path_scope(&dir)).is_some(),
             "an empty compilation database is not a warmable project",
         );
         std::fs::write(
@@ -616,7 +665,9 @@ mod tests {
             r#"[{"directory":"/x","file":"/x/a.c","command":"cc -c a.c"}]"#,
         )
         .unwrap();
-        assert!(manifest.prerequisite_blocked(&dir).is_none());
+        assert!(
+            manifest.prerequisite_blocked(&crate::test_support::every_path_scope(&dir)).is_none()
+        );
     }
 
     #[test]
@@ -628,7 +679,9 @@ mod tests {
         // whose open would signal readiness?"), so the two cannot disagree.
         let manifest = ToolManifest::for_tool(OracleTool::TsLsp);
         let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-prereq");
-        let blocked = manifest.prerequisite_blocked(&dir).expect("no project ⇒ Blocked");
+        let blocked = manifest
+            .prerequisite_blocked(&crate::test_support::every_path_scope(&dir))
+            .expect("no project ⇒ Blocked");
         // Its own marker, its own measured symptom, its own nudge — and none of clangd's, which
         // shares the gate and would otherwise be indistinguishable here.
         assert!(blocked.contains("the live TypeScript oracle"), "{blocked}");
@@ -642,15 +695,19 @@ mod tests {
         std::fs::create_dir_all(dir.join("packages/app")).unwrap();
         std::fs::write(dir.join("packages/app/tsconfig.json"), "{}").unwrap();
         assert!(
-            manifest.prerequisite_blocked(&dir).is_some(),
+            manifest.prerequisite_blocked(&crate::test_support::every_path_scope(&dir)).is_some(),
             "a project with no TypeScript file cannot warm the server",
         );
         std::fs::write(dir.join("packages/app/main.ts"), "export function x() {}\n").unwrap();
         assert!(
-            manifest.prerequisite_blocked(&dir).is_none(),
+            manifest.prerequisite_blocked(&crate::test_support::every_path_scope(&dir)).is_none(),
             "a nested project with a file satisfies the gate",
         );
         // The Rust live backend has no such gate: its signal works for any checkout.
-        assert!(ToolManifest::for_tool(OracleTool::RaLsp).prerequisite_blocked(&dir).is_none());
+        assert!(
+            ToolManifest::for_tool(OracleTool::RaLsp)
+                .prerequisite_blocked(&crate::test_support::every_path_scope(&dir))
+                .is_none()
+        );
     }
 }

--- a/crates/rag-rat-oracle/src/test_support.rs
+++ b/crates/rag-rat-oracle/src/test_support.rs
@@ -4,7 +4,7 @@
 //! memory-relocation tests, so it is NOT `#[cfg(test)]` — the gate does not propagate cross-crate.
 //! Not part of the semver-stable API surface.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use ::protobuf::{EnumOrUnknown, Message};
 use ::scip::types::{Document, Index, Occurrence, PositionEncoding};
@@ -38,6 +38,9 @@ pub struct EdgeContentKey {
 /// A test corpus written to a temp checkout + an index DB seeded to match.
 pub struct Harness {
     pub conn: Connection,
+    /// Built on first use and reused, because a `LivePassInput` borrows it: a per-call temporary
+    /// would not outlive the input it is handed to.
+    scope: std::sync::OnceLock<crate::backend::CheckoutScope<'static>>,
     // Fields drop in declaration order: close SQLite before removing its directory on Windows.
     root: ScratchDir,
 }
@@ -58,7 +61,7 @@ impl Harness {
         // hook-using migration runs over empty tables, so the harness stays engine-free.
         schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         let root = ScratchDir::new("oracle");
-        Harness { conn, root }
+        Harness { conn, scope: std::sync::OnceLock::new(), root }
     }
 
     /// Write a source file to the checkout and insert its `files` row, returning the file id. The
@@ -260,6 +263,12 @@ impl Harness {
 
     pub fn root(&self) -> &Path {
         self.root.path()
+    }
+
+    /// The checkout scope over this harness's root, with a corpus that claims every path — these
+    /// tests are about the live pass, not about which files a checkout owns.
+    pub fn scope(&self) -> &crate::backend::CheckoutScope<'static> {
+        self.scope.get_or_init(|| crate::test_support::every_path_scope(self.root()))
     }
 
     /// Insert a `files` row in an explicit `(commit_sha, worktree_id)` scope (no checkout write —
@@ -479,4 +488,66 @@ pub fn move_target_with_edit(h: &Harness, old_file: i64, new_kind: &str) -> i64 
     h.add_chunk(moved, "moved.rs::target", "fn target(changed: u32) {}\n");
     h.add_logical_symbol(2002, "moved.rs", "target", "moved.rs::target", sym);
     sym
+}
+
+/// A checkout scope over `dir` whose corpus claims every path.
+///
+/// Most layout and manifest tests are about the marker/document SEARCH or the prerequisite gate,
+/// not about which files a checkout owns; a corpus that refused anything would make them pass or
+/// fail for a reason they are not testing. Tests that ARE about ownership build their own corpus.
+pub fn every_path_scope(dir: &Path) -> crate::backend::CheckoutScope<'static> {
+    struct EveryPath;
+
+    impl crate::backend::IndexedCorpus for EveryPath {
+        fn indexes_file(&self, _absolute: &Path) -> bool {
+            true
+        }
+
+        fn may_hold_indexed_files(&self, _dir: &Path) -> bool {
+            true
+        }
+    }
+
+    static EVERY_PATH: EveryPath = EveryPath;
+    crate::backend::CheckoutScope::resolve(dir, &EVERY_PATH)
+}
+
+/// A corpus that indexes exactly the files under the given root-relative prefixes.
+///
+/// The governance tests are about which files a checkout OWNS, so they cannot use
+/// [`every_path_scope`] — a corpus that claims everything would make a vendored database look like
+/// it governs first-party source, which is the exact confusion #1008 is about.
+pub struct PrefixCorpus {
+    root: PathBuf,
+    indexed: Vec<PathBuf>,
+}
+
+impl PrefixCorpus {
+    pub fn new(root: &Path, indexed: &[&str]) -> Self {
+        Self {
+            root: root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+            indexed: indexed.iter().map(PathBuf::from).collect(),
+        }
+    }
+
+    fn under_an_indexed_prefix(&self, path: &Path) -> bool {
+        let Ok(relative) = path.strip_prefix(&self.root) else {
+            return false;
+        };
+        self.indexed.iter().any(|prefix| relative.starts_with(prefix))
+    }
+}
+
+impl crate::backend::IndexedCorpus for PrefixCorpus {
+    fn indexes_file(&self, absolute: &Path) -> bool {
+        self.under_an_indexed_prefix(absolute)
+    }
+
+    fn may_hold_indexed_files(&self, dir: &Path) -> bool {
+        // A directory counts when it is under an indexed prefix OR could still contain one.
+        self.under_an_indexed_prefix(dir)
+            || dir.strip_prefix(&self.root).is_ok_and(|relative| {
+                self.indexed.iter().any(|prefix| prefix.starts_with(relative))
+            })
+    }
 }

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -67,7 +67,7 @@ fn pass_input<'a>(h: &'a Harness, worklist: &'a [String], max_requests: u64) -> 
     LivePassInput {
         commit_sha: COMMIT,
         worktree_id: WORKTREE,
-        checkout_root: h.root(),
+        scope: h.scope(),
         worklist,
         max_requests,
         started_at_ms: 1_000,
@@ -1448,7 +1448,7 @@ mod clangd {
     fn clangd_layout(h: &Harness) -> ProjectLayout {
         LiveBackend::for_tool(OracleTool::ClangdLsp)
             .expect("a live backend")
-            .resolve_layout(h.root())
+            .resolve_layout(h.scope())
     }
 
     /// A clangd-backed session over a fake server that reports a completed index cycle alongside

--- a/crates/rag-rat-oracle/src/tests/live_real_server.rs
+++ b/crates/rag-rat-oracle/src/tests/live_real_server.rs
@@ -89,13 +89,13 @@ fn real_typescript_server_warms_before_it_resolves_an_imported_callee() {
     let call = MAIN_TS.rfind("greet").expect("the call site");
     let edge = h.add_edge(src, "greet", call, call + "greet".len(), "NameOnly", None);
 
-    let mut session = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.root())
+    let mut session = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.scope())
         .expect("typescript-language-server must be on PATH for this test");
     let worklist = vec!["src/main.ts".to_string()];
     let input = LivePassInput {
         commit_sha: COMMIT,
         worktree_id: WORKTREE,
-        checkout_root: h.root(),
+        scope: h.scope(),
         worklist: &worklist,
         max_requests: 100,
         started_at_ms: 1_000,
@@ -169,13 +169,13 @@ fn a_file_its_ancestor_config_excludes_still_warms_the_server() {
     let call = MAIN_TS.rfind("greet").expect("the call site");
     let edge = h.add_edge(src, "greet", call, call + "greet".len(), "NameOnly", None);
 
-    let mut session = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.root())
+    let mut session = LiveOracleSession::spawn(crate::OracleTool::TsLsp, h.scope())
         .expect("an excluded file still lives under a config, so the backend is not blocked");
     let worklist = vec!["scripts/main.ts".to_string()];
     let input = LivePassInput {
         commit_sha: COMMIT,
         worktree_id: WORKTREE,
-        checkout_root: h.root(),
+        scope: h.scope(),
         worklist: &worklist,
         max_requests: 100,
         started_at_ms: 1_000,
@@ -249,13 +249,13 @@ fn real_clangd_resolves_a_call_into_another_translation_unit() {
     let header = h.add_file("src/lib.h", C_LIB_H);
     let declaration = h.add_symbol(header, "greet", 0, C_LIB_H.len());
 
-    let mut session = LiveOracleSession::spawn(crate::OracleTool::ClangdLsp, h.root())
+    let mut session = LiveOracleSession::spawn(crate::OracleTool::ClangdLsp, h.scope())
         .expect("clangd must be on PATH for this test");
     let worklist = vec!["src/main.c".to_string()];
     let input = LivePassInput {
         commit_sha: COMMIT,
         worktree_id: WORKTREE,
-        checkout_root: h.root(),
+        scope: h.scope(),
         worklist: &worklist,
         max_requests: 100,
         started_at_ms: 1_000,


### PR DESCRIPTION
The live oracle used one path — the configured `[index] root` — for four different jobs: the ceiling of the project-marker walk, that walk's symlink-containment bound, the stop of every ancestor walk, and, implicitly, the definition of which sources the checkout owns. #1008 and #1011 are the two faces of that conflation, and fixing either alone makes the other worse.

**Too wide.** A checkout whose only committed compilation database belongs to a vendored subtree had that database pinned for its *first-party* sources. `--compile-commands-dir` is global, so clangd inferred commands for those files from a vendored sibling entry, carrying its `-D` and include flags — a different preprocessor branch, and so a different definition, persisted as trusted evidence.

**Too narrow.** `[index] root` may sit below the checkout root, and a `compile_commands.json` at the worktree top was then outside the walk entirely, so the backend reported the checkout `Blocked` even though clangd's own ancestor search would have found that database for every source under the root. Separately, the warm-up document search excluded every dot-directory, so a checkout whose indexed sources live only under one had a usable database and no findable document — also a false `Blocked`.

## The change

The three concepts become distinct. `CheckoutScope` carries the configured root, the enclosing checkout ceiling (derived, never passed), and the indexed corpus.

- The marker descent still starts at the index root — a database in a sibling subtree governs no indexed source — and gains an **ancestor leg** from the root up to the ceiling covering each directory and its `build/`, which is the set clangd itself searches. O(depth) `exists()` calls, not a widened traversal.
- Ancestor walks and symlink containment stop at the **ceiling**.
- The document search asks the **corpus** instead of testing directory names.

**Pinning gains a governance gate:** a database may be pinned only if at least one of its entries names a file inside the indexed corpus. The database's own location is deliberately never tested — `build`, `.build`, `target`, and `dist` are in the indexing floor and gitignored besides, so a `build/compile_commands.json` is never in the corpus of *any* repo, and a location test would withdraw pinning from essentially every real single-database checkout. Each entry's `file` is resolved per the format, normalized lexically, and tested against the corpus inside the pass `read_marker_file` already makes — buffers reused across entries, short-circuiting on the first qualifying entry.

The corpus is `rag-rat-core`'s to define and the oracle cannot derive it, so `IndexedCorpus` is declared in the oracle and implemented in core over the same two authorities the indexing walk consults.

## Supporting changes

- `push_target` refuses a target directory that does not lie under `[index] root`. Such a config already failed its index run with a bare `prefix not found` from `collect_index_files`, so this removes no working setup and moves an undiagnosable runtime failure to the point the mistake was made. It is also what lets the marker descent treat "under the index root" as a property rather than a convention.
- The manifest prerequisite splits by what it needs: `batch_prerequisite_blocked` answers the root-level marker question, `prerequisite_blocked_with` the whole-checkout one.
- The live pass states which root is authoritative. `scope.root()` wins, because the server was spawned with it as its working directory and `rootUri`; `source_root` is row provenance and is now checked rather than used, with a distinct error when the two disagree.
- `lexically_normalized` moves to `rag_rat_base::paths` so config validation and the governance predicate share one definition.
- `ProjectLayout::complete` now certifies a narrower proposition — every database that could govern an indexed file, rather than every database under the root — and its comment says so.
- A checkout whose database describes nothing it indexes is reported apart from the other reasons for not pinning, because the remedies differ: regenerate the database so it covers the indexed sources, or bind the tree it does describe.

## A bug the worktree coverage caught

The ancestor leg recorded each directory *before* testing whether it had reached the ceiling, so when the index root already **is** the checkout root — the common case — the walk stepped past the ceiling and climbed to the filesystem root, counting databases from outside the checkout. A linked worktree nested inside another checkout climbed out of itself, found the enclosing checkout's database, counted it as a second one, and declined to pin, silently losing `--compile-commands-dir`. Every single-checkout fixture passed throughout; only the real `git worktree add` fixture exposed it.

## Verification

4275 tests pass; `cargo +nightly fmt --check` and both CI clippy configurations (`--no-default-features` and `--all-features`, `-D warnings`) exit 0. Rebased on current `main`.

New coverage includes the vendored subtree, the mainstream `build/` database (asserting the database's own location is outside the corpus, so it cannot pass for the wrong reason), a database above the index root, sources under a hidden directory, a mixed database, absolute entry paths, a symlinked build directory, a non-git root, escaping target directories, the ancestor leg's boundary, and a real linked-worktree fixture.

## Not addressed here

The live oracle still spawns one session rooted at `config.root`, so an edit that exists only in a linked worktree gets no live evidence. That is #1010, unchanged by this branch — `watch/overlay.rs` and `watch/pass.rs` are untouched, and the spawn was already `config.root`-rooted before it. The ceiling is derived from the root the scope is resolved for, never from the main checkout, and a test pins that property now so #1010 can land without re-litigating it.

#996 and #1016 are likewise out of scope. Note for #996: `pins_same_database_as` is structurally vacuous for `ra-lsp` and `ts-lsp`, whose `resolve_layout` returns the empty default, so it always reports "unchanged" — that signal is not a foundation to build on.

Fixes #1008
Fixes #1011