### PR TITLE
fix(lens): resolve hop endpoints by symbol handle, not qualified name

### DIFF
--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -83,11 +83,11 @@ pub use query_api::{
     LensClonePartner, LensCloneRefine, LensCloneRegion, LensCouplingPartner, LensDecisionRecord,
     LensDispatchDetail, LensFileClones, LensFileCoupling, LensFileGraph, LensFileMemories,
     LensFileMemory, LensFilePapertrail, LensFileSymbolGraph, LensFileSymbols,
-    LensGraphCallerCounts, LensPapertrailRef, LensStatus, LensSymbol, LensSymbolHop, LensTreemap,
-    LensTreemapFile, LensVersion, MemoryCounts, MemoryKindCounts, OracleShaSnapshots,
-    PapertrailCursor, RepoContent, RepoFreshness, RepoPapertrail, RepoStatus, RoiFactors,
-    SearchRequest, SyncCatchUpReport, TextCloneMatch, WAL_CHECKPOINT_MIN_BYTES,
-    WalCheckpointReport, WorktreeOverlay, reclaim_freelist_at,
+    LensGraphCallerCounts, LensHopResolvedBy, LensHopSelector, LensPapertrailRef, LensStatus,
+    LensSymbol, LensSymbolHop, LensTreemap, LensTreemapFile, LensVersion, MemoryCounts,
+    MemoryKindCounts, OracleShaSnapshots, PapertrailCursor, RepoContent, RepoFreshness,
+    RepoPapertrail, RepoStatus, RoiFactors, SearchRequest, SyncCatchUpReport, TextCloneMatch,
+    WAL_CHECKPOINT_MIN_BYTES, WalCheckpointReport, WorktreeOverlay, reclaim_freelist_at,
 };
 pub use schema::RegisteredRepo;
 pub(crate) use util::*;

--- a/crates/rag-rat-core/src/index/query_api/lens/files.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/files.rs
@@ -19,8 +19,10 @@ pub struct LensFileSymbols {
 #[derive(Debug, Serialize)]
 pub struct LensSymbol {
     /// The stable `sym_<hex>` logical-symbol handle, and the selector a hop request should send
-    /// back: a qualified name is shared by every overload in the file, this is not. `None` only
-    /// where the symbol has no logical-symbol member row in the active scope.
+    /// back: a qualified name is shared by every overload in the file, while this is shared only
+    /// by overloads the grouping key cannot tell apart (identical declaration lines), and a hop
+    /// answer says how many symbols the handle it was given covered. `None` only where the symbol
+    /// has no logical-symbol member row in the active scope.
     #[serde(
         rename = "id",
         serialize_with = "rag_rat_base::serde_big_id::sym_handle_opt::serialize"

--- a/crates/rag-rat-core/src/index/query_api/lens/files.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/files.rs
@@ -18,6 +18,14 @@ pub struct LensFileSymbols {
 
 #[derive(Debug, Serialize)]
 pub struct LensSymbol {
+    /// The stable `sym_<hex>` logical-symbol handle, and the selector a hop request should send
+    /// back: a qualified name is shared by every overload in the file, this is not. `None` only
+    /// where the symbol has no logical-symbol member row in the active scope.
+    #[serde(
+        rename = "id",
+        serialize_with = "rag_rat_base::serde_big_id::sym_handle_opt::serialize"
+    )]
+    pub logical_symbol_id: Option<i64>,
     pub name: String,
     pub qname: Option<String>,
     pub kind: String,
@@ -36,6 +44,14 @@ pub struct LensFileGraph {
 
 #[derive(Debug, Serialize)]
 pub struct LensFileSymbolGraph {
+    /// Same handle, same contract as [`LensSymbol::logical_symbol_id`]: the graph lane is where a
+    /// CodeLens is built, so the row that reports a caller count also carries the selector that
+    /// drills into exactly those callers.
+    #[serde(
+        rename = "id",
+        serialize_with = "rag_rat_base::serde_big_id::sym_handle_opt::serialize"
+    )]
+    pub logical_symbol_id: Option<i64>,
     pub name: String,
     pub qname: Option<String>,
     pub kind: String,
@@ -70,6 +86,7 @@ pub struct LensDispatchDetail {
 #[derive(Debug)]
 struct FileSymbolRow {
     id: i64,
+    logical_symbol_id: Option<i64>,
     name: String,
     qname: Option<String>,
     kind: String,
@@ -134,6 +151,7 @@ impl IndexDatabase {
         let symbols = list_file_symbols_with_graph_counts(self.storage.connection(), path)?
             .into_iter()
             .map(|row| LensSymbol {
+                logical_symbol_id: row.logical_symbol_id,
                 name: row.name,
                 qname: row.qname,
                 kind: row.kind,
@@ -191,6 +209,7 @@ impl IndexDatabase {
             .map(|row| {
                 let load = importance.get(&row.id);
                 LensFileSymbolGraph {
+                    logical_symbol_id: row.logical_symbol_id,
                     name: row.name,
                     qname: row.qname,
                     kind: row.kind,
@@ -226,12 +245,15 @@ fn list_file_symbols_with_graph_counts(
     path: &str,
 ) -> anyhow::Result<Vec<FileSymbolRow>> {
     let mut stmt = conn.prepare(
+        // `logical_symbol_members` is keyed `(logical_symbol_id, symbol_id)`, and a symbol belongs
+        // to at most one logical symbol, so the LEFT JOIN cannot duplicate a requested row.
         "WITH requested AS MATERIALIZED (
-             SELECT s.id, s.name, ns.value AS qname, s.kind, s.start_line, s.end_line,
-                    s.is_test, s.signature
+             SELECT s.id, member.logical_symbol_id, s.name, ns.value AS qname, s.kind,
+                    s.start_line, s.end_line, s.is_test, s.signature
              FROM symbols s
              JOIN files ON files.id = s.file_id
              LEFT JOIN name_strings ns ON ns.id = s.qualified_name_id
+             LEFT JOIN logical_symbol_members member ON member.symbol_id = s.id
              WHERE files.path = ?1
          ),
          incoming AS (
@@ -257,8 +279,9 @@ fn list_file_symbols_with_graph_counts(
              JOIN files target_file ON target_file.id = target_symbol.file_id
              GROUP BY e.from_symbol_id
          )
-         SELECT requested.id, requested.name, requested.qname, requested.kind,
-                requested.start_line, requested.end_line, requested.is_test, requested.signature,
+         SELECT requested.id, requested.logical_symbol_id, requested.name, requested.qname,
+                requested.kind, requested.start_line, requested.end_line, requested.is_test,
+                requested.signature,
                 COALESCE(incoming.fan_in, 0), COALESCE(outgoing.fan_out, 0),
                 COALESCE(incoming.exact, 0), COALESCE(incoming.syntactic, 0),
                 COALESCE(incoming.name_only, 0), COALESCE(incoming.ambiguous, 0),
@@ -271,22 +294,23 @@ fn list_file_symbols_with_graph_counts(
     let rows = stmt.query_map([path], |row| {
         Ok(FileSymbolRow {
             id: row.get(0)?,
-            name: row.get(1)?,
-            qname: row.get(2)?,
-            kind: row.get(3)?,
-            start_line: row.get(4)?,
-            end_line: row.get(5)?,
-            is_test: row.get(6)?,
-            signature: row.get(7)?,
-            fan_in: u64::try_from(row.get::<_, i64>(8)?).unwrap_or(0),
-            fan_out: u64::try_from(row.get::<_, i64>(9)?).unwrap_or(0),
+            logical_symbol_id: row.get(1)?,
+            name: row.get(2)?,
+            qname: row.get(3)?,
+            kind: row.get(4)?,
+            start_line: row.get(5)?,
+            end_line: row.get(6)?,
+            is_test: row.get(7)?,
+            signature: row.get(8)?,
+            fan_in: u64::try_from(row.get::<_, i64>(9)?).unwrap_or(0),
+            fan_out: u64::try_from(row.get::<_, i64>(10)?).unwrap_or(0),
             callers: LensGraphCallerCounts {
-                exact: u64::try_from(row.get::<_, i64>(10)?).unwrap_or(0),
-                syntactic: u64::try_from(row.get::<_, i64>(11)?).unwrap_or(0),
-                name_only: u64::try_from(row.get::<_, i64>(12)?).unwrap_or(0),
-                ambiguous: u64::try_from(row.get::<_, i64>(13)?).unwrap_or(0),
-                tests: u64::try_from(row.get::<_, i64>(14)?).unwrap_or(0),
-                dispatch: u64::try_from(row.get::<_, i64>(15)?).unwrap_or(0),
+                exact: u64::try_from(row.get::<_, i64>(11)?).unwrap_or(0),
+                syntactic: u64::try_from(row.get::<_, i64>(12)?).unwrap_or(0),
+                name_only: u64::try_from(row.get::<_, i64>(13)?).unwrap_or(0),
+                ambiguous: u64::try_from(row.get::<_, i64>(14)?).unwrap_or(0),
+                tests: u64::try_from(row.get::<_, i64>(15)?).unwrap_or(0),
+                dispatch: u64::try_from(row.get::<_, i64>(16)?).unwrap_or(0),
             },
         })
     })?;

--- a/crates/rag-rat-core/src/index/query_api/lens/files.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/files.rs
@@ -9,6 +9,7 @@ use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
 use unicase::UniCase;
 
+use super::handles;
 use crate::index::IndexDatabase;
 
 #[derive(Debug, Serialize)]
@@ -20,14 +21,17 @@ pub struct LensFileSymbols {
 pub struct LensSymbol {
     /// The stable `sym_<hex>` logical-symbol handle, and the selector a hop request should send
     /// back: a qualified name is shared by every overload in the file, while this is shared only
-    /// by overloads the grouping key cannot tell apart (identical declaration lines), and a hop
-    /// answer says how many symbols the handle it was given covered. `None` only where the symbol
-    /// has no logical-symbol member row in the active scope.
+    /// by declarations the grouping key cannot tell apart. `None` only where the symbol has no
+    /// logical-symbol member row in the active scope.
     #[serde(
         rename = "id",
         serialize_with = "rag_rat_base::serde_big_id::sym_handle_opt::serialize"
     )]
     pub logical_symbol_id: Option<i64>,
+    /// How many declarations `id` covers in the active checkout — see
+    /// [`LensFileSymbolGraph::logical_symbol_declarations`], which carries the same contract.
+    #[serde(rename = "id_declarations")]
+    pub logical_symbol_declarations: u64,
     pub name: String,
     pub qname: Option<String>,
     pub kind: String,
@@ -54,6 +58,23 @@ pub struct LensFileSymbolGraph {
         serialize_with = "rag_rat_base::serde_big_id::sym_handle_opt::serialize"
     )]
     pub logical_symbol_id: Option<i64>,
+    /// How many DECLARATIONS `id` covers in the active checkout. `1` for almost every row; `0`
+    /// where there is no handle at all.
+    ///
+    /// `> 1` is the case a handle cannot express, and it has to be on the wire rather than left
+    /// for a reader to infer. The grouping key is deliberately coarser than a declaration — cfg
+    /// variants of one function are one symbol on purpose, and languages whose overloads the key
+    /// cannot separate land in one group the same way — so a hop request carrying this handle is
+    /// answered for the whole group, and the answer's `matched_symbols` repeats this number. A row
+    /// that offered the handle while saying nothing about its reach would present a union as a
+    /// definite answer, which is the failure mode the handle exists to remove.
+    ///
+    /// Narrowing a genuinely-shared handle is the identity layer's job, not this route's: what
+    /// belongs in one logical symbol is decided where the grouping key is computed, and a second,
+    /// declaration-level identity minted here would answer differently from every other
+    /// handle-keyed surface (repo-memory bindings included) for the same declaration.
+    #[serde(rename = "id_declarations")]
+    pub logical_symbol_declarations: u64,
     pub name: String,
     pub qname: Option<String>,
     pub kind: String,
@@ -89,6 +110,7 @@ pub struct LensDispatchDetail {
 struct FileSymbolRow {
     id: i64,
     logical_symbol_id: Option<i64>,
+    logical_symbol_declarations: u64,
     name: String,
     qname: Option<String>,
     kind: String,
@@ -154,6 +176,7 @@ impl IndexDatabase {
             .into_iter()
             .map(|row| LensSymbol {
                 logical_symbol_id: row.logical_symbol_id,
+                logical_symbol_declarations: row.logical_symbol_declarations,
                 name: row.name,
                 qname: row.qname,
                 kind: row.kind,
@@ -212,6 +235,7 @@ impl IndexDatabase {
                 let load = importance.get(&row.id);
                 LensFileSymbolGraph {
                     logical_symbol_id: row.logical_symbol_id,
+                    logical_symbol_declarations: row.logical_symbol_declarations,
                     name: row.name,
                     qname: row.qname,
                     kind: row.kind,
@@ -246,7 +270,11 @@ fn list_file_symbols_with_graph_counts(
     conn: &Connection,
     path: &str,
 ) -> anyhow::Result<Vec<FileSymbolRow>> {
-    let mut stmt = conn.prepare(
+    // Counted in the same statement rather than per row: a file lens is drawn on every open, and
+    // the handle's reach has to travel WITH the handle — a client that has to ask a second route
+    // whether the selector it was just handed disambiguates has already rendered it as if it did.
+    let declarations = handles::scope_visible_members_sql("requested.logical_symbol_id");
+    let mut stmt = conn.prepare(&format!(
         // `logical_symbol_members` is keyed `(logical_symbol_id, symbol_id)`, and a symbol belongs
         // to at most one logical symbol, so the LEFT JOIN cannot duplicate a requested row.
         "WITH requested AS MATERIALIZED (
@@ -281,7 +309,8 @@ fn list_file_symbols_with_graph_counts(
              JOIN files target_file ON target_file.id = target_symbol.file_id
              GROUP BY e.from_symbol_id
          )
-         SELECT requested.id, requested.logical_symbol_id, requested.name, requested.qname,
+         SELECT requested.id, requested.logical_symbol_id, {declarations},
+                requested.name, requested.qname,
                 requested.kind, requested.start_line, requested.end_line, requested.is_test,
                 requested.signature,
                 COALESCE(incoming.fan_in, 0), COALESCE(outgoing.fan_out, 0),
@@ -291,28 +320,29 @@ fn list_file_symbols_with_graph_counts(
          FROM requested
          LEFT JOIN incoming ON incoming.symbol_id = requested.id
          LEFT JOIN outgoing ON outgoing.symbol_id = requested.id
-         ORDER BY requested.start_line, requested.id",
-    )?;
+         ORDER BY requested.start_line, requested.id"
+    ))?;
     let rows = stmt.query_map([path], |row| {
         Ok(FileSymbolRow {
             id: row.get(0)?,
             logical_symbol_id: row.get(1)?,
-            name: row.get(2)?,
-            qname: row.get(3)?,
-            kind: row.get(4)?,
-            start_line: row.get(5)?,
-            end_line: row.get(6)?,
-            is_test: row.get(7)?,
-            signature: row.get(8)?,
-            fan_in: u64::try_from(row.get::<_, i64>(9)?).unwrap_or(0),
-            fan_out: u64::try_from(row.get::<_, i64>(10)?).unwrap_or(0),
+            logical_symbol_declarations: u64::try_from(row.get::<_, i64>(2)?).unwrap_or(0),
+            name: row.get(3)?,
+            qname: row.get(4)?,
+            kind: row.get(5)?,
+            start_line: row.get(6)?,
+            end_line: row.get(7)?,
+            is_test: row.get(8)?,
+            signature: row.get(9)?,
+            fan_in: u64::try_from(row.get::<_, i64>(10)?).unwrap_or(0),
+            fan_out: u64::try_from(row.get::<_, i64>(11)?).unwrap_or(0),
             callers: LensGraphCallerCounts {
-                exact: u64::try_from(row.get::<_, i64>(11)?).unwrap_or(0),
-                syntactic: u64::try_from(row.get::<_, i64>(12)?).unwrap_or(0),
-                name_only: u64::try_from(row.get::<_, i64>(13)?).unwrap_or(0),
-                ambiguous: u64::try_from(row.get::<_, i64>(14)?).unwrap_or(0),
-                tests: u64::try_from(row.get::<_, i64>(15)?).unwrap_or(0),
-                dispatch: u64::try_from(row.get::<_, i64>(16)?).unwrap_or(0),
+                exact: u64::try_from(row.get::<_, i64>(12)?).unwrap_or(0),
+                syntactic: u64::try_from(row.get::<_, i64>(13)?).unwrap_or(0),
+                name_only: u64::try_from(row.get::<_, i64>(14)?).unwrap_or(0),
+                ambiguous: u64::try_from(row.get::<_, i64>(15)?).unwrap_or(0),
+                tests: u64::try_from(row.get::<_, i64>(16)?).unwrap_or(0),
+                dispatch: u64::try_from(row.get::<_, i64>(17)?).unwrap_or(0),
             },
         })
     })?;

--- a/crates/rag-rat-core/src/index/query_api/lens/handles.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/handles.rs
@@ -1,0 +1,56 @@
+//! What a `sym_<hex>` logical-symbol handle resolves to in the ACTIVE checkout.
+//!
+//! Two lens surfaces speak about the same handle and must not disagree: `files` hands one out per
+//! symbol row, and `hops` answers a request that sends one back. Both have to report the same
+//! number of declarations behind it, so the counting SQL lives here once rather than twice.
+
+use rusqlite::{Connection, OptionalExtension as _};
+
+/// Members of a logical symbol the ACTIVE SCOPE can see, as a correlated scalar subquery.
+///
+/// `owner` is a SQL expression naming the logical-symbol id in the enclosing query — a column
+/// reference or a bound parameter. A NULL there counts zero, which is the honest answer for a
+/// symbol row that has no handle at all.
+///
+/// SCOPED through the `files` view, like every other member read (#897): `logical_symbol_members`
+/// is corpus-level and holds one member per scope of a path, so an unscoped count would report a
+/// sibling checkout's replica — or a linked worktree's overlay row — as another declaration this
+/// checkout must answer for.
+pub(super) fn scope_visible_members_sql(owner: &str) -> String {
+    format!(
+        "(SELECT COUNT(*)
+            FROM logical_symbol_members member_scope
+            JOIN symbols member_symbol ON member_symbol.id = member_scope.symbol_id
+            JOIN files member_file ON member_file.id = member_symbol.file_id
+           WHERE member_scope.logical_symbol_id = {owner})"
+    )
+}
+
+/// The logical symbol's qualified name and how many members it has IN THE ACTIVE SCOPE. Scoping
+/// through the `files` view is what makes a handle minted in a sibling checkout read as absent
+/// instead of resolving against rows this checkout cannot see; `None` means no member survives.
+pub(super) fn logical_symbol_in_scope(
+    conn: &Connection,
+    logical_symbol_id: i64,
+) -> anyhow::Result<Option<(String, u64)>> {
+    let members = scope_visible_members_sql("?1");
+    let row = conn
+        .query_row(
+            // Short name as the second-choice seed: `qualified_name_id` is nullable, and a seed of
+            // `''` leaves the traversal's query log naming nothing at all.
+            &format!(
+                "SELECT COALESCE(MIN(qn.value), MIN(symbols.name), ''), {members}
+                 FROM logical_symbol_members member
+                 JOIN symbols ON symbols.id = member.symbol_id
+                 JOIN files ON files.id = symbols.file_id
+                 LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+                 WHERE member.logical_symbol_id = ?1"
+            ),
+            [logical_symbol_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()?;
+    Ok(row
+        .filter(|(_, members)| *members > 0)
+        .map(|(qualified_name, members)| (qualified_name, u64::try_from(members).unwrap_or(0))))
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -3,9 +3,10 @@
 use std::collections::HashMap;
 
 use rag_rat_query::graph::{self, GraphTraversalOptions};
-use rusqlite::{Connection, OptionalExtension as _, params_from_iter};
+use rusqlite::{Connection, params_from_iter};
 use serde::Serialize;
 
+use super::handles;
 use crate::index::IndexDatabase;
 
 /// How a hop request names the symbol it wants the neighbours of.
@@ -15,13 +16,15 @@ use crate::index::IndexDatabase;
 /// — the grouping key folds the signature in, so `Alpha::run(&self)` and `Beta::run(&self, extra:
 /// i64)` are different logical symbols even though both qualify as `src/lib.rs::run`.
 ///
-/// It separates them exactly as far as that key does, and no further: the signature the key folds
-/// in is the declaration's first line, so overloads that DECLARE identically (`fn new() -> Self {`
-/// on two impls, one trait method implemented for several types in a file) land in one logical
-/// symbol and behind one handle, which then answers for the group. That is a property of the
-/// grouping key — which is deliberately body-insensitive so a symbol keeps its handle, and its
-/// bound memories, across an edit — not something a hop route can narrow. What the route owes a
-/// reader instead is an honest count: see [`LensCallers::matched_symbols`].
+/// It separates them exactly as far as that key does, and no further. Some declarations belong in
+/// one logical symbol on purpose — a function's cfg variants are one entity the build picks one
+/// spelling of — and others land there because the key cannot yet tell them apart. Either way the
+/// handle answers for the whole group, and how precise the grouping is belongs to the layer that
+/// computes the key, not to a hop route: minting a second, declaration-level identity here would
+/// answer differently from every other handle-keyed surface (repo-memory bindings included) for
+/// the same declaration. What the route owes a reader instead is an honest count of what the
+/// handle it was given reached — see [`LensCallers::matched_symbols`], and
+/// `LensSymbol::logical_symbol_declarations` where the handle is handed out.
 #[derive(Clone, Debug)]
 pub enum LensHopSelector {
     /// Preferred: the `sym_<hex>` handle, already decoded to its logical-symbol id.
@@ -58,13 +61,12 @@ pub struct LensCallers {
     /// answer precisely where the handle covers a group.
     ///
     /// The lanes count different sets. On the handle lane it is the logical symbol's scope-visible
-    /// member rows: one for almost every symbol, more for a group holding a symbol's cfg variants
-    /// or several same-file symbols the grouping key could not tell apart (identical declaration
-    /// lines — see [`LensHopSelector`]). On the fallback lane it is every symbol the traversal
-    /// seeds from the name — by qualified name, or by short name while that short name is
-    /// unambiguous. Zero therefore means the name expanded to no symbol at all, never that the
-    /// answer is unknown, and only the fallback lane can report it: a handle with no scope-visible
-    /// member is absent, not empty.
+    /// member rows — the same number `/api/file/{symbols,graph}` reports as `id_declarations`
+    /// beside that handle (see [`LensHopSelector`]). On the fallback lane it is every symbol the
+    /// traversal seeds from the name — by qualified name, or by short name while that short name
+    /// is unambiguous. Zero therefore means the name expanded to no symbol at all, never that
+    /// the answer is unknown, and only the fallback lane can report it: a handle with no
+    /// scope-visible member is absent, not empty.
     pub matched_symbols: u64,
 }
 
@@ -180,8 +182,10 @@ impl IndexDatabase {
     ) -> anyhow::Result<Option<HopTraversal>> {
         match selector {
             LensHopSelector::Handle(logical_symbol_id) => {
-                let Some((seed, matched_symbols)) =
-                    logical_symbol_in_scope(self.storage.connection(), *logical_symbol_id)?
+                let Some((seed, matched_symbols)) = handles::logical_symbol_in_scope(
+                    self.storage.connection(),
+                    *logical_symbol_id,
+                )?
                 else {
                     return Ok(None);
                 };
@@ -209,32 +213,6 @@ impl IndexDatabase {
             })),
         }
     }
-}
-
-/// The logical symbol's qualified name and how many members it has IN THE ACTIVE SCOPE. Scoping
-/// through the `files` view is what makes a handle minted in a sibling checkout read as absent
-/// instead of resolving against rows this checkout cannot see; `None` means no member survives.
-fn logical_symbol_in_scope(
-    conn: &Connection,
-    logical_symbol_id: i64,
-) -> anyhow::Result<Option<(String, u64)>> {
-    let row = conn
-        .query_row(
-            // Short name as the second-choice seed: `qualified_name_id` is nullable, and a seed of
-            // `''` leaves the traversal's query log naming nothing at all.
-            "SELECT COALESCE(MIN(qn.value), MIN(symbols.name), ''), COUNT(*)
-             FROM logical_symbol_members member
-             JOIN symbols ON symbols.id = member.symbol_id
-             JOIN files ON files.id = symbols.file_id
-             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
-             WHERE member.logical_symbol_id = ?1",
-            [logical_symbol_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
-        )
-        .optional()?;
-    Ok(row
-        .filter(|(_, members)| *members > 0)
-        .map(|(qualified_name, members)| (qualified_name, u64::try_from(members).unwrap_or(0))))
 }
 
 pub(super) fn adapt_hops(

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use rag_rat_query::graph::{self, GraphResolutionMode, GraphTraversalOptions};
+use rag_rat_query::graph::{self, GraphTraversalOptions};
 use rusqlite::{Connection, OptionalExtension as _, params_from_iter};
 use serde::Serialize;
 
@@ -38,8 +38,11 @@ pub enum LensHopSelector {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LensHopResolvedBy {
-    /// Resolved by the `sym_<hex>` handle: the hops belong to exactly one logical symbol — which
-    /// is one source symbol unless `matched_symbols > 1`.
+    /// Resolved by the `sym_<hex>` handle: every RESOLVED hop belongs to exactly one logical
+    /// symbol — which is one source symbol unless `matched_symbols > 1`. An unresolved hop is
+    /// matched by the name its call site wrote, so it can also belong to a same-name sibling —
+    /// the index has nothing finer to attribute it by, and dropping it would hide the neighbours a
+    /// compiler oracle later verifies.
     Id,
     /// Resolved by qualified name: every symbol the traversal seeds from it.
     Ref,
@@ -98,8 +101,9 @@ struct HopSymbolInfo {
 /// The traversal a [`LensHopSelector`] resolved to, plus what the answer should report about it.
 #[derive(Debug)]
 struct HopTraversal {
-    /// Name seed for the traversal. Inert on the handle lane, where the seeded predicate is the
-    /// logical-symbol membership set alone; kept truthful so a query log still names the symbol.
+    /// Name seed for the traversal. On the handle lane it no longer selects the RESOLVED edges —
+    /// logical membership does — but it still carries the unresolved arm, which has no symbol id
+    /// to match and only the qualified name the call site wrote.
     seed: String,
     options: GraphTraversalOptions,
     resolved_by: LensHopResolvedBy,
@@ -145,12 +149,20 @@ impl IndexDatabase {
 
     /// Turn the request's selector into the traversal that answers it.
     ///
-    /// The handle lane traverses in `Exact` mode seeded on the logical symbol, which reduces both
-    /// predicates to "an edge endpoint is a member of THIS logical symbol" — the qualified-name OR
-    /// arms that the other modes keep are exactly what re-collapses overloads. Dropping them takes
-    /// nothing off THIS symbol's list: an edge those arms add is either resolved to a DIFFERENT
-    /// symbol that shares the name — where it is already counted, on that symbol's row — or
-    /// resolved to nothing at all, matched through `target_qualified_name`, where no row counts it.
+    /// BOTH lanes traverse in the historical `Syntactic` mode; the handle lane differs only by
+    /// carrying `logical_symbol_id`, which swaps the predicates' qualified-name seed for logical
+    /// membership. That is the whole narrowing, and it is the right one: a RESOLVED edge is
+    /// attributed to the symbol the resolver actually bound, so two overloads sharing a qualified
+    /// name stop reporting each other's neighbours (#1028), while an UNRESOLVED edge keeps being
+    /// matched through the name it wrote at the call site.
+    ///
+    /// Keeping that unresolved arm is load-bearing, not laxity. Traversal SQL runs BEFORE
+    /// `enrich_hops_with_oracle`, and the oracle never mutates the `edges` row — so an edge the
+    /// SQL refuses can never be rescued by a compiler verdict, no matter how many oracle runs
+    /// follow. A stricter mode here would silently answer "no callers" for a caller the compiler
+    /// verified. What the arm costs is precision the index does not have anyway: an unresolved
+    /// edge naming a qualified name two overloads share appears under both, exactly as it does on
+    /// the fallback lane.
     ///
     /// The counts are still NOT this hop list. They count every in-scope edge kind reaching the
     /// symbol id, a traversal keeps only the call kinds, so the hops are a SUBSET and the two
@@ -159,9 +171,9 @@ impl IndexDatabase {
     /// `matched_symbols` being 1 says nothing about that gap. Closing it means restricting the
     /// counts' edge kinds, not widening the traversal.
     ///
-    /// The qualified-name lane keeps the historical `Syntactic` default so an older client that
-    /// sends no handle sees byte-identical hops; `matched_symbols` is how it learns that the name
-    /// it sent covers more than one symbol.
+    /// On the qualified-name lane the traversal is untouched, so an older client that sends no
+    /// handle sees byte-identical hops; `matched_symbols` is how it learns that the name it sent
+    /// covers more than one symbol.
     fn resolve_lens_hop_selector(
         &self,
         selector: &LensHopSelector,
@@ -176,7 +188,6 @@ impl IndexDatabase {
                 Ok(Some(HopTraversal {
                     seed,
                     options: GraphTraversalOptions {
-                        resolution_mode: GraphResolutionMode::Exact,
                         logical_symbol_id: Some(*logical_symbol_id),
                         ..GraphTraversalOptions::default()
                     },

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -11,9 +11,17 @@ use crate::index::IndexDatabase;
 /// How a hop request names the symbol it wants the neighbours of.
 ///
 /// The opaque `sym_<hex>` logical-symbol handle is the stable identity every symbol-shaped surface
-/// hands out, and it is the only selector that distinguishes two overloads sharing one qualified
-/// name — the grouping key folds the signature in, so `Alpha::run` and `Beta::run` are different
-/// logical symbols even though both qualify as `src/lib.rs::run`.
+/// hands out, and it is the only selector that distinguishes overloads sharing one qualified name
+/// — the grouping key folds the signature in, so `Alpha::run(&self)` and `Beta::run(&self, extra:
+/// i64)` are different logical symbols even though both qualify as `src/lib.rs::run`.
+///
+/// It separates them exactly as far as that key does, and no further: the signature the key folds
+/// in is the declaration's first line, so overloads that DECLARE identically (`fn new() -> Self {`
+/// on two impls, one trait method implemented for several types in a file) land in one logical
+/// symbol and behind one handle, which then answers for the group. That is a property of the
+/// grouping key — which is deliberately body-insensitive so a symbol keeps its handle, and its
+/// bound memories, across an edit — not something a hop route can narrow. What the route owes a
+/// reader instead is an honest count: see [`LensCallers::matched_symbols`].
 #[derive(Clone, Debug)]
 pub enum LensHopSelector {
     /// Preferred: the `sym_<hex>` handle, already decoded to its logical-symbol id.
@@ -30,9 +38,10 @@ pub enum LensHopSelector {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LensHopResolvedBy {
-    /// Resolved by the `sym_<hex>` handle: the hops belong to exactly one logical symbol.
+    /// Resolved by the `sym_<hex>` handle: the hops belong to exactly one logical symbol — which
+    /// is one source symbol unless `matched_symbols > 1`.
     Id,
-    /// Resolved by qualified name: `matched_symbols > 1` means the answer is a union.
+    /// Resolved by qualified name: every symbol the traversal seeds from it.
     Ref,
 }
 
@@ -40,13 +49,19 @@ pub enum LensHopResolvedBy {
 pub struct LensCallers {
     pub callers: Vec<LensSymbolHop>,
     pub resolved_by: LensHopResolvedBy,
-    /// Active-scope symbols the selector expanded to. Read it against `resolved_by`, because the
-    /// two lanes count different things: on the handle lane it is the logical symbol's member
-    /// rows (its cfg variants — one symbol for almost every symbol, and always ONE logical
-    /// symbol, so it never signals ambiguity there), and on the fallback lane it is every symbol
-    /// the traversal seeds from the name — by qualified name, or by short name while that short
-    /// name is unambiguous — so `> 1` there says the hops are a union. Zero therefore means the
-    /// name expanded to no symbol at all, never that the answer is unknown.
+    /// Active-scope symbols the selector expanded to. `> 1` means the hops are a union over that
+    /// many symbols, and it means that ON BOTH LANES — a surface has one rule to render, and
+    /// reading the count only on the fallback lane would state the narrow claim over the wide
+    /// answer precisely where the handle covers a group.
+    ///
+    /// The lanes count different sets. On the handle lane it is the logical symbol's scope-visible
+    /// member rows: one for almost every symbol, more for a group holding a symbol's cfg variants
+    /// or several same-file symbols the grouping key could not tell apart (identical declaration
+    /// lines — see [`LensHopSelector`]). On the fallback lane it is every symbol the traversal
+    /// seeds from the name — by qualified name, or by short name while that short name is
+    /// unambiguous. Zero therefore means the name expanded to no symbol at all, never that the
+    /// answer is unknown, and only the fallback lane can report it: a handle with no scope-visible
+    /// member is absent, not empty.
     pub matched_symbols: u64,
 }
 
@@ -133,8 +148,10 @@ impl IndexDatabase {
     /// The handle lane traverses in `Exact` mode seeded on the logical symbol, which reduces both
     /// predicates to "an edge endpoint is a member of THIS logical symbol" — the qualified-name OR
     /// arms that the other modes keep are exactly what re-collapses overloads, and dropping them
-    /// also makes the hop list the drill-down of the caller/fan-out counts `/api/file/symbols` and
-    /// `/api/file/graph` already show, which are counted per symbol id over resolved edges.
+    /// also lines the hop list up with the caller/fan-out counts `/api/file/symbols` and
+    /// `/api/file/graph` already show: those are counted per symbol id over resolved edges, and
+    /// these are the same edges over the handle's members — one and the same set whenever
+    /// `matched_symbols` is 1, which is every handle covering a single symbol.
     ///
     /// The qualified-name lane keeps the historical `Syntactic` default so an older client that
     /// sends no handle sees byte-identical hops; `matched_symbols` is how it learns that the name

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -2,19 +2,57 @@
 
 use std::collections::HashMap;
 
-use rusqlite::{Connection, params_from_iter};
+use rag_rat_query::graph::{self, GraphResolutionMode, GraphTraversalOptions};
+use rusqlite::{Connection, OptionalExtension as _, params_from_iter};
 use serde::Serialize;
 
 use crate::index::IndexDatabase;
 
+/// How a hop request names the symbol it wants the neighbours of.
+///
+/// The opaque `sym_<hex>` logical-symbol handle is the stable identity every symbol-shaped surface
+/// hands out, and it is the only selector that distinguishes two overloads sharing one qualified
+/// name — the grouping key folds the signature in, so `Alpha::run` and `Beta::run` are different
+/// logical symbols even though both qualify as `src/lib.rs::run`.
+#[derive(Clone, Debug)]
+pub enum LensHopSelector {
+    /// Preferred: the `sym_<hex>` handle, already decoded to its logical-symbol id.
+    Handle(i64),
+    /// Compatibility fallback for a client that sends no handle. A name expands to EVERY symbol
+    /// the traversal seeds from it — every symbol carrying it as a qualified name, or, while the
+    /// short name is unambiguous, the one carrying it as a short name — so a file with overloads
+    /// reports the union of their neighbours.
+    QualifiedName(String),
+}
+
+/// Which selector answered a hop request, echoed so a caller can tell an id-resolved answer from
+/// the qualified-name fallback without inspecting its own request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LensHopResolvedBy {
+    /// Resolved by the `sym_<hex>` handle: the hops belong to exactly one logical symbol.
+    Id,
+    /// Resolved by qualified name: `matched_symbols > 1` means the answer is a union.
+    Ref,
+}
+
 #[derive(Debug, Serialize)]
 pub struct LensCallers {
     pub callers: Vec<LensSymbolHop>,
+    pub resolved_by: LensHopResolvedBy,
+    /// Active-scope symbols the selector expanded to: the logical symbol's members on the handle
+    /// lane (always one thing), and on the fallback lane every symbol the traversal seeds from the
+    /// name — by qualified name, or by short name while that short name is unambiguous. Zero
+    /// therefore means the name expanded to no symbol at all, never that the answer is unknown.
+    pub matched_symbols: u64,
 }
 
 #[derive(Debug, Serialize)]
 pub struct LensCallees {
     pub callees: Vec<LensSymbolHop>,
+    pub resolved_by: LensHopResolvedBy,
+    /// Same meaning as [`LensCallers::matched_symbols`].
+    pub matched_symbols: u64,
 }
 
 /// Compatibility projection of the #216 endpoint hop. Reindex-churning edge, file, and symbol
@@ -39,37 +77,130 @@ struct HopSymbolInfo {
     kind: String,
 }
 
+/// The traversal a [`LensHopSelector`] resolved to, plus what the answer should report about it.
+#[derive(Debug)]
+struct HopTraversal {
+    /// Name seed for the traversal. Inert on the handle lane, where the seeded predicate is the
+    /// logical-symbol membership set alone; kept truthful so a query log still names the symbol.
+    seed: String,
+    options: GraphTraversalOptions,
+    resolved_by: LensHopResolvedBy,
+    matched_symbols: u64,
+}
+
 impl IndexDatabase {
+    /// `None` when a `sym_<hex>` handle names no symbol in the active checkout — a handle held
+    /// across a rename or from another checkout. Reported as such rather than silently answering
+    /// with an empty neighbour set or falling through to the ambiguous qualified-name lane.
     pub fn lens_symbol_callers(
         &self,
-        qualified_name: &str,
+        selector: &LensHopSelector,
         limit: u32,
-    ) -> anyhow::Result<LensCallers> {
-        let hops = self.find_callers_with_options(
-            qualified_name,
-            limit,
-            &rag_rat_query::graph::GraphTraversalOptions::default(),
-        )?;
-        Ok(LensCallers { callers: adapt_hops(self.storage.connection(), hops, true)? })
+    ) -> anyhow::Result<Option<LensCallers>> {
+        let Some(traversal) = self.resolve_lens_hop_selector(selector)? else {
+            return Ok(None);
+        };
+        let hops = self.find_callers_with_options(&traversal.seed, limit, &traversal.options)?;
+        Ok(Some(LensCallers {
+            callers: adapt_hops(self.storage.connection(), hops, true)?,
+            resolved_by: traversal.resolved_by,
+            matched_symbols: traversal.matched_symbols,
+        }))
     }
 
+    /// `None` carries the same meaning as in [`Self::lens_symbol_callers`].
     pub fn lens_symbol_callees(
         &self,
-        qualified_name: &str,
+        selector: &LensHopSelector,
         limit: u32,
-    ) -> anyhow::Result<LensCallees> {
-        let hops = self.trace_callees_with_options(
-            qualified_name,
-            limit,
-            &rag_rat_query::graph::GraphTraversalOptions::default(),
-        )?;
-        Ok(LensCallees { callees: adapt_hops(self.storage.connection(), hops, false)? })
+    ) -> anyhow::Result<Option<LensCallees>> {
+        let Some(traversal) = self.resolve_lens_hop_selector(selector)? else {
+            return Ok(None);
+        };
+        let hops = self.trace_callees_with_options(&traversal.seed, limit, &traversal.options)?;
+        Ok(Some(LensCallees {
+            callees: adapt_hops(self.storage.connection(), hops, false)?,
+            resolved_by: traversal.resolved_by,
+            matched_symbols: traversal.matched_symbols,
+        }))
     }
+
+    /// Turn the request's selector into the traversal that answers it.
+    ///
+    /// The handle lane traverses in `Exact` mode seeded on the logical symbol, which reduces both
+    /// predicates to "an edge endpoint is a member of THIS logical symbol" — the qualified-name OR
+    /// arms that the other modes keep are exactly what re-collapses overloads, and dropping them
+    /// also makes the hop list the drill-down of the caller/fan-out counts `/api/file/symbols` and
+    /// `/api/file/graph` already show, which are counted per symbol id over resolved edges.
+    ///
+    /// The qualified-name lane keeps the historical `Syntactic` default so an older client that
+    /// sends no handle sees byte-identical hops; `matched_symbols` is how it learns that the name
+    /// it sent covers more than one symbol.
+    fn resolve_lens_hop_selector(
+        &self,
+        selector: &LensHopSelector,
+    ) -> anyhow::Result<Option<HopTraversal>> {
+        match selector {
+            LensHopSelector::Handle(logical_symbol_id) => {
+                let Some((seed, matched_symbols)) =
+                    logical_symbol_in_scope(self.storage.connection(), *logical_symbol_id)?
+                else {
+                    return Ok(None);
+                };
+                Ok(Some(HopTraversal {
+                    seed,
+                    options: GraphTraversalOptions {
+                        resolution_mode: GraphResolutionMode::Exact,
+                        logical_symbol_id: Some(*logical_symbol_id),
+                        ..GraphTraversalOptions::default()
+                    },
+                    resolved_by: LensHopResolvedBy::Id,
+                    matched_symbols,
+                }))
+            },
+            LensHopSelector::QualifiedName(reference) => Ok(Some(HopTraversal {
+                seed: reference.clone(),
+                options: GraphTraversalOptions::default(),
+                resolved_by: LensHopResolvedBy::Ref,
+                // Counted by the traversal's own seed rule rather than by qualified name alone:
+                // the fallback also answers a bare short name, and reporting zero next to that
+                // answer's hops would read as "the selector matched nothing".
+                matched_symbols: graph::syntactic_seed_symbol_count(
+                    self.storage.connection(),
+                    reference,
+                )?,
+            })),
+        }
+    }
+}
+
+/// The logical symbol's qualified name and how many members it has IN THE ACTIVE SCOPE. Scoping
+/// through the `files` view is what makes a handle minted in a sibling checkout read as absent
+/// instead of resolving against rows this checkout cannot see; `None` means no member survives.
+fn logical_symbol_in_scope(
+    conn: &Connection,
+    logical_symbol_id: i64,
+) -> anyhow::Result<Option<(String, u64)>> {
+    let row = conn
+        .query_row(
+            "SELECT COALESCE(MIN(qn.value), ''), COUNT(*)
+             FROM logical_symbol_members member
+             JOIN symbols ON symbols.id = member.symbol_id
+             JOIN files ON files.id = symbols.file_id
+             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+             WHERE member.logical_symbol_id = ?1",
+            [logical_symbol_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()?;
+    Ok(row
+        .filter(|(_, members)| *members > 0)
+        .map(|(qualified_name, members)| (qualified_name, u64::try_from(members).unwrap_or(0))))
 }
 
 pub(super) fn adapt_hops(
     conn: &Connection,
-    hops: Vec<rag_rat_query::graph::GraphHop>,
+    hops: Vec<graph::GraphHop>,
     reverse: bool,
 ) -> anyhow::Result<Vec<LensSymbolHop>> {
     let edge_ids = hops.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -147,11 +147,17 @@ impl IndexDatabase {
     ///
     /// The handle lane traverses in `Exact` mode seeded on the logical symbol, which reduces both
     /// predicates to "an edge endpoint is a member of THIS logical symbol" — the qualified-name OR
-    /// arms that the other modes keep are exactly what re-collapses overloads, and dropping them
-    /// also lines the hop list up with the caller/fan-out counts `/api/file/symbols` and
-    /// `/api/file/graph` already show: those are counted per symbol id over resolved edges, and
-    /// these are the same edges over the handle's members — one and the same set whenever
-    /// `matched_symbols` is 1, which is every handle covering a single symbol.
+    /// arms that the other modes keep are exactly what re-collapses overloads. Dropping them takes
+    /// nothing off THIS symbol's list: an edge those arms add is either resolved to a DIFFERENT
+    /// symbol that shares the name — where it is already counted, on that symbol's row — or
+    /// resolved to nothing at all, matched through `target_qualified_name`, where no row counts it.
+    ///
+    /// The counts are still NOT this hop list. They count every in-scope edge kind reaching the
+    /// symbol id, a traversal keeps only the call kinds, so the hops are a SUBSET and the two
+    /// coincide only for a symbol whose incoming edges are all calls. A trait with two impls draws
+    /// `implements` and `references_type` edges and so reports callers with no hops behind them;
+    /// `matched_symbols` being 1 says nothing about that gap. Closing it means restricting the
+    /// counts' edge kinds, not widening the traversal.
     ///
     /// The qualified-name lane keeps the historical `Syntactic` default so an older client that
     /// sends no handle sees byte-identical hops; `matched_symbols` is how it learns that the name

--- a/crates/rag-rat-core/src/index/query_api/lens/hops.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/hops.rs
@@ -40,10 +40,13 @@ pub enum LensHopResolvedBy {
 pub struct LensCallers {
     pub callers: Vec<LensSymbolHop>,
     pub resolved_by: LensHopResolvedBy,
-    /// Active-scope symbols the selector expanded to: the logical symbol's members on the handle
-    /// lane (always one thing), and on the fallback lane every symbol the traversal seeds from the
-    /// name — by qualified name, or by short name while that short name is unambiguous. Zero
-    /// therefore means the name expanded to no symbol at all, never that the answer is unknown.
+    /// Active-scope symbols the selector expanded to. Read it against `resolved_by`, because the
+    /// two lanes count different things: on the handle lane it is the logical symbol's member
+    /// rows (its cfg variants — one symbol for almost every symbol, and always ONE logical
+    /// symbol, so it never signals ambiguity there), and on the fallback lane it is every symbol
+    /// the traversal seeds from the name — by qualified name, or by short name while that short
+    /// name is unambiguous — so `> 1` there says the hops are a union. Zero therefore means the
+    /// name expanded to no symbol at all, never that the answer is unknown.
     pub matched_symbols: u64,
 }
 
@@ -183,7 +186,9 @@ fn logical_symbol_in_scope(
 ) -> anyhow::Result<Option<(String, u64)>> {
     let row = conn
         .query_row(
-            "SELECT COALESCE(MIN(qn.value), ''), COUNT(*)
+            // Short name as the second-choice seed: `qualified_name_id` is nullable, and a seed of
+            // `''` leaves the traversal's query log naming nothing at all.
+            "SELECT COALESCE(MIN(qn.value), MIN(symbols.name), ''), COUNT(*)
              FROM logical_symbol_members member
              JOIN symbols ON symbols.id = member.symbol_id
              JOIN files ON files.id = symbols.file_id

--- a/crates/rag-rat-core/src/index/query_api/lens/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/mod.rs
@@ -23,7 +23,7 @@ pub use files::{
     LensDispatchDetail, LensFileGraph, LensFileSymbolGraph, LensFileSymbols, LensGraphCallerCounts,
     LensSymbol,
 };
-pub use hops::{LensCallees, LensCallers, LensSymbolHop};
+pub use hops::{LensCallees, LensCallers, LensHopResolvedBy, LensHopSelector, LensSymbolHop};
 pub use status::{LensStatus, LensVersion};
 pub use treemap::{LensTreemap, LensTreemapFile};
 

--- a/crates/rag-rat-core/src/index/query_api/lens/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/mod.rs
@@ -9,6 +9,7 @@ mod chunks;
 pub(crate) mod clones;
 mod enrichments;
 mod files;
+mod handles;
 mod hops;
 mod status;
 mod treemap;

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1290,6 +1290,68 @@ fn hop_selectors_separate_overloads_by_handle_and_unite_them_by_qualified_name()
     assert_eq!(shared_callees.matched_symbols, 2);
 }
 
+/// PINS WHERE THE HANDLE LANE STOPS BEING EXACT, AND WHY IT HAS TO. Its reverse predicate has two
+/// arms: logical membership, and — only for an edge the resolver could NOT bind — the qualified
+/// name the call site wrote. The line between them is the whole design.
+///
+/// Above the line: a BOUND edge is attributed by membership alone. Letting the name arm see it too
+/// would hand one overload an edge the resolver gave the other, which is the collapse the handle
+/// exists to end.
+///
+/// Below it: an UNBOUND edge has nothing finer than that name, which two overloads share, so it
+/// lands on both. That is not laxity — traversal SQL runs before the oracle enrichment, and the
+/// oracle never rewrites the `edges` row, so an edge this predicate refuses is one no compiler
+/// verdict can ever put back. Dropping the arm would answer "no callers" for a caller the compiler
+/// verified (`a_compiler_upgraded_unresolved_edge_reaches_the_handle_lane_too`).
+#[test]
+fn a_handle_attributes_a_bound_edge_by_membership_and_an_unbound_one_by_name() {
+    let (_temp, config) = overloaded_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let (alpha, beta) = overload_handles(&db);
+    let conn = db.storage.connection();
+    let callers = |handle: i64| {
+        hop_names(
+            &db.lens_symbol_callers(&LensHopSelector::Handle(handle), 50)
+                .unwrap()
+                .expect("a handle from this checkout resolves")
+                .callers,
+        )
+    };
+
+    // Give both call sites the qualified name the overloads share, on top of the binding the
+    // fixture already made. Each edge is still bound to exactly one overload.
+    conn.execute(
+        "UPDATE edges_data
+            SET target_qualified_name_id =
+                (SELECT id FROM name_strings WHERE value = 'src/lib.rs::run')
+          WHERE to_name_id = (SELECT id FROM name_strings WHERE value = 'run')",
+        [],
+    )
+    .unwrap();
+    assert_eq!(callers(alpha), ["calls_alpha"], "a bound edge is not re-collapsed by its name");
+    assert_eq!(callers(beta), ["calls_beta"]);
+
+    // Now unbind the beta call. Nothing in the index can say which overload it meant any more.
+    let beta_edge: i64 = conn
+        .query_row(
+            "SELECT edges.id
+             FROM edges
+             JOIN symbols source ON source.id = edges.from_symbol_id
+             WHERE edges.edge_kind = 'calls_name' AND edges.to_name = 'run'
+               AND source.name = 'calls_beta'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    conn.execute("UPDATE edges_data SET to_symbol_id = NULL WHERE id = ?1", [beta_edge]).unwrap();
+    assert_eq!(
+        callers(alpha),
+        ["calls_alpha", "calls_beta"],
+        "an unbound edge reaches every overload the name it wrote could mean"
+    );
+    assert_eq!(callers(beta), ["calls_beta"]);
+}
+
 /// Two `run` overloads whose DECLARATION LINES are byte-identical, so the only thing that told the
 /// overloads in [`OVERLOAD_SOURCE`] apart is gone. The bodies are multi-line on purpose: the
 /// signature the grouping key folds in is the declaration's first non-empty line, which for a

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1394,6 +1394,83 @@ fn a_short_name_fallback_counts_the_symbol_its_traversal_expanded_to() {
     assert_eq!(ambiguous.matched_symbols, 0);
 }
 
+/// A trait implemented twice: the only incoming edges the trait itself carries are `implements`
+/// and `references_type`, and the only ones its method carries are the `contains` edges from the
+/// two impl blocks. Nothing here is a call, which is what makes the fixture the counter-example.
+const NON_CALL_INBOUND_SOURCE: &str = r#"
+pub trait Runner { fn go(&self); }
+
+pub struct Alpha;
+pub struct Beta;
+
+impl Runner for Alpha { fn go(&self) {} }
+impl Runner for Beta { fn go(&self) {} }
+
+pub fn leaf() {}
+pub fn calls_leaf() { leaf(); }
+"#;
+
+/// PINS THE RELATIONSHIP BETWEEN A CALLER COUNT AND ITS DRILL-DOWN: subset, not equality. The file
+/// lanes count every in-scope edge landing on a symbol id; a hop traversal keeps only the call
+/// edge kinds. So a symbol whose inbound edges are all `implements`/`references_type`/`contains`
+/// reports callers and has no hops behind them, `matched_symbols` of 1 notwithstanding — a handle
+/// covering exactly one symbol is not what decides whether the two agree.
+///
+/// Pinned so the gap is not read as a handle-lane regression: it predates that lane and the
+/// qualified-name lane shows it identically. Closing it is a change to what the counts count, and
+/// this test is what would have to change with them.
+#[test]
+fn a_caller_count_spans_edge_kinds_a_hop_traversal_does_not() {
+    let (_temp, config) = rust_source_config(NON_CALL_INBOUND_SOURCE);
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    let graph = db.lens_file_graph("src/lib.rs").unwrap().symbols;
+    let counted_callers = |name: &str, kind: &str| {
+        let row = graph
+            .iter()
+            .find(|symbol| symbol.name == name && symbol.kind == kind)
+            .unwrap_or_else(|| panic!("the fixture must index {kind} {name}"));
+        let callers = &row.callers;
+        (
+            row.logical_symbol_id.expect("an indexed row carries a handle"),
+            callers.exact + callers.syntactic + callers.name_only + callers.ambiguous,
+        )
+    };
+    let hops = |handle: i64| {
+        let answer = db
+            .lens_symbol_callers(&LensHopSelector::Handle(handle), 50)
+            .unwrap()
+            .expect("a handle from this checkout resolves");
+        (answer.callers.len() as i64, answer.matched_symbols)
+    };
+
+    let (runner, runner_counted) = counted_callers("Runner", "trait");
+    assert!(
+        runner_counted > 0,
+        "the impls must draw non-call edges at the trait: {runner_counted}"
+    );
+    assert_eq!(
+        hops(runner),
+        (0, 1),
+        "an `implements`/`references_type` inbound edge is counted as a caller and is not a hop"
+    );
+
+    // Same divergence one level down, where the counted edge is a `contains` from each impl block
+    // — so the count outrunning the hop list is not particular to the trait row.
+    let (go, go_counted) = counted_callers("go", "function");
+    assert!(
+        go_counted > 0,
+        "the impl blocks must draw `contains` edges at the method: {go_counted}"
+    );
+    assert_eq!(hops(go), (0, 2), "the two `go` bodies share a handle and neither is called");
+
+    // The control: where the inbound edge IS a call, the count and the drill-down agree.
+    let (leaf, leaf_counted) = counted_callers("leaf", "function");
+    assert_eq!(leaf_counted, 1);
+    assert_eq!(hops(leaf), (1, 1));
+}
+
 /// Both selectors read the symbol table through the connection's `files` view, so a sibling
 /// checkout's rows are invisible to them: its same-named symbol must not inflate the fallback's
 /// ambiguity report, and its handle must not resolve here. The active checkout keeps answering.

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1225,8 +1225,8 @@ fn file_papertrail_deduplicates_items_before_applying_the_limit() {
 
 /// Two `run` overloads in one file. Both qualify as `src/lib.rs::run`; only their declarations —
 /// and therefore their logical-symbol handles — differ, which is exactly the case a qualified-name
-/// selector cannot express. [`COLLAPSED_OVERLOAD_SOURCE`] is the other half of the story: what
-/// happens when the declarations do not differ either.
+/// selector cannot express. [`CFG_VARIANT_SOURCE`] is the other half of the story: what a handle
+/// answers when the declarations behind it are one symbol.
 const OVERLOAD_SOURCE: &str = r#"
 pub struct Alpha;
 pub struct Beta;
@@ -1352,60 +1352,67 @@ fn a_handle_attributes_a_bound_edge_by_membership_and_an_unbound_one_by_name() {
     assert_eq!(callers(beta), ["calls_beta"]);
 }
 
-/// Two `run` overloads whose DECLARATION LINES are byte-identical, so the only thing that told the
-/// overloads in [`OVERLOAD_SOURCE`] apart is gone. The bodies are multi-line on purpose: the
-/// signature the grouping key folds in is the declaration's first non-empty line, which for a
-/// single-line body would include the body and separate these two again.
-const COLLAPSED_OVERLOAD_SOURCE: &str = r#"
-pub struct Alpha;
-pub struct Beta;
+/// One function, two cfg variants. This is what the grouping key is FOR — a single entity the
+/// build picks one spelling of — so unlike two impls that merely happen to declare alike, these
+/// stay one logical symbol behind one handle no matter how precise symbol identity becomes.
+const CFG_VARIANT_SOURCE: &str = r#"
+pub fn unix_leaf() {}
+pub fn windows_leaf() {}
 
-pub fn alpha_leaf() {}
-pub fn beta_leaf() {}
-
-impl Alpha {
-    pub fn run(&self) {
-        alpha_leaf();
-    }
+#[cfg(unix)]
+pub fn run() {
+    unix_leaf();
 }
 
-impl Beta {
-    pub fn run(&self) {
-        beta_leaf();
-    }
+#[cfg(windows)]
+pub fn run() {
+    windows_leaf();
 }
 "#;
 
-/// PINS THE LIMIT OF THE HANDLE. Overloads that declare identically land in ONE logical symbol, so
-/// they share one handle and the handle lane answers for the whole group — `fn new() -> Self {` on
-/// two impls, or one trait method implemented for several types in a module, are the everyday
-/// shapes of this. Separating them is a property of the grouping key (which folds in the
-/// declaration line so a symbol keeps its handle when its body changes), not of the hop routes.
+/// PINS THE LIMIT OF THE HANDLE, on the case where the limit is permanent. Members of one logical
+/// symbol share one handle, so a hop request carrying it is answered for the whole group — and
+/// there is no identity refinement that could separate cfg variants, because they ARE one symbol.
 ///
-/// What the routes owe a reader is therefore not precision they cannot have but an honest count:
-/// `matched_symbols` reports the group's members on the handle lane exactly as it reports the
-/// name's symbols on the fallback lane, so `> 1` means "a union" on BOTH lanes and a surface has
-/// one rule to render. Were this to report 1, a client would state the narrow claim over the wide
-/// answer with nothing on the wire to contradict it.
+/// What the routes owe a reader is therefore not precision they cannot have but an honest count,
+/// on both surfaces: `id_declarations` beside the handle that is handed out, and `matched_symbols`
+/// beside the answer it produces. Were either to report 1, a client would state the narrow claim
+/// over the wide answer with nothing on the wire to contradict it.
 #[test]
-fn a_handle_covering_identically_declared_overloads_reports_them_all() {
-    let (_temp, config) = collapsed_overload_config();
+fn a_handle_covering_one_symbols_cfg_variants_reports_them_all() {
+    let (_temp, config) = cfg_variant_config();
     let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
 
     let symbols = db.lens_file_symbols("src/lib.rs").unwrap().symbols;
     let runs = symbols.iter().filter(|symbol| symbol.name == "run").collect::<Vec<_>>();
     assert_eq!(runs.len(), 2);
-    assert!(runs.iter().all(|symbol| symbol.signature.as_deref() == Some("pub fn run(&self) {")));
     let shared = runs[0].logical_symbol_id.expect("both rows carry a handle");
     assert_eq!(
         runs[1].logical_symbol_id,
         Some(shared),
-        "identical declaration lines collapse into one logical symbol, so one handle"
+        "cfg variants of one function are one logical symbol, so one handle"
     );
+    assert!(
+        runs.iter().all(|symbol| symbol.logical_symbol_declarations == 2),
+        "the row that hands out a grouped handle must say how far it reaches: {runs:?}"
+    );
+    let graph = db.lens_file_graph("src/lib.rs").unwrap().symbols;
+    assert!(
+        graph
+            .iter()
+            .filter(|symbol| symbol.name == "run")
+            .all(|symbol| symbol.logical_symbol_declarations == 2),
+        "both file lanes hand out the same handle, so both owe the same reach: {graph:?}"
+    );
+    let leaf = symbols
+        .iter()
+        .find(|symbol| symbol.name == "unix_leaf")
+        .expect("the fixture must index unix_leaf");
+    assert_eq!(leaf.logical_symbol_declarations, 1, "an ungrouped handle covers its one row");
 
     let callees =
         db.lens_symbol_callees(&LensHopSelector::Handle(shared), 50).unwrap().expect("shared");
-    assert_eq!(hop_names(&callees.callees), ["alpha_leaf", "beta_leaf"]);
+    assert_eq!(hop_names(&callees.callees), ["unix_leaf", "windows_leaf"]);
     assert_eq!(callees.resolved_by, LensHopResolvedBy::Id);
     assert_eq!(
         callees.matched_symbols, 2,
@@ -1704,10 +1711,10 @@ fn overloaded_config() -> (tempfile::TempDir, Config) {
     (temp, config)
 }
 
-/// Index [`COLLAPSED_OVERLOAD_SOURCE`]. No call sites to rewire: each overload's own body reaches
-/// its own leaf, so the callee direction alone shows what the shared handle expands to.
-fn collapsed_overload_config() -> (tempfile::TempDir, Config) {
-    let (temp, config) = rust_source_config(COLLAPSED_OVERLOAD_SOURCE);
+/// Index [`CFG_VARIANT_SOURCE`]. No call sites to rewire: each variant's own body reaches its own
+/// leaf, so the callee direction alone shows what the shared handle expands to.
+fn cfg_variant_config() -> (tempfile::TempDir, Config) {
+    let (temp, config) = rust_source_config(CFG_VARIANT_SOURCE);
     drop(IndexDatabase::rebuild(&config).unwrap());
     (temp, config)
 }

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1223,9 +1223,10 @@ fn file_papertrail_deduplicates_items_before_applying_the_limit() {
     assert!(refs.iter().any(|reference| reference.item_key == "unique-0"));
 }
 
-/// Two `run` overloads in one file. Both qualify as `src/lib.rs::run`; only their signatures —
+/// Two `run` overloads in one file. Both qualify as `src/lib.rs::run`; only their declarations —
 /// and therefore their logical-symbol handles — differ, which is exactly the case a qualified-name
-/// selector cannot express.
+/// selector cannot express. [`COLLAPSED_OVERLOAD_SOURCE`] is the other half of the story: what
+/// happens when the declarations do not differ either.
 const OVERLOAD_SOURCE: &str = r#"
 pub struct Alpha;
 pub struct Beta;
@@ -1287,6 +1288,68 @@ fn hop_selectors_separate_overloads_by_handle_and_unite_them_by_qualified_name()
         .expect("a qualified name always resolves");
     assert_eq!(hop_names(&shared_callees.callees), ["alpha_leaf", "beta_leaf"]);
     assert_eq!(shared_callees.matched_symbols, 2);
+}
+
+/// Two `run` overloads whose DECLARATION LINES are byte-identical, so the only thing that told the
+/// overloads in [`OVERLOAD_SOURCE`] apart is gone. The bodies are multi-line on purpose: the
+/// signature the grouping key folds in is the declaration's first non-empty line, which for a
+/// single-line body would include the body and separate these two again.
+const COLLAPSED_OVERLOAD_SOURCE: &str = r#"
+pub struct Alpha;
+pub struct Beta;
+
+pub fn alpha_leaf() {}
+pub fn beta_leaf() {}
+
+impl Alpha {
+    pub fn run(&self) {
+        alpha_leaf();
+    }
+}
+
+impl Beta {
+    pub fn run(&self) {
+        beta_leaf();
+    }
+}
+"#;
+
+/// PINS THE LIMIT OF THE HANDLE. Overloads that declare identically land in ONE logical symbol, so
+/// they share one handle and the handle lane answers for the whole group — `fn new() -> Self {` on
+/// two impls, or one trait method implemented for several types in a module, are the everyday
+/// shapes of this. Separating them is a property of the grouping key (which folds in the
+/// declaration line so a symbol keeps its handle when its body changes), not of the hop routes.
+///
+/// What the routes owe a reader is therefore not precision they cannot have but an honest count:
+/// `matched_symbols` reports the group's members on the handle lane exactly as it reports the
+/// name's symbols on the fallback lane, so `> 1` means "a union" on BOTH lanes and a surface has
+/// one rule to render. Were this to report 1, a client would state the narrow claim over the wide
+/// answer with nothing on the wire to contradict it.
+#[test]
+fn a_handle_covering_identically_declared_overloads_reports_them_all() {
+    let (_temp, config) = collapsed_overload_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    let symbols = db.lens_file_symbols("src/lib.rs").unwrap().symbols;
+    let runs = symbols.iter().filter(|symbol| symbol.name == "run").collect::<Vec<_>>();
+    assert_eq!(runs.len(), 2);
+    assert!(runs.iter().all(|symbol| symbol.signature.as_deref() == Some("pub fn run(&self) {")));
+    let shared = runs[0].logical_symbol_id.expect("both rows carry a handle");
+    assert_eq!(
+        runs[1].logical_symbol_id,
+        Some(shared),
+        "identical declaration lines collapse into one logical symbol, so one handle"
+    );
+
+    let callees =
+        db.lens_symbol_callees(&LensHopSelector::Handle(shared), 50).unwrap().expect("shared");
+    assert_eq!(hop_names(&callees.callees), ["alpha_leaf", "beta_leaf"]);
+    assert_eq!(callees.resolved_by, LensHopResolvedBy::Id);
+    assert_eq!(
+        callees.matched_symbols, 2,
+        "the handle lane must report a group's members, or the union it returned reads as one \
+         symbol's hops"
+    );
 }
 
 /// A handle that names nothing in the active checkout — held across a rename, or minted in another
@@ -1467,20 +1530,7 @@ fn overload_handles(db: &IndexDatabase) -> (i64, i64) {
 /// overloads. Binding them here is what a compiler oracle pass produces, and it is the only way
 /// the caller direction can be observed at all.
 fn overloaded_config() -> (tempfile::TempDir, Config) {
-    let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().to_path_buf();
-    fs::create_dir(root.join("src")).unwrap();
-    fs::write(root.join("src/lib.rs"), OVERLOAD_SOURCE).unwrap();
-    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root);
-    config.database_key_pinned = true;
-    config.targets = vec![ResolvedTarget {
-        name: "rust".into(),
-        language: Language::Rust,
-        directories: vec![PathBuf::from("src")],
-        include: vec!["**/*.rs".into()],
-        exclude: Vec::new(),
-        kind: TargetKind::Source,
-    }];
+    let (temp, config) = rust_source_config(OVERLOAD_SOURCE);
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
     for (caller, callee) in [("calls_alpha", "alpha_leaf"), ("calls_beta", "beta_leaf")] {
@@ -1512,6 +1562,34 @@ fn overloaded_config() -> (tempfile::TempDir, Config) {
             .unwrap();
     }
     drop(db);
+    (temp, config)
+}
+
+/// Index [`COLLAPSED_OVERLOAD_SOURCE`]. No call sites to rewire: each overload's own body reaches
+/// its own leaf, so the callee direction alone shows what the shared handle expands to.
+fn collapsed_overload_config() -> (tempfile::TempDir, Config) {
+    let (temp, config) = rust_source_config(COLLAPSED_OVERLOAD_SOURCE);
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    (temp, config)
+}
+
+/// A config over one indexed `src/lib.rs`. NOT indexed yet — a fixture that has to reach into the
+/// database it builds needs the handle `rebuild` returns.
+fn rust_source_config(source: &str) -> (tempfile::TempDir, Config) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().to_path_buf();
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), source).unwrap();
+    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root);
+    config.database_key_pinned = true;
+    config.targets = vec![ResolvedTarget {
+        name: "rust".into(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from("src")],
+        include: vec!["**/*.rs".into()],
+        exclude: Vec::new(),
+        kind: TargetKind::Source,
+    }];
     (temp, config)
 }
 

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -7,7 +7,7 @@ use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
 use rusqlite::params;
 
 use super::hops::adapt_hops;
-use crate::index::IndexDatabase;
+use crate::index::{IndexDatabase, LensHopResolvedBy, LensHopSelector};
 
 const SOURCE: &str = r#"
 pub enum Req { Upsert { id: i64 } }
@@ -120,7 +120,10 @@ fn hops_and_chunk_text_keep_stable_compatibility_fields_on_read_only_open() {
         .find(|symbol| symbol.name == "target")
         .and_then(|symbol| symbol.qname)
         .unwrap();
-    let callers = db.lens_symbol_callers(&target_qname, 50).unwrap();
+    let callers = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName(target_qname), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
     assert!(callers.callers.iter().any(|hop| hop.name == "caller"));
     let wire = serde_json::to_value(&callers).unwrap();
     let first = wire["callers"].as_array().unwrap().first().unwrap();
@@ -137,8 +140,9 @@ fn hops_and_chunk_text_keep_stable_compatibility_fields_on_read_only_open() {
         .and_then(|symbol| symbol.qname)
         .unwrap();
     assert!(
-        db.lens_symbol_callees(&caller_qname, 50)
+        db.lens_symbol_callees(&LensHopSelector::QualifiedName(caller_qname.clone()), 50)
             .unwrap()
+            .expect("a qualified name always resolves")
             .callees
             .iter()
             .any(|hop| hop.name == "target")
@@ -614,18 +618,20 @@ fn graph_compositions_exclude_edges_with_out_of_scope_endpoints() {
             && detail.other_name.as_deref() != Some("dead_caller")
     }));
     assert!(
-        db.lens_symbol_callers(&target_qname, 50)
+        db.lens_symbol_callers(&LensHopSelector::QualifiedName(target_qname), 50)
             .unwrap()
+            .expect("a qualified name always resolves")
             .callers
             .iter()
             .all(|hop| hop.name != "dead_caller")
     );
     assert!(
-        db.lens_symbol_callees(&caller_qname, 50).unwrap().callees.iter().all(|hop| hop
-            .qname
-            .as_deref()
-            != Some("crate::missing")
-            && hop.name != "dead_target")
+        db.lens_symbol_callees(&LensHopSelector::QualifiedName(caller_qname), 50)
+            .unwrap()
+            .expect("a qualified name always resolves")
+            .callees
+            .iter()
+            .all(|hop| hop.qname.as_deref() != Some("crate::missing") && hop.name != "dead_target")
     );
 }
 
@@ -656,7 +662,11 @@ fn symbol_callers_preserve_file_level_edges() {
     )
     .unwrap();
 
-    let callers = db.lens_symbol_callers(&target_qname, 50).unwrap().callers;
+    let callers = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName(target_qname), 50)
+        .unwrap()
+        .expect("a qualified name always resolves")
+        .callers;
     let file_caller = callers.iter().find(|hop| hop.name == "src/lib.rs").unwrap();
     assert_eq!(file_caller.path, "src/lib.rs");
     assert_eq!(file_caller.source_start_line, 2);
@@ -1211,6 +1221,298 @@ fn file_papertrail_deduplicates_items_before_applying_the_limit() {
     assert_eq!(refs.len(), 50);
     assert_eq!(refs.iter().filter(|reference| reference.item_key == "duplicate").count(), 1);
     assert!(refs.iter().any(|reference| reference.item_key == "unique-0"));
+}
+
+/// Two `run` overloads in one file. Both qualify as `src/lib.rs::run`; only their signatures —
+/// and therefore their logical-symbol handles — differ, which is exactly the case a qualified-name
+/// selector cannot express.
+const OVERLOAD_SOURCE: &str = r#"
+pub struct Alpha;
+pub struct Beta;
+
+pub fn alpha_leaf() {}
+pub fn beta_leaf() {}
+
+impl Alpha {
+    pub fn run(&self) { alpha_leaf(); }
+}
+
+impl Beta {
+    pub fn run(&self, extra: i64) { beta_leaf(); let _ = extra; }
+}
+
+pub fn calls_alpha(alpha: &Alpha) { alpha.run(); }
+pub fn calls_beta(beta: &Beta) { beta.run(1); }
+"#;
+
+/// Each overload's own callers and callees are reachable only through its handle: the qualified
+/// name they share reports the union of both, in both directions.
+#[test]
+fn hop_selectors_separate_overloads_by_handle_and_unite_them_by_qualified_name() {
+    let (_temp, config) = overloaded_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    let (alpha, beta) = overload_handles(&db);
+    let qname = "src/lib.rs::run".to_string();
+
+    let alpha_callers =
+        db.lens_symbol_callers(&LensHopSelector::Handle(alpha), 50).unwrap().expect("alpha");
+    assert_eq!(hop_names(&alpha_callers.callers), ["calls_alpha"]);
+    assert_eq!(alpha_callers.resolved_by, LensHopResolvedBy::Id);
+    assert_eq!(alpha_callers.matched_symbols, 1);
+    let beta_callers =
+        db.lens_symbol_callers(&LensHopSelector::Handle(beta), 50).unwrap().expect("beta");
+    assert_eq!(hop_names(&beta_callers.callers), ["calls_beta"]);
+
+    let shared_callers = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName(qname.clone()), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert_eq!(hop_names(&shared_callers.callers), ["calls_alpha", "calls_beta"]);
+    assert_eq!(shared_callers.resolved_by, LensHopResolvedBy::Ref);
+    assert_eq!(
+        shared_callers.matched_symbols, 2,
+        "the fallback must report how many symbols the name it was given covers"
+    );
+
+    let alpha_callees =
+        db.lens_symbol_callees(&LensHopSelector::Handle(alpha), 50).unwrap().expect("alpha");
+    assert_eq!(hop_names(&alpha_callees.callees), ["alpha_leaf"]);
+    let beta_callees =
+        db.lens_symbol_callees(&LensHopSelector::Handle(beta), 50).unwrap().expect("beta");
+    assert_eq!(hop_names(&beta_callees.callees), ["beta_leaf"]);
+    let shared_callees = db
+        .lens_symbol_callees(&LensHopSelector::QualifiedName(qname), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert_eq!(hop_names(&shared_callees.callees), ["alpha_leaf", "beta_leaf"]);
+    assert_eq!(shared_callees.matched_symbols, 2);
+}
+
+/// A handle that names nothing in the active checkout — held across a rename, or minted in another
+/// checkout — is reported as absent. Answering it with an empty hop list would read as "this
+/// symbol has no callers", and falling back to the qualified name would reintroduce the union.
+#[test]
+fn an_unresolvable_handle_is_absent_rather_than_empty() {
+    let (_temp, config) = overloaded_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    assert!(db.lens_symbol_callers(&LensHopSelector::Handle(i64::MAX), 50).unwrap().is_none());
+    assert!(db.lens_symbol_callees(&LensHopSelector::Handle(i64::MAX), 50).unwrap().is_none());
+}
+
+/// The fallback's traversal also resolves a BARE SHORT NAME, through the unique-short-name arm its
+/// predicate carries, so `matched_symbols` has to model that arm as well: counting only the
+/// symbols whose QUALIFIED name is the selector reports zero beside a non-empty hop list, which
+/// reads as "the selector matched nothing" — the opposite of the ambiguity signal the field
+/// exists to carry. When the short name is ambiguous the arm is off and nothing is expanded, so
+/// zero is then the truthful answer.
+#[test]
+fn a_short_name_fallback_counts_the_symbol_its_traversal_expanded_to() {
+    let (_temp, config) = overloaded_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    let unique = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName("alpha_leaf".into()), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert_eq!(hop_names(&unique.callers), ["run"], "the short name resolves through the index");
+    assert_eq!(unique.resolved_by, LensHopResolvedBy::Ref);
+    assert_eq!(
+        unique.matched_symbols, 1,
+        "a request answered with hops must not report that it matched no symbol"
+    );
+
+    let ambiguous = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName("run".into()), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert!(ambiguous.callers.is_empty(), "an ambiguous short name expands to nothing");
+    assert_eq!(ambiguous.matched_symbols, 0);
+}
+
+/// Both selectors read the symbol table through the connection's `files` view, so a sibling
+/// checkout's rows are invisible to them: its same-named symbol must not inflate the fallback's
+/// ambiguity report, and its handle must not resolve here. The active checkout keeps answering.
+#[test]
+fn hop_selectors_see_only_the_active_checkouts_symbols() {
+    let (_temp, config) = overloaded_config();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let (alpha, _) = overload_handles(&db);
+    let conn = db.storage.connection();
+
+    // A file belonging to another checkout of this repo, carrying a THIRD `src/lib.rs::run` under
+    // its own logical symbol.
+    conn.execute(
+        "INSERT INTO main.files(
+             path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+             commit_sha, worktree_id, repo_id, generation
+         ) VALUES ('sibling.rs', 'rust', 'source', 'sibling-sha', 0, 0, 'sibling-commit', '', ?1, \
+         ?2)",
+        params![db.active_repo_id, db.active_generation],
+    )
+    .unwrap();
+    let sibling_file_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO symbols(
+             file_id, language, name, qualified_name_id, kind,
+             start_byte, end_byte, start_line, end_line
+         ) VALUES (
+             ?1, 'rust', 'run',
+             (SELECT id FROM name_strings WHERE value = 'src/lib.rs::run'),
+             'function', 0, 10, 1, 1
+         )",
+        [sibling_file_id],
+    )
+    .unwrap();
+    let sibling_symbol_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO logical_symbols(language, path, logical_name, qualified_name_id, kind,
+             variant_count, group_reason)
+         VALUES ('rust', 'sibling.rs', 'run',
+             (SELECT id FROM name_strings WHERE value = 'src/lib.rs::run'), 'function', 1, 'test')",
+        [],
+    )
+    .unwrap();
+    let sibling_logical_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, end_line)
+         VALUES (?1, ?2, 1, 1)",
+        [sibling_logical_id, sibling_symbol_id],
+    )
+    .unwrap();
+
+    let shared = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName("src/lib.rs::run".into()), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert_eq!(
+        shared.matched_symbols, 2,
+        "a sibling checkout's symbol is not one this checkout's name covers"
+    );
+    assert_eq!(hop_names(&shared.callers), ["calls_alpha", "calls_beta"]);
+    assert!(
+        db.lens_symbol_callers(&LensHopSelector::Handle(sibling_logical_id), 50).unwrap().is_none(),
+        "a handle whose only member lives in another checkout must read as absent"
+    );
+    assert!(db.lens_symbol_callers(&LensHopSelector::Handle(alpha), 50).unwrap().is_some());
+}
+
+/// The file lanes are where a CodeLens is built, so every row has to carry the handle its own hop
+/// request needs — and two overloads must not share it.
+#[test]
+fn file_lanes_carry_a_distinct_symbol_handle_per_overload() {
+    let (_temp, config) = overloaded_config();
+    let db = IndexDatabase::try_open_config_read_only(&config).unwrap().expect("read-only index");
+
+    let symbols = db.lens_file_symbols("src/lib.rs").unwrap().symbols;
+    let runs = symbols.iter().filter(|symbol| symbol.name == "run").collect::<Vec<_>>();
+    assert_eq!(runs.len(), 2);
+    assert!(runs.iter().all(|symbol| symbol.qname.as_deref() == Some("src/lib.rs::run")));
+    assert_ne!(runs[0].logical_symbol_id, runs[1].logical_symbol_id);
+    assert!(runs.iter().all(|symbol| symbol.logical_symbol_id.is_some()));
+
+    let graph = db.lens_file_graph("src/lib.rs").unwrap().symbols;
+    let graph_runs = graph
+        .iter()
+        .filter(|symbol| symbol.name == "run")
+        .map(|symbol| symbol.logical_symbol_id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        graph_runs,
+        runs.iter().map(|symbol| symbol.logical_symbol_id).collect::<Vec<_>>(),
+        "both file lanes must hand out the same handle for the same row"
+    );
+
+    // The handle crosses the wire as its opaque `sym_<hex>` token, never as a number a JSON client
+    // could round past 2^53.
+    let wire = serde_json::to_value(db.lens_file_graph("src/lib.rs").unwrap()).unwrap();
+    let ids = wire["symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|row| row["name"] == "run")
+        .map(|row| row["id"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(ids.len(), 2);
+    assert!(ids.iter().all(|id| id.starts_with("sym_")), "{ids:?}");
+    assert_ne!(ids[0], ids[1]);
+}
+
+fn hop_names(hops: &[super::LensSymbolHop]) -> Vec<String> {
+    let mut names = hops.iter().map(|hop| hop.name.clone()).collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// The two handles behind `src/lib.rs::run`, alpha's first.
+fn overload_handles(db: &IndexDatabase) -> (i64, i64) {
+    let mut runs = db
+        .lens_file_symbols("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .filter(|symbol| symbol.name == "run")
+        .collect::<Vec<_>>();
+    runs.sort_by_key(|symbol| symbol.start_line);
+    assert_eq!(runs.len(), 2, "the fixture must index both overloads");
+    (runs[0].logical_symbol_id.unwrap(), runs[1].logical_symbol_id.unwrap())
+}
+
+/// Index [`OVERLOAD_SOURCE`] and bind each `run` call site to the overload it actually targets.
+///
+/// The heuristic resolver deliberately leaves a same-name method call unresolved — with two
+/// candidates it refuses to guess — so on the caller side no natural edge distinguishes the
+/// overloads. Binding them here is what a compiler oracle pass produces, and it is the only way
+/// the caller direction can be observed at all.
+fn overloaded_config() -> (tempfile::TempDir, Config) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().to_path_buf();
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), OVERLOAD_SOURCE).unwrap();
+    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root);
+    config.database_key_pinned = true;
+    config.targets = vec![ResolvedTarget {
+        name: "rust".into(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from("src")],
+        include: vec!["**/*.rs".into()],
+        exclude: Vec::new(),
+        kind: TargetKind::Source,
+    }];
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    for (caller, callee) in [("calls_alpha", "alpha_leaf"), ("calls_beta", "beta_leaf")] {
+        // The overload each caller means is the one whose body calls that caller's leaf.
+        let target: i64 = conn
+            .query_row(
+                "SELECT run.id
+                 FROM symbols run
+                 JOIN files ON files.id = run.file_id
+                 JOIN edges body ON body.from_symbol_id = run.id
+                 JOIN symbols leaf ON leaf.id = body.to_symbol_id
+                 WHERE run.name = 'run' AND leaf.name = ?1",
+                [callee],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let edge: i64 = conn
+            .query_row(
+                "SELECT edges.id
+                 FROM edges
+                 JOIN symbols source ON source.id = edges.from_symbol_id
+                 WHERE edges.edge_kind = 'calls_name' AND edges.to_name = 'run'
+                   AND source.name = ?1",
+                [caller],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute("UPDATE edges_data SET to_symbol_id = ?1 WHERE id = ?2", [target, edge])
+            .unwrap();
+    }
+    drop(db);
+    (temp, config)
 }
 
 fn indexed_config() -> (tempfile::TempDir, Config) {

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -55,8 +55,8 @@ pub use lens::{
     LensCallees, LensCallers, LensChunkText, LensCloneGraphCache, LensCouplingPartner,
     LensDecisionRecord, LensDispatchDetail, LensFileCoupling, LensFileGraph, LensFileMemories,
     LensFileMemory, LensFilePapertrail, LensFileSymbolGraph, LensFileSymbols,
-    LensGraphCallerCounts, LensPapertrailRef, LensStatus, LensSymbol, LensSymbolHop, LensTreemap,
-    LensTreemapFile, LensVersion,
+    LensGraphCallerCounts, LensHopResolvedBy, LensHopSelector, LensPapertrailRef, LensStatus,
+    LensSymbol, LensSymbolHop, LensTreemap, LensTreemapFile, LensVersion,
 };
 pub use memory::SyncCatchUpReport;
 pub use oracle_runs::OracleShaSnapshots;

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -1476,3 +1476,108 @@ fn oracle_surfaces_compiler_tier_on_a_real_git_checkout() {
     assert_eq!(hop.confidence, "compiler", "Compiler tier must surface on a real git checkout");
     assert_eq!(hop.resolution_reason.as_deref(), Some("scip:rust-analyzer@v-test"));
 }
+
+/// THE HANDLE LANE MUST NOT LOSE A COMPILER-VERIFIED NEIGHBOUR. A call the heuristic left
+/// unresolved — no `to_symbol_id`, only the target name written at the call site — is exactly the
+/// shape an oracle `Upgrade` exists to rescue, and the rescue happens in `enrich_hops_with_oracle`,
+/// AFTER the traversal's SQL has already decided which edges it admits. An admission filter that
+/// requires a resolved endpoint therefore drops the edge before the compiler ever speaks, and no
+/// oracle run can bring it back: the verdict lives in a side table and the `edges` row is never
+/// mutated.
+///
+/// So the two hop lanes have to agree here, in both directions. A `sym_<hex>` answer that omits a
+/// caller `?ref=` returns reads as "this symbol has no callers", which is the one thing a hop route
+/// must never say wrongly.
+#[test]
+fn a_compiler_upgraded_unresolved_edge_reaches_the_handle_lane_too() {
+    let root = temp_root();
+    fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+    let config = rust_config(root.to_path_buf());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (edge_id, callee_start, callee_end, path) = call_edge(&db);
+    // Put the edge in the unresolved-but-qualified state: the heuristic bound nothing, and all
+    // that survives is the name the call site wrote. `Syntactic` confidence is what that shape
+    // carries, and what the default callee visibility filter admits an unresolved edge under.
+    let conn = db.storage.connection();
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('Syntactic')", []).unwrap();
+    let changed = conn
+        .execute(
+            "UPDATE edges_data
+                SET to_symbol_id = NULL,
+                    confidence_id = (SELECT id FROM name_strings WHERE value = 'Syntactic'),
+                    target_qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = 'src/lib.rs::target')
+              WHERE id = ?1",
+            params![edge_id],
+        )
+        .unwrap();
+    assert_eq!(changed, 1);
+    let (to_symbol_id, target_qualified_name): (Option<i64>, Option<String>) = conn
+        .query_row(
+            "SELECT to_symbol_id, target_qualified_name FROM edges WHERE id = ?1",
+            params![edge_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(to_symbol_id, None, "the fixture must leave the edge unresolved");
+    assert_eq!(target_qualified_name.as_deref(), Some("src/lib.rs::target"));
+
+    let symbol = "scip-rust crate held-mini `target`().";
+    let scip = scip_with(&path, callee_start, callee_end, symbol, Some(&path), Some((29, 35)));
+    let report = db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+    assert!(report.upgraded >= 1, "the oracle must bind the unresolved call; got {report:?}");
+
+    let handle = |name: &str| {
+        db.lens_file_symbols("src/lib.rs")
+            .unwrap()
+            .symbols
+            .into_iter()
+            .find(|symbol| symbol.name == name)
+            .and_then(|symbol| symbol.logical_symbol_id)
+            .unwrap_or_else(|| panic!("the fixture must index {name}"))
+    };
+    let described = |hops: &[LensSymbolHop]| {
+        hops.iter()
+            .map(|hop| (hop.name.clone(), hop.confidence.clone()))
+            .collect::<Vec<(String, String)>>()
+    };
+
+    let callers_by_name = db
+        .lens_symbol_callers(&LensHopSelector::QualifiedName("src/lib.rs::target".into()), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert_eq!(
+        described(&callers_by_name.callers),
+        [("caller".to_string(), "compiler".to_string())],
+        "the fallback lane must surface the compiler-verified caller"
+    );
+    let callers_by_handle = db
+        .lens_symbol_callers(&LensHopSelector::Handle(handle("target")), 50)
+        .unwrap()
+        .expect("a handle from this checkout resolves");
+    assert_eq!(
+        described(&callers_by_handle.callers),
+        described(&callers_by_name.callers),
+        "the handle lane must not drop the edge the compiler bound to this very symbol"
+    );
+
+    let callees_by_name = db
+        .lens_symbol_callees(&LensHopSelector::QualifiedName("src/lib.rs::caller".into()), 50)
+        .unwrap()
+        .expect("a qualified name always resolves");
+    assert_eq!(
+        described(&callees_by_name.callees),
+        [("target".to_string(), "compiler".to_string())],
+        "the fallback lane must surface the compiler-verified callee"
+    );
+    let callees_by_handle = db
+        .lens_symbol_callees(&LensHopSelector::Handle(handle("caller")), 50)
+        .unwrap()
+        .expect("a handle from this checkout resolves");
+    assert_eq!(
+        described(&callees_by_handle.callees),
+        described(&callees_by_name.callees),
+        "same loss in the forward direction, where the admission filter is the target filter"
+    );
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod delta_refresh;
+mod lens_handles;
 mod lifecycle;
 mod logical_rebuild;
 mod quiet_window;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lens_handles.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lens_handles.rs
@@ -1,0 +1,219 @@
+use super::*;
+
+/// The main checkout: two `run` overloads sharing `src/lib.rs::run`, each reaching its own leaf,
+/// plus `alpha_leaf`, which the branch below leaves byte-identical.
+const MAIN_SOURCE: &str = r#"
+pub struct Alpha;
+pub struct Beta;
+
+pub fn alpha_leaf() {}
+pub fn beta_leaf() {}
+
+impl Alpha {
+    pub fn run(&self) { alpha_leaf(); }
+}
+
+impl Beta {
+    pub fn run(&self, extra: i64) { beta_leaf(); let _ = extra; }
+}
+"#;
+
+/// The linked checkout: `Beta` is gone, `Alpha::run` reaches a different leaf, and `alpha_leaf` is
+/// carried over unchanged — so one symbol is shared between the checkouts, one is re-declared into
+/// its own logical symbol, and one exists in each checkout alone.
+const BRANCH_SOURCE: &str = r#"
+pub struct Alpha;
+
+pub fn alpha_leaf() {}
+pub fn gamma_leaf() {}
+
+impl Alpha {
+    pub fn run(&self) { gamma_leaf(); }
+}
+"#;
+
+/// A `sym_<hex>` handle is scoped to the checkout that minted it, and the file lane that hands it
+/// out reports its reach in the same scope.
+///
+/// A shared database is what makes this a question at all: `logical_symbol_members` is
+/// corpus-level, so a symbol carried over unchanged has ONE logical symbol with a member row per
+/// checkout, and a re-declared one has a second logical symbol whose members the other checkout
+/// must not see. Reading either unscoped gives an answer that looks authoritative and is wrong in
+/// both directions — a handle from the sibling checkout resolving here, and a handle that covers
+/// one declaration reporting two.
+///
+/// Only a real linked worktree exercises that: planting an out-of-scope row proves the `files` view
+/// filters, but not that the overlay pass populates the rows the filter then has to separate, nor
+/// that switching the active checkout back leaves the first checkout's answers intact.
+#[test]
+fn lens_symbol_handles_are_scoped_to_the_active_checkout() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/lib.rs"), MAIN_SOURCE).unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.to_path_buf(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/lib.rs"), BRANCH_SOURCE).unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // The base checkout's own answers, taken before any scope switch.
+    db.use_worktree_scope(&main, None).unwrap();
+    let base = handles(&db);
+    assert_eq!(
+        base.iter().map(|(name, ..)| name.as_str()).collect::<Vec<_>>(),
+        // Each type name is indexed twice — the struct and its impl block.
+        ["Alpha", "Alpha", "Beta", "Beta", "alpha_leaf", "beta_leaf", "run", "run"],
+        "the base scope sees the main checkout's file, not the branch's"
+    );
+    let base_alpha_run = handle_reaching(&db, &base, "run", "alpha_leaf");
+    let base_beta_run = handle_reaching(&db, &base, "run", "beta_leaf");
+    let base_shared_leaf = named(&base, "alpha_leaf");
+    assert_ne!(base_alpha_run.0, base_beta_run.0, "the overloads are distinct logical symbols");
+
+    // The shared symbol is the one that could inflate: `alpha_leaf` is byte-identical in both
+    // checkouts, so its logical symbol has a member row per checkout — and exactly one of them is
+    // a declaration THIS checkout has.
+    assert_eq!(
+        base_shared_leaf.1, 1,
+        "a symbol carried over unchanged is one declaration per checkout, not two"
+    );
+    assert_eq!(base_alpha_run.1, 1);
+    assert_eq!(
+        callee_names(&db, base_alpha_run.0),
+        ["alpha_leaf"],
+        "the base overload reaches the leaf its own body calls"
+    );
+    assert_eq!(callee_names(&db, base_beta_run.0), ["beta_leaf"]);
+
+    // The linked checkout: its own re-declared `run`, and no trace of `Beta`.
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    let branch = handles(&db);
+    assert_eq!(
+        branch.iter().map(|(name, ..)| name.as_str()).collect::<Vec<_>>(),
+        ["Alpha", "Alpha", "alpha_leaf", "gamma_leaf", "run"],
+        "the overlay scope serves the branch's file"
+    );
+    let branch_run = named(&branch, "run");
+    assert_ne!(
+        branch_run.0, base_alpha_run.0,
+        "a re-declared symbol is a different logical symbol, so a different handle"
+    );
+    assert_eq!(branch_run.1, 1);
+    assert_eq!(callee_names(&db, branch_run.0), ["gamma_leaf"]);
+    assert_eq!(
+        named(&branch, "alpha_leaf"),
+        base_shared_leaf,
+        "the shared symbol keeps one handle across checkouts, and still covers one declaration"
+    );
+
+    // ISOLATION: neither base-only handle answers here. Both name a member whose file the overlay
+    // shadows or replaces, so they are absent — never an empty hop list, which reads as "this
+    // symbol has no callees".
+    for (label, handle) in [("Alpha::run", base_alpha_run.0), ("Beta::run", base_beta_run.0)] {
+        assert!(
+            db.lens_symbol_callees(&LensHopSelector::Handle(handle), 50).unwrap().is_none(),
+            "the base checkout's {label} must not resolve under the linked checkout's scope"
+        );
+    }
+
+    // PRESERVATION: switching back restores the base checkout's answers unchanged, and the
+    // branch-only handle is now the absent one.
+    db.use_worktree_scope(&main, None).unwrap();
+    assert_eq!(handles(&db), base, "the overlay pass must not have moved the base checkout's rows");
+    assert_eq!(callee_names(&db, base_alpha_run.0), ["alpha_leaf"]);
+    assert_eq!(callee_names(&db, base_beta_run.0), ["beta_leaf"]);
+    assert!(
+        db.lens_symbol_callees(&LensHopSelector::Handle(branch_run.0), 50).unwrap().is_none(),
+        "the linked checkout's handle must not resolve back in the base scope"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// `(name, handle, declarations)` for every `src/lib.rs` symbol in the active scope, with the graph
+/// lane asserted to agree — both lanes hand out the selector a CodeLens sends back.
+fn handles(db: &IndexDatabase) -> Vec<(String, i64, u64)> {
+    let mut rows = db
+        .lens_file_symbols("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .map(|symbol| {
+            (
+                symbol.name,
+                symbol.logical_symbol_id.expect("an indexed row carries a handle"),
+                symbol.logical_symbol_declarations,
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut graph = db
+        .lens_file_graph("src/lib.rs")
+        .unwrap()
+        .symbols
+        .into_iter()
+        .map(|symbol| {
+            (
+                symbol.name,
+                symbol.logical_symbol_id.expect("an indexed row carries a handle"),
+                symbol.logical_symbol_declarations,
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+    graph.sort();
+    assert_eq!(rows, graph, "both file lanes must hand out the same handle and the same reach");
+    rows
+}
+
+fn named(rows: &[(String, i64, u64)], name: &str) -> (i64, u64) {
+    let matched = rows
+        .iter()
+        .filter(|(row_name, ..)| row_name == name)
+        .map(|(_, handle, declarations)| (*handle, *declarations))
+        .collect::<Vec<_>>();
+    assert_eq!(matched.len(), 1, "{name} must be one row in this scope: {rows:?}");
+    matched[0]
+}
+
+/// The `name` row whose own body reaches `callee` — how the two same-named overloads are told
+/// apart without depending on which order the index returned them in.
+fn handle_reaching(
+    db: &IndexDatabase,
+    rows: &[(String, i64, u64)],
+    name: &str,
+    callee: &str,
+) -> (i64, u64) {
+    let matched = rows
+        .iter()
+        .filter(|(row_name, ..)| row_name == name)
+        .filter(|(_, handle, _)| callee_names(db, *handle).iter().any(|hop| hop == callee))
+        .map(|(_, handle, declarations)| (*handle, *declarations))
+        .collect::<Vec<_>>();
+    assert_eq!(matched.len(), 1, "exactly one {name} may reach {callee}: {rows:?}");
+    matched[0]
+}
+
+fn callee_names(db: &IndexDatabase, handle: i64) -> Vec<String> {
+    let answer = db
+        .lens_symbol_callees(&LensHopSelector::Handle(handle), 50)
+        .unwrap()
+        .expect("a handle from the active checkout resolves");
+    assert_eq!(
+        answer.matched_symbols, 1,
+        "no fixture symbol here groups, so the answer covers one declaration"
+    );
+    let mut names = answer.callees.into_iter().map(|hop| hop.name).collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
+}

--- a/crates/rag-rat-mcp/src/http.rs
+++ b/crates/rag-rat-mcp/src/http.rs
@@ -483,18 +483,24 @@ async fn symbol_callers(
     State(state): State<HttpState>,
     Query(query): Query<SymbolHopQuery>,
 ) -> Result<Json<rag_rat_core::index::LensCallers>, ApiError> {
-    let qname = required_qname(query.qname)?;
+    let selector = hop_selector(&query)?;
     let limit = hop_limit(query.limit.as_deref());
-    run_db(state, move |db, _, _| Ok(db.lens_symbol_callers(&qname, limit)?)).await.map(Json)
+    run_db(state, move |db, _, _| Ok(db.lens_symbol_callers(&selector, limit)?))
+        .await?
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(UNKNOWN_SYMBOL_HANDLE.into()))
 }
 
 async fn symbol_callees(
     State(state): State<HttpState>,
     Query(query): Query<SymbolHopQuery>,
 ) -> Result<Json<rag_rat_core::index::LensCallees>, ApiError> {
-    let qname = required_qname(query.qname)?;
+    let selector = hop_selector(&query)?;
     let limit = hop_limit(query.limit.as_deref());
-    run_db(state, move |db, _, _| Ok(db.lens_symbol_callees(&qname, limit)?)).await.map(Json)
+    run_db(state, move |db, _, _| Ok(db.lens_symbol_callees(&selector, limit)?))
+        .await?
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(UNKNOWN_SYMBOL_HANDLE.into()))
 }
 
 async fn chunk_text(
@@ -528,12 +534,25 @@ fn canonical_file_path(
     Ok(db.lens_canonical_file_path(&path, case_insensitive)?.unwrap_or(path))
 }
 
-fn required_qname(qname: Option<String>) -> Result<String, ApiError> {
-    let qname = qname.ok_or_else(|| ApiError::bad_query("missing query parameter `qname`"))?;
-    if qname.is_empty() {
-        return Err(ApiError::bad_query("`qname` must not be empty"));
+const UNKNOWN_SYMBOL_HANDLE: &str = "unknown symbol handle";
+
+/// Pick the selector a hop request is answered by, preferring the stable `sym_<hex>` handle.
+///
+/// `qname` stays accepted because the server and the editor extension version independently: an
+/// installed extension built before the handle existed sends only a name, and answering it with a
+/// 400 would break call navigation on every such install. It is a documented fallback rather than
+/// an equal alternative — a qualified name is shared by every overload in a file, so the answer is
+/// their union, which the response says out loud via `resolved_by` / `matched_symbols`.
+fn hop_selector(query: &SymbolHopQuery) -> Result<rag_rat_core::index::LensHopSelector, ApiError> {
+    if let Some(id) = query.id.as_deref().filter(|value| !value.is_empty()) {
+        return rag_rat_base::serde_big_id::parse_sym_handle(id)
+            .map(rag_rat_core::index::LensHopSelector::Handle)
+            .ok_or_else(|| ApiError::bad_query("`id` must be a `sym_<hex>` symbol handle"));
     }
-    Ok(qname)
+    let qname = query.qname.as_deref().filter(|value| !value.is_empty()).ok_or_else(|| {
+        ApiError::bad_query("missing query parameter `id` (preferred) or `qname`")
+    })?;
+    Ok(rag_rat_core::index::LensHopSelector::QualifiedName(qname.to_string()))
 }
 
 fn hop_limit(raw: Option<&str>) -> u32 {
@@ -746,6 +765,9 @@ struct FileQuery {
 
 #[derive(Deserialize)]
 struct SymbolHopQuery {
+    /// The `sym_<hex>` logical-symbol handle from `/api/file/{symbols,graph}`. Preferred.
+    id: Option<String>,
+    /// Compatibility fallback for a client that has no handle to send.
     qname: Option<String>,
     limit: Option<String>,
 }

--- a/crates/rag-rat-mcp/src/http.rs
+++ b/crates/rag-rat-mcp/src/http.rs
@@ -543,8 +543,14 @@ const UNKNOWN_SYMBOL_HANDLE: &str = "unknown symbol handle";
 /// 400 would break call navigation on every such install. It is a documented fallback rather than
 /// an equal alternative — a qualified name is shared by every overload in a file, so the answer is
 /// their union, which the response says out loud via `resolved_by` / `matched_symbols`.
+///
+/// A request that CARRIES `id` is answered by the handle lane or not at all — an empty or
+/// malformed handle is a 400, never a fall-through to `qname`. The two lanes answer different
+/// questions, so degrading between them silently is the failure this route exists to remove: a
+/// client that meant one overload would get the union of every symbol sharing its name back,
+/// under a `resolved_by` it never asked for and has no reason to re-read.
 fn hop_selector(query: &SymbolHopQuery) -> Result<rag_rat_core::index::LensHopSelector, ApiError> {
-    if let Some(id) = query.id.as_deref().filter(|value| !value.is_empty()) {
+    if let Some(id) = query.id.as_deref() {
         return rag_rat_base::serde_big_id::parse_sym_handle(id)
             .map(rag_rat_core::index::LensHopSelector::Handle)
             .ok_or_else(|| ApiError::bad_query("`id` must be a `sym_<hex>` symbol handle"));

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -730,6 +730,23 @@ pub fn calls_alpha(alpha: &Alpha) { alpha.run(); }
 pub fn calls_beta(beta: &Beta) { beta.run(1); }
 "#;
 
+/// One function's cfg variants: one logical symbol, one handle, two declarations behind it — the
+/// case no selector can narrow, so the route has to report the reach instead.
+const CFG_VARIANT_SOURCE: &str = r#"
+pub fn unix_leaf() {}
+pub fn windows_leaf() {}
+
+#[cfg(unix)]
+pub fn run() {
+    unix_leaf();
+}
+
+#[cfg(windows)]
+pub fn run() {
+    windows_leaf();
+}
+"#;
+
 /// The whole protocol on one fixture: `/api/file/graph` hands out a handle per overload, and the
 /// hop routes answer each handle with that overload's own neighbours. The `qname` fallback stays
 /// reachable and says, in the response, that it covered two symbols at once.
@@ -738,6 +755,7 @@ async fn hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name() {
     let (root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), OVERLOAD_SOURCE).unwrap();
+    fs::write(root.join("src/cfg.rs"), CFG_VARIANT_SOURCE).unwrap();
     drop(IndexDatabase::rebuild(&config).unwrap());
     let conn = rusqlite::Connection::open(&config.database).unwrap();
     resolve_overload_call_sites(&conn);
@@ -754,6 +772,10 @@ async fn hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name() {
         .collect::<Vec<_>>();
     assert_eq!(handles.len(), 2);
     assert_ne!(handles[0], handles[1], "overloads must not share one handle");
+    assert!(
+        graph["symbols"].as_array().unwrap().iter().all(|row| row["id_declarations"] == 1),
+        "every handle here covers exactly the row it sits on: {graph}"
+    );
     let symbols = get_json(&app, "/api/file/symbols?path=src/lib.rs").await;
     assert_eq!(
         symbols["symbols"]
@@ -841,6 +863,45 @@ async fn hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name() {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert_eq!(json_body(response).await["error"], "unknown symbol handle");
     }
+
+    // A handle that CANNOT single out its row says so where it is handed out, so a client never
+    // renders a grouped selector as if it disambiguated. Both file lanes report it, and the hop
+    // answer repeats the same number rather than leaving the two to be reconciled.
+    let cfg = get_json(&app, "/api/file/graph?path=src/cfg.rs").await;
+    let variants = cfg["symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|row| row["name"] == "run")
+        .collect::<Vec<_>>();
+    assert_eq!(variants.len(), 2);
+    assert_eq!(variants[0]["id"], variants[1]["id"], "cfg variants are one logical symbol");
+    assert!(
+        variants.iter().all(|row| row["id_declarations"] == 2),
+        "a grouped handle must state its reach: {cfg}"
+    );
+    assert_eq!(
+        get_json(&app, "/api/file/symbols?path=src/cfg.rs").await["symbols"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|row| row["name"] == "run")
+            .map(|row| (row["id"].clone(), row["id_declarations"].clone()))
+            .collect::<Vec<_>>(),
+        variants
+            .iter()
+            .map(|row| (row["id"].clone(), row["id_declarations"].clone()))
+            .collect::<Vec<_>>(),
+        "both file lanes must agree on the handle and on its reach"
+    );
+    let shared = variants[0]["id"].as_str().unwrap();
+    let grouped = get_json(&app, &format!("/api/symbol/callees?id={shared}")).await;
+    assert_eq!(hop_names(&grouped["callees"]), ["unix_leaf", "windows_leaf"]);
+    assert_eq!(grouped["resolved_by"], "id");
+    assert_eq!(
+        grouped["matched_symbols"], 2,
+        "the answer repeats the reach the file lane already reported"
+    );
     let _ = fs::remove_dir_all(root);
 }
 

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -343,6 +343,11 @@ async fn new_routes_reject_missing_or_invalid_parameters() {
         "/api/file/papertrail",
         "/api/symbol/callers",
         "/api/symbol/callees?qname=",
+        // An empty `id` falls through to the qualified name, which is also absent.
+        "/api/symbol/callers?id=",
+        // Neither is a `sym_<hex>` handle, and neither may be read as one.
+        "/api/symbol/callers?id=12345",
+        "/api/symbol/callees?id=sym_zzz",
         "/api/chunk/text",
         "/api/chunk/text?chunk_id=nope",
         "/api/chunk/text?chunk_id=0",
@@ -701,6 +706,164 @@ async fn a_queued_clone_read_holds_no_database_worker() {
         queued.await.expect("the queued clone read completes once the build releases the graph");
     assert!(clones.clone_regions.is_empty(), "a one-function corpus has no clone regions");
     let _ = fs::remove_dir_all(root);
+}
+
+/// Two `run` overloads sharing `src/lib.rs::run`, each with its own caller and its own callee.
+const OVERLOAD_SOURCE: &str = r#"
+pub struct Alpha;
+pub struct Beta;
+
+pub fn alpha_leaf() {}
+pub fn beta_leaf() {}
+
+impl Alpha {
+    pub fn run(&self) { alpha_leaf(); }
+}
+
+impl Beta {
+    pub fn run(&self, extra: i64) { beta_leaf(); let _ = extra; }
+}
+
+pub fn calls_alpha(alpha: &Alpha) { alpha.run(); }
+pub fn calls_beta(beta: &Beta) { beta.run(1); }
+"#;
+
+/// The whole protocol on one fixture: `/api/file/graph` hands out a handle per overload, and the
+/// hop routes answer each handle with that overload's own neighbours. The `qname` fallback stays
+/// reachable and says, in the response, that it covered two symbols at once.
+#[tokio::test]
+async fn hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name() {
+    let (root, config) = test_config();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), OVERLOAD_SOURCE).unwrap();
+    drop(IndexDatabase::rebuild(&config).unwrap());
+    let conn = rusqlite::Connection::open(&config.database).unwrap();
+    resolve_overload_call_sites(&conn);
+    drop(conn);
+    let app = router(config, ServeOptions::default());
+
+    let graph = get_json(&app, "/api/file/graph?path=src/lib.rs").await;
+    let handles = graph["symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|row| row["name"] == "run")
+        .map(|row| row["id"].as_str().expect("every graph row carries its handle").to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(handles.len(), 2);
+    assert_ne!(handles[0], handles[1], "overloads must not share one handle");
+    let symbols = get_json(&app, "/api/file/symbols?path=src/lib.rs").await;
+    assert_eq!(
+        symbols["symbols"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|row| row["name"] == "run")
+            .map(|row| row["id"].clone())
+            .collect::<Vec<_>>(),
+        handles.iter().map(|id| Value::String(id.clone())).collect::<Vec<_>>(),
+        "both file lanes must agree on the handle"
+    );
+
+    for (handle, caller, callee) in
+        [(&handles[0], "calls_alpha", "alpha_leaf"), (&handles[1], "calls_beta", "beta_leaf")]
+    {
+        let callers = get_json(&app, &format!("/api/symbol/callers?id={handle}")).await;
+        assert_eq!(hop_names(&callers["callers"]), [caller]);
+        assert_eq!(callers["resolved_by"], "id");
+        assert_eq!(callers["matched_symbols"], 1);
+        let callees = get_json(&app, &format!("/api/symbol/callees?id={handle}")).await;
+        assert_eq!(hop_names(&callees["callees"]), [callee]);
+        assert_eq!(callees["resolved_by"], "id");
+    }
+
+    let shared = get_json(&app, "/api/symbol/callers?qname=src/lib.rs::run").await;
+    assert_eq!(hop_names(&shared["callers"]), ["calls_alpha", "calls_beta"]);
+    assert_eq!(shared["resolved_by"], "ref");
+    assert_eq!(
+        shared["matched_symbols"], 2,
+        "an older client must be able to see that its selector was ambiguous"
+    );
+    let shared = get_json(&app, "/api/symbol/callees?qname=src/lib.rs::run").await;
+    assert_eq!(hop_names(&shared["callees"]), ["alpha_leaf", "beta_leaf"]);
+    assert_eq!(shared["resolved_by"], "ref");
+
+    // The fallback also answers an unqualified name, so its count has to model that resolution
+    // too: `matched_symbols: 0` beside a non-empty hop list would tell a client its selector
+    // matched nothing.
+    let short = get_json(&app, "/api/symbol/callers?qname=alpha_leaf").await;
+    assert_eq!(hop_names(&short["callers"]), ["run"]);
+    assert_eq!(short["resolved_by"], "ref");
+    assert_eq!(short["matched_symbols"], 1);
+
+    // A handle wins over a qualified name sent in the same request.
+    let both =
+        get_json(&app, &format!("/api/symbol/callers?id={}&qname=src/lib.rs::run", handles[0]))
+            .await;
+    assert_eq!(hop_names(&both["callers"]), ["calls_alpha"]);
+    assert_eq!(both["resolved_by"], "id");
+
+    // A well-formed handle naming nothing here is a 404, not an empty caller list.
+    for route in ["callers", "callees"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(format!("/api/symbol/{route}?id=sym_7fffffffffffffff"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(json_body(response).await["error"], "unknown symbol handle");
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Sorted, de-duplicated hop names from a `callers`/`callees` payload.
+fn hop_names(hops: &Value) -> Vec<String> {
+    let mut names = hops
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hop| hop["name"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Bind each `run` call site to the overload it actually targets, as a compiler oracle pass does.
+/// The heuristic resolver leaves a same-name method call unresolved on purpose, so without this
+/// the caller direction has no edge that could tell the two overloads apart.
+fn resolve_overload_call_sites(conn: &rusqlite::Connection) {
+    for (caller, callee) in [("calls_alpha", "alpha_leaf"), ("calls_beta", "beta_leaf")] {
+        let target: i64 = conn
+            .query_row(
+                "SELECT run.id
+                 FROM symbols run
+                 JOIN files ON files.id = run.file_id
+                 JOIN edges body ON body.from_symbol_id = run.id
+                 JOIN symbols leaf ON leaf.id = body.to_symbol_id
+                 WHERE run.name = 'run' AND leaf.name = ?1",
+                [callee],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let edge: i64 = conn
+            .query_row(
+                "SELECT edges.id
+                 FROM edges
+                 JOIN symbols source ON source.id = edges.from_symbol_id
+                 WHERE edges.edge_kind = 'calls_name' AND edges.to_name = 'run'
+                   AND source.name = ?1",
+                [caller],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute("UPDATE edges_data SET to_symbol_id = ?1 WHERE id = ?2", [target, edge])
+            .unwrap();
+    }
 }
 
 async fn json_body(response: axum::response::Response) -> Value {

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -343,9 +343,11 @@ async fn new_routes_reject_missing_or_invalid_parameters() {
         "/api/file/papertrail",
         "/api/symbol/callers",
         "/api/symbol/callees?qname=",
-        // An empty `id` falls through to the qualified name, which is also absent.
+        // A present `id` is a handle or an error; none of these is a `sym_<hex>` handle, and none
+        // may be read as a name instead. The lane-swap this refuses is covered end to end, with a
+        // resolvable `qname` alongside, in
+        // `hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name`.
         "/api/symbol/callers?id=",
-        // Neither is a `sym_<hex>` handle, and neither may be read as one.
         "/api/symbol/callers?id=12345",
         "/api/symbol/callees?id=sym_zzz",
         "/api/chunk/text",
@@ -802,6 +804,28 @@ async fn hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name() {
             .await;
     assert_eq!(hop_names(&both["callers"]), ["calls_alpha"]);
     assert_eq!(both["resolved_by"], "id");
+
+    // A request that CARRIES `id` is answered by the handle lane or refused. Degrading a bad
+    // handle to the qualified name beside it would hand back the union of both overloads to a
+    // client that asked for one — the very answer this route exists to stop giving.
+    for id in ["", "12345", "sym_zzz"] {
+        for route in ["callers", "callees"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::get(format!("/api/symbol/{route}?id={id}&qname=src/lib.rs::run"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "id={id:?} route={route}");
+            assert_eq!(
+                json_body(response).await["error"],
+                "`id` must be a `sym_<hex>` symbol handle"
+            );
+        }
+    }
 
     // A well-formed handle naming nothing here is a 404, not an empty caller list.
     for route in ["callers", "callees"] {

--- a/crates/rag-rat-query/src/graph/predicates.rs
+++ b/crates/rag-rat-query/src/graph/predicates.rs
@@ -383,6 +383,27 @@ pub fn unique_symbol_name(conn: &Connection, name: &str) -> anyhow::Result<bool>
     )?;
     Ok(count == 1)
 }
+/// How many active-scope symbols a NAME seed expands to under the `Syntactic` predicates above.
+///
+/// Lives beside those predicates because it answers the same question they do and must not drift
+/// from them: a symbol is a seed match when its qualified name IS `symbol`, or — only while the
+/// seed's short name is unique, which is the `?7` gate the predicates themselves carry — when its
+/// name is that short name. A caller that counts the qualified arm alone reports zero for the
+/// unqualified seed a traversal resolves perfectly well through the short-name arm.
+///
+/// GENERATION-SCOPED via the `files` view, for the reason spelled out on `unique_symbol_name`.
+pub fn syntactic_seed_symbol_count(conn: &Connection, symbol: &str) -> anyhow::Result<u64> {
+    let short = short_name(symbol);
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) AS symbol_count FROM symbols
+         JOIN files ON files.id = symbols.file_id
+         LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+         WHERE qn.value = ?1 OR (?2 = 1 AND symbols.name = ?3)",
+        rusqlite::params![symbol, unique_symbol_name(conn, short)?, short],
+        |row| row.get("symbol_count"),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
 pub(crate) fn resolution_label(
     mode: GraphResolutionMode,
     stored: String,

--- a/crates/rag-rat-query/src/graph/predicates.rs
+++ b/crates/rag-rat-query/src/graph/predicates.rs
@@ -73,14 +73,25 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                  )",
+            // LOGICAL ATTRIBUTION RULE (mirrored in `forward_source_predicate`): a RESOLVED
+            // endpoint is attributed by logical membership ALONE. The name arm applies only where
+            // `to_symbol_id IS NULL` — an edge the resolver could not bind, whose recorded target
+            // name is the only attribution there is (and shared with any same-name sibling). Were
+            // the name arm to run on resolved rows too it would hand this symbol an edge the
+            // resolver bound to a DIFFERENT symbol of the same qualified name, which is the
+            // overload collapse the logical seed exists to end (#1028). Dropping the arm entirely
+            // is the opposite error: this SQL runs BEFORE the read-side oracle enrichment, which
+            // rewrites hops in memory and never touches the `edges` row — so an unresolved edge
+            // refused here is one no compiler verdict can put back, in any later run.
             GraphResolutionMode::Syntactic =>
                 "(edges.to_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                   )
-                  OR edges.target_qualified_name_id =
-                        (SELECT id FROM name_strings WHERE value = ?1))",
+                  OR (edges.to_symbol_id IS NULL
+                      AND edges.target_qualified_name_id =
+                            (SELECT id FROM name_strings WHERE value = ?1)))",
             GraphResolutionMode::Fuzzy =>
                 "edges.to_symbol_id IN (
                     SELECT symbol_id
@@ -160,13 +171,19 @@ pub(crate) fn forward_source_predicate(mode: GraphResolutionMode, logical: bool)
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                  )",
+            // Mirror of the logical attribution rule on `reverse_predicate`: membership decides a
+            // resolved source, the name arm covers only a source the resolver left unbound — a
+            // file-level edge, or a body whose enclosing symbol was not indexed. `from_name` holds
+            // the ENCLOSING SYMBOL'S QUALIFIED NAME, which two overloads share, so an ungated arm
+            // would put a sibling overload's outgoing edges on this symbol's callee list.
             GraphResolutionMode::Syntactic =>
                 "edges.from_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                  )
-                 OR edges.from_name_id = (SELECT id FROM name_strings WHERE value = ?1)",
+                 OR (edges.from_symbol_id IS NULL
+                     AND edges.from_name_id = (SELECT id FROM name_strings WHERE value = ?1))",
             GraphResolutionMode::Fuzzy =>
                 "from_symbols.id IN (
                     SELECT symbol_id

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -17,10 +17,10 @@ export interface Status {
 /**
  * How a hop request names its symbol. `id` — the server's opaque `sym_<hex>` symbol handle — is
  * the stable identity and the only selector that separates two overloads: they share a qualified
- * name, so `qname` alone reports the union of their callers. Overloads that DECLARE identically
- * share a handle too, and the answer then reports how many symbols it covered. `qname` remains as
- * the fallback for a row the server could not hand a handle for, and for a handle it no longer
- * knows.
+ * name, so `qname` alone reports the union of their callers. Declarations the server groups under
+ * one identity share a handle too, and both the row that hands it out and the answer it produces
+ * report how far it reaches. `qname` remains as the fallback for a row the server could not hand a
+ * handle for, and for a handle it no longer knows.
  */
 export interface SymbolSelector {
   id: string | null;
@@ -46,6 +46,8 @@ export interface SymbolCallers {
 export interface FileSymbol {
   /** Opaque `sym_<hex>` symbol handle — pass it back verbatim; never parse it as a number. */
   id: string | null;
+  /** Declarations `id` covers — see [`SymbolGraph.id_declarations`]. */
+  id_declarations?: number;
   name: string;
   qname: string | null;
   kind: string;
@@ -117,6 +119,15 @@ export interface FileMemory {
 export interface SymbolGraph {
   /** Opaque `sym_<hex>` symbol handle — pass it back verbatim; never parse it as a number. */
   id: string | null;
+  /**
+   * How many declarations `id` covers. `1` for almost every row; `> 1` where the server groups
+   * several declarations — a function's cfg variants, say — under one identity, so a hop request
+   * carrying this handle is answered for all of them and no selector can narrow it further.
+   *
+   * OPTIONAL because a server built before this field sends nothing, and absence must read as
+   * "this server cannot say" rather than an assumed `1`.
+   */
+  id_declarations?: number;
   name: string;
   qname: string | null;
   kind: string;

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -14,7 +14,20 @@ export interface Status {
   live_file_count: number;
 }
 
+/**
+ * How a hop request names its symbol. `id` — the server's opaque `sym_<hex>` symbol handle — is
+ * the stable identity and the only selector that separates two overloads: they share a qualified
+ * name, so `qname` alone reports the union of their callers. `qname` remains as the fallback for
+ * a row the server could not hand a handle for.
+ */
+export interface SymbolSelector {
+  id: string | null;
+  qname: string | null;
+}
+
 export interface FileSymbol {
+  /** Opaque `sym_<hex>` symbol handle — pass it back verbatim; never parse it as a number. */
+  id: string | null;
   name: string;
   qname: string | null;
   kind: string;
@@ -84,6 +97,8 @@ export interface FileMemory {
 }
 
 export interface SymbolGraph {
+  /** Opaque `sym_<hex>` symbol handle — pass it back verbatim; never parse it as a number. */
+  id: string | null;
   name: string;
   qname: string | null;
   kind: string;
@@ -239,8 +254,21 @@ export class LensClient {
   ): Promise<{ refs: PapertrailRef[]; decisions: DecisionRecord[] }> {
     return this.get('/api/file/papertrail', { path }, signal);
   }
-  async symbolCallers(qname: string, limit = 50): Promise<unknown[]> {
-    return (await this.get<{ callers: unknown[] }>('/api/symbol/callers', { qname, limit: String(limit) })).callers;
+  /**
+   * Callers of ONE symbol. Sends the handle when the row carried one so overloads stay apart, and
+   * falls back to the qualified name only when it did not — the server then answers with every
+   * symbol of that name, which is the older, ambiguous behaviour.
+   */
+  async symbolCallers(selector: SymbolSelector, limit = 50): Promise<unknown[]> {
+    const params: Record<string, string> = { limit: String(limit) };
+    if (selector.id) {
+      params.id = selector.id;
+    } else if (selector.qname) {
+      params.qname = selector.qname;
+    } else {
+      throw new Error('symbolCallers needs a symbol handle or a qualified name');
+    }
+    return (await this.get<{ callers: unknown[] }>('/api/symbol/callers', params)).callers;
   }
 
   async watchVersions(signal: AbortSignal, onVersion: (version: VersionToken) => void): Promise<void> {

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -325,9 +325,9 @@ export class LensClient {
    * from the declaration, so editing a signature mints a new one on the next index pass while the
    * CodeLens already drawn in the gutter still carries the old — a 404 there means the row went
    * stale, not that the symbol is gone, and the same row supplied a name that still resolves.
-   * Answering wide (labelled as such by `resolved_by`) beats failing a click that worked before
-   * the handle lane existed. Retried only on 404: a 400 means this client built a malformed
-   * handle, and quietly widening the answer would hide the bug that produced it.
+   * Answering wide (and saying so, through `matched_symbols`) beats failing a click that worked
+   * before the handle lane existed. Retried only on 404: a 400 means this client built a
+   * malformed handle, and quietly widening the answer would hide the bug that produced it.
    */
   // `async` so a selector-less call REJECTS rather than throwing synchronously: the command
   // handler awaits this, and a synchronous throw would escape its error path.

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -17,8 +17,10 @@ export interface Status {
 /**
  * How a hop request names its symbol. `id` — the server's opaque `sym_<hex>` symbol handle — is
  * the stable identity and the only selector that separates two overloads: they share a qualified
- * name, so `qname` alone reports the union of their callers. `qname` remains as the fallback for
- * a row the server could not hand a handle for.
+ * name, so `qname` alone reports the union of their callers. Overloads that DECLARE identically
+ * share a handle too, and the answer then reports how many symbols it covered. `qname` remains as
+ * the fallback for a row the server could not hand a handle for, and for a handle it no longer
+ * knows.
  */
 export interface SymbolSelector {
   id: string | null;
@@ -37,7 +39,7 @@ export interface SymbolSelector {
 export interface SymbolCallers {
   callers: unknown[];
   resolved_by?: 'id' | 'ref';
-  /** Symbols the selector expanded to; `> 1` on the `ref` lane means `callers` is their union. */
+  /** Symbols the selector expanded to; `> 1` on EITHER lane means `callers` is their union. */
   matched_symbols?: number;
 }
 
@@ -171,6 +173,49 @@ export interface VersionToken {
   revision: string;
 }
 
+/**
+ * A rejection that carries the status the Lens server answered with.
+ *
+ * Read it through [`lensHttpStatus`] rather than `instanceof`: the extension ships two bundles
+ * (desktop and web worker) and a class identity is per-bundle, so the structural read is the one
+ * that holds wherever the error is caught.
+ */
+export class LensHttpError extends Error {
+  constructor(
+    readonly lensHttpStatus: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'LensHttpError';
+  }
+}
+
+/** The status behind a rejection; `undefined` when nothing answered at all (transport failure). */
+export function lensHttpStatus(error: unknown): number | undefined {
+  const status = (error as { lensHttpStatus?: unknown } | null | undefined)?.lensHttpStatus;
+  return typeof status === 'number' ? status : undefined;
+}
+
+/**
+ * Whether re-reading discovery could change this outcome.
+ *
+ * A 4xx is a statement about the REQUEST: the discovered endpoint understood it and rejected it,
+ * so re-deriving that endpoint cannot turn a 404 for a stale symbol handle — or a 400 for a
+ * malformed one — into a hit. Invalidating on it discards a working endpoint, and the cached
+ * identity every other lane shares, to arrive back at the same one. The credential statuses are
+ * the exception, because the credential is exactly what discovery carries.
+ *
+ * A transport failure (no status at all) or a 5xx says nothing about the request, and either can
+ * mean this is no longer the server to be talking to — the pre-existing retry stands there.
+ */
+function rediscoveryCanHelp(error: unknown): boolean {
+  const status = lensHttpStatus(error);
+  if (status === undefined || status >= 500) {
+    return true;
+  }
+  return status === 401 || status === 403;
+}
+
 export class LensClient {
   constructor(private readonly resolver: LensEndpointResolver) {}
 
@@ -183,7 +228,7 @@ export class LensClient {
     try {
       return await this.request<T>(endpoint, route, params, signal);
     } catch (error) {
-      if (signal?.aborted) {
+      if (signal?.aborted || !rediscoveryCanHelp(error)) {
         throw error;
       }
       this.resolver.invalidate();
@@ -214,7 +259,7 @@ export class LensClient {
     });
     if (!res.ok) {
       const body = (await res.text()).slice(0, 200);
-      throw new Error(`${route} -> ${res.status}: ${body}`);
+      throw new LensHttpError(res.status, `${route} -> ${res.status}: ${body}`);
     }
     return (await res.json()) as T;
   }
@@ -272,22 +317,36 @@ export class LensClient {
   }
   /**
    * Callers of ONE symbol. Sends the handle when the row carried one so overloads stay apart, and
-   * falls back to the qualified name only when it did not — the server then answers with every
-   * symbol of that name, which is the older, ambiguous behaviour. The whole envelope is returned
-   * so the caller can say which of the two it got.
+   * falls back to the qualified name when it did not — the server then answers with every symbol
+   * of that name, which is the older, ambiguous behaviour. The whole envelope is returned so the
+   * caller can say which of the two it got.
+   *
+   * The name is ALSO the fallback for a handle the server no longer knows. A handle is derived
+   * from the declaration, so editing a signature mints a new one on the next index pass while the
+   * CodeLens already drawn in the gutter still carries the old — a 404 there means the row went
+   * stale, not that the symbol is gone, and the same row supplied a name that still resolves.
+   * Answering wide (labelled as such by `resolved_by`) beats failing a click that worked before
+   * the handle lane existed. Retried only on 404: a 400 means this client built a malformed
+   * handle, and quietly widening the answer would hide the bug that produced it.
    */
   // `async` so a selector-less call REJECTS rather than throwing synchronously: the command
   // handler awaits this, and a synchronous throw would escape its error path.
   async symbolCallers(selector: SymbolSelector, limit = 50): Promise<SymbolCallers> {
-    const params: Record<string, string> = { limit: String(limit) };
+    const route = '/api/symbol/callers';
+    const limits: Record<string, string> = { limit: String(limit) };
     if (selector.id) {
-      params.id = selector.id;
-    } else if (selector.qname) {
-      params.qname = selector.qname;
-    } else {
+      try {
+        return await this.get<SymbolCallers>(route, { ...limits, id: selector.id });
+      } catch (error) {
+        if (lensHttpStatus(error) !== 404 || !selector.qname) {
+          throw error;
+        }
+      }
+    }
+    if (!selector.qname) {
       throw new Error('symbolCallers needs a symbol handle or a qualified name');
     }
-    return this.get<SymbolCallers>('/api/symbol/callers', params);
+    return this.get<SymbolCallers>(route, { ...limits, qname: selector.qname });
   }
 
   async watchVersions(signal: AbortSignal, onVersion: (version: VersionToken) => void): Promise<void> {

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -25,6 +25,22 @@ export interface SymbolSelector {
   qname: string | null;
 }
 
+/**
+ * The `/api/symbol/callers` envelope, kept whole rather than unwrapped to `callers`: the server
+ * says which selector it answered by and how many symbols that selector covered, and a reader
+ * shown the union of two overloads' callers has to be told that is what it is.
+ *
+ * Both fields are OPTIONAL because the server and this extension version independently — a server
+ * built before the hop routes took a handle sends neither, and absence must read as "this server
+ * cannot say", never as an assumed `'id'`.
+ */
+export interface SymbolCallers {
+  callers: unknown[];
+  resolved_by?: 'id' | 'ref';
+  /** Symbols the selector expanded to; `> 1` on the `ref` lane means `callers` is their union. */
+  matched_symbols?: number;
+}
+
 export interface FileSymbol {
   /** Opaque `sym_<hex>` symbol handle — pass it back verbatim; never parse it as a number. */
   id: string | null;
@@ -257,9 +273,12 @@ export class LensClient {
   /**
    * Callers of ONE symbol. Sends the handle when the row carried one so overloads stay apart, and
    * falls back to the qualified name only when it did not — the server then answers with every
-   * symbol of that name, which is the older, ambiguous behaviour.
+   * symbol of that name, which is the older, ambiguous behaviour. The whole envelope is returned
+   * so the caller can say which of the two it got.
    */
-  async symbolCallers(selector: SymbolSelector, limit = 50): Promise<unknown[]> {
+  // `async` so a selector-less call REJECTS rather than throwing synchronously: the command
+  // handler awaits this, and a synchronous throw would escape its error path.
+  async symbolCallers(selector: SymbolSelector, limit = 50): Promise<SymbolCallers> {
     const params: Record<string, string> = { limit: String(limit) };
     if (selector.id) {
       params.id = selector.id;
@@ -268,7 +287,7 @@ export class LensClient {
     } else {
       throw new Error('symbolCallers needs a symbol handle or a qualified name');
     }
-    return (await this.get<{ callers: unknown[] }>('/api/symbol/callers', params)).callers;
+    return this.get<SymbolCallers>('/api/symbol/callers', params);
   }
 
   async watchVersions(signal: AbortSignal, onVersion: (version: VersionToken) => void): Promise<void> {

--- a/editors/vscode/src/hover.ts
+++ b/editors/vscode/src/hover.ts
@@ -1,7 +1,7 @@
 // Symbol hovers: graph trust data at a glance — caller decomposition,
 // load-bearing bucket, dispatch variants — without opening a quick pick.
 import * as vscode from 'vscode';
-import { callerCommandArguments } from './lenses';
+import { callerCommandArguments, sharedHandleMarker } from './lenses';
 import type { FileStore } from './store';
 
 export class GraphHoverProvider implements vscode.HoverProvider {
@@ -41,6 +41,13 @@ export class GraphHoverProvider implements vscode.HoverProvider {
         : '_no static callers (never proof of dead code)_',
     ].filter(Boolean);
     md.appendMarkdown(parts.join('  \n'));
+    // Same qualifier the CodeLens shows: the counts above are this declaration's, the link below
+    // answers for every declaration the row's handle covers, and where those differ the reader is
+    // told before following it.
+    const shared = sharedHandleMarker(s.id_declarations);
+    if (shared) {
+      md.appendMarkdown(`  \n⧉ ${escapeMarkdown(shared.tooltip)}`);
+    }
     // Same command, same arguments as the CodeLens over this row — see `callerCommandArguments`.
     const callers = callerCommandArguments(s);
     if (callers) {

--- a/editors/vscode/src/hover.ts
+++ b/editors/vscode/src/hover.ts
@@ -1,6 +1,7 @@
 // Symbol hovers: graph trust data at a glance — caller decomposition,
 // load-bearing bucket, dispatch variants — without opening a quick pick.
 import * as vscode from 'vscode';
+import { callerCommandArguments } from './lenses';
 import type { FileStore } from './store';
 
 export class GraphHoverProvider implements vscode.HoverProvider {
@@ -40,8 +41,10 @@ export class GraphHoverProvider implements vscode.HoverProvider {
         : '_no static callers (never proof of dead code)_',
     ].filter(Boolean);
     md.appendMarkdown(parts.join('  \n'));
-    if (s.qname) {
-      const args = encodeURIComponent(JSON.stringify([s.qname, s.name]));
+    // Same command, same arguments as the CodeLens over this row — see `callerCommandArguments`.
+    const callers = callerCommandArguments(s);
+    if (callers) {
+      const args = encodeURIComponent(JSON.stringify(callers));
       md.appendMarkdown(`  \n[show callers](command:rag-rat-lens.showCallers?${args})`);
     }
     if (s.dispatch.length) {

--- a/editors/vscode/src/lenses.ts
+++ b/editors/vscode/src/lenses.ts
@@ -9,6 +9,7 @@ import type {
   DecisionRecord,
   LensClient,
   PapertrailRef,
+  SymbolCallers,
   SymbolGraph,
   SymbolSelector,
 } from './client';
@@ -98,13 +99,42 @@ function openDoc(title: string, markdown: string): Thenable<void> {
  * row's name instead of its handle answers for every overload sharing that name rather than for
  * the row the reader is looking at. `undefined` = the row names no symbol the server can resolve,
  * so the surface must offer no link at all.
+ *
+ * Both fields are normalized to `null` because the hover's half of this contract is a JSON
+ * `command:` URI, which drops an `undefined` field entirely — a server that omits `id` would
+ * otherwise have the two surfaces build tuples that differ in shape while behaving alike, which is
+ * exactly the drift an untyped boundary hides.
  */
 export function callerCommandArguments(
   symbol: SymbolGraph,
 ): [SymbolSelector, string] | undefined {
   return symbol.id || symbol.qname
-    ? [{ id: symbol.id, qname: symbol.qname }, symbol.name]
+    ? [{ id: symbol.id ?? null, qname: symbol.qname ?? null }, symbol.name]
     : undefined;
+}
+
+/**
+ * What the caller quick pick says it is showing.
+ *
+ * The rows are the callers of ONE symbol only when the server resolved the request by handle. On
+ * the qualified-name fallback they are the union over every symbol of that name, and `0` matched
+ * symbols means the name named nothing indexed and the rows came from unresolved call sites alone.
+ * Rendering all three as `N callers of foo` states the narrow claim while showing the wide answer.
+ * A server that reports neither field says nothing, so neither do we.
+ */
+export function callersPlaceholder(
+  name: string,
+  rowCount: number,
+  answer: Pick<SymbolCallers, 'resolved_by' | 'matched_symbols'>,
+): string {
+  const matched = answer.resolved_by === 'ref' ? answer.matched_symbols : undefined;
+  if (matched === 0) {
+    return `${rowCount} callers by name — nothing indexed is named ${name}`;
+  }
+  if (matched !== undefined && matched > 1) {
+    return `${rowCount} callers of ${matched} symbols named ${name}`;
+  }
+  return `${rowCount} callers of ${name}`;
 }
 
 export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
@@ -250,7 +280,8 @@ export function registerSignalCommands(
     vscode.workspace.registerTextDocumentContentProvider(DOC_SCHEME, (lensDocs = new LensDocProvider())),
 
     vscode.commands.registerCommand('rag-rat-lens.showCallers', async (selector: SymbolSelector, name: string) => {
-      const rows = (await client.symbolCallers(selector)) as CallerRow[];
+      const answer = await client.symbolCallers(selector);
+      const rows = answer.callers as CallerRow[];
       const picked = await vscode.window.showQuickPick(
         rows.map((r) => ({
           label: `$(symbol-method) ${r.name}`,
@@ -258,7 +289,7 @@ export function registerSignalCommands(
           detail: `${r.path}:${r.source_start_line}`,
           row: r,
         })),
-        { placeHolder: `${rows.length} callers of ${name}` },
+        { placeHolder: callersPlaceholder(name, rows.length, answer) },
       );
       if (picked) {
         await openLocation(picked.row.path, picked.row.source_start_line);

--- a/editors/vscode/src/lenses.ts
+++ b/editors/vscode/src/lenses.ts
@@ -3,6 +3,7 @@
 // coupling, issues/PRs per file, distill decision records, extract-helper
 // preview for refined clone classes.
 import * as vscode from 'vscode';
+import { lensHttpStatus } from './client';
 import type {
   CloneRegion,
   CouplingPartner,
@@ -116,25 +117,31 @@ export function callerCommandArguments(
 /**
  * What the caller quick pick says it is showing.
  *
- * The rows are the callers of ONE symbol only when the server resolved the request by handle. On
- * the qualified-name fallback they are the union over every symbol of that name, and `0` matched
- * symbols means the name named nothing indexed and the rows came from unresolved call sites alone.
- * Rendering all three as `N callers of foo` states the narrow claim while showing the wide answer.
- * A server that reports neither field says nothing, so neither do we.
+ * `matched_symbols` is the whole answer, and it is read the same way on BOTH lanes: `> 1` means
+ * the rows are a union over that many symbols, so `N callers of foo` would state a narrower claim
+ * than the server made. Which selector produced the union does not change what a reader is
+ * looking at, and both selectors can produce one — a qualified name covers every overload in the
+ * file, and a handle covers every overload the grouping key could not tell apart, which is every
+ * overload declared on an identical line (`fn new() -> Self {` on two impls). Reading the count
+ * only on the fallback lane discards the one signal that is present and correct on the other.
+ *
+ * `0` is reachable only from the fallback lane — a handle with no symbol behind it is a 404, not
+ * an empty answer — and means the name named nothing indexed, so the rows came from unresolved
+ * call sites alone. A server that reports no count says nothing, so neither do we.
  */
 export function callersPlaceholder(
   name: string,
   rowCount: number,
-  answer: Pick<SymbolCallers, 'resolved_by' | 'matched_symbols'>,
+  answer: Pick<SymbolCallers, 'matched_symbols'>,
 ): string {
-  const matched = answer.resolved_by === 'ref' ? answer.matched_symbols : undefined;
+  const matched = answer.matched_symbols;
+  if (matched === undefined || matched === 1) {
+    return `${rowCount} callers of ${name}`;
+  }
   if (matched === 0) {
     return `${rowCount} callers by name — nothing indexed is named ${name}`;
   }
-  if (matched !== undefined && matched > 1) {
-    return `${rowCount} callers of ${matched} symbols named ${name}`;
-  }
-  return `${rowCount} callers of ${name}`;
+  return `${rowCount} callers of ${matched} symbols named ${name}`;
 }
 
 export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
@@ -183,8 +190,9 @@ export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Dispo
                 : ''),
             command: 'rag-rat-lens.showCallers',
             // The lens is built from ONE symbol row, so it carries that row's handle: two
-            // overloads share a qualified name but not a handle, and the count in this title is
-            // counted per symbol. Passing the name alone is what made both lenses answer alike.
+            // overloads always share a qualified name, and share a handle only when they declare
+            // on an identical line. The count in this title is counted per symbol. Passing the
+            // name alone is what made every lens on a name answer alike.
             arguments: callers,
           }),
         );
@@ -280,7 +288,24 @@ export function registerSignalCommands(
     vscode.workspace.registerTextDocumentContentProvider(DOC_SCHEME, (lensDocs = new LensDocProvider())),
 
     vscode.commands.registerCommand('rag-rat-lens.showCallers', async (selector: SymbolSelector, name: string) => {
-      const answer = await client.symbolCallers(selector);
+      let answer: SymbolCallers;
+      try {
+        answer = await client.symbolCallers(selector);
+      } catch (error) {
+        // A handle the server no longer knows is a stale gutter decoration, not something the
+        // reader did wrong: the declaration was edited and reindexed under a new handle while
+        // this lens kept the old one. `symbolCallers` already retried by name for every row that
+        // carried one, so reaching here means this row had only the handle. Say that, rather
+        // than raising a "contributed command failed" notification over it. Any other failure is
+        // a real one and keeps surfacing as one.
+        if (lensHttpStatus(error) !== 404) {
+          throw error;
+        }
+        await vscode.window.showWarningMessage(
+          `${name} is no longer in the index under the handle this lens carries — reopen the file to refresh it.`,
+        );
+        return;
+      }
       const rows = answer.callers as CallerRow[];
       const picked = await vscode.window.showQuickPick(
         rows.map((r) => ({

--- a/editors/vscode/src/lenses.ts
+++ b/editors/vscode/src/lenses.ts
@@ -10,6 +10,7 @@ import type {
   LensClient,
   PapertrailRef,
   SymbolGraph,
+  SymbolSelector,
 } from './client';
 import type { FileStore } from './store';
 
@@ -87,6 +88,25 @@ function openDoc(title: string, markdown: string): Thenable<void> {
   return lensDocs ? lensDocs.open(title, markdown) : Promise.resolve();
 }
 
+/**
+ * Arguments for `rag-rat-lens.showCallers`, built in ONE place for every surface that dispatches
+ * it.
+ *
+ * The CodeLens and the hover link render from the same `SymbolGraph` row and reach the same
+ * handler, so the tuple is a shared contract rather than each surface's own detail: a surface that
+ * assembles it locally can pass a shape the handler no longer reads, and a surface that sends the
+ * row's name instead of its handle answers for every overload sharing that name rather than for
+ * the row the reader is looking at. `undefined` = the row names no symbol the server can resolve,
+ * so the surface must offer no link at all.
+ */
+export function callerCommandArguments(
+  symbol: SymbolGraph,
+): [SymbolSelector, string] | undefined {
+  return symbol.id || symbol.qname
+    ? [{ id: symbol.id, qname: symbol.qname }, symbol.name]
+    : undefined;
+}
+
 export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
   private readonly changed = new vscode.EventEmitter<void>();
   readonly onDidChangeCodeLenses = this.changed.event;
@@ -112,7 +132,8 @@ export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Dispo
       const line = Math.min(Math.max(0, s.start_line - 1), document.lineCount - 1);
       const range = new vscode.Range(line, 0, line, 0);
       const total = s.callers.exact + s.callers.syntactic + s.callers.name_only + s.callers.ambiguous;
-      if (total > 0 && s.qname) {
+      const callers = callerCommandArguments(s);
+      if (total > 0 && callers) {
         const tiers = [
           s.callers.exact ? `${s.callers.exact} exact` : '',
           s.callers.syntactic ? `${s.callers.syntactic} syntactic` : '',
@@ -131,7 +152,10 @@ export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Dispo
                 ? `  ⚑${s.fan_in_bucket} load`
                 : ''),
             command: 'rag-rat-lens.showCallers',
-            arguments: [s.qname, s.name],
+            // The lens is built from ONE symbol row, so it carries that row's handle: two
+            // overloads share a qualified name but not a handle, and the count in this title is
+            // counted per symbol. Passing the name alone is what made both lenses answer alike.
+            arguments: callers,
           }),
         );
       } else if (s.fan_in_bucket === 'critical' || s.fan_in_bucket === 'high') {
@@ -225,8 +249,8 @@ export function registerSignalCommands(
   context.subscriptions.push(
     vscode.workspace.registerTextDocumentContentProvider(DOC_SCHEME, (lensDocs = new LensDocProvider())),
 
-    vscode.commands.registerCommand('rag-rat-lens.showCallers', async (qname: string, name: string) => {
-      const rows = (await client.symbolCallers(qname)) as CallerRow[];
+    vscode.commands.registerCommand('rag-rat-lens.showCallers', async (selector: SymbolSelector, name: string) => {
+      const rows = (await client.symbolCallers(selector)) as CallerRow[];
       const picked = await vscode.window.showQuickPick(
         rows.map((r) => ({
           label: `$(symbol-method) ${r.name}`,

--- a/editors/vscode/src/lenses.ts
+++ b/editors/vscode/src/lenses.ts
@@ -115,15 +115,40 @@ export function callerCommandArguments(
 }
 
 /**
+ * How a caller lens says its handle covers more than the declaration it sits on.
+ *
+ * The count in the lens title is this row's own, but the drill-down behind it is answered for
+ * every declaration the row's handle covers — and where those differ, the reader is entitled to
+ * know BEFORE clicking, not only from the quick pick's placeholder afterwards. A grouped handle is
+ * the server's answer about identity (cfg variants of one function are one symbol), so the lens
+ * neither hides it nor pretends a narrower selector exists.
+ *
+ * `undefined` = a server that does not report the reach, and `1` = a handle that covers this row
+ * alone; neither gets a marker, because there is nothing to qualify.
+ */
+export function sharedHandleMarker(
+  declarations: number | undefined,
+): { title: string; tooltip: string } | undefined {
+  return declarations !== undefined && declarations > 1
+    ? {
+        title: `  ⧉${declarations}`,
+        tooltip: `This symbol shares one identity with ${declarations - 1} other declaration${
+          declarations > 2 ? 's' : ''
+        } — cfg variants, or declarations the index cannot tell apart. Callers are reported for all of them.`,
+      }
+    : undefined;
+}
+
+/**
  * What the caller quick pick says it is showing.
  *
  * `matched_symbols` is the whole answer, and it is read the same way on BOTH lanes: `> 1` means
  * the rows are a union over that many symbols, so `N callers of foo` would state a narrower claim
  * than the server made. Which selector produced the union does not change what a reader is
  * looking at, and both selectors can produce one — a qualified name covers every overload in the
- * file, and a handle covers every overload the grouping key could not tell apart, which is every
- * overload declared on an identical line (`fn new() -> Self {` on two impls). Reading the count
- * only on the fallback lane discards the one signal that is present and correct on the other.
+ * file, and a handle covers every declaration grouped under one identity (a function's cfg
+ * variants, say). Reading the count only on the fallback lane discards the one signal that is
+ * present and correct on the other.
  *
  * `0` is reachable only from the fallback lane — a handle with no symbol behind it is a 404, not
  * an empty answer — and means the name named nothing indexed, so the rows came from unresolved
@@ -181,18 +206,21 @@ export class SignalLensProvider implements vscode.CodeLensProvider, vscode.Dispo
         ]
           .filter(Boolean)
           .join(' · ');
+        const shared = sharedHandleMarker(s.id_declarations);
         lenses.push(
           new vscode.CodeLens(range, {
             title:
               `⤴ ${total} (${tiers})` +
               (s.fan_in_bucket === 'critical' || s.fan_in_bucket === 'high'
                 ? `  ⚑${s.fan_in_bucket} load`
-                : ''),
+                : '') +
+              (shared?.title ?? ''),
+            ...(shared ? { tooltip: shared.tooltip } : {}),
             command: 'rag-rat-lens.showCallers',
-            // The lens is built from ONE symbol row, so it carries that row's handle: two
-            // overloads always share a qualified name, and share a handle only when they declare
-            // on an identical line. The count in this title is counted per symbol. Passing the
-            // name alone is what made every lens on a name answer alike.
+            // The lens is built from ONE symbol row, so it carries that row's handle, and the
+            // count in this title is that row's own. Where the handle covers a group, the
+            // drill-down behind it is wider than the count in front of it — which is what the
+            // marker says. Passing the name alone is what made every lens on a name answer alike.
             arguments: callers,
           }),
         );

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -2418,6 +2418,82 @@ test('each overload lens carries its own symbol handle', async () => {
   ]);
 });
 
+test('a lens whose handle covers several declarations says so before it is clicked', async () => {
+  const lenses = [];
+  const vscode = {
+    CodeLens: class {
+      constructor(range, command) {
+        Object.assign(this, { range, command });
+        lenses.push(this);
+      }
+    },
+    EventEmitter: class {
+      constructor() {
+        this.event = () => ({ dispose() {} });
+      }
+      fire() {}
+      dispose() {}
+    },
+    Range: class {
+      constructor(startLine) {
+        this.startLine = startLine;
+      }
+    },
+  };
+  const { SignalLensProvider, sharedHandleMarker } = await loadSourceModule('lenses.ts', vscode);
+
+  // The reach is only worth rendering when it exceeds this row: `1` is what almost every symbol
+  // reports, and an absent field is a server that cannot say — neither qualifies anything.
+  assert.equal(sharedHandleMarker(undefined), undefined);
+  assert.equal(sharedHandleMarker(1), undefined);
+  assert.equal(sharedHandleMarker(0), undefined);
+  assert.equal(sharedHandleMarker(2).title, '  ⧉2');
+  assert.match(sharedHandleMarker(2).tooltip, /1 other declaration —/);
+  assert.match(sharedHandleMarker(3).tooltip, /2 other declarations —/);
+
+  const symbol = (id_declarations, startLine) => ({
+    id: 'sym_shared',
+    id_declarations,
+    name: 'run',
+    qname: 'src/lib.rs::run',
+    kind: 'function',
+    start_line: startLine,
+    end_line: startLine,
+    is_test: false,
+    callers: { exact: 1, syntactic: 0, name_only: 0, ambiguous: 0, tests: 0, dispatch: 0 },
+    fan_in_score: 1,
+    fan_in_bucket: 'low',
+    dispatch: [],
+  });
+  const alone = symbol(1, 9);
+  const legacy = symbol(undefined, 17);
+  delete legacy.id_declarations;
+  const provider = new SignalLensProvider({
+    dataFor: async () => ({
+      data: {
+        symbols: [alone, symbol(2, 13), legacy],
+        coupling: [],
+        refs: [],
+        decisions: [],
+        clones: [],
+      },
+    }),
+  });
+
+  await provider.provideCodeLenses({ lineCount: 40 });
+  const callerLenses = lenses.filter((lens) => lens.command.command === 'rag-rat-lens.showCallers');
+  // The count in the title is this declaration's own, but the quick pick behind the grouped row
+  // answers for both — so that row, and only that row, carries the qualifier.
+  assert.deepEqual(
+    callerLenses.map((lens) => lens.command.title),
+    ['⤴ 1 (1 exact)', '⤴ 1 (1 exact)  ⧉2', '⤴ 1 (1 exact)'],
+  );
+  assert.deepEqual(
+    callerLenses.map((lens) => lens.command.tooltip),
+    [undefined, sharedHandleMarker(2).tooltip, undefined],
+  );
+});
+
 test('the hover link dispatches show callers exactly as the lens does', async () => {
   const vscode = {
     MarkdownString: class {
@@ -2459,14 +2535,18 @@ test('the hover link dispatches show callers exactly as the lens does', async ()
   // rather than a null one.
   const legacy = row(null, 'src/lib.rs::legacy', 25);
   delete legacy.id;
+  const grouped = row('sym_shared', 'src/lib.rs::grouped', 29);
+  grouped.id_declarations = 2;
   const symbols = [
     row('sym_alpha', 'src/lib.rs::run', 9),
     row('sym_beta', 'src/lib.rs::run', 13),
     row(null, 'src/lib.rs::only_named', 17),
     row(null, null, 21),
     legacy,
+    grouped,
   ];
   const provider = new GraphHoverProvider({ dataFor: async () => ({ data: { symbols } }) });
+  const hoverText = async (line) => (await provider.provideHover({}, { line: line - 1 })).contents.value;
   const commandArguments = async (line) => {
     const hover = await provider.provideHover({}, { line: line - 1 });
     const link = /command:rag-rat-lens\.showCallers\?([^)]*)\)/.exec(hover.contents.value);
@@ -2488,6 +2568,10 @@ test('the hover link dispatches show callers exactly as the lens does', async ()
   // `undefined` field, so the hover would otherwise ship a selector one key short of the one the
   // CodeLens dispatches — a shape difference no typecheck can see across a `command:` URI.
   assert.deepEqual(await commandArguments(25), [{ id: null, qname: 'src/lib.rs::legacy' }, 'run']);
+  // The hover offers the same link, so it owes the same qualifier: the counts above it are this
+  // declaration's, the link below it answers for both.
+  assert.match(await hoverText(29), /⧉ This symbol shares one identity with 1 other declaration/);
+  assert.doesNotMatch(await hoverText(9), /⧉/);
 });
 
 test('a symbol handle the server no longer knows falls back to the name, not to rediscovery', async (t) => {

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -2292,6 +2292,63 @@ test('caller requests prefer the symbol handle and fall back to the qualified na
 
   await assert.rejects(client.symbolCallers({ id: null, qname: null }), /handle or a qualified name/);
   assert.equal(requests.length, 2, 'a selector-less request must never reach the server');
+
+  // The envelope reaches the caller whole: unwrapping to `callers` here would throw away the
+  // server's own statement of how many symbols it answered for.
+  const answer = await client.symbolCallers({ id: 'sym_2029231588695800bf', qname: null });
+  assert.deepEqual(answer, { callers: [], resolved_by: 'id', matched_symbols: 1 });
+});
+
+test('the caller quick pick says when its rows are a union rather than one symbol', async () => {
+  const quickPicks = [];
+  const vscode = {
+    EventEmitter: class {
+      constructor() {
+        this.event = () => ({ dispose() {} });
+      }
+      fire() {}
+      dispose() {}
+    },
+    window: {
+      showQuickPick: async (_items, options) => {
+        quickPicks.push(options.placeHolder);
+        return undefined;
+      },
+    },
+    workspace: { registerTextDocumentContentProvider: () => ({ dispose() {} }) },
+    commands: { registerCommand: () => ({ dispose() {} }), executeCommand: async () => undefined },
+  };
+  const registered = new Map();
+  vscode.commands.registerCommand = (id, handler) => {
+    registered.set(id, handler);
+    return { dispose() {} };
+  };
+  const { registerSignalCommands, callersPlaceholder } = await loadSourceModule('lenses.ts', vscode);
+
+  let answer;
+  registerSignalCommands({ subscriptions: [] }, { symbolCallers: async () => answer });
+  const showCallers = registered.get('rag-rat-lens.showCallers');
+  const selector = { id: null, qname: 'src/lib.rs::run' };
+
+  // The qualified name covered both overloads, so these rows belong to two different functions.
+  // Reporting them as "callers of run" would state a narrower claim than the answer supports.
+  answer = { callers: [{}, {}], resolved_by: 'ref', matched_symbols: 2 };
+  await showCallers(selector, 'run');
+  assert.equal(quickPicks.at(-1), '2 callers of 2 symbols named run');
+
+  // Resolved by handle: the rows really are one symbol's.
+  answer = { callers: [{}], resolved_by: 'id', matched_symbols: 1 };
+  await showCallers({ id: 'sym_alpha', qname: 'src/lib.rs::run' }, 'run');
+  assert.equal(quickPicks.at(-1), '1 callers of run');
+
+  // Nothing indexed carries the name: the rows came from unresolved call sites alone, so calling
+  // them that symbol's callers would invent a symbol.
+  answer = { callers: [], resolved_by: 'ref', matched_symbols: 0 };
+  await showCallers(selector, 'run');
+  assert.equal(quickPicks.at(-1), '0 callers by name — nothing indexed is named run');
+
+  // A server too old to report either field says nothing, and neither do we.
+  assert.equal(callersPlaceholder('run', 3, {}), '3 callers of run');
 });
 
 test('each overload lens carries its own symbol handle', async () => {
@@ -2390,11 +2447,16 @@ test('the hover link dispatches show callers exactly as the lens does', async ()
     fan_in_bucket: 'low',
     dispatch: [],
   });
+  // The last row is what a server built before the handle existed sends: no `id` FIELD at all,
+  // rather than a null one.
+  const legacy = row(null, 'src/lib.rs::legacy', 25);
+  delete legacy.id;
   const symbols = [
     row('sym_alpha', 'src/lib.rs::run', 9),
     row('sym_beta', 'src/lib.rs::run', 13),
     row(null, 'src/lib.rs::only_named', 17),
     row(null, null, 21),
+    legacy,
   ];
   const provider = new GraphHoverProvider({ dataFor: async () => ({ data: { symbols } }) });
   const commandArguments = async (line) => {
@@ -2414,4 +2476,8 @@ test('the hover link dispatches show callers exactly as the lens does', async ()
     'run',
   ]);
   assert.equal(await commandArguments(21), undefined);
+  // An absent `id` must be normalized to null before the tuple is serialized: JSON drops an
+  // `undefined` field, so the hover would otherwise ship a selector one key short of the one the
+  // CodeLens dispatches — a shape difference no typecheck can see across a `command:` URI.
+  assert.deepEqual(await commandArguments(25), [{ id: null, qname: 'src/lib.rs::legacy' }, 'run']);
 });

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -2257,3 +2257,161 @@ test('open rag-rat-doc documents are withdrawn when the server they came from is
   // Withdrawal is not deletion: an unknown key still reads as absent.
   assert.equal(provider.provideTextDocumentContent({ path: '/never.md' }), 'not found');
 });
+
+test('caller requests prefer the symbol handle and fall back to the qualified name', async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push(request.url);
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"callers":[],"resolved_by":"id","matched_symbols":1}');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+
+  const LensClient = await loadClient();
+  const address = server.address();
+  const client = new LensClient({
+    invalidate() {},
+    async resolve() {
+      return { baseUrl: `http://127.0.0.1:${address.port}`, token: null };
+    },
+  });
+
+  // Two overloads share `src/lib.rs::run`, so the handle is the only selector that separates
+  // them — it must win even when a qualified name is available alongside it.
+  await client.symbolCallers({ id: 'sym_2029231588695800bf', qname: 'src/lib.rs::run' });
+  const withHandle = new URL(requests[0], 'http://localhost');
+  assert.equal(withHandle.searchParams.get('id'), 'sym_2029231588695800bf');
+  assert.equal(withHandle.searchParams.get('qname'), null);
+
+  // A row the server could not hand a handle for still navigates, by name.
+  await client.symbolCallers({ id: null, qname: 'src/lib.rs::run' });
+  const withName = new URL(requests[1], 'http://localhost');
+  assert.equal(withName.searchParams.get('qname'), 'src/lib.rs::run');
+  assert.equal(withName.searchParams.get('id'), null);
+
+  await assert.rejects(client.symbolCallers({ id: null, qname: null }), /handle or a qualified name/);
+  assert.equal(requests.length, 2, 'a selector-less request must never reach the server');
+});
+
+test('each overload lens carries its own symbol handle', async () => {
+  const lenses = [];
+  const vscode = {
+    CodeLens: class {
+      constructor(range, command) {
+        Object.assign(this, { range, command });
+        lenses.push(this);
+      }
+    },
+    EventEmitter: class {
+      constructor() {
+        this.event = () => ({ dispose() {} });
+      }
+      fire() {}
+      dispose() {}
+    },
+    Range: class {
+      constructor(startLine) {
+        this.startLine = startLine;
+      }
+    },
+  };
+  const { SignalLensProvider } = await loadSourceModule('lenses.ts', vscode);
+
+  const overload = (id, startLine) => ({
+    id,
+    name: 'run',
+    qname: 'src/lib.rs::run',
+    kind: 'function',
+    start_line: startLine,
+    end_line: startLine,
+    is_test: false,
+    callers: { exact: 1, syntactic: 0, name_only: 0, ambiguous: 0, tests: 0, dispatch: 0 },
+    fan_in_score: 1,
+    fan_in_bucket: 'low',
+    dispatch: [],
+  });
+  const provider = new SignalLensProvider({
+    dataFor: async () => ({
+      data: {
+        symbols: [overload('sym_alpha', 9), overload('sym_beta', 13)],
+        coupling: [],
+        refs: [],
+        decisions: [],
+        clones: [],
+      },
+    }),
+  });
+
+  await provider.provideCodeLenses({ lineCount: 40 });
+  const selectors = lenses
+    .filter((lens) => lens.command.command === 'rag-rat-lens.showCallers')
+    .map((lens) => lens.command.arguments[0]);
+  assert.deepEqual(selectors, [
+    { id: 'sym_alpha', qname: 'src/lib.rs::run' },
+    { id: 'sym_beta', qname: 'src/lib.rs::run' },
+  ]);
+});
+
+test('the hover link dispatches show callers exactly as the lens does', async () => {
+  const vscode = {
+    MarkdownString: class {
+      constructor(value) {
+        this.value = value ?? '';
+      }
+      appendMarkdown(text) {
+        this.value += text;
+        return this;
+      }
+    },
+    Hover: class {
+      constructor(contents, range) {
+        Object.assign(this, { contents, range });
+      }
+    },
+    Range: class {
+      constructor(startLine) {
+        this.startLine = startLine;
+      }
+    },
+  };
+  const { GraphHoverProvider } = await loadSourceModule('hover.ts', vscode);
+
+  const row = (id, qname, startLine) => ({
+    id,
+    name: 'run',
+    qname,
+    kind: 'function',
+    start_line: startLine,
+    end_line: startLine,
+    is_test: false,
+    callers: { exact: 1, syntactic: 0, name_only: 0, ambiguous: 0, tests: 0, dispatch: 0 },
+    fan_in_score: 1,
+    fan_in_bucket: 'low',
+    dispatch: [],
+  });
+  const symbols = [
+    row('sym_alpha', 'src/lib.rs::run', 9),
+    row('sym_beta', 'src/lib.rs::run', 13),
+    row(null, 'src/lib.rs::only_named', 17),
+    row(null, null, 21),
+  ];
+  const provider = new GraphHoverProvider({ dataFor: async () => ({ data: { symbols } }) });
+  const commandArguments = async (line) => {
+    const hover = await provider.provideHover({}, { line: line - 1 });
+    const link = /command:rag-rat-lens\.showCallers\?([^)]*)\)/.exec(hover.contents.value);
+    return link ? JSON.parse(decodeURIComponent(link[1])) : undefined;
+  };
+
+  // The hover dispatches the SAME command as the CodeLens, so it has to send what the handler
+  // reads — a selector, not a bare name — and its own row's handle: the two overloads share a
+  // qualified name, so the name alone answers for both.
+  assert.deepEqual(await commandArguments(9), [{ id: 'sym_alpha', qname: 'src/lib.rs::run' }, 'run']);
+  assert.deepEqual(await commandArguments(13), [{ id: 'sym_beta', qname: 'src/lib.rs::run' }, 'run']);
+  // A row without a handle still navigates by name; a row with neither offers no link at all.
+  assert.deepEqual(await commandArguments(17), [
+    { id: null, qname: 'src/lib.rs::only_named' },
+    'run',
+  ]);
+  assert.equal(await commandArguments(21), undefined);
+});

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -2341,6 +2341,14 @@ test('the caller quick pick says when its rows are a union rather than one symbo
   await showCallers({ id: 'sym_alpha', qname: 'src/lib.rs::run' }, 'run');
   assert.equal(quickPicks.at(-1), '1 callers of run');
 
+  // Resolved by handle, but the handle covers a GROUP: two overloads that declare identically
+  // share one logical symbol, so the server answered for both and said so. The count is the only
+  // signal that distinguishes this from the line above, and it is present on this lane too — a
+  // reader shown a union has to be told, whichever selector produced it.
+  answer = { callers: [{}, {}], resolved_by: 'id', matched_symbols: 2 };
+  await showCallers({ id: 'sym_shared', qname: 'src/lib.rs::run' }, 'run');
+  assert.equal(quickPicks.at(-1), '2 callers of 2 symbols named run');
+
   // Nothing indexed carries the name: the rows came from unresolved call sites alone, so calling
   // them that symbol's callers would invent a symbol.
   answer = { callers: [], resolved_by: 'ref', matched_symbols: 0 };
@@ -2480,4 +2488,153 @@ test('the hover link dispatches show callers exactly as the lens does', async ()
   // `undefined` field, so the hover would otherwise ship a selector one key short of the one the
   // CodeLens dispatches — a shape difference no typecheck can see across a `command:` URI.
   assert.deepEqual(await commandArguments(25), [{ id: null, qname: 'src/lib.rs::legacy' }, 'run']);
+});
+
+test('a symbol handle the server no longer knows falls back to the name, not to rediscovery', async (t) => {
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push(request.url);
+    if (new URL(request.url, 'http://localhost').searchParams.has('id')) {
+      response.writeHead(404, { 'content-type': 'application/json' });
+      response.end('{"error":"unknown symbol handle"}');
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"callers":[{}],"resolved_by":"ref","matched_symbols":2}');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+
+  const { LensClient, lensHttpStatus } = await loadClientModule();
+  const address = server.address();
+  let invalidations = 0;
+  const client = new LensClient({
+    invalidate() {
+      invalidations += 1;
+    },
+    async resolve() {
+      return { baseUrl: `http://127.0.0.1:${address.port}`, token: null };
+    },
+  });
+
+  // The handle is derived from the declaration, so editing a signature mints a new one on the
+  // next index pass while the CodeLens already drawn in the gutter still carries the old. The
+  // click must still answer — by the name the same row supplied, wider and labelled as such.
+  const answer = await client.symbolCallers({ id: 'sym_stale', qname: 'src/lib.rs::run' });
+  assert.deepEqual(answer, { callers: [{}], resolved_by: 'ref', matched_symbols: 2 });
+  assert.equal(requests.length, 2);
+  assert.equal(new URL(requests[0], 'http://localhost').searchParams.get('id'), 'sym_stale');
+  assert.equal(
+    new URL(requests[1], 'http://localhost').searchParams.get('qname'),
+    'src/lib.rs::run',
+  );
+
+  // A status line proves the discovered endpoint answered, so discarding it cannot help: it only
+  // costs every other reader a rediscovery of the server that just replied.
+  assert.equal(invalidations, 0);
+
+  // Nothing to fall back to. The rejection carries the status so the surface can tell a stale
+  // lens from a broken server.
+  await assert.rejects(
+    client.symbolCallers({ id: 'sym_stale', qname: null }),
+    (error) => lensHttpStatus(error) === 404,
+  );
+  assert.equal(invalidations, 0);
+});
+
+test('only a failure discovery could fix discards the discovered endpoint', async (t) => {
+  let status = 401;
+  const server = http.createServer((_request, response) => {
+    response.writeHead(status, { 'content-type': 'application/json' });
+    response.end('{"error":"nope"}');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+
+  const LensClient = await loadClient();
+  const address = server.address();
+  let invalidations = 0;
+  const client = new LensClient({
+    invalidate() {
+      invalidations += 1;
+    },
+    async resolve() {
+      return { baseUrl: `http://127.0.0.1:${address.port}`, token: 'rotated' };
+    },
+  });
+
+  // The credential is what discovery carries, so a rejected one is exactly what re-reading it
+  // fixes; so is a server that has stopped behaving like itself.
+  await assert.rejects(client.status(), /401/);
+  assert.equal(invalidations, 1);
+  status = 503;
+  await assert.rejects(client.status(), /503/);
+  assert.equal(invalidations, 2);
+
+  // A 4xx is a statement about the request. The endpoint understood it and said no; deriving the
+  // same endpoint again cannot change that, and costs every other lane its cached identity.
+  status = 400;
+  await assert.rejects(client.status(), /400/);
+  assert.equal(invalidations, 2);
+});
+
+test('a click on a lens whose symbol was reindexed says so instead of failing the command', async () => {
+  const quickPicks = [];
+  const warnings = [];
+  const vscode = {
+    EventEmitter: class {
+      constructor() {
+        this.event = () => ({ dispose() {} });
+      }
+      fire() {}
+      dispose() {}
+    },
+    window: {
+      showQuickPick: async (_items, options) => {
+        quickPicks.push(options.placeHolder);
+        return undefined;
+      },
+      showWarningMessage: async (message) => {
+        warnings.push(message);
+        return undefined;
+      },
+    },
+    workspace: { registerTextDocumentContentProvider: () => ({ dispose() {} }) },
+    commands: { executeCommand: async () => undefined },
+  };
+  const registered = new Map();
+  vscode.commands.registerCommand = (id, handler) => {
+    registered.set(id, handler);
+    return { dispose() {} };
+  };
+  const { registerSignalCommands } = await loadSourceModule('lenses.ts', vscode);
+
+  let failure;
+  registerSignalCommands(
+    { subscriptions: [] },
+    {
+      symbolCallers: async () => {
+        throw failure;
+      },
+    },
+  );
+  const showCallers = registered.get('rag-rat-lens.showCallers');
+
+  // The row carried a handle and no name, so the client had nothing to retry with. Before the
+  // handle lane existed this click produced a quick pick; a raw "contributed command failed"
+  // notification is not what a stale gutter decoration deserves.
+  failure = Object.assign(new Error('/api/symbol/callers -> 404: {"error":"unknown symbol handle"}'), {
+    lensHttpStatus: 404,
+  });
+  await showCallers({ id: 'sym_stale', qname: null }, 'run');
+  assert.equal(quickPicks.length, 0);
+  assert.match(warnings.at(-1), /run/);
+  assert.match(warnings.at(-1), /no longer in the index/);
+
+  // Everything else is still a real failure and must keep surfacing as one.
+  failure = Object.assign(new Error('/api/symbol/callers -> 500: boom'), { lensHttpStatus: 500 });
+  await assert.rejects(showCallers({ id: 'sym_stale', qname: null }, 'run'), /500/);
+  failure = new TypeError('fetch failed');
+  await assert.rejects(showCallers({ id: null, qname: 'src/lib.rs::run' }, 'run'), /fetch failed/);
+  assert.equal(warnings.length, 1);
 });


### PR DESCRIPTION
## The problem

`/api/symbol/callers` and `/api/symbol/callees` took only a qualified name and handed it straight to
the graph traversal. A qualified name expands to *every* symbol that carries it, and a qualified name
is not unique: `LogicalSymbolKey` folds the signature in, so

```rust
impl Alpha { fn run(&self) { alpha_leaf() } }
impl Beta  { fn run(&self, extra: i64) { beta_leaf() } }
```

are two distinct logical symbols with two distinct `sym_<hex>` handles, but both qualify as
`src/lib.rs::run`. Clicking either overload's CodeLens therefore reported the union of both.

`/api/file/graph` had the matching gap on the way in: each lens is built from its own symbol row,
but only the name survived into the request, so the client had no way to be more specific even if it
wanted to be.

Measured on a fixture with two same-qualified-name overloads, one caller and one callee each:

| request | before | after |
|---|---|---|
| callers of `Alpha::run` | 2 hops — `["calls_alpha", "calls_beta"]` | 1 hop — `["calls_alpha"]` |
| callees of `Alpha::run` | 2 hops — `["alpha_leaf", "beta_leaf"]` | 1 hop — `["alpha_leaf"]` |

Both "before" figures were produced by running the new tests against a build with the handle lane
neutered back to the qualified-name traversal, not inferred. The extra hop in each case belongs to a
different function entirely.

## The fix

Thread the `sym_<hex>` logical-symbol handle — the stable identity every symbol-shaped surface
already hands out — end to end.

**Core** (`crates/rag-rat-core/src/index/query_api/lens/`)

- `hops.rs` gains `LensHopSelector { Handle(i64), QualifiedName(String) }`. `lens_symbol_callers` /
  `lens_symbol_callees` take `&LensHopSelector` and return `Result<Option<_>>`, where `None` means
  the handle names nothing in the active checkout. Responses gain `resolved_by` (`"id"` / `"ref"`)
  and `matched_symbols`.
- The handle lane traverses in the same `GraphResolutionMode::Syntactic` as the qualified-name lane
  and differs only by carrying `logical_symbol_id`. That single difference is the fix, and it lands
  in the traversal predicates rather than the resolution mode — see the design notes below.
- `reverse_predicate` / `forward_source_predicate` (`crates/rag-rat-query/src/graph/predicates.rs`)
  state the logical attribution rule explicitly on their `Syntactic` arms: a **bound** endpoint is
  attributed by logical membership alone, and the qualified-name arm applies only where that
  endpoint is `NULL`.
- `handles.rs` (new) owns what a handle means in the active checkout: `scope_visible_members_sql`
  (the correlated member count, joining the connection-local `files` view) and
  `logical_symbol_in_scope`, the hop lane's resolver, which counts through the same fragment. Both
  file lanes splice the same fragment, so the reach a handle is handed out with and the reach the
  answer reports cannot drift. `syntactic_seed_symbol_count` is the fallback lane's equivalent and
  lives beside the traversal predicates in `rag-rat-query`; it joins the `files` view too.
- `files.rs`: `LensSymbol` and `LensFileSymbolGraph` carry `id`, serialized through
  `rag_rat_base::serde_big_id::sym_handle_opt`. It is filled by a `LEFT JOIN logical_symbol_members`
  inside the existing `requested` CTE; the table is keyed `(logical_symbol_id, symbol_id)` and a
  symbol belongs to at most one logical symbol, so no rows are duplicated. Beside it they carry
  `id_declarations` — how many declarations that handle covers in this checkout — so a grouped
  handle is never offered as though it singled the row out.

**HTTP** (`crates/rag-rat-mcp/src/http.rs`)

`SymbolHopQuery` gains `id`. A request that *carries* `id` is answered by the handle lane or not at
all: empty and malformed values are both a 400, never a fall-through to a `qname` sent alongside.
`qname` answers only when `id` is absent entirely. A well-formed handle the index does not know is a
404 `unknown symbol handle`.

**Extension** (`editors/vscode/`)

`FileSymbol` / `SymbolGraph` gain `id`; `symbolCallers` takes a `SymbolSelector` and sends `id` when
present, `qname` otherwise. The CodeLens and the hover's "show callers" link both build their command
arguments through one `callerCommandArguments` builder, so the row's own handle reaches the handler
from either surface and the "is there anything to link to" guard is spelled once. A markdown
`command:` URI is untyped at its boundary, which is why the two surfaces could disagree without
failing the build; the builder also normalizes both selector fields to `null`, because JSON drops an
`undefined` field and an older server omits `id` rather than sending it null.

`symbolCallers` returns the whole hop envelope rather than unwrapping to `callers`, and the quick
pick titles itself through one `callersPlaceholder` helper — so a `qname`-resolved answer that
covered several symbols says so instead of being rendered as one symbol's callers.

`FileSymbol` / `SymbolGraph` also gain the optional `id_declarations`, rendered through one
`sharedHandleMarker` helper: a caller lens whose handle reaches further than its own row carries a
`⧉N` suffix and a tooltip, and the hover offering the same link says the same thing. That puts the
qualification *before* the click, where the row's own caller count and the group's drill-down first
disagree, rather than only in the quick pick afterwards. `undefined` (a server too old to report it)
and `1` both render nothing — absence is never read as an assumed `1`.

## Design decisions

**Does `qname` stay now that a handle exists?** Yes, as an explicitly documented fallback that is
preferred against, not an equal alternative. The server and the editor extension version
independently — a user can update the server without updating the extension, and an
already-installed build sends only a name. Rejecting a name would break call navigation outright on
every such install, and the endpoints are plain HTTP that other tools may call. The ambiguity is
contained rather than removed.

**Is a bad handle allowed to become a name?** No. `hop_selector` reads `id` whenever the parameter
is present, not merely when it is present and non-empty, so `?id=&qname=src/lib.rs::run` and
`?id=nonsense&qname=src/lib.rs::run` are 400 rather than 200-with-the-union. The two lanes answer
different questions; degrading between them silently is the failure these routes exist to remove,
and it is worse than the original bug, because the client believed it had asked by handle and has no
reason to re-read `resolved_by`.

**Does the ambiguity reach a human, not just a machine?** Yes, on the one surface that consumes
these routes. Reporting `matched_symbols` and then discarding it in the client would be worse than
not measuring it: the quick pick would title a union `N callers of run` with the server's authority
behind a claim the server did not make. `callersPlaceholder` reads the count on **both** lanes —
`> 1` means the rows are a union over that many symbols, whichever selector produced it, and both
selectors can produce one (a qualified name covers every overload in the file; a handle covers
every overload the grouping key cannot tell apart, see *Outstanding*). Reading it only on the
fallback lane would state the narrow claim over the wide answer in exactly the case the handle
covers a group. `0` is reachable only from the fallback lane — a handle with no symbol behind it is
a 404, not an empty answer — and says nothing indexed carries the name, so rows that came from
unresolved call sites alone are not presented as some symbol's callers. Both fields are optional in
the TS type on purpose: absence means "this server cannot say", never an assumed `"id"`.

**Can a handle that covers several declarations be narrowed here?** No, and it should not be. Some
groups are correct and permanent — a function's cfg variants are one entity the build picks one
spelling of, so there is nothing to single out — and where a group *is* too coarse, that is a
property of `LogicalSymbolKey`, computed in `index/graph_index.rs`. Minting a second,
declaration-level identity at the lens would give one declaration two identities that answer
differently on every other handle-keyed surface: `symbol_lookup`, `impact_surface`, and above all
`repo_memory_bindings`, whose `logical_symbol` bindings *are* the `sym_<hex>` id. Two identities for
one thing is worse than one coarse identity.

What the routes owe a reader instead is the reach they do have, on the surface that hands the handle
out as well as the one that answers it: `id_declarations` on `/api/file/{symbols,graph}` and
`matched_symbols` on the hop response, the same number by construction because both read
`handles.rs::scope_visible_members_sql`. Reporting it only on the answer leaves the file lane
offering a selector it has already been established cannot discriminate, and the client renders the
row's own caller count against a wider drill-down with nothing to reconcile them.

**Can a client tell it landed on the fallback?** Yes. Both hop responses carry `resolved_by` and
`matched_symbols` — the number of active-scope symbols the selector expanded to. `matched_symbols > 1`
is a machine-readable statement that the hop list is a union, and it reads that way on either lane,
so a client can surface or log it instead of silently rendering collapsed data. Both fields are
additive.

`matched_symbols` mirrors *both* seed arms of the traversal predicate, including the
unique-short-name arm, and lives next to those predicates so the two cannot drift. Counting only
exact qualified-name matches would report `matched_symbols: 0` alongside a real, non-empty caller
list for a request like `?qname=hop_limit` — the inverse of the signal the field exists to carry.
Zero stays meaningful: an ambiguous short name turns that arm off, nothing expands, and no hops come
back either.

**What happens to a well-formed handle the index does not know** (held across a rename, or minted in
another checkout)? HTTP 404 `unknown symbol handle`; the core method returns `Ok(None)`. Both silent
alternatives are wrong. An empty hop list reads as "this symbol has no callers", indistinguishable
from the truthful zero-caller case, and a server-side fall-through to the request's qualified name
would reintroduce exactly the union the handle exists to avoid, precisely when the client believed
it was being specific.

Widening is the *client's* call, because only the client knows the request came from a gutter
decoration rather than from a caller that typed a handle. A handle is derived from the declaration,
so editing a signature mints a new one on the next index pass while a CodeLens already drawn still
carries the old; `symbolCallers` retries such a 404 with the `qname` the same row supplied, and
`matched_symbols` says the answer went wide. Only on 404 — a 400 means this client built a
malformed handle, and quietly widening would hide the bug that produced it. A row with no name to
retry with gets a "reopen the file to refresh it" notice rather than a raw contributed-command
failure. Relatedly, `LensClient.get` no longer invalidates the discovered endpoint for a 4xx other
than 401/403: a status line proves the endpoint understood the request, so re-deriving it cannot
turn a 404 into a hit, and discarding it costs every other lane the cached identity it shares.

**Does this need an API version bump?** No. The only version number in the lens surface is
`DISCOVERY_VERSION`, which describes the `.rag-rat/sockets/lens.json` discovery *document*, not the
HTTP API — the routes are unversioned by convention, and the discovery document's shape is unchanged.
The route change is additive on both sides (one optional query parameter, new response fields, a new
row field), so an old client keeps working against a new server and a new client degrades to the
fallback against an old one.

**Where does the narrowing belong — the resolution mode or the predicate?** The predicate. Passing
the handle alongside `GraphTraversalOptions::default()` does not on its own fix the bug: the
logical-symbol branches of `reverse_predicate` / `forward_source_predicate` used to OR in
`edges.target_qualified_name_id = <the shared qname>` (and `edges.from_name_id`, which holds the
*enclosing* symbol's qualified name and so collapses the callee direction too), letting the other
overload's hops back in through the name arm.

`GraphResolutionMode::Exact` is the wrong lever for that, because it is not only a narrower seed: it
also swaps the edge-**admission** filters to require a bound endpoint — `forward_target_filter(Exact)`
is `edges.to_symbol_id IS NOT NULL` outright, and `reverse_predicate(Exact, ..)` prefixes the same
clause. Those run in traversal SQL, strictly before `enrich_hops_with_oracle`, which rewrites hops in
memory and never mutates the `edges` row. An unresolved call the compiler later binds is therefore
dropped before the verdict can be applied, and no `oracle run` can put it back — measured on a
fixture whose single call edge a real SCIP pass upgrades: `?qname=` returned a compiler-tier hop
where `?id=` returned an empty list, in both directions.

So both lanes traverse in `Syntactic`, and the logical `Syntactic` predicates carry the attribution
rule instead: membership decides a **bound** endpoint, and the qualified-name arm applies **only**
where that endpoint is `NULL`. Both halves are load-bearing — ungate the arm and the overloads
re-collapse; drop it and the compiler-verified neighbour disappears. What remains is honest
imprecision: an unbound edge naming a qualified name two overloads share lands under both handles,
exactly as it does on the qualified-name lane, because the index has nothing finer to attribute it
by. The fallback lane's traversal is untouched, so an older extension's hops are byte-identical to
before.

The hop list is **not** the drill-down of the caller counts in the lens title. `/api/file/symbols`
and `/api/file/graph` count every in-scope edge kind that lands on the symbol id — `implements`,
`references_type`, `contains`, `imports` — while a traversal keeps the call kinds alone, so the
hops are a subset and the two coincide only where nothing but calls reaches the symbol. A trait
implemented twice reports callers and has no hops behind any of them, with `matched_symbols` at 1
throughout. `a_caller_count_spans_edge_kinds_a_hop_traversal_does_not` pins the relationship, with
a called function as the control where the two do agree; adding a `CALL_EDGE_KINDS` predicate to
the `incoming` CTE makes it fail, so realigning them has to pass through it deliberately.

**Where is the `sym_<hex>` token parsed?** At the HTTP boundary; the core API takes the decoded
`i64`. `rag_rat_base::serde_big_id::parse_sym_handle` is the single source of truth for the wire
shape, and HTTP is where a malformed token must become a 400. No second identity was invented: there
is still no numeric `symbol_id` on the wire, and the internal rowid is never exposed.

**Should the CodeLens still require a qualified name?** No — it is emitted when either `id` or
`qname` is present. Requiring the name is the same mistake in a different place: the handle is the
identity, and a row that has one is navigable regardless. The fallback still needs `qname`, so the
condition is a disjunction rather than a swap.

**How is the caller direction of an overload observable at all,** given the resolver refuses to
disambiguate same-name calls? The fixture binds its two call sites itself
(`UPDATE edges_data SET to_symbol_id = …`), the way a compiler oracle pass does, and says so in a
comment. This was confirmed empirically by indexing candidate sources: the *callee* direction is
naturally attributed, because `edges.from_symbol_id` comes from the enclosing symbol's span — but
every same-name call site indexes as `calls_name` / `NameOnly` with `to_symbol_id IS NULL`, since the
receiver hint records the variable name and not the type. Module-scoped same-name free functions
behave identically. `contains` edges were rejected as a fixture basis: both impl blocks' `contains`
edges resolve to the first overload's symbol id (contains-resolution is by qualified name), so a
fixture built on them would encode an indexer bug rather than test around it.

## Cost

One extra `LEFT JOIN logical_symbol_members` inside the existing `requested` CTE on the file lanes
(joining `idx_logical_symbol_members_symbol`), one correlated `COUNT(*)` per symbol row for
`id_declarations`, and one indexed `COUNT(*)` per hop request for `matched_symbols`. No new round
trip on the handle lane beyond that count-and-name lookup.

The per-row count was measured rather than argued, because a per-row join against the live `files`
view is the shape of a known pathology (the reconcile batch query that went `O(chunks × files)`).
Run against this repo's own 417 MB index on its largest file — `crates/rag-rat-core/src/config.rs`,
611 symbols, warm cache, three interleaved runs — the file-lane statement took 0.176 / 0.201 /
0.163 s without the count and 0.181 / 0.218 / 0.204 s with it: roughly +15%, on a statement that
already performs one `JOIN files` per symbol row and one per outgoing edge. The difference from the
pathological case is that this probe is an equality on `files.id`, which flattens into each of the
view's `UNION ALL` branches and hits the rowid index; the reconcile probe was on a non-key column
and each branch had to scan.

## Verification

New tests:

- `rag-rat-core lens::tests::hop_selectors_separate_overloads_by_handle_and_unite_them_by_qualified_name`
  — the overload fixture. Each handle resolves to its own callers and its own callees; the shared
  qualified name returns the union in both directions with `resolved_by: Ref` and
  `matched_symbols == 2`. Observed failing against the neutered handle lane in both directions.
- `rag-rat-core lens::tests::file_lanes_carry_a_distinct_symbol_handle_per_overload` — both file
  lanes hand out a handle per row, the two overloads' handles differ while their qnames are
  identical, the lanes agree per row, and the wire form is a `sym_<hex>` string rather than a number.
- `rag-rat-core lens::tests::hop_selectors_see_only_the_active_checkouts_symbols` — a sibling
  checkout's `src/lib.rs::run` must neither inflate `matched_symbols` nor resolve as a handle.
  Observed failing (count 3 instead of 2) with the `JOIN files` removed from the two new helpers.
- `rag-rat-core worktree_overlay::lens_handles::lens_symbol_handles_are_scoped_to_the_active_checkout`
  — the same question against a real `git worktree add` sharing the database. A main checkout with
  two `run` overloads, a branch that re-declares one, drops the other, and carries a third symbol
  over byte-identical; `index_worktree_overlay`, then the file lanes and hop routes read under each
  scope in turn and back again. The carried-over symbol is what decides the reach count — it has one
  `logical_symbol_members` row per checkout — and the base checkout's answers must survive the round
  trip while the branch's handle reads as absent, and vice versa. Observed failing with the count's
  `files` join pointed at `main.files`: `left: 2, right: 1` on the carried-over symbol's reach, which
  is the same unscoped read that lets a sibling checkout's handle resolve here.
- `rag-rat-core lens::tests::an_unresolvable_handle_is_absent_rather_than_empty` — pins the `None`
  contract.
- `rag-rat-mcp http::tests::hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name` —
  end-to-end over the routes: distinct `id` per overload from both file lanes; `?id=` returns that
  overload's own neighbour with `resolved_by: "id"` / `matched_symbols: 1`; `?qname=` returns the
  union with `resolved_by: "ref"` / `matched_symbols: 2`; `id` wins when both are sent; an unknown
  handle is 404 on both routes.
- `rag-rat-mcp http::tests::new_routes_reject_missing_or_invalid_parameters` (extended) — `?id=`
  empty, `?id=12345` and `?id=sym_zzz` all 400. A malformed handle is never quietly read as a name.
  The same three values are re-asserted inside the overload test **with a resolvable `qname`
  alongside**, on both routes, which is where the lane-swap is actually observable: against the
  earlier `.filter(|v| !v.is_empty())` that test fails with `left: 200, right: 400` on `?id=` —
  it had been answering with the union.
- `rag-rat-core lens::tests::a_handle_covering_one_symbols_cfg_variants_reports_them_all` — one
  function's `#[cfg(unix)]` / `#[cfg(windows)]` variants share a handle; both file lanes report
  `id_declarations == 2` for them and `1` for an ungrouped neighbour, and the handle lane returns
  the union of their callees with `matched_symbols == 2`. Pins the limit of the handle on a group
  that stays one symbol however precise declaration identity becomes — see the note on #1023 below.
- `rag-rat-core lens::tests::a_caller_count_spans_edge_kinds_a_hop_traversal_does_not` — a trait
  implemented twice counts callers and has no hops behind them, and its method's `contains` edges
  do the same one level down, with a called function as the control where count and drill-down
  agree. Observed failing when the `incoming` CTE is restricted to `CALL_EDGE_KINDS`.
- `rag-rat-core index::query_api::oracle_surfacing_tests::a_compiler_upgraded_unresolved_edge_reaches_the_handle_lane_too`
  — an unresolved-but-qualified call edge, upgraded by a real `run_oracle_from_scip` pass, must
  surface identically on both lanes in both directions. Observed failing with the handle lane put
  back on `Exact`: `left: []` against `right: [("caller", "compiler")]`.
- `rag-rat-core lens::tests::a_handle_attributes_a_bound_edge_by_membership_and_an_unbound_one_by_name`
  — pins the line between the two predicate arms: a bound edge carrying the shared qualified name
  stays on its own overload, and unbinding it puts it on both. Observed failing with the name arm
  ungated (`["calls_alpha", "calls_beta"]` against `["calls_alpha"]`), which is also where
  `hop_selectors_separate_overloads_by_handle_and_unite_them_by_qualified_name` fails.
- `editors/vscode` — a stale handle falls back to the row's qualified name rather than to
  rediscovery (two requests, zero resolver invalidations); only 401/403/5xx/transport failures
  discard the discovered endpoint, a 400 does not; a click whose row carried no name reports a
  stale lens instead of failing the command, while a 500 and a transport failure still surface.
  Observed failing against each seam reverted individually.
- `editors/vscode` — `sharedHandleMarker` renders nothing for an absent reach, `1`, or `0`, and a
  `⧉N` title plus a tooltip above that; a lens whose row reports two declarations carries both while
  its neighbours carry neither, and the hover over the same row says the same thing. Observed
  failing with the title suffix and the hover line removed.
- `editors/vscode` — `symbolCallers` sends `id` and omits `qname` when a handle is present and the
  reverse when it is not, rejects a selector-less call without touching the network, and returns the
  envelope whole; the caller quick pick's placeholder names the union, the empty-name case, and the
  plain case, and a server reporting neither field gets the plain wording; each overload's lens
  carries its own `{ id, qname }`; the hover link decodes to the same argument tuple the lens
  dispatches, including the handle-less, selector-less, and `id`-key-absent rows. All observed
  failing against reverted sources.

Gates run on this branch, all exit 0:

| gate | exit |
|---|---|
| `cargo build --workspace --locked` | 0 |
| `cargo nextest run --workspace --no-default-features --locked --profile ci` (4359 passed) | 0 |
| `cargo nextest run --workspace` (4361 passed) | 0 |
| `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` | 0 |
| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | 0 |
| `cargo clippy -p rag-rat-core -p rag-rat --no-default-features --features eval --all-targets --locked -- -D warnings` | 0 |
| `cargo clippy -p rag-rat-core -p rag-rat --features eval --all-targets --locked -- -D warnings` | 0 |
| `cargo +nightly fmt --all --check` | 0 |
| `cargo test` for the touched modules (the coverage job's shared-process runner) | 0 |
| `editors/vscode`: `npm ci`, `npm run package`, `npm run lint`, `npm test` (62 passed), `npm audit --audit-level=moderate` | 0 |
| `editors/vscode`: `npx @vscode/vsce package --no-dependencies` | 0 |

All of the above ran on Linux only, and PR CI is Linux only as well. The macOS and Windows legs live
in `ci-cross-platform.yml`, which triggers on release tags and `workflow_dispatch` — so this change
is unverified on those platforms and will stay unverified until a tag or a manual dispatch runs them.
Nothing here is platform-specific (no new paths, no filesystem or process assumptions; the tests
hardcode `src/lib.rs::run` following the existing cross-platform-safe convention in this workspace),
but that is reasoning, not evidence.

## Outstanding

- **An unresolved call site still reaches every overload the name it wrote could mean.** The
  heuristic resolver deliberately leaves same-name method calls unbound, and such an edge carries
  nothing but the qualified name at the call site — which two overloads share. Both lanes therefore
  show it, and `?id=` is narrower than `?qname=` only on the edges the resolver (or a compiler
  oracle) actually bound. Admitting those rows is the deliberate choice: the alternative drops them
  in SQL before `enrich_hops_with_oracle` runs, which is unrecoverable, so precision on unbound
  edges has to come from binding them — an `oracle run` — not from a stricter traversal.
- **The handle separates declarations only as far as the grouping key does,** and the routes report
  that rather than working around it. `LogicalSymbolKey` folds in the declaration's *first line*, so
  declarations that look alike there land in one logical symbol and behind one handle. Widening the
  key at the lens is not the fix — see the design note above — and body-insensitivity is what lets a
  symbol keep its handle, and its bound memories, across an edit to its body. `id_declarations` and
  `matched_symbols` are the honest answer, and they are the same number.
- **An oracle verdict cannot attribute an unresolved edge on either lane.** Where a repo has
  same-qualified-name overloads *and* a completed oracle run, an unresolved call the compiler bound
  to one of them is admitted under both (by the name it wrote) and then stamped
  `confidence: "compiler"` by `enrich_hops_with_oracle` — so under the sibling it is both foreign and
  labelled compiler-verified. Narrowing the traversal SQL is not the fix and is what the previous
  commit undid: that SQL runs before enrichment and the verdict never touches the `edges` row, so a
  refused edge is unrecoverable. The fix is post-traversal — carry `resolved_symbol_id` out of the
  one existing verdict-merge site onto the hop and drop a hop the compiler bound outside the selected
  logical symbol — and it is deliberately not in this change, because doing it any other way adds a
  second merge site that has to replicate batch-first verdict precedence, and these predicates feed
  `impact_surface` as well. Only the caller direction is addressable that way: a verdict describes an
  edge's target, not which overload wrote the call.

## Relationship to #1023

#1023 (`fix(index): make an impl's owner part of logical identity`) fixes, at the identity layer, the
case where `impl Alpha { fn run(&self) }` and `impl Beta { fn run(&self) }` in one file share a
`sym_<hex>` handle: `LogicalSymbolKey` gains an owner discriminator, and the two stop collapsing.
That is the right layer for it, and this change does not duplicate it.

**Merge order: either, but #1023 first is cleaner.** The two touch different files and do not
conflict. This branch's separation fixture (`OVERLOAD_SOURCE`) gives its two overloads different
parameter lists, so they are distinct logical symbols under both the current key and #1023's, and
`hop_selectors_separate_overloads_by_handle_and_unite_them_by_qualified_name` asserts the same thing
before and after. The grouped fixture deliberately does **not** use two impls — it uses one
function's cfg variants, which #1023 does not touch and which no identity refinement should ever
split. So nothing here has to be revisited when #1023 lands, and #1023 does not have to wait for
this.

What remains true after #1023 is what `id_declarations` exists for: cfg variants are one symbol by
design, and #1023's discriminator is Rust-specific, so grouped handles do not go away — the routes
still have to say when one is answering for more than the row it was taken from.

Fixes #1028




