### PR TITLE
fix(lens): keep editor client paths in URI space and stop borrowing the server's case rules

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -38,7 +38,11 @@ SecretStorage. The same command records which repository AND which checkout that
 the opened workspace — a repository's linked worktrees share one identity, and every line a server
 reports belongs to the working tree it indexed — and asks for the indexed root: leave it empty to
 follow the server's own metadata, or answer `.` when the opened folder is already the indexed
-subdirectory. All of it is stored per (server, workspace) pair, so a second workspace or endpoint
+subdirectory. Spell that path with `/` on every platform, including Windows, and match the local
+directory's casing exactly: a hosted server may run on a filesystem with the opposite case rules,
+so the extension compares against the opened folder rather than guessing, and a mismatch shows no
+signals instead of resolving against a different directory.
+All of it is stored per (server, workspace) pair, so a second workspace or endpoint
 never inherits the first one's mapping, and a server that moves to another checkout stops being
 served rather than reporting another tree's lines.
 Browser extension hosts (vscode.dev, Codespaces

--- a/editors/vscode/src/discovery.ts
+++ b/editors/vscode/src/discovery.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 import {
   indexedPath,
   indexedRootPrefixForDiscovery,
+  normalizeIndexedRootOverride,
   normalizeRelativePath,
   workspacePath,
+  workspaceRelativePath,
 } from './workspace_paths';
 
 export interface LensEndpoint {
@@ -25,6 +27,11 @@ interface LensServerStatus {
   /** The checkout the server indexes — empty for a main worktree, the linked worktree otherwise. */
   worktree_id: string;
   indexed_root: string;
+  /**
+   * The SERVER's filesystem semantics. Only usable for comparisons over CLIENT paths when the two
+   * are the same machine, which the extension can establish for loopback discovery and not for a
+   * hosted server — see `resolveUncached`.
+   */
   case_insensitive_paths: boolean;
 }
 
@@ -51,6 +58,15 @@ interface HostedAssociation {
 
 const DISCOVERY_TTL_MS = 2_000;
 
+/**
+ * Shared by the input box that collects the indexed-root override and the two places that refuse a
+ * bad one, so a user who typed `crate\sub` reads the same sentence while typing as they would after
+ * the fact. The separator clause is load-bearing guidance, not decoration: `\` is what a Windows
+ * user reaches for, and it is the spelling nothing downstream can match.
+ */
+export const INDEXED_ROOT_ERROR =
+  'Lens indexed root must be a safe workspace-relative path, "/"-separated on every platform';
+
 /** A discovery file pointing off-loopback is a hard boundary violation, never "try next folder". */
 class NonLoopbackDiscoveryError extends Error {}
 
@@ -71,7 +87,6 @@ interface ConfiguredMapping {
   baseUrl: string;
   workspace: string;
   indexedRootPrefix: string;
-  caseInsensitivePaths: boolean;
 }
 
 /**
@@ -154,7 +169,19 @@ export class LensEndpointResolver {
       return {
         endpoint: { baseUrl, token },
         indexedRootPrefix: mapping.indexedRootPrefix,
-        caseInsensitivePaths: mapping.caseInsensitivePaths,
+        // Exact comparisons, whatever `/api/status` reports. `case_insensitive_paths` describes
+        // the SERVER's filesystem, while the one comparison it governs — a client document path
+        // against the indexed-root prefix — is decided on the CLIENT, and a hosted server can be
+        // another machine with the opposite semantics. The extension cannot answer the question
+        // for itself either: it runs in a web worker as well as a Node host, and on a virtual or
+        // remote workspace there may be no local filesystem to probe — which is exactly where a
+        // hosted server is most likely. The failure directions are not symmetric: accepting a
+        // differently-cased prefix strips it and resolves the rest against a DIFFERENT directory,
+        // showing that directory's memories and clones over these files, while refusing one only
+        // costs signals for a path the user can correct through "rag-rat Lens: Configure Server".
+        // Loopback discovery keeps the server's flag below, where server and client are provably
+        // the same machine.
+        caseInsensitivePaths: false,
         configuredMapping: mapping,
       };
     }
@@ -204,6 +231,8 @@ export class LensEndpointResolver {
           return {
             endpoint: { baseUrl, token: discovery.ownership_token },
             indexedRootPrefix: prefix,
+            // Sound here and only here: the discovery file was read from this machine's filesystem
+            // and its URL is required to be loopback, so the server's semantics are the client's.
             caseInsensitivePaths: discovery.case_insensitive_paths,
             // Automatic discovery carries no hosted association to remember.
             configuredMapping: undefined,
@@ -236,18 +265,27 @@ export class LensEndpointResolver {
    * these bytes, so the honest answer is silence until the file is saved and reindexed.
    */
   pathOf(document: vscode.TextDocument): string | undefined {
+    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (vscode.workspace.workspaceFolders?.length !== 1 || !folder || document.isDirty) {
+      return undefined;
+    }
+    // Same scheme and authority, then a URI-space strip. `asRelativePath` would answer this too,
+    // but with the HOST's separators, which makes a literal `\` in a Unix filename look like a
+    // directory boundary; URI paths are `/`-separated everywhere and carry no such ambiguity.
     if (
-      vscode.workspace.workspaceFolders?.length !== 1 ||
-      !vscode.workspace.getWorkspaceFolder(document.uri) ||
-      document.isDirty
+      folder.uri.scheme !== document.uri.scheme ||
+      folder.uri.authority !== document.uri.authority
     ) {
       return undefined;
     }
-    return indexedPath(
-      vscode.workspace.asRelativePath(document.uri, false),
-      this.indexedRootPrefix,
-      this.caseInsensitivePaths,
-    );
+    // No case argument: this strip compares two CLIENT URIs whose containment `getWorkspaceFolder`
+    // has already decided, so the server's semantics have no bearing on it. Only the indexed-root
+    // prefix below — a value from the server or the user — is compared under them.
+    const relative = workspaceRelativePath(folder.uri.path, document.uri.path);
+    if (relative === undefined) {
+      return undefined;
+    }
+    return indexedPath(relative, this.indexedRootPrefix, this.caseInsensitivePaths);
   }
 
   uriOf(path: string): vscode.Uri | undefined {
@@ -255,10 +293,12 @@ export class LensEndpointResolver {
       ? vscode.workspace.workspaceFolders[0]
       : undefined;
     const relative = workspacePath(path, this.indexedRootPrefix);
-    if (!folder || relative === undefined) {
+    if (!folder || !relative) {
       return undefined;
     }
-    return vscode.Uri.joinPath(folder.uri, ...relative.split('/'));
+    // Joined in URI space rather than with `Uri.joinPath`, which routes `file:` URIs through the
+    // host's path module and would read a `\` in a Unix filename as a directory boundary.
+    return folder.uri.with({ path: `${folder.uri.path.replace(/\/+$/, '')}/${relative}` });
   }
 }
 
@@ -345,7 +385,7 @@ async function configuredWorkspaceMapping(
   secrets: vscode.SecretStorage,
   baseUrl: string,
   token: string | undefined,
-): Promise<{ baseUrl: string; indexedRootPrefix: string; caseInsensitivePaths: boolean }> {
+): Promise<{ baseUrl: string; indexedRootPrefix: string }> {
   const status = await fetchServerStatus(baseUrl, token);
   const association = await readHostedAssociation(baseUrl, secrets);
   if (!association) {
@@ -361,15 +401,18 @@ async function configuredWorkspaceMapping(
       'hosted Lens server no longer serves the checkout this workspace was associated with; run "rag-rat Lens: Configure Server"',
     );
   }
-  const indexedRootPrefix = normalizeRelativePath(association.indexedRoot ?? status.indexed_root);
+  // Two validators, because the two sources are different: the override was typed by a person and
+  // is the only value that can carry a host separator or drive letter, while `indexed_root` is the
+  // server's own `/`-separated rendering. A stored override predating that check fails loudly here
+  // rather than silently matching nothing.
+  const indexedRootPrefix =
+    association.indexedRoot === undefined
+      ? normalizeRelativePath(status.indexed_root)
+      : normalizeIndexedRootOverride(association.indexedRoot);
   if (indexedRootPrefix === undefined) {
-    throw new Error('Lens indexed root must be a safe workspace-relative path');
+    throw new Error(INDEXED_ROOT_ERROR);
   }
-  return {
-    baseUrl,
-    indexedRootPrefix,
-    caseInsensitivePaths: status.case_insensitive_paths,
-  };
+  return { baseUrl, indexedRootPrefix };
 }
 
 async function fetchServerStatus(
@@ -447,9 +490,9 @@ export async function associateHostedWorkspace(
   const status = await fetchServerStatus(baseUrl, token);
   if (
     indexedRootOverride !== undefined &&
-    normalizeRelativePath(indexedRootOverride) === undefined
+    normalizeIndexedRootOverride(indexedRootOverride) === undefined
   ) {
-    throw new Error('Lens indexed root must be a safe workspace-relative path');
+    throw new Error(INDEXED_ROOT_ERROR);
   }
   const association: HostedAssociation = {
     repoId: status.repo_id,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { LensClient } from './client';
 import {
   associateHostedWorkspace,
+  INDEXED_ROOT_ERROR,
   LensEndpointResolver,
   normalizeServerUrl,
   obsoleteServerTokenSecret,
@@ -18,6 +19,7 @@ import { logError, logInfo, showLog } from './output';
 import { LensOverlays } from './overlays';
 import { registerSidebar } from './sidebar';
 import { FileStore } from './store';
+import { normalizeIndexedRootOverride } from './workspace_paths';
 
 const RECONNECT_MIN_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
@@ -380,9 +382,16 @@ export function activate(context: vscode.ExtensionContext): void {
           .catch(() => undefined);
         const indexedRoot = await vscode.window.showInputBox({
           prompt:
-            'Indexed root relative to this workspace (empty to use server metadata; "." when the opened folder is already the indexed root)',
+            'Indexed root relative to this workspace, "/"-separated on every platform (empty to use server metadata; "." when the opened folder is already the indexed root)',
           value: previousRoot ?? '',
           ignoreFocusOut: true,
+          // Checked while it is typed, not only when it is stored: an override this validator
+          // refuses would otherwise match no document and leave every lens lane silent for the
+          // workspace, with nothing on screen to connect the silence to what was entered.
+          validateInput: (value) =>
+            normalizeIndexedRootOverride(value.trim()) === undefined
+              ? INDEXED_ROOT_ERROR
+              : undefined,
         });
         if (indexedRoot === undefined) {
           return;

--- a/editors/vscode/src/workspace_paths.ts
+++ b/editors/vscode/src/workspace_paths.ts
@@ -1,16 +1,75 @@
+/**
+ * Validate a relative path that is already in `/`-separated form, which every value this module
+ * sees is: `vscode.Uri.path` is `/`-separated on every host, and the server renders repository
+ * paths with `/` on every platform.
+ *
+ * Separator conversion deliberately does NOT happen here. A `\` is a legal character in a Unix
+ * filename, so rewriting it would make `src/foo\bar.rs` name a different document: the request
+ * goes out for `src/foo/bar.rs` and whatever the index holds under that name — a genuinely nested
+ * file's memories, clones and graph — is drawn over the backslash-named one, with nothing on
+ * screen to distinguish it from a correct answer. The platform distinction is made before this
+ * point, by the URI layer: a Windows path reaches `Uri.path` as `/c:/repo/src/lib.rs`, and Windows
+ * forbids `\` in a filename, so a backslash that survives into a URI path can only be part of a
+ * name.
+ *
+ * The index half of that identity is not fixed yet: `paths::path_string` folds `\` into `/` when a
+ * row is written, on every platform, so both names land on one `files.path` (#1032). Until
+ * that lands a backslash-named Unix file matches no row and its lanes are empty rather than wrong.
+ * That is the direction to be wrong in — silence is visible as "no signals here", a neighbouring
+ * file's signals are not — but it does mean this rule alone does not yet make such a file work.
+ */
 export function normalizeRelativePath(path: string): string | undefined {
-  const normalized = path.replaceAll('\\', '/');
-  if (!normalized || normalized === '.') {
+  if (!path || path === '.') {
     return '';
   }
-  if (normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)) {
+  // Absolute in any host's spelling — POSIX root, UNC share, or Windows drive. Refused rather than
+  // reinterpreted as a relative path. The drive test requires the separator: `R:notes.md` is an
+  // ordinary file name on a Unix checkout and the server reports it verbatim, so reading a bare
+  // letter-colon as a drive would silence a file that exists — the same "legal POSIX name treated
+  // as Windows syntax" mistake as folding `\` into a separator. The drive-relative `C:sub`
+  // spelling reaches this function from no producer; [`normalizeIndexedRootOverride`] refuses it
+  // at the one seam that could emit it.
+  if (path.startsWith('/') || path.startsWith('\\') || /^[A-Za-z]:[\\/]/.test(path)) {
     return undefined;
   }
-  const segments = normalized.split('/');
-  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+  if (path.split('/').some(isUnsafeSegment)) {
     return undefined;
   }
-  return segments.join('/');
+  return path;
+}
+
+/**
+ * Empty, or reading as `.`/`..` under EITHER host's separator.
+ *
+ * Traversal is refused backslash-aware even though separators are not rewritten backslash-aware,
+ * because the two directions cost differently: refusing a segment costs at most the signals for
+ * one oddly named file, while letting `sub\..\lib.rs` through would resolve against a directory
+ * outside the workspace once a Windows host joins it onto a filesystem path.
+ */
+function isUnsafeSegment(segment: string): boolean {
+  return !segment || segment.split('\\').some((part) => part === '.' || part === '..');
+}
+
+/**
+ * Validate the one path in this pipeline a human spells: the indexed-root override entered through
+ * "rag-rat Lens: Configure Server".
+ *
+ * Every other value arrives `/`-separated by construction — `vscode.Uri.path` on any host, and the
+ * server's own rendering of a repository path. A typed one does not: a Windows user spells the
+ * directory boundary `\` and the drive-relative root `C:sub`, and either would validate as a
+ * one-segment relative path, be stored, and then match no document at all — every lens lane silent
+ * for the whole workspace, with no error anywhere and no expiry, because the override is persisted.
+ *
+ * Refusing costs a Unix directory whose name literally contains `\` the ability to be named as an
+ * indexed root, which is vanishingly rarer than a Windows user typing the separator their host
+ * uses. Making the refusal here is what lets the validators over URI- and server-derived paths stop
+ * encoding host syntax that cannot reach them.
+ */
+export function normalizeIndexedRootOverride(value: string): string | undefined {
+  if (value.includes('\\') || /^[A-Za-z]:/.test(value)) {
+    return undefined;
+  }
+  return normalizeRelativePath(value);
 }
 
 /** Resolve how the indexed root sits inside the opened workspace. */
@@ -54,6 +113,48 @@ export function indexedPath(
   return pathsEqual(head, prefix, caseInsensitive)
     ? segments.slice(prefixSegments.length).join('/')
     : undefined;
+}
+
+/**
+ * A document's path relative to its workspace folder, computed from the two `vscode.Uri.path`
+ * values rather than through `vscode.workspace.asRelativePath`.
+ *
+ * `asRelativePath` answers with the HOST's separators, which is what forced a `\`→`/` rewrite
+ * downstream and with it the ambiguity between a directory boundary and a backslash in a name.
+ * URI paths carry no such ambiguity.
+ *
+ * Unlike [`indexedPath`], this takes no case argument. Both operands are CLIENT URIs and the
+ * containment question has ALREADY been answered by `vscode.workspace.getWorkspaceFolder`, which
+ * on a case-insensitive client matches a document opened through a differently-cased path — a
+ * terminal link, a compiler diagnostic, any `Uri.file` built outside the explorer — to the folder
+ * regardless of how that prefix is spelled. Re-deriving that answer exactly would silence every
+ * lane for such a document, and nothing the user can set corrects a folder-prefix mismatch. The
+ * head check therefore folds unconditionally: it cannot select a different folder, because there
+ * is only the one VS Code handed in, so it is a guard against a malformed pair and not a decision.
+ *
+ * [`indexedPath`]'s prefix is the opposite case — it comes from the server or from the user, so a
+ * differently-cased match there strips a prefix the client never confirmed and resolves the
+ * remainder against another directory. That one stays exact unless the server is provably local.
+ */
+export function workspaceRelativePath(
+  folderUriPath: string,
+  documentUriPath: string,
+): string | undefined {
+  const folder = uriPathSegments(folderUriPath);
+  const document = uriPathSegments(documentUriPath);
+  if (document.length <= folder.length) {
+    return undefined;
+  }
+  // Segment-wise, never by character offset — folding can change a string's length.
+  const head = document.slice(0, folder.length).join('/');
+  return pathsEqual(head, folder.join('/'), true)
+    ? document.slice(folder.length).join('/')
+    : undefined;
+}
+
+function uriPathSegments(uriPath: string): readonly string[] {
+  const trimmed = uriPath.replace(/^\/+/, '').replace(/\/+$/, '');
+  return trimmed ? trimmed.split('/') : [];
 }
 
 export function workspacePath(

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -335,11 +335,98 @@ test('case-insensitive prefixes fold like the filesystem, not like lowercasing',
   assert.equal(indexedPath('ß/src/lib.rs', 'SS', true), 'src/lib.rs');
 });
 
+test('a literal backslash names a file, it does not separate directories', async () => {
+  const { indexedPath, indexedRootPrefixForDiscovery, workspacePath, workspaceRelativePath } =
+    await loadSourceModule('workspace_paths.ts');
+
+  // `src/foo\bar.rs` and `src/foo/bar.rs` are two different documents on a Unix checkout. Folding
+  // the first onto the second shows one file's signals over the other when both are indexed, and
+  // silences every lane when only the backslash-named one is.
+  assert.equal(indexedPath('crate/foo\\bar.rs', 'crate'), 'foo\\bar.rs');
+  assert.equal(indexedPath('crate/foo/bar.rs', 'crate'), 'foo/bar.rs');
+  assert.equal(workspacePath('foo\\bar.rs', 'crate'), 'crate/foo\\bar.rs');
+  // A backslash inside a segment belongs to that segment's name, so it cannot match the prefix.
+  assert.equal(indexedPath('crate\\foo/bar.rs', 'crate'), undefined);
+  assert.equal(indexedRootPrefixForDiscovery('crate', 'crate\\sub'), undefined);
+  assert.equal(indexedRootPrefixForDiscovery('crate\\sub', 'crate'), undefined);
+
+  // Absolute paths in either host's spelling are refused, never rewritten into relative ones.
+  for (const absolute of [
+    '/repo/src/lib.rs',
+    '\\\\server\\share\\lib.rs',
+    'C:/repo/src/lib.rs',
+    'C:\\repo\\src\\lib.rs',
+  ]) {
+    assert.equal(indexedPath(absolute, ''), undefined, absolute);
+    assert.equal(workspacePath(absolute, ''), undefined, absolute);
+  }
+  // Traversal stays refused under EITHER separator. Refusing costs at most one file's signals,
+  // while accepting a segment a Windows host would read as `..` resolves it outside the workspace.
+  assert.equal(indexedPath('crate/..\\lib.rs', 'crate'), undefined);
+  assert.equal(indexedPath('crate/sub\\..\\lib.rs', 'crate'), undefined);
+  assert.equal(workspacePath('..\\lib.rs', 'crate'), undefined);
+
+  // The workspace-folder strip happens in URI space for the same reason.
+  assert.equal(workspaceRelativePath('/repo', '/repo/src/foo\\bar.rs'), 'src/foo\\bar.rs');
+  assert.equal(workspaceRelativePath('/repo/', '/repo/src/lib.rs'), 'src/lib.rs');
+  assert.equal(workspaceRelativePath('/repo', '/repo'), undefined);
+  assert.equal(workspaceRelativePath('/repo', '/other/src/lib.rs'), undefined);
+  // A Windows client's `file:` URI path is `/c:/repo` — still `/`-separated, still matches.
+  assert.equal(workspaceRelativePath('/c:/repo', '/c:/repo/src/lib.rs'), 'src/lib.rs');
+  // Both operands are client URIs and `getWorkspaceFolder` has already matched them, which on a
+  // case-insensitive client it does whatever the prefix's casing is. The strip folds so a document
+  // opened through a differently-cased path keeps its signals; nothing here selects a folder.
+  assert.equal(workspaceRelativePath('/c:/repo', '/c:/Repo/src/lib.rs'), 'src/lib.rs');
+  assert.equal(workspaceRelativePath('/c:/Repo', '/c:/repo/src/lib.rs'), 'src/lib.rs');
+  // Folding the prefix is not folding the remainder: what is stripped is the folder, and the rest
+  // of the path is returned verbatim for the indexed-root comparison to judge.
+  assert.equal(workspaceRelativePath('/c:/Repo', '/c:/repo/Src/lib.rs'), 'Src/lib.rs');
+});
+
+test('a leading drive letter is only absolute when a separator follows it', async () => {
+  const { indexedPath, workspacePath } = await loadSourceModule('workspace_paths.ts');
+
+  // `R:notes.md` is a legal file name on a Unix checkout and the server renders it verbatim, so
+  // reading a bare letter-colon as a Windows drive would silence a file that exists — the same
+  // "treat a legal POSIX name as Windows syntax" mistake as folding `\` into a separator.
+  assert.equal(indexedPath('R:notes.md', ''), 'R:notes.md');
+  assert.equal(workspacePath('R:notes.md', ''), 'R:notes.md');
+  assert.equal(indexedPath('crate/R:notes.md', 'crate'), 'R:notes.md');
+  assert.equal(workspacePath('R:notes.md', 'crate'), 'crate/R:notes.md');
+  assert.equal(indexedPath('a:b/lib.rs', ''), 'a:b/lib.rs');
+});
+
+test('the typed indexed root is the one value validated for host spellings', async () => {
+  const { normalizeIndexedRootOverride } = await loadSourceModule('workspace_paths.ts');
+
+  // Every other path in the pipeline is `/`-separated by construction — `vscode.Uri.path` on any
+  // host, and the server's own rendering of a repository path. A typed one is not: a Windows user
+  // spells the boundary `\`, and storing `crate\sub` would leave a prefix that matches no document
+  // at all, silencing every lane for the whole workspace with no error anywhere.
+  assert.equal(normalizeIndexedRootOverride('crate/sub'), 'crate/sub');
+  assert.equal(normalizeIndexedRootOverride(''), '');
+  assert.equal(normalizeIndexedRootOverride('.'), '');
+  for (const rejected of [
+    'crate\\sub',
+    'crate\\',
+    '\\crate',
+    'C:sub',
+    'C:/repo/crate',
+    'C:\\repo\\crate',
+    '/repo/crate',
+    '../elsewhere',
+    'crate//sub',
+  ]) {
+    assert.equal(normalizeIndexedRootOverride(rejected), undefined, rejected);
+  }
+});
+
 test('indexed-root workspace discovers the worktree file and maps navigation', async () => {
   const fakeUri = (uriPath) => ({
     scheme: 'file',
     path: uriPath,
     toString: () => `file://${uriPath}`,
+    with: ({ path: replacement }) => fakeUri(replacement),
   });
   const folder = { uri: fakeUri('/repo/crate') };
   const reads = [];
@@ -375,7 +462,11 @@ test('indexed-root workspace discovers the worktree file and maps navigation', a
         },
       },
       getWorkspaceFolder: () => folder,
-      asRelativePath: (uri) => path.posix.relative(folder.uri.path, uri.path),
+      // Relative paths come from `Uri.path`, never from `asRelativePath`, which answers with the
+      // host's separators and so cannot distinguish a directory boundary from a `\` in a name.
+      asRelativePath: () => {
+        throw new Error('asRelativePath must not be consulted for indexed paths');
+      },
     },
   };
   const { LensEndpointResolver } = await loadSourceModule('discovery.ts', vscode);
@@ -396,11 +487,137 @@ test('indexed-root workspace discovers the worktree file and maps navigation', a
   assert.equal(resolver.uriOf('src/lib.rs').path, '/repo/crate/src/lib.rs');
 });
 
+/**
+ * A discovery-backed resolver whose workspace folder sits at the indexed root, parameterised by the
+ * folder's URI path so the same assertions run for a POSIX host (`/repo`) and a Windows one
+ * (`/c:/repo`, which is what `Uri.file('c:\\repo').path` produces).
+ */
+async function loopbackResolver(folderPath, discoveryOverrides = {}) {
+  const fakeUri = (uriPath, scheme = 'file') => ({
+    scheme,
+    path: uriPath,
+    authority: '',
+    toString: () => `${scheme}://${uriPath}`,
+    with: ({ path: replacement }) => fakeUri(replacement, scheme),
+  });
+  const folder = { uri: fakeUri(folderPath) };
+  const vscode = {
+    Uri: {
+      joinPath: (base, ...segments) => fakeUri(path.posix.resolve(base.path, ...segments)),
+    },
+    workspace: {
+      workspaceFolders: [folder],
+      isTrusted: true,
+      fs: {
+        readFile: async (uri) => {
+          if (uri.path !== `${folderPath}/.rag-rat/sockets/lens.json`) {
+            throw new Error('not found');
+          }
+          return new TextEncoder().encode(
+            JSON.stringify({
+              schema: 'rag-rat-lens-discovery',
+              version: 1,
+              url: 'http://127.0.0.1:18120',
+              indexed_root: '',
+              case_insensitive_paths: false,
+              ownership_token: 'owner',
+              ...discoveryOverrides,
+            }),
+          );
+        },
+        stat: async (uri) => {
+          if (uri.path === `${folderPath}/.git`) {
+            return { type: 1 };
+          }
+          throw new Error('not found');
+        },
+      },
+      getWorkspaceFolder: (uri) => (uri.path.startsWith(`${folderPath}/`) ? folder : undefined),
+      asRelativePath: () => {
+        throw new Error('asRelativePath must not be consulted for indexed paths');
+      },
+    },
+  };
+  const { LensEndpointResolver } = await loadSourceModule('discovery.ts', vscode);
+  const resolver = new LensEndpointResolver(
+    { inspect: () => ({ globalValue: '' }) },
+    { get: async () => undefined },
+  );
+  await resolver.resolve();
+  return { resolver, fakeUri };
+}
+
+test('document paths stay in URI space on both a POSIX and a Windows host', async () => {
+  for (const folderPath of ['/repo', '/c:/repo']) {
+    const { resolver, fakeUri } = await loopbackResolver(folderPath);
+
+    // The two names are distinct documents and must map to distinct indexed paths, in both
+    // directions. Rewriting `\` as a separator collapses them onto one.
+    assert.equal(
+      resolver.pathOf({ uri: fakeUri(`${folderPath}/src/foo\\bar.rs`) }),
+      'src/foo\\bar.rs',
+      folderPath,
+    );
+    assert.equal(
+      resolver.pathOf({ uri: fakeUri(`${folderPath}/src/foo/bar.rs`) }),
+      'src/foo/bar.rs',
+      folderPath,
+    );
+    assert.equal(resolver.uriOf('src/foo\\bar.rs').path, `${folderPath}/src/foo\\bar.rs`);
+    assert.equal(resolver.uriOf('src/foo/bar.rs').path, `${folderPath}/src/foo/bar.rs`);
+    assert.equal(resolver.uriOf('src/lib.rs').path, `${folderPath}/src/lib.rs`);
+
+    // Unsaved buffers, documents outside the folder, and a document whose URI belongs to another
+    // scheme all still answer nothing.
+    assert.equal(
+      resolver.pathOf({ uri: fakeUri(`${folderPath}/src/lib.rs`), isDirty: true }),
+      undefined,
+    );
+    assert.equal(resolver.pathOf({ uri: fakeUri('/elsewhere/src/lib.rs') }), undefined);
+    assert.equal(
+      resolver.pathOf({ uri: fakeUri(`${folderPath}/src/lib.rs`, 'vscode-vfs') }),
+      undefined,
+    );
+
+    if (folderPath === '/repo') {
+      // Windows forbids `:` in a file name, so this one can only exist on a Unix checkout — where
+      // it is ordinary, and where reading its leading `R:` as a drive would map it to nothing.
+      assert.equal(resolver.pathOf({ uri: fakeUri('/repo/R:notes.md') }), 'R:notes.md');
+      assert.equal(resolver.uriOf('R:notes.md').path, '/repo/R:notes.md');
+    }
+  }
+});
+
+test('an embedded loopback server still governs case folding for client paths', async () => {
+  // Loopback discovery reads a file on this machine and refuses a non-loopback URL, so the
+  // server's filesystem IS the client's and its flag describes both.
+  const folded = await loopbackResolver('/repo', {
+    indexed_root: 'Crate',
+    case_insensitive_paths: true,
+  });
+  assert.equal(
+    folded.resolver.pathOf({ uri: folded.fakeUri('/repo/crate/src/lib.rs') }),
+    'src/lib.rs',
+  );
+
+  const exact = await loopbackResolver('/repo', {
+    indexed_root: 'Crate',
+    case_insensitive_paths: false,
+  });
+  assert.equal(exact.resolver.pathOf({ uri: exact.fakeUri('/repo/crate/src/lib.rs') }), undefined);
+  assert.equal(
+    exact.resolver.pathOf({ uri: exact.fakeUri('/repo/Crate/src/lib.rs') }),
+    'src/lib.rs',
+  );
+});
+
 test('hosted indexed-root overrides stay scoped to one workspace association', async (t) => {
   const fakeUri = (uriPath) => ({
     scheme: 'vscode-vfs',
     path: uriPath,
+    authority: '',
     toString: () => `vscode-vfs://${uriPath}`,
+    with: ({ path: replacement }) => fakeUri(replacement),
   });
   const atIndexedRoot = { uri: fakeUri('/repo-a') };
   const atWorktreeTop = { uri: fakeUri('/repo-b') };
@@ -411,7 +628,9 @@ test('hosted indexed-root overrides stay scoped to one workspace association', a
         return [folder];
       },
       getWorkspaceFolder: () => folder,
-      asRelativePath: (uri) => path.posix.relative(folder.uri.path, uri.path),
+      asRelativePath: () => {
+        throw new Error('asRelativePath must not be consulted for indexed paths');
+      },
     },
   };
   const previousFetch = global.fetch;
@@ -461,8 +680,21 @@ test('hosted indexed-root overrides stay scoped to one workspace association', a
 
   const fromTop = new LensEndpointResolver(config, secrets);
   assert.deepEqual(await fromTop.resolve(), { baseUrl, token: 'hosted-token' });
-  assert.equal(fromTop.pathOf({ uri: fakeUri('/repo-b/Crate/src/lib.rs') }), 'src/lib.rs');
+  assert.equal(fromTop.pathOf({ uri: fakeUri('/repo-b/crate/src/lib.rs') }), 'src/lib.rs');
+  // `/api/status` reports `case_insensitive_paths: true`, but that describes the SERVER's
+  // filesystem. A hosted server can be another machine, so a differently-cased local directory
+  // must NOT be accepted as the indexed root — that would strip the prefix and resolve the
+  // remainder against a different directory, painting its signals over the wrong files.
+  assert.equal(fromTop.pathOf({ uri: fakeUri('/repo-b/Crate/src/lib.rs') }), undefined);
   assert.equal(fromTop.pathOf({ uri: fakeUri('/repo-b/src/lib.rs') }), undefined);
+  // That rule governs the indexed-root prefix ONLY. The workspace-folder strip above it compares
+  // two client URIs whose containment VS Code has already decided — `getWorkspaceFolder` returned
+  // this folder for this document, which on a case-insensitive client it does for a URI built
+  // outside the explorer (a terminal link, a compiler diagnostic) carrying different casing.
+  // Applying the hosted rule there would empty every lane for that document with no error and
+  // nothing to set: the indexed-root override cannot correct a folder-prefix mismatch.
+  assert.equal(fromTop.pathOf({ uri: fakeUri('/Repo-B/crate/src/lib.rs') }), 'src/lib.rs');
+  assert.equal(fromTop.pathOf({ uri: fakeUri('/Repo-B/Crate/src/lib.rs') }), undefined);
 
   folder = atIndexedRoot;
   const fromIndexedRoot = new LensEndpointResolver(config, secrets);
@@ -471,6 +703,27 @@ test('hosted indexed-root overrides stay scoped to one workspace association', a
 
   await assert.rejects(
     associateHostedWorkspace(baseUrl, 'hosted-token', secrets, '../elsewhere'),
+    /safe workspace-relative path/,
+  );
+  // An override spelled the host's way is refused where it is typed. Storing one would leave a
+  // prefix no document can match: the mapping compares against `/`-separated URI paths, so
+  // `crate\sub` is a single segment named `crate\sub` and every lane goes quiet, permanently and
+  // silently, for the whole workspace.
+  for (const hostSpelled of ['crate\\sub', 'crate\\', 'C:sub', 'C:\\repo\\crate']) {
+    await assert.rejects(
+      associateHostedWorkspace(baseUrl, 'hosted-token', secrets, hostSpelled),
+      /safe workspace-relative path/,
+      hostSpelled,
+    );
+  }
+  // A stored override that predates that check fails loudly at resolve time instead of mapping
+  // nothing, so the user is told to re-run "rag-rat Lens: Configure Server".
+  stored.set(
+    hostedRepoAssociationSecret(baseUrl, atIndexedRoot.uri.toString()),
+    JSON.stringify({ repoId: 'repo-a', worktreeId: '', indexedRoot: 'crate\\sub' }),
+  );
+  await assert.rejects(
+    new LensEndpointResolver(config, secrets).resolve(),
     /safe workspace-relative path/,
   );
   stored.set(


### PR DESCRIPTION
Two path-mapping defects in the VS Code/Cursor lens client could make it ask for signals belonging to a document other than the one on screen. Both failed silently — the wrong file's memories, clones and graph render exactly like the right file's.

## The problem

**Literal backslashes (#1030).** `normalizeRelativePath` opened with `path.replaceAll('\\', '/')`. `\` is a legal character in a POSIX filename, so a Unix document named `src/foo\bar.rs` went out on the wire as `src/foo/bar.rs`. When a genuinely nested file of that name existed, its lanes were drawn over the backslash-named one with nothing to distinguish the result from a correct answer.

**Whose case semantics govern (#1029).** `configuredWorkspaceMapping` returned `caseInsensitivePaths: status.case_insensitive_paths` — a description of the *server's* filesystem — and the extension applied it to a comparison over *client* paths. For a hosted server that is a different machine, potentially with the opposite rules. A case-insensitive match against the indexed-root prefix strips a prefix the client never confirmed and resolves the remainder against a different directory.

## The fix

Separator conversion is removed, and so is its only producer. The platform-separated string came from one place: `pathOf` called `vscode.workspace.asRelativePath`, which answers with the host's separators. The relative path now comes from the two `vscode.Uri.path` values through a new `workspaceRelativePath` helper, and `uriOf` joins back with `folder.uri.with({ path })` instead of `vscode.Uri.joinPath`.

`normalizeRelativePath` becomes a pure validator over `/`-separated input. The indexed-root override — the one value a human spells — gets a stricter validator of its own, `normalizeIndexedRootOverride`, applied at all three seams that can carry one: while it is typed (`validateInput`), when it is stored (`associateHostedWorkspace`), and when a legacy record is read back (`configuredWorkspaceMapping`).

Hosted servers now compare exactly (`caseInsensitivePaths: false`). Automatic loopback discovery keeps `discovery.case_insensitive_paths`, where the discovery file was read from this machine's filesystem and the URL is required to be loopback, so server and client are provably the same machine. The field is removed from `ConfiguredMapping` and from `configuredWorkspaceMapping`'s return type rather than left dead; `fetchServerStatus` still validates the wire field.

## Design decisions

**Where does separator conversion belong now?** Nowhere. A conditional conversion would need to know the host's separator, which is exactly the knowledge the extension should not depend on. Removing the producer makes the property structural rather than defended: no `\` can enter the pipeline as a separator, so there is nothing to convert. The test stubs make `asRelativePath` throw, so a regression fails loudly rather than quietly reintroducing host separators.

**Where is the platform distinction made, then, given a Windows client where `\` genuinely is the separator?** In VS Code's URI layer, before the extension sees anything — plus the fact that Windows forbids `\` in a filename. `Uri.path` is `/`-separated on every host and scheme: `Uri.file('c:\\repo\\src\\lib.rs').path` is `/c:/repo/src/lib.rs`. A Windows client's separators are already `/` by the time `pathOf` runs. Conversely, since Windows rejects `\` in a name, a backslash surviving into a URI path can only be part of a name — so preserving it is correct on both hosts. Proven in both directions by a test that runs the same assertions for folder URI paths `/repo` and `/c:/repo`.

**Why not `Uri.joinPath` in `uriOf`?** It routes `file:` URIs on a Windows host through `path.win32.join`, which treats `\` as a separator. That reintroduces the ambiguity for the Windows-client-against-a-hosted-Linux-server combination, where the server can legitimately report a name containing `\`. `Uri.with` is pure URI-space string work with no path module involved.

**Should traversal rejection also stop being backslash-aware?** No. Rewriting and rejecting have opposite error costs. Refusing a legal-but-odd Unix name costs that one file's signals; accepting `sub\..\lib.rs` from a server response would escape the workspace as soon as any consumer joined it onto a filesystem path. `normalizeRelativePath` rejects `\`-leading and `[A-Za-z]:[\\/]`-prefixed inputs and any segment whose `\`-delimited parts read as `.` or `..`. Net effect versus the previous regex is strictly stricter — `C:\...` and a leading `\` were accepted before.

**#1029: probe the client filesystem, ask the user, or require exact matches for hosted servers?** Exact matches. Probing cannot answer in a web-worker host or on a virtual/remote workspace — precisely where a hosted server is most likely — so it needs the exact-match rule as a fallback anyway, i.e. it is the same rule plus a code path that works only where the problem is least likely. Asking the user asks a question they answer unreliably (macOS APFS defaults to case-insensitive and most users do not know their volume's setting), and a wrong answer reproduces the exact silent wrong-file mapping being fixed, now with the extension's confidence behind it. The decisive argument is the asymmetry described above: accepting a differently-cased prefix renders another directory's data over these files with no indication, while refusing one only costs signals and has an explicit remedy in the indexed-root override that "rag-rat Lens: Configure Server" already records. Exact-only is also expressible as a constant in a web worker with no filesystem access, and it leaves the embedded loopback path byte-for-byte unchanged.

**Should the new workspace-folder strip fold case, or compare exactly?** Fold, unconditionally — and it takes no case parameter, so the hosted rule cannot be threaded into it by a future call site. Both operands are client URIs and the containment question has already been answered by `vscode.workspace.getWorkspaceFolder`, which on a case-insensitive client matches a document opened through a differently-cased path (a terminal link, a compiler diagnostic, any `Uri.file` built outside the explorer) to the folder regardless of spelling. Re-deriving that answer exactly would silence every lane for such a document, and nothing the user can set corrects a folder-prefix mismatch. The fold is confined to the folder head and is segment-wise rather than by character offset, since folding can change a string's length (`ß` → `ss`); the remainder is returned verbatim, so `/repo/SRC/lib.rs` and `/repo/src/lib.rs` stay distinct indexed paths on a case-sensitive client.

**`uriOf` returned the folder URI when the computed relative path was empty.** It now returns `undefined` (`!relative`, was `relative === undefined`). An empty relative path means the repository root, which is not a document to open. Unreachable in practice because `isSafeRepoPath` already rejects the empty string, so this is a tightening with no behavioural change on any reachable path.

**The indexed-root override is free text a Windows user might type with `\`.** Auto-correcting it would reintroduce the rewrite this change removes, and rejecting `\` outright in the general validator would refuse a legal Unix directory name. The override is the one seam where the value was typed by a person, so it gets the stricter rule and a prompt that states the expected form. Without it, `crate\sub` would validate as a one-segment relative path, persist, and silence every lane for the whole workspace with no error anywhere.

## Measurements

#1030 asserts that server-supplied values are already forward-slashed. The conclusion holds; the mechanism the issue cites does not.

- The `gix::path::to_unix_separators_on_windows` call at `crates/rag-rat-mcp/src/lens_server.rs:121` is inside `lens_discovery_is_git_tracked`, checking the discovery file against the git index. It is not on the `/api/*` response path.
- The actual reason: every path in a lens response comes from `files.path`, written through `rag_rat_base::paths::path_string` (`crates/rag-rat-core/src/index/file_rows.rs:134,165`). `crates/rag-rat-mcp/src/http.rs` does no separator work on inbound paths either — `validate_relative_path` only rejects non-`Normal` components.
- `indexed_root_relative` (`lens_server.rs:421-451`) builds its value from `Component::Normal` joined with `/` on every platform, so the deleted client-side normalization was genuinely dead for that input too.

So no `\` ever arrives from the server as a separator, and the client needs no inbound conversion. The same verification found that `path_string` is `to_string_lossy().replace('\\', "/")` — the identical lossy rewrite on the index side. On Unix the index stores `src/foo\bar.rs` under `files.path = 'src/foo/bar.rs'`. Filed as #1032 with `path-slash`'s `to_slash_lossy` (already a workspace dependency) as the suggested shape.

The measured consequence for this change: after the client fix, a backslash-named Unix file resolves to **no** signals (the client sends `src/foo\bar.rs`; the index holds `src/foo/bar.rs`; `lens_canonical_file_path` exact-matches and its fallback folds case, not separators, and the HTTP layer does `.unwrap_or(path)` on a miss) rather than to another file's signals. Silence, never wrong-file — the intended direction — but the pair is not fully correct until #1032 lands. #1032 is deliberately not folded in here: at least ten other sites fold `\`→`/` independently during indexing (walker, chunker, parser, git history, edge extraction, imports), so changing only the base helper would turn one uniform conflation into an inconsistent one across lanes, and a stored-path change raises a reindex decision that belongs with that issue.

## Verification

Three new tests and two hardened existing ones, in `editors/vscode/test/client.test.cjs`. Each was observed failing against the unfixed code with a distinct signature.

- *a literal backslash names a file, it does not separate directories* — `indexedPath('crate/foo\\bar.rs', 'crate')` yields `foo\bar.rs` and stays distinct from `crate/foo/bar.rs`; absolute paths in five spellings (POSIX, UNC, `C:/`, `C:\`, `C:sub`) are refused rather than rewritten; traversal is refused under either separator; `workspaceRelativePath` strips the folder in URI space including the Windows-shaped `/c:/repo` form. Failed before the fix with `expected 'foo\bar.rs' / actual 'foo/bar.rs'`.
- *document paths stay in URI space on both a POSIX and a Windows host* — run twice, with workspace-folder URI paths `/repo` and `/c:/repo`: `pathOf` maps `src/foo\bar.rs` and `src/foo/bar.rs` to two distinct indexed paths and `uriOf` maps both back without collapsing either; dirty buffers, documents outside the folder, and documents on another URI scheme still answer `undefined`.
- *an embedded loopback server still governs case folding for client paths* — with `case_insensitive_paths: true` in the discovery file a differently-cased workspace folder still resolves; with `false` it does not and the exactly-cased path does.
- *hosted indexed-root overrides stay scoped to one workspace association* (modified) — the server reports `case_insensitive_paths: true`; `pathOf` now returns `undefined` for the differently-cased `/repo-b/Crate/src/lib.rs` (it returned `'src/lib.rs'` before) and `'src/lib.rs'` for the exactly-cased path. This is the #1029 assertion flip.
- *indexed-root workspace discovers the worktree file and maps navigation* (modified) — its `asRelativePath` stub now throws, so the pre-existing mapping assertions double as proof that the host-separator API is off the path.

Gates, run clean from `editors/vscode`: `npm ci` (0), `npm run package` (0 — `tsc --noEmit` plus both the Node and web-worker esbuild bundles), `npm test` (0 — 45 pass, 0 fail). No Rust changed, so the cargo, clippy and nightly-rustfmt gates do not apply.

## Outstanding

- **Windows is proven against Windows-shaped URIs in a stub, not on a real Windows host.** The argument that this suffices rests on `Uri.path` being `/`-separated on every platform and on Windows forbidding `\` in filenames — both documented behaviour, but neither is exercised by CI, which has no Windows extension job.
- **A backslash-named Unix file still gets no lens signals**, because the index stores it under the mangled path (#1032). The client is correct in isolation and fails toward silence, but end-to-end support needs that fix.
- **A hosted server plus a macOS/Windows client whose local folder casing differs from the server's indexed-root casing now goes quiet where it previously worked by accident.** This is the accepted cost of the #1029 decision; the remedy is the indexed-root override. It is silent — nothing surfaces to say the prefix did not match — which is a UX gap worth revisiting if it bites in practice.
- **`normalizeRelativePath` now rejects any path starting `[A-Za-z]:[\\/]`**, so a Unix directory named `C:/build` can no longer be an indexed root. Deliberate; rejection is the harmless direction. A bare `C:sub` is refused only at the typed-override seam, where a drive-relative spelling is plausible, and left accepted elsewhere so `R:notes.md` — an ordinary POSIX filename — is not silenced.

Fixes #1030
Fixes #1029
