### PR TITLE
fix(lens): load sidebar tree data in a pump and read it synchronously

### DIFF
--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -1,6 +1,7 @@
 // Sidebar tree views: per-file Clone Classes, Memories, and Issues & Decisions.
-// All three refresh off the active editor and the index-version poll, and all
-// read from the shared per-file FileStore (no per-view fetching).
+// All three describe the active editor's file, are filled by one pump off the
+// active-editor event and the index-version poll, and read from the shared
+// per-file FileStore (no per-view fetching).
 import * as vscode from 'vscode';
 import type { CloneRegion, DecisionRecord, PapertrailRef } from './client';
 import type { FileData, FileStore } from './store';
@@ -37,68 +38,135 @@ class Item extends vscode.TreeItem {
 }
 
 /**
- * How many times a tree load may be re-aimed at a newly active editor before giving up. Each
- * attempt awaits a real load, so the bound exists to end an unwinnable race with a user paging
- * through files, not to prevent a hot loop.
+ * One of the three trees. It holds what it is showing; the pump is the only writer.
+ *
+ * `getChildren` is deliberately SYNCHRONOUS. `TreeDataProvider.getChildren` has no cancellation
+ * token and no way to decline to publish, so an implementation that awaits inside it makes
+ * completion order the arbiter of what the sidebar shows: with several invocations in flight a
+ * late one overwrites a newer one's result, and every value it can return is a publication — a
+ * cached tree can predate an invalidation, an empty one can blank a tree a newer load just filled.
+ * There is no safe return value, so the loading moves out instead. Reading state that is already
+ * resolved makes a read atomic, and leaves only the load path having to decide whether it is still
+ * entitled to write.
  */
-const STALE_LOAD_RETRIES = 4;
-
 abstract class FileView implements vscode.TreeDataProvider<Item> {
-  private emitter = new vscode.EventEmitter<Item | undefined>();
+  private readonly emitter = new vscode.EventEmitter<Item | undefined>();
   readonly onDidChangeTreeData = this.emitter.event;
-
-  constructor(protected readonly store: FileStore) {}
-
-  refresh(): void {
-    this.emitter.fire(undefined);
-  }
+  private items: Item[] = [];
 
   getTreeItem(element: Item): vscode.TreeItem {
     return element;
   }
 
-  async getChildren(element?: Item): Promise<Item[]> {
-    if (element) {
-      return element.children ?? [];
-    }
-    // These views describe the ACTIVE file, so an answer about a document that stopped being
-    // active is wrong however good the data is. Rather than discard it — which would let a slow
-    // load, resolving after a newer one, blank the tree the newer one just filled — re-ask about
-    // wherever the user now is. Whichever request settles last then still describes the current
-    // editor, so the outcome no longer depends on completion order.
-    for (let attempt = 0; attempt < STALE_LOAD_RETRIES; attempt += 1) {
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
-        return [
-          new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') }),
-        ];
-      }
-      const document = editor.document.uri.toString();
-      const loaded = await this.store.dataFor(editor.document);
-      if (vscode.window.activeTextEditor?.document.uri.toString() !== document) {
-        continue;
-      }
-      if (!loaded) {
-        // Distinguish "nothing to show for this buffer" from "the server did not answer": an
-        // unsaved buffer has no indexed path, and reporting that as an outage would be wrong.
-        return this.store.pathOf(editor.document)
-          ? [new Item('lens server offline', { icon: new vscode.ThemeIcon('cloud-offline') })]
-          : [new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') })];
-      }
-      return this.roots(loaded.path, loaded.data);
-    }
-    // The active editor changed on every attempt, so the user is still moving and every switch
-    // has queued its own refresh. Returning nothing can still blank a tree a newer request just
-    // filled, because `getChildren` has no way to decline to publish — that residual is #1022,
-    // which replaces this shape with a synchronous read over state a single pump owns.
-    return [];
+  getChildren(element?: Item): Item[] {
+    return element ? element.children ?? [] : this.items;
   }
 
-  protected abstract roots(path: string, data: FileData): Item[];
+  /** Replace what this view shows and make VS Code re-read it. The pump is the only caller. */
+  publish(items: Item[]): void {
+    this.items = items;
+    this.emitter.fire(undefined);
+  }
+
+  /**
+   * This view's tree for one file's data. The contract is unchanged by the pump — only its caller
+   * moved out of `getChildren`, so it now runs once a load is entitled to publish.
+   */
+  abstract roots(path: string, data: FileData): Item[];
+}
+
+const loading = (): Item => new Item('loading…', { icon: new vscode.ThemeIcon('loading~spin') });
+
+const noIndexedFile = (): Item =>
+  new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') });
+
+const serverOffline = (): Item =>
+  new Item('lens server offline', { icon: new vscode.ThemeIcon('cloud-offline') });
+
+/**
+ * Loads the sidebar's data and publishes it to the three views.
+ *
+ * Everything the views show describes ONE document — whichever editor is active — so which
+ * document a load was aimed at is part of its answer, and an answer about another document is
+ * wrong however good the data is. This is where that is checked: the document and the store's data
+ * epoch are captured before the await and re-read after it, and the result is written only if this
+ * is still the newest load, still aimed at the active editor, and still under the index state it
+ * started from. Anything else is dropped rather than published — whatever superseded it publishes
+ * its own answer, which is why every `invalidate`/`reset` in the extension is paired with a
+ * `refresh`.
+ *
+ * One pump for all three views rather than one each: they sit stacked in a single container, so a
+ * slow view left describing the previous file beside two describing the current one is the same
+ * wrong answer, only visibly. It also puts the decision to publish in one place instead of three.
+ */
+class SidebarPump {
+  private generation = 0;
+  /** The document the views describe, `undefined` when no editor is active. */
+  private document: string | undefined;
+
+  constructor(
+    private readonly store: FileStore,
+    private readonly views: readonly FileView[],
+  ) {}
+
+  /** Reload for whatever editor is active now. */
+  refresh(): void {
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    const generation = ++this.generation;
+    const editor = vscode.window.activeTextEditor;
+    const document = editor?.document.uri.toString();
+    const switched = document !== this.document;
+    this.document = document;
+    if (!editor) {
+      this.publishMessage(noIndexedFile);
+      return;
+    }
+    if (switched) {
+      // The views still hold the previous file's tree, and leaving it up asserts it about the file
+      // now on screen. Only a document CHANGE clears: an index refresh reloads the same document,
+      // and emptying its tree on every version event would flicker for no gain.
+      this.publishMessage(loading);
+    }
+    const epoch = this.store.dataEpoch();
+    const loaded = await this.store.dataFor(editor.document);
+    if (
+      // A newer load owns the views. Same document and same epoch are not enough to make two loads
+      // interchangeable: the store re-points to a replacement endpoint and reloads without moving
+      // its epoch, so the earlier request can be carrying an older server's answer.
+      generation !== this.generation ||
+      // The host updates `activeTextEditor` before it delivers the change event, so a load can
+      // settle after the user has moved on but before anything told the pump to reload.
+      vscode.window.activeTextEditor?.document.uri.toString() !== document ||
+      // The index moved. `dataFor` withholds a payload computed under the old epoch, and reporting
+      // that withholding below as an outage would clear the tree over an ordinary reindex.
+      this.store.dataEpoch() !== epoch
+    ) {
+      return;
+    }
+    if (!loaded) {
+      // Distinguish "nothing to show for this buffer" from "the server did not answer": an
+      // unsaved buffer has no indexed path, and reporting that as an outage would be wrong.
+      this.publishMessage(this.store.pathOf(editor.document) ? serverOffline : noIndexedFile);
+      return;
+    }
+    for (const view of this.views) {
+      view.publish(view.roots(loaded.path, loaded.data));
+    }
+  }
+
+  /** The same message in all three views, built per view: a `TreeItem` belongs to one tree. */
+  private publishMessage(item: () => Item): void {
+    for (const view of this.views) {
+      view.publish([item()]);
+    }
+  }
 }
 
 export class CloneClassesView extends FileView {
-  protected roots(path: string, data: FileData): Item[] {
+  roots(path: string, data: FileData): Item[] {
     const out: Item[] = [];
     const unavailable = cloneGraphUnavailableReason(data.cloneGraph);
     if (unavailable) {
@@ -186,7 +254,7 @@ function regionItem(path: string, r: CloneRegion): Item {
 }
 
 export class MemoriesView extends FileView {
-  protected roots(path: string, data: FileData): Item[] {
+  roots(path: string, data: FileData): Item[] {
     const memories = data.memories;
     if (!memories.length) {
       return [new Item('no memories bound to this file', { icon: new vscode.ThemeIcon('check') })];
@@ -205,7 +273,7 @@ export class MemoriesView extends FileView {
 }
 
 export class PapertrailView extends FileView {
-  protected roots(_path: string, data: FileData): Item[] {
+  roots(_path: string, data: FileData): Item[] {
     const { refs, decisions } = data;
     const out: Item[] = [];
     if (decisions.length) {
@@ -294,24 +362,17 @@ export function registerSidebar(
   context: vscode.ExtensionContext,
   store: FileStore,
 ): { refresh: () => void } {
-  const clones = new CloneClassesView(store);
-  const memories = new MemoriesView(store);
-  const papertrail = new PapertrailView(store);
+  const clones = new CloneClassesView();
+  const memories = new MemoriesView();
+  const papertrail = new PapertrailView();
+  const pump = new SidebarPump(store, [clones, memories, papertrail]);
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider('rag-rat-lens.cloneClasses', clones),
     vscode.window.registerTreeDataProvider('rag-rat-lens.memories', memories),
     vscode.window.registerTreeDataProvider('rag-rat-lens.papertrail', papertrail),
-    vscode.window.onDidChangeActiveTextEditor(() => {
-      clones.refresh();
-      memories.refresh();
-      papertrail.refresh();
-    }),
+    // A switch is a reload, driven through the same pump as the index-version poll so the two
+    // cannot publish over each other.
+    vscode.window.onDidChangeActiveTextEditor(() => pump.refresh()),
   );
-  return {
-    refresh: () => {
-      clones.refresh();
-      memories.refresh();
-      papertrail.refresh();
-    },
-  };
+  return { refresh: () => pump.refresh() };
 }

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -4,6 +4,7 @@
 // per-file FileStore (no per-view fetching).
 import * as vscode from 'vscode';
 import type { CloneRegion, DecisionRecord, PapertrailRef } from './client';
+import { logError } from './output';
 import type { FileData, FileStore } from './store';
 
 class Item extends vscode.TreeItem {
@@ -38,6 +39,48 @@ class Item extends vscode.TreeItem {
 }
 
 /**
+ * What the sidebar is showing: one file's data, or the reason there is none.
+ *
+ * A state rather than a rendered list, because the pump decides what is TRUE and each view decides
+ * how to say it. That split is what lets the three views agree by construction, and it is where a
+ * new truth goes — a further reason the data cannot be shown, or a qualification on data that can
+ * (which lane of it is a carried-forward fallback, whether the file has moved under the answer) is
+ * a member here plus a rendering arm, not a special case threaded through the load path.
+ */
+type SidebarState =
+  | { kind: 'loading' }
+  /** No active editor, or a buffer with no indexed path — an unsaved one, or outside the repo. */
+  | { kind: 'unindexed' }
+  | { kind: 'offline' }
+  /** The load itself failed. Distinct from `offline`: nothing was learned about the server. */
+  | { kind: 'failed' }
+  | { kind: 'file'; path: string; data: FileData };
+
+type SidebarMessage = Exclude<SidebarState, { kind: 'file' }>;
+
+/** The one row a message state renders as. Built per view: a `TreeItem` belongs to one tree. */
+function messageItem(state: SidebarMessage): Item {
+  switch (state.kind) {
+    case 'loading':
+      return new Item('loading…', { icon: new vscode.ThemeIcon('loading~spin') });
+    case 'unindexed':
+      return new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') });
+    case 'offline':
+      return new Item('lens server offline', { icon: new vscode.ThemeIcon('cloud-offline') });
+    case 'failed':
+      return new Item('lens data unavailable', {
+        description: 'see the rag-rat Lens log',
+        icon: new vscode.ThemeIcon('warning', new vscode.ThemeColor('editorWarning.foreground')),
+      });
+    default: {
+      // Adding a state without a row is a compile error, not a blank tree at runtime.
+      const unhandled: never = state;
+      throw new Error(`unhandled sidebar state: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+/**
  * One of the three trees. It holds what it is showing; the pump is the only writer.
  *
  * `getChildren` is deliberately SYNCHRONOUS. `TreeDataProvider.getChildren` has no cancellation
@@ -52,7 +95,11 @@ class Item extends vscode.TreeItem {
 abstract class FileView implements vscode.TreeDataProvider<Item> {
   private readonly emitter = new vscode.EventEmitter<Item | undefined>();
   readonly onDidChangeTreeData = this.emitter.event;
-  private items: Item[] = [];
+  /**
+   * `loading`, never `[]`. The views exist before the first load can have answered, and an empty
+   * tree is a claim — "this file has nothing" — that nothing has established yet.
+   */
+  private items: Item[] = [messageItem({ kind: 'loading' })];
 
   getTreeItem(element: Item): vscode.TreeItem {
     return element;
@@ -62,7 +109,15 @@ abstract class FileView implements vscode.TreeDataProvider<Item> {
     return element ? element.children ?? [] : this.items;
   }
 
-  /** Replace what this view shows and make VS Code re-read it. The pump is the only caller. */
+  /**
+   * This view's rows for `state`. PURE — it shows nothing on its own, so the pump can render all
+   * three views before committing any of them.
+   */
+  render(state: SidebarState): Item[] {
+    return state.kind === 'file' ? this.roots(state.path, state.data) : [messageItem(state)];
+  }
+
+  /** Show already-rendered rows and make VS Code re-read them. The pump is the only caller. */
   publish(items: Item[]): void {
     this.items = items;
     this.emitter.fire(undefined);
@@ -72,28 +127,23 @@ abstract class FileView implements vscode.TreeDataProvider<Item> {
    * This view's tree for one file's data. The contract is unchanged by the pump — only its caller
    * moved out of `getChildren`, so it now runs once a load is entitled to publish.
    */
-  abstract roots(path: string, data: FileData): Item[];
+  protected abstract roots(path: string, data: FileData): Item[];
 }
-
-const loading = (): Item => new Item('loading…', { icon: new vscode.ThemeIcon('loading~spin') });
-
-const noIndexedFile = (): Item =>
-  new Item('open a file in the indexed repo', { icon: new vscode.ThemeIcon('info') });
-
-const serverOffline = (): Item =>
-  new Item('lens server offline', { icon: new vscode.ThemeIcon('cloud-offline') });
 
 /**
  * Loads the sidebar's data and publishes it to the three views.
  *
- * Everything the views show describes ONE document — whichever editor is active — so which
- * document a load was aimed at is part of its answer, and an answer about another document is
- * wrong however good the data is. This is where that is checked: the document and the store's data
- * epoch are captured before the await and re-read after it, and the result is written only if this
- * is still the newest load, still aimed at the active editor, and still under the index state it
- * started from. Anything else is dropped rather than published — whatever superseded it publishes
- * its own answer, which is why every `invalidate`/`reset` in the extension is paired with a
- * `refresh`.
+ * Everything the views show describes ONE document, loaded from ONE data source — so the premise a
+ * load ran under is part of its answer, and an answer under another premise is wrong however good
+ * the data is. This is where that is checked, on both sides of the await:
+ *
+ * - AFTER it, before publishing: the result is written only if this is still the newest load, still
+ *   aimed at the active editor, and still under the index state it started from. Anything else is
+ *   dropped rather than published — whatever superseded it publishes its own answer, which is why
+ *   every `invalidate`/`reset` in the extension is paired with a `refresh`.
+ * - BEFORE it, over what is already on screen: content whose premise no longer holds comes down
+ *   immediately rather than standing until a replacement arrives, which can take as long as the
+ *   request timeout.
  *
  * One pump for all three views rather than one each: they sit stacked in a single container, so a
  * slow view left describing the previous file beside two describing the current one is the same
@@ -101,8 +151,12 @@ const serverOffline = (): Item =>
  */
 class SidebarPump {
   private generation = 0;
-  /** The document the views describe, `undefined` when no editor is active. */
-  private document: string | undefined;
+  /**
+   * The premise the views' current CONTENT answers: which document it describes, and which data
+   * source it came from. `undefined` while they hold a message — a message describes no file, so
+   * no change of premise can falsify it.
+   */
+  private shown: { document: string; source: number } | undefined;
 
   constructor(
     private readonly store: FileStore,
@@ -111,27 +165,37 @@ class SidebarPump {
 
   /** Reload for whatever editor is active now. */
   refresh(): void {
-    void this.load();
+    // The load reports its own failures; this is the backstop for a throw inside that reporting.
+    void this.load().catch((error: unknown) => logError('sidebar', error));
   }
 
   private async load(): Promise<void> {
     const generation = ++this.generation;
     const editor = vscode.window.activeTextEditor;
-    const document = editor?.document.uri.toString();
-    const switched = document !== this.document;
-    this.document = document;
     if (!editor) {
-      this.publishMessage(noIndexedFile);
+      this.publish({ kind: 'unindexed' });
       return;
     }
-    if (switched) {
-      // The views still hold the previous file's tree, and leaving it up asserts it about the file
-      // now on screen. Only a document CHANGE clears: an index refresh reloads the same document,
-      // and emptying its tree on every version event would flicker for no gain.
-      this.publishMessage(loading);
+    const document = editor.document.uri.toString();
+    const source = this.store.sourceEpoch();
+    if (this.shown && (this.shown.document !== document || this.shown.source !== source)) {
+      // What is on screen answers a question nobody is asking any more — a different document, or a
+      // server/repository the store has declared unusable — and leaving it up asserts it about the
+      // file now on screen. Both premises are known to have changed BEFORE the load, so the tree
+      // comes down now rather than when a replacement happens to arrive.
+      //
+      // Only a CHANGED premise clears. An ordinary index invalidation reloads the same document
+      // from the same source, and emptying its tree on every version event would flicker for no
+      // gain.
+      this.publish({ kind: 'loading' });
     }
     const epoch = this.store.dataEpoch();
-    const loaded = await this.store.dataFor(editor.document);
+    // Settle the load into a value, the way `probeStatus` does: a rejection has to pass the same
+    // entitlement checks as an answer before it may say anything.
+    const settled = await this.store.dataFor(editor.document).then(
+      (loaded) => ({ ok: true as const, loaded }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
     if (
       // A newer load owns the views. Same document and same epoch are not enough to make two loads
       // interchangeable: the store re-points to a replacement endpoint and reloads without moving
@@ -146,27 +210,52 @@ class SidebarPump {
     ) {
       return;
     }
-    if (!loaded) {
-      // Distinguish "nothing to show for this buffer" from "the server did not answer": an
-      // unsaved buffer has no indexed path, and reporting that as an outage would be wrong.
-      this.publishMessage(this.store.pathOf(editor.document) ? serverOffline : noIndexedFile);
+    if (!settled.ok) {
+      // Nothing is known about this file, and a spinner left up forever says the opposite.
+      logError('sidebar', settled.error);
+      this.publish({ kind: 'failed' });
       return;
     }
-    for (const view of this.views) {
-      view.publish(view.roots(loaded.path, loaded.data));
+    if (!settled.loaded) {
+      // Distinguish "nothing to show for this buffer" from "the server did not answer": an
+      // unsaved buffer has no indexed path, and reporting that as an outage would be wrong.
+      this.publish(
+        this.store.pathOf(editor.document) ? { kind: 'offline' } : { kind: 'unindexed' },
+      );
+      return;
     }
+    this.publish({ kind: 'file', path: settled.loaded.path, data: settled.loaded.data }, document);
   }
 
-  /** The same message in all three views, built per view: a `TreeItem` belongs to one tree. */
-  private publishMessage(item: () => Item): void {
-    for (const view of this.views) {
-      view.publish([item()]);
+  /**
+   * Show `state` in all three views. `document` is the document a `file` state answers about, and
+   * recording it is what lets a later load tell whether the views still describe anything.
+   */
+  private publish(state: SidebarState, document?: string): void {
+    let rendered: readonly (readonly [FileView, Item[]])[];
+    try {
+      // Render every view BEFORE committing any: a payload one view's builder cannot turn into
+      // rows would otherwise leave the other two describing it, which is exactly the disagreement
+      // a single pump exists to prevent.
+      rendered = this.views.map((view) => [view, view.render(state)] as const);
+    } catch (error) {
+      logError('sidebar', error);
+      if (state.kind !== 'failed') {
+        this.publish({ kind: 'failed' });
+      }
+      return;
+    }
+    // Read the source HERE, after the load: one that re-points mid-flight answers from the source
+    // serving now, not the one it started under.
+    this.shown = document === undefined ? undefined : { document, source: this.store.sourceEpoch() };
+    for (const [view, items] of rendered) {
+      view.publish(items);
     }
   }
 }
 
 export class CloneClassesView extends FileView {
-  roots(path: string, data: FileData): Item[] {
+  protected roots(path: string, data: FileData): Item[] {
     const out: Item[] = [];
     const unavailable = cloneGraphUnavailableReason(data.cloneGraph);
     if (unavailable) {
@@ -254,7 +343,7 @@ function regionItem(path: string, r: CloneRegion): Item {
 }
 
 export class MemoriesView extends FileView {
-  roots(path: string, data: FileData): Item[] {
+  protected roots(path: string, data: FileData): Item[] {
     const memories = data.memories;
     if (!memories.length) {
       return [new Item('no memories bound to this file', { icon: new vscode.ThemeIcon('check') })];
@@ -273,7 +362,7 @@ export class MemoriesView extends FileView {
 }
 
 export class PapertrailView extends FileView {
-  roots(_path: string, data: FileData): Item[] {
+  protected roots(_path: string, data: FileData): Item[] {
     const { refs, decisions } = data;
     const out: Item[] = [];
     if (decisions.length) {

--- a/editors/vscode/src/store.ts
+++ b/editors/vscode/src/store.ts
@@ -88,6 +88,8 @@ export class FileStore {
    */
   private lastGoodEndpoint: string | undefined;
   private epoch = 0;
+  /** See [`sourceEpoch`](FileStore#sourceEpoch) — moves only when the served identity changes. */
+  private source = 0;
   private online = false;
 
   constructor(
@@ -132,6 +134,22 @@ export class FileStore {
    */
   dataEpoch(): number {
     return this.epoch;
+  }
+
+  /**
+   * WHERE the store is serving from, as an opaque counter that moves whenever everything fetched
+   * so far stops being attributable to the server now answering: a `reset`, or a discovery
+   * re-point observed while loading.
+   *
+   * Deliberately not `dataEpoch`, which also moves on every ordinary index invalidation. A caller
+   * holding a rendered copy of a payload needs the two apart. The index moving means its copy is
+   * merely out of date, and the replacement is already on its way — taking it down would flicker
+   * every surface on every reindex. The SOURCE moving means its copy describes a different
+   * repository or a different server, so it is not out of date but wrong, and it has to come down
+   * NOW rather than stand for as long as the replacement request takes.
+   */
+  sourceEpoch(): number {
+    return this.source;
   }
 
   /** The last load's error, if any — present for a partial load too, so the caller can log it. */
@@ -259,13 +277,7 @@ export class FileStore {
         // Nothing arrived at all: that is a file-level failure, and the caller clears its signals.
         return this.recordFailure(path, rejected[0].reason);
       }
-      if (endpoint !== this.lastGoodEndpoint) {
-        for (const state of this.paths.values()) {
-          state.lastGood = undefined;
-          state.laneAt = undefined;
-        }
-        this.lastGoodEndpoint = endpoint;
-      }
+      this.noteServedEndpoint(endpoint);
       const entry = this.state(path);
       // A rejected lane keeps the last value that arrived for it, for a while. An empty array would
       // be a claim — "no memories on this file" — that the caller acts on by clearing diagnostics
@@ -351,6 +363,30 @@ export class FileStore {
       state.laneAt = undefined;
     }
     this.lastGoodEndpoint = undefined;
+    this.source += 1;
+  }
+
+  /**
+   * Attribute what is about to be stored to the endpoint that answered it, dropping the fallbacks
+   * of any earlier one.
+   *
+   * Both of the store's own writers of the served identity move `source` — this one and
+   * `forgetServedState` — so a consumer holding rendered data learns that it now describes a
+   * different server WITHOUT having to know which of the extension's actions can re-point
+   * discovery. A stream failure is the case that makes that matter: it re-resolves the endpoint
+   * but reloads without an explicit reset, so a server that came back on another port changes the
+   * identity with nothing having declared it.
+   */
+  private noteServedEndpoint(endpoint: string): void {
+    if (endpoint === this.lastGoodEndpoint) {
+      return;
+    }
+    for (const state of this.paths.values()) {
+      state.lastGood = undefined;
+      state.laneAt = undefined;
+    }
+    this.lastGoodEndpoint = endpoint;
+    this.source += 1;
   }
 
   /**

--- a/editors/vscode/src/store.ts
+++ b/editors/vscode/src/store.ts
@@ -121,6 +121,19 @@ export class FileStore {
     this.forgetServedState();
   }
 
+  /**
+   * Which index state the store is serving, as an opaque counter that moves on every
+   * `invalidate` / `reset` / reachability change.
+   *
+   * A caller that awaits data and then writes it to a surface reads this before and after: `data`
+   * already REFUSES to return a payload computed under a superseded epoch, but the caller still
+   * has to tell that refusal apart from a server that did not answer — both read as `undefined` —
+   * and rendering the second over the first turns an ordinary index refresh into a cleared surface.
+   */
+  dataEpoch(): number {
+    return this.epoch;
+  }
+
   /** The last load's error, if any — present for a partial load too, so the caller can log it. */
   failure(path: string): unknown {
     return this.paths.get(path)?.failure;

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -1490,14 +1490,54 @@ test('data that arrives after its document went dirty is withheld, not drawn', a
   assert.equal(loaded.path, 'src/lib.rs');
 });
 
-test('a sidebar load that resolves after the active editor moved on re-aims at the new one', async () => {
-  const uriFor = (value) => ({ toString: () => value });
-  const first = { document: { uri: uriFor('file:///repo/src/first.rs') } };
-  const second = { document: { uri: uriFor('file:///repo/src/second.rs') } };
-  const active = { editor: first };
+/** Everything the three sidebar views render, tagged so each one's source file is identifiable. */
+function sidebarData(name) {
+  return {
+    at: 0,
+    symbols: [],
+    coupling: [],
+    clones: [
+      { start_line: 1, end_line: 2, class_id: 1, max_similarity: 0.9, symbol: `clone_of_${name}`, partners: [] },
+    ],
+    cloneGraph: { eligible: true },
+    memories: [{ title: `memory_of_${name}`, kind: 'Invariant', line: 1 }],
+    refs: [
+      {
+        item_key: '1',
+        title: `ref_of_${name}`,
+        item_kind: 'issue',
+        ref_kind: 'mention',
+        source_text: '',
+        state_normalized: 'open',
+        url: null,
+      },
+    ],
+    decisions: [],
+  };
+}
+
+const sidebarEditor = (name) => ({
+  document: { uri: { toString: () => `file:///repo/src/${name}` } },
+});
+
+/** Let every queued microtask and the pump's own continuation run. */
+async function settle() {
+  for (let tick = 0; tick < 5; tick += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+/** The three views wired to a fake window, with the store's async surface under test control. */
+async function sidebarHarness(store) {
+  const active = { editor: undefined };
+  const listeners = [];
+  const providers = new Map();
+  const fires = [];
   const vscode = {
     EventEmitter: class {
-      fire() {}
+      fire(value) {
+        fires.push(value);
+      }
       get event() {
         return () => ({ dispose() {} });
       }
@@ -1518,43 +1558,192 @@ test('a sidebar load that resolves after the active editor moved on re-aims at t
       get activeTextEditor() {
         return active.editor;
       },
+      registerTreeDataProvider: (id, provider) => {
+        providers.set(id, provider);
+        return { dispose() {} };
+      },
+      onDidChangeActiveTextEditor: (listener) => {
+        listeners.push(listener);
+        return { dispose() {} };
+      },
     },
   };
-  const { CloneClassesView } = await loadSourceModule('sidebar.ts', vscode);
-  const gate = deferred();
-  const asked = [];
-  const store = {
-    async dataFor(document) {
-      const uri = document.uri.toString();
-      asked.push(uri);
-      if (uri.endsWith('first.rs')) {
-        // Hold the first load open so the user can switch editors while it is in flight.
-        await gate.promise;
-        return {
-          path: 'src/first.rs',
-          data: { clones: [{ symbol: 'from_first', partners: [] }], cloneGraph: { eligible: true } },
-        };
+  const { registerSidebar } = await loadSourceModule('sidebar.ts', vscode);
+  const sidebar = registerSidebar({ subscriptions: [] }, store);
+  return {
+    refresh: () => sidebar.refresh(),
+    /** Make `editor` active, as the host does before it delivers the change event. */
+    focus(editor) {
+      active.editor = editor;
+    },
+    activate(editor) {
+      active.editor = editor;
+      for (const listener of listeners) {
+        listener(editor);
       }
-      return {
-        path: 'src/second.rs',
-        data: { clones: [{ symbol: 'from_second', partners: [] }], cloneGraph: { eligible: true } },
-      };
     },
-    pathOf: () => 'src/whatever.rs',
+    /** What one view is showing right now — a synchronous read, as VS Code performs it. */
+    shown(view = 'cloneClasses') {
+      const items = providers.get(`rag-rat-lens.${view}`).getChildren();
+      assert.ok(Array.isArray(items), 'getChildren must answer synchronously');
+      return JSON.stringify(items);
+    },
+    /** How many times the views have told VS Code to re-read — one per view per publication. */
+    published: () => fires.length,
   };
-  const view = new CloneClassesView(store);
+}
 
-  const pending = view.getChildren();
-  active.editor = second;
+test('a sidebar load that settles after a newer one cannot overwrite it', async () => {
+  const gates = { 'first.rs': deferred(), 'second.rs': deferred() };
+  const asked = [];
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    pathOf: () => 'src/whatever.rs',
+    async dataFor(document) {
+      const name = document.uri.toString().split('/').pop();
+      asked.push(name);
+      await gates[name].promise;
+      return { path: `src/${name}`, data: sidebarData(name) };
+    },
+  });
+
+  harness.activate(sidebarEditor('first.rs'));
+  // Both loads are now in flight: the user switched while the first was still running.
+  harness.activate(sidebarEditor('second.rs'));
+  assert.deepEqual(asked, ['first.rs', 'second.rs']);
+  // The first file's tree came down with the switch. Holding it up until the new one arrives
+  // would state one file's clone classes about another, which is the whole defect.
+  assert.match(harness.shown(), /loading/);
+  assert.doesNotMatch(harness.shown(), /from_first|clone_of_first/);
+
+  gates['second.rs'].resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_second\.rs/);
+  assert.match(harness.shown('memories'), /memory_of_second\.rs/);
+  assert.match(harness.shown('papertrail'), /ref_of_second\.rs/);
+  const published = harness.published();
+
+  // The OLDER load settles last. `getChildren` has no way to decline to publish, so under the
+  // previous shape whichever invocation settled last decided what the sidebar showed; here the
+  // load itself declines, and publishes nothing at all.
+  gates['first.rs'].resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_second\.rs/);
+  assert.doesNotMatch(harness.shown(), /clone_of_first\.rs/);
+  assert.equal(harness.published(), published, 'a superseded load must not publish anything');
+});
+
+test('a sidebar load settling between the editor moving and the event arriving is dropped', async () => {
+  const gate = deferred();
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    pathOf: () => 'src/first.rs',
+    async dataFor(document) {
+      const name = document.uri.toString().split('/').pop();
+      await gate.promise;
+      return { path: `src/${name}`, data: sidebarData(name) };
+    },
+  });
+
+  harness.activate(sidebarEditor('first.rs'));
+  const published = harness.published();
+  // `activeTextEditor` is updated by the host before the change event reaches an extension, so a
+  // load can settle inside that window — with nothing having told the pump to reload yet, which
+  // is the one thing a generation counter cannot see.
+  harness.focus(sidebarEditor('second.rs'));
   gate.resolve();
+  await settle();
+  assert.doesNotMatch(harness.shown(), /clone_of_first/, 'not a tree for a file that moved off');
+  assert.equal(harness.published(), published);
 
-  const items = await pending;
-  assert.deepEqual(asked, ['file:///repo/src/first.rs', 'file:///repo/src/second.rs']);
-  // Not the stale file, and NOT empty: a load settling late must not blank the tree a newer one
-  // filled, so it answers about wherever the user actually is.
-  assert.equal(items.length, 1);
-  assert.match(JSON.stringify(items), /from_second/);
-  assert.doesNotMatch(JSON.stringify(items), /from_first/);
+  // The event arrives and the sidebar fills for the file the user is actually on.
+  harness.activate(sidebarEditor('second.rs'));
+  await settle();
+  assert.match(harness.shown(), /clone_of_second/);
+});
+
+test('a same-document sidebar load that settles last cannot put the older payload back', async () => {
+  const gates = [deferred(), deferred()];
+  let started = 0;
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    pathOf: () => 'src/lib.rs',
+    async dataFor() {
+      const load = started++;
+      await gates[load].promise;
+      return { path: 'src/lib.rs', data: sidebarData(`load_${load}`) };
+    },
+  });
+
+  // Two loads for the SAME document under the SAME index state, and they can still disagree: the
+  // store re-points and reloads wholly against a replacement endpoint without moving its epoch, so
+  // the earlier request can be carrying an older server's answer. Neither the document nor the
+  // epoch separates them — only which request is the newest.
+  harness.activate(sidebarEditor('lib.rs'));
+  harness.refresh();
+  gates[1].resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_load_1/);
+  const published = harness.published();
+
+  gates[0].resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_load_1/);
+  assert.doesNotMatch(harness.shown(), /clone_of_load_0/, 'the overtaken load must not publish');
+  assert.equal(harness.published(), published);
+});
+
+test('an invalidation while a sidebar load runs neither blanks the tree nor republishes', async () => {
+  const epoch = { value: 0 };
+  const gate = { current: deferred() };
+  const answer = { name: 'index_1' };
+  const harness = await sidebarHarness({
+    dataEpoch: () => epoch.value,
+    pathOf: () => 'src/lib.rs',
+    async dataFor() {
+      const started = epoch.value;
+      await gate.current.promise;
+      // What the real store does: a payload computed under a superseded epoch is not returned,
+      // and neither is one for a server that did not answer. The caller sees the same `undefined`.
+      return started === epoch.value && answer.name
+        ? { path: 'src/lib.rs', data: sidebarData(answer.name) }
+        : undefined;
+    },
+  });
+
+  harness.activate(sidebarEditor('lib.rs'));
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_index_1/);
+  const published = harness.published();
+
+  // The index moves while the next load is in flight. Its answer is withheld by the store, and
+  // rendering that withholding as an outage would clear a tree over an ordinary reindex.
+  gate.current = deferred();
+  harness.refresh();
+  epoch.value += 1;
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_index_1/, 'an overtaken load must not blank the tree');
+  assert.doesNotMatch(harness.shown(), /offline/);
+  assert.equal(harness.published(), published, 'an overtaken load must not publish anything');
+
+  // The refresh that every invalidation is paired with is what repaints, from the new index state.
+  answer.name = 'index_2';
+  gate.current = deferred();
+  harness.refresh();
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_index_2/);
+
+  // Withholding is for a superseded premise only: a server that stops answering under a stable
+  // index state still has to be reported, or the sidebar would show the last good tree forever.
+  answer.name = '';
+  gate.current = deferred();
+  harness.refresh();
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /lens server offline/);
 });
 
 test('open memory documents are withdrawn when the server stops answering', async () => {

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -251,6 +251,11 @@ test('clone minimum token setting accepts integers only', () => {
   assert.equal(setting.type, 'integer');
 });
 
+/** The output channel the extension opens at import; the sidebar logs failures to it. */
+const fakeOutput = () => ({
+  createOutputChannel: () => ({ appendLine() {}, show() {} }),
+});
+
 test('clone sidebar distinguishes unavailable analysis from an empty result', async () => {
   const vscode = {
     EventEmitter: class {},
@@ -258,6 +263,7 @@ test('clone sidebar distinguishes unavailable analysis from an empty result', as
     ThemeIcon: class {},
     TreeItem: class {},
     TreeItemCollapsibleState: { Expanded: 1, None: 0 },
+    window: fakeOutput(),
   };
   const { cloneGraphUnavailableReason } = await loadSourceModule('sidebar.ts', vscode);
 
@@ -279,6 +285,7 @@ test('papertrail sidebar keeps unknown states separate from closed items', async
     ThemeIcon: class {},
     TreeItem: class {},
     TreeItemCollapsibleState: { Expanded: 1, None: 0 },
+    window: fakeOutput(),
   };
   const { groupPapertrailRefs } = await loadSourceModule('sidebar.ts', vscode);
   const refs = ['open', 'closed', 'merged', null, 'draft'].map((state_normalized) => ({
@@ -1108,6 +1115,45 @@ test('an invalidation during the identity read is not overwritten', async () => 
   assert.equal(reloaded.symbols[0].name, 'load-2', 'the next read refetches instead of the stale one');
 });
 
+test('the served-source counter moves on a re-point and a reset, not on a reindex', async () => {
+  const FileStore = await loadStore();
+  const client = {
+    fileSymbolGraph: async () => [],
+    fileClonesFull: async () => ({ clone_regions: [], clone_graph: { eligible: true } }),
+    fileMemories: async () => [],
+    fileCoupling: async () => [],
+    filePapertrail: async () => ({ refs: [], decisions: [] }),
+  };
+  const server = { identity: 'http://127.0.0.1:18120 owner-token' };
+  const store = new FileStore(client, () => 0.9, () => 100, () => 'src/lib.rs', async () => server.identity);
+  store.setOnline(true);
+  await store.data('src/lib.rs');
+  const served = store.sourceEpoch();
+
+  // The index moved under the same server. Anything already drawn from it is out of date, and its
+  // replacement is on the way — not wrong, so a consumer has no reason to take it down.
+  store.invalidate();
+  await store.data('src/lib.rs');
+  assert.equal(store.sourceEpoch(), served, 'a reindex is not a change of source');
+
+  // Discovery re-points with nothing having declared it: `rag-rat mcp` restarted on another port,
+  // or minted a fresh ownership token. A consumer holding rows from the previous server has no
+  // other way to learn that they describe a different index.
+  server.identity = 'http://127.0.0.1:18121 restarted-token';
+  store.invalidate();
+  await store.data('src/lib.rs');
+  const repointed = store.sourceEpoch();
+  assert.notEqual(repointed, served, 'another server is another source');
+
+  store.invalidate();
+  await store.data('src/lib.rs');
+  assert.equal(store.sourceEpoch(), repointed, 'the same server twice is one source');
+
+  // The explicit declaration: a reconfigured server or a replaced workspace folder.
+  store.reset();
+  assert.notEqual(store.sourceEpoch(), repointed, 'a reset makes everything served unusable');
+});
+
 test('a lane that keeps failing stops being carried forward', async (t) => {
   const FileStore = await loadStore();
   const realNow = Date.now;
@@ -1533,6 +1579,7 @@ async function sidebarHarness(store) {
   const listeners = [];
   const providers = new Map();
   const fires = [];
+  const logged = [];
   const vscode = {
     EventEmitter: class {
       fire(value) {
@@ -1566,6 +1613,10 @@ async function sidebarHarness(store) {
         listeners.push(listener);
         return { dispose() {} };
       },
+      createOutputChannel: () => ({
+        appendLine: (line) => logged.push(line),
+        show() {},
+      }),
     },
   };
   const { registerSidebar } = await loadSourceModule('sidebar.ts', vscode);
@@ -1590,6 +1641,8 @@ async function sidebarHarness(store) {
     },
     /** How many times the views have told VS Code to re-read — one per view per publication. */
     published: () => fires.length,
+    /** What reached the extension's output channel. */
+    logged: () => logged.join('\n'),
   };
 }
 
@@ -1598,6 +1651,7 @@ test('a sidebar load that settles after a newer one cannot overwrite it', async 
   const asked = [];
   const harness = await sidebarHarness({
     dataEpoch: () => 0,
+    sourceEpoch: () => 0,
     pathOf: () => 'src/whatever.rs',
     async dataFor(document) {
       const name = document.uri.toString().split('/').pop();
@@ -1611,9 +1665,10 @@ test('a sidebar load that settles after a newer one cannot overwrite it', async 
   // Both loads are now in flight: the user switched while the first was still running.
   harness.activate(sidebarEditor('second.rs'));
   assert.deepEqual(asked, ['first.rs', 'second.rs']);
-  // The first file's tree came down with the switch. Holding it up until the new one arrives
-  // would state one file's clone classes about another, which is the whole defect.
-  assert.match(harness.shown(), /loading/);
+  // Neither load has answered, so no file's tree is up — the views are still on the row they were
+  // created with. (What happens to a tree that IS up when the document changes is pinned by "a
+  // document switch takes the previous file down before the new one loads".)
+  assert.match(harness.shown(), /loading…/);
   assert.doesNotMatch(harness.shown(), /from_first|clone_of_first/);
 
   gates['second.rs'].resolve();
@@ -1637,6 +1692,7 @@ test('a sidebar load settling between the editor moving and the event arriving i
   const gate = deferred();
   const harness = await sidebarHarness({
     dataEpoch: () => 0,
+    sourceEpoch: () => 0,
     pathOf: () => 'src/first.rs',
     async dataFor(document) {
       const name = document.uri.toString().split('/').pop();
@@ -1667,6 +1723,7 @@ test('a same-document sidebar load that settles last cannot put the older payloa
   let started = 0;
   const harness = await sidebarHarness({
     dataEpoch: () => 0,
+    sourceEpoch: () => 0,
     pathOf: () => 'src/lib.rs',
     async dataFor() {
       const load = started++;
@@ -1699,6 +1756,7 @@ test('an invalidation while a sidebar load runs neither blanks the tree nor repu
   const answer = { name: 'index_1' };
   const harness = await sidebarHarness({
     dataEpoch: () => epoch.value,
+    sourceEpoch: () => 0,
     pathOf: () => 'src/lib.rs',
     async dataFor() {
       const started = epoch.value;
@@ -1744,6 +1802,167 @@ test('an invalidation while a sidebar load runs neither blanks the tree nor repu
   gate.current.resolve();
   await settle();
   assert.match(harness.shown(), /lens server offline/);
+});
+
+test('the sidebar shows a loading row before anything has asked it to load', async () => {
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    sourceEpoch: () => 0,
+    pathOf: () => 'src/lib.rs',
+    dataFor: async () => undefined,
+  });
+
+  // The views exist from `registerSidebar` and are filled by the first pump. An empty tree in that
+  // window is a claim about the file — that it has no clones, no memories, no tracker items —
+  // which nothing has established.
+  assert.match(harness.shown(), /loading…/);
+  assert.match(harness.shown('memories'), /loading…/);
+  assert.match(harness.shown('papertrail'), /loading…/);
+});
+
+test('a document switch takes the previous file down before the new one loads', async () => {
+  const gate = { current: deferred() };
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    sourceEpoch: () => 0,
+    pathOf: () => 'src/lib.rs',
+    async dataFor(document) {
+      const name = document.uri.toString().split('/').pop();
+      await gate.current.promise;
+      return { path: `src/${name}`, data: sidebarData(name) };
+    },
+  });
+
+  harness.activate(sidebarEditor('first.rs'));
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_first\.rs/);
+
+  // The load for the new document is in flight and the views still hold the old one's tree.
+  // Leaving it up for the length of that request states one file's clone classes, memories and
+  // tracker items about another.
+  gate.current = deferred();
+  harness.activate(sidebarEditor('second.rs'));
+  await settle();
+  assert.doesNotMatch(harness.shown(), /clone_of_first\.rs/, "the previous file's tree must not stand");
+  assert.doesNotMatch(harness.shown('memories'), /memory_of_first\.rs/);
+  assert.doesNotMatch(harness.shown('papertrail'), /ref_of_first\.rs/);
+  assert.match(harness.shown(), /loading…/);
+
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_second\.rs/);
+});
+
+test('a data-source reset takes the previous tree down before the replacement arrives', async () => {
+  const store = { epoch: 0, source: 0 };
+  const gate = { current: deferred() };
+  const answer = { name: 'server_1' };
+  const harness = await sidebarHarness({
+    dataEpoch: () => store.epoch,
+    sourceEpoch: () => store.source,
+    pathOf: () => 'src/lib.rs',
+    async dataFor() {
+      await gate.current.promise;
+      return { path: 'src/lib.rs', data: sidebarData(answer.name) };
+    },
+  });
+
+  harness.activate(sidebarEditor('lib.rs'));
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_server_1/);
+
+  // An ordinary index invalidation: same document, same server. What is on screen is merely out of
+  // date and its replacement is already loading, so it stays up — clearing it on every version
+  // event would flicker all three views for no gain.
+  store.epoch += 1;
+  gate.current = deferred();
+  harness.refresh();
+  await settle();
+  assert.match(harness.shown(), /clone_of_server_1/, 'a reindex must not blank the tree');
+  gate.current.resolve();
+  await settle();
+
+  // `store.reset()` — configuring a server, changing Lens configuration, replacing the workspace
+  // folder. The active document is unchanged, so nothing about the DOCUMENT says the tree is
+  // wrong; what changed is where its rows came from. Every one of them describes a server or a
+  // repository that is no longer being asked, and holding them up until the new request answers
+  // shows one repository's clones, memories and tracker items over another's file.
+  store.epoch += 1;
+  store.source += 1;
+  answer.name = 'server_2';
+  gate.current = deferred();
+  harness.refresh();
+  await settle();
+  assert.doesNotMatch(harness.shown(), /clone_of_server_1/, "another source's tree must not stand");
+  assert.doesNotMatch(harness.shown('memories'), /memory_of_server_1/);
+  assert.doesNotMatch(harness.shown('papertrail'), /ref_of_server_1/);
+  assert.match(harness.shown(), /loading…/);
+
+  gate.current.resolve();
+  await settle();
+  assert.match(harness.shown(), /clone_of_server_2/);
+});
+
+test('a sidebar load that rejects is reported, not left as a spinner', async () => {
+  const failing = { now: false };
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    sourceEpoch: () => 0,
+    pathOf: () => 'src/lib.rs',
+    async dataFor() {
+      if (failing.now) {
+        throw new Error('resolving the document path failed');
+      }
+      return { path: 'src/lib.rs', data: sidebarData('lib') };
+    },
+  });
+
+  harness.activate(sidebarEditor('lib.rs'));
+  await settle();
+  assert.match(harness.shown(), /clone_of_lib/);
+
+  // The load path is the only thing that can fill the views, so an error inside it that nothing
+  // catches leaves them on whatever the switch put up — a spinner that never resolves, saying the
+  // answer is on its way when there is no longer anything coming.
+  failing.now = true;
+  harness.activate(sidebarEditor('other.rs'));
+  await settle();
+  assert.doesNotMatch(harness.shown(), /loading…/, 'a failed load must not leave the spinner up');
+  assert.doesNotMatch(harness.shown(), /clone_of_lib/);
+  assert.match(harness.shown(), /lens data unavailable/);
+  assert.match(harness.shown('memories'), /lens data unavailable/);
+  assert.match(harness.shown('papertrail'), /lens data unavailable/);
+  assert.match(harness.logged(), /resolving the document path failed/);
+});
+
+test('a payload one view cannot render leaves all three views agreeing', async () => {
+  const answer = { data: sidebarData('good') };
+  const harness = await sidebarHarness({
+    dataEpoch: () => 0,
+    sourceEpoch: () => 0,
+    pathOf: () => 'src/lib.rs',
+    async dataFor() {
+      return { path: 'src/lib.rs', data: answer.data };
+    },
+  });
+
+  harness.activate(sidebarEditor('lib.rs'));
+  await settle();
+  assert.match(harness.shown('papertrail'), /ref_of_good/);
+
+  // `/api/file/papertrail` is served to the views unvalidated, so a server version that omits a
+  // field the payload is trusted to carry throws in ONE view's builder. Publishing view by view
+  // would then leave two views describing that payload and the third on the previous file — the
+  // disagreement between panes that the single pump exists to prevent.
+  answer.data = { ...sidebarData('broken'), decisions: undefined };
+  harness.refresh();
+  await settle();
+  assert.doesNotMatch(harness.shown(), /clone_of_broken/, 'no view may describe an unrenderable payload');
+  assert.match(harness.shown(), /lens data unavailable/);
+  assert.match(harness.shown('memories'), /lens data unavailable/);
+  assert.match(harness.shown('papertrail'), /lens data unavailable/);
 });
 
 test('open memory documents are withdrawn when the server stops answering', async () => {


### PR DESCRIPTION
## The problem

`FileView.getChildren` loaded its data inline: it read `vscode.window.activeTextEditor`, awaited a
load from the store, and returned the tree. `TreeDataProvider.getChildren` has no cancellation
token and no way to decline to publish, so whichever invocation settled last decided what all three
sidebar views showed — regardless of which document it had been asked about.

The trap is that *every* value `getChildren` can return is a publication, so no return value is
safe. Returning a cached tree can put back a payload that predates an invalidation; returning an
empty one blanks a tree that a newer load just filled. The old code papered over this with a
`STALE_LOAD_RETRIES` loop, which can only re-ask — it cannot decline.

Concrete failures:

- Switch files quickly: the load for the first file settles after the load for the second, and the
  three views end up describing the previous file. Worse, they can *disagree* — one pane showing
  the old file's clone classes beside two showing the new file's.
- The host updates `activeTextEditor` *before* it delivers `onDidChangeActiveTextEditor`. A load can
  settle inside that window with nothing having bumped any counter, and publish for a document the
  user has already left.
- `FileStore.data` deliberately withholds a payload computed under a superseded epoch and returns
  `undefined` — indistinguishable from "the server did not answer". The sidebar rendered the first
  case as an outage, so an ordinary reindex could clear the tree and claim the lens server was
  offline.

## The fix

The await moves out of the read path.

`FileView` now owns what it is showing and `getChildren` returns it synchronously. A new
`SidebarPump` — driven by exactly the same two inputs as before, `refresh()` and the active-editor
listener — loads for the current active editor and publishes only if the premise it started under
still holds. It captures `(generation, document, dataEpoch)` before the await and re-reads all three
after it:

1. **`generation !== this.generation`** — a newer load owns the views. Same document plus same epoch
   does not make two loads interchangeable: `FileStore.load` re-points to a replacement endpoint and
   reloads without moving its epoch, so an earlier request can carry an older server's answer.
2. **the live `activeTextEditor` still matches the document the load was aimed at** — covers the
   window between the host updating `activeTextEditor` and delivering the change event, where
   nothing has bumped the generation yet.
3. **`store.dataEpoch()` unchanged** — distinguishes a withheld superseded payload from a real
   outage, so a reindex no longer blanks the tree or reports the server as offline.

A superseded load publishes nothing at all. That is sound because whatever superseded it publishes
its own answer: every `store.invalidate()` / `store.reset()` in `extension.ts` is already paired
with a `refreshViews()`.

`STALE_LOAD_RETRIES` and its retry loop are gone.

## What is on screen has a premise too

The checks above decide whether a load may write. The other half is what the views are already
showing, which answers a premise of its own: **which document it describes, and which server and
repository it came from.**

Both halves have to be checked, and only the first was. `store.reset()` — configuring a server,
changing Lens configuration, replacing the workspace folder — declares every prior payload
unusable, but the active document is commonly unchanged. Nothing cleared the views, so they kept
exposing the previous repository's clone classes, memories and tracker items until the new
file-data request answered, potentially for its whole timeout. Every other surface is already
cleared on those paths (`restartEvents` → `clearSignals`); the sidebar was the one left standing.

`FileStore.sourceEpoch()` is the reader for the second half. It moves only when what has been
served stops being attributable to the server now answering — a `reset`, or a discovery re-point
the store observes while loading — and never on an ordinary index invalidation, so a reindex still
replaces the tree in place without flickering it through `loading…`. Both of the store's own
writers of the served identity move it, which is what keeps the rule out of the callers: a stream
failure re-resolves the endpoint and reloads *without* an explicit reset, so a server that came
back on another port changes the identity with nothing having declared it.

The pump records the premise its content answers and compares both halves before each load, so one
check covers a document switch and a source change. A document *change* still clears to a
`loading…` row rather than leaving one file's clone classes up as a statement about another.

## States the views could not express

`FileView` now takes a state — `loading` / `unindexed` / `offline` / `failed` / `file` — and renders
it itself, rather than rows the pump builds for it. Three consequences:

- **A load that rejected left the spinner up forever** and dropped the error as an unhandled
  rejection. The result is settled into a value the way `probeStatus` settles its own, passes the
  same entitlement checks as an answer, and is reported as a row with the detail in the Lens log.
- **A payload one view's builder cannot render no longer splits the panes.** `/api/file/papertrail`
  is served to the views unvalidated, so a server version omitting a field throws in one builder
  where the other two succeed; publishing view by view left two views describing that payload and
  the third on the previous file. All three are rendered before any is committed.
- **The views start on `loading…`, not empty.** An empty tree is a claim — this file has no clones,
  no memories, no tracker items — that nothing has established before the first load answers.

`FileStore.dataEpoch()` and `FileStore.sourceEpoch()` are the two new store APIs. `roots()` stays
`protected`: the pump asks a view to render, and the view decides how.

## Design decisions

**Should the pump also drive the status bar and CodeLens refresh?** No. `refreshViews()` in
`extension.ts` stays the fan-out point; the pump replaces only the sidebar's own load path. Three
reasons, the first of which corrects the premise:

- *They do not key off the active editor.* Exactly two listeners subscribe to
  `onDidChangeActiveTextEditor`: the sidebar's own and `refreshEditor` (overlays/diagnostics).
  `codeLens.refresh()` / `signalLens.refresh()` are driven by `refreshViews()` from index
  invalidation, reachability transitions and indexability changes — a different event set — and the
  status bar is driven by `probeStatus` inside `reloadIndexData`.
- *They do not have the defect.* `provideCodeLenses(document)` is handed its document by the
  framework and never reads ambient active-editor state, so a late invocation can only publish for
  the document it was asked about. The status bar is not per-document at all and already has its own
  `reloadGeneration` guard.
- *There is nothing to guard.* `codeLens.refresh()` publishes no data; it fires "your cache is
  stale, ask again". Routing it through a document-shaped pump would be a **regression** —
  CodeLenses render in every visible editor, not just the active one, so a split pane's non-active
  side would stop being refreshed.

**One pump per view, or one for all three?** One pump for all three; `FileView` becomes a
synchronous renderer with no `FileStore` reference. The three views stack in a single container, so
per-view pumps let them disagree about which document they describe — a slow view showing the
previous file beside two showing the current one is the same wrong answer, only more visible. A
shared pump also puts the decision to publish in one place instead of three, and drops the store
dependency from the views entirely (they now only implement `roots`).

**How does the pump tell "the store withheld a superseded payload" from "the server did not
answer", given both surface as `undefined`?** By adding `FileStore.dataEpoch()` and comparing across
the await, rather than inferring from call ordering. Relying on the fact that every invalidation
happens to be followed by a `refreshViews()` would make the guarantee non-local and untestable; a
two-line reader makes it intrinsic to the pump and directly testable. A discriminated result from
`dataFor` was the alternative, but that would change a contract every other surface depends on.

**Where do the tests live and how do they drive the code?** In
`editors/vscode/test/client.test.cjs` (the repo's single extension test file), driving the real
`registerSidebar` through a fake `vscode.window` rather than exporting `SidebarPump`. That keeps the
pump private and exercises the wiring — provider registration, the active-editor subscription, the
returned `refresh` — as well as the guards. The harness reads views the way VS Code does
(`getChildren()` with no argument) and asserts the answer is an array, which is what pins the
synchronous contract.

**Why a counter on the store rather than clearing the sidebar from `extension.ts`?** The store
already owns this knowledge — it keys its per-lane fallbacks by which server answered, precisely so
"no caller has to know which of its actions can change the endpoint". Clearing from the four
endpoint-changing commands would re-introduce that obligation, and would miss the re-point the
store discovers on its own mid-load.

## Verification

Gates run from a clean `node_modules` in `editors/vscode`, exit codes checked directly:

- `npm ci` → 0
- `npm run package` (`tsc --noEmit` + esbuild node & web bundles) → 0
- `npm test` (`node:test` over the esbuild-bundled modules) → 0, **54 pass / 0 fail**

Every behavior was removed in turn and the full suite re-run, restoring a clean tree after each, to
confirm the tests are not passing by accident:

| removed | result | test that caught it |
| --- | --- | --- |
| generation guard | 53 pass / 1 fail | a same-document sidebar load that settles last cannot put the older payload back |
| live active-editor check | 53 / 1 | a sidebar load settling between the editor moving and the event arriving is dropped |
| epoch check | 53 / 1 | an invalidation while a sidebar load runs neither blanks the tree nor republishes |
| premise clearing (both halves) | 52 / 2 | a document switch takes the previous file down…; a data-source reset takes the previous tree down… |
| the source half of the premise | 53 / 1 | a data-source reset takes the previous tree down before the replacement arrives |
| the document half of the premise | 53 / 1 | a document switch takes the previous file down before the new one loads |
| render-all-then-commit | 53 / 1 | a payload one view cannot render leaves all three views agreeing |
| settling the load instead of awaiting it | 53 / 1 | a sidebar load that rejects is reported, not left as a spinner |
| `loading` as the initial state | 52 / 2 | the sidebar shows a loading row before anything has asked it to load |
| the served-source counter | 53 / 1 | the served-source counter moves on a re-point and a reset, not on a reindex |

Each is individually pinned. The two halves of the premise fail different tests, so neither is
covering for the other, and the reset test asserts the complement in the same run — a reindex under
the same source must *not* clear the tree.

I also enumerated every epoch-moving call site in `extension.ts` to confirm the pump cannot get
stuck on `loading…`: `discardIndexData` (`store.reset` / `store.invalidate`, from `reloadIndexData`)
and `setDataOnline` (`store.setOnline`) are both followed synchronously by `refreshViews()`, so the
epoch guard can never drop the last load in a chain. `resolver.invalidate()` and `restartEvents()` /
`clearSignals()` do not move the store epoch. The generation guard only fires when a newer load
exists; the active-editor guard only fires when an `onDidChangeActiveTextEditor` delivery is still
pending. `AbortSignal.timeout(35_000)` in `LensClient.request` bounds every lane, so `dataFor`
always settles.

Other counts:

- Ambient `activeTextEditor` reads in `editors/vscode/src`: **2 before** (both in
  `FileView.getChildren`), **2 after** (both in `SidebarPump.load` — the aim and the guard). Zero in
  any other module. That is the evidence behind the CodeLens/status-bar decision above.
- `onDidChangeActiveTextEditor` subscribers: **2, unchanged** (the sidebar's, now one listener
  instead of three `refresh()` calls; and `refreshEditor`).
- Bundles after `npm run package`: `dist/node/extension.js` 45.3 KB, `dist/web/extension.js`
  45.2 KB.

## Outstanding

- **The pairing convention is not enforced by the type system.** "Drop rather than publish" relies
  on every `store.invalidate()` / `store.reset()` being paired with a `refreshViews()`. That holds
  at all call sites today and is stated in a code comment, but an unpaired invalidation added later
  would leave the sidebar on its last tree until the next refresh.
- **The lane payloads other than clones are still unvalidated at the client boundary.** The pump
  now contains the blast radius — an unrenderable payload reports itself in all three views instead
  of splitting them — but `fileMemories`, `fileCoupling` and `filePapertrail` still trust the
  response shape, and the same field would throw in the CodeLens, overlay and diagnostic lanes,
  which have no such containment. Worth its own change.
- **The `loading~spin` ThemeIcon id is not covered.** The tests use a fake `ThemeIcon` and assert
  only the label text (`loading…`), so an icon-id typo would not be caught by CI.
- **Tree expansion state resets on every publication**, since `roots()` builds fresh `Item` objects
  each time. This was equally true before (`getChildren` rebuilt the tree on every call), so it is
  unchanged behavior rather than a new regression — but the pump publishes on index-version events
  as well, the same cadence `refresh()` already had.
- **Not exercised in a running VS Code / Cursor host.** The extension has no integration-test
  harness in this repo; CI is typecheck + bundles + `node:test` over the bundled modules. The
  assumption that the host updates `activeTextEditor` before delivering
  `onDidChangeActiveTextEditor` is the documented ordering, and it is defended in both directions —
  the check is a guard, and its absence only costs a dropped publication.

Fixes #1022
