### PR TITLE
test(sync): close the two table-sync coverage gates — migration arming and two openers of one file (#1018, #1019)

### DIFF
--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -1687,3 +1687,103 @@ pub fn ensure_compatible_or_migrate(
         SchemaState::Newer | SchemaState::Dirty => anyhow::bail!("{}", current.message),
     }
 }
+
+/// Registering a migration takes six coordinated edits — the `MIGRATION_0NN_{ID,CHECKSUM,
+/// DESCRIPTION}` consts, the [`ADDITIVE_MIGRATIONS`] entry, [`LATEST_SCHEMA_VERSION`], and three
+/// separate recognizers in `migrations.rs` ([`known_version`], [`known_migration`],
+/// [`migration_checksum_mismatch`]) — and only the first two fail to compile when forgotten.
+///
+/// These tests make the remaining four mechanical by ranging over the shipped ladder itself, so a
+/// new migration is checked automatically. The `known_migration` arm is the one that is otherwise
+/// invisible: leave it out and `status` reports `Newer` while `current_version` still reads
+/// correctly, so a per-migration `current_version == LATEST_SCHEMA_VERSION` assertion passes and
+/// only a broad integration test notices.
+#[cfg(test)]
+mod migration_arming {
+    use super::*;
+
+    /// `(id, checksum)` for every migration this binary ships, in ladder order: the baseline (001,
+    /// applied by `apply_baseline` rather than the additive loop, but armed in the same three
+    /// recognizers) followed by [`ADDITIVE_MIGRATIONS`].
+    fn shipped_ladder() -> Vec<(&'static str, &'static str)> {
+        std::iter::once((MIGRATION_001_ID, MIGRATION_001_CHECKSUM))
+            .chain(ADDITIVE_MIGRATIONS.iter().map(|step| (step.id, step.checksum)))
+            .collect()
+    }
+
+    /// The ledger row `applied_migrations` would report for `id` at `checksum`.
+    fn ledger_row(id: &str, checksum: &str) -> AppliedMigration {
+        AppliedMigration {
+            id: id.to_string(),
+            applied_at_ms: 0,
+            checksum: checksum.to_string(),
+            description: String::new(),
+        }
+    }
+
+    /// The version [`known_version`] assigns to `id` on its own, or `None` when no arm claims it.
+    /// No migration maps to 0, so the `unwrap_or(0)` floor is an unambiguous "unarmed".
+    fn armed_version(id: &str) -> Option<u32> {
+        match known_version(&[ledger_row(id, "")]) {
+            0 => None,
+            version => Some(version),
+        }
+    }
+
+    #[test]
+    fn every_shipped_migration_has_a_known_version_arm() {
+        for (id, _) in shipped_ladder() {
+            assert!(
+                armed_version(id).is_some(),
+                "{id} has no `known_version` arm, so a store that applied it still reports the \
+                 version below it and every open re-runs the ladder",
+            );
+        }
+    }
+
+    #[test]
+    fn every_shipped_migration_is_a_known_migration() {
+        for (id, _) in shipped_ladder() {
+            assert!(
+                known_migration(id),
+                "{id} is missing from `known_migration`, so its own ledger row reads as written \
+                 by a future binary and `status` refuses the store as `Newer`",
+            );
+        }
+        // The dirty marker is not a migration and has no version or checksum arm, but it rides the
+        // same roster: drop it and a crashed migration's marker reads as `Newer` instead of
+        // `Dirty`, which names the wrong remedy.
+        assert!(known_migration(DIRTY_MIGRATION_ID), "the dirty marker stays a recognized id");
+    }
+
+    #[test]
+    fn every_shipped_migration_has_a_checksum_arm() {
+        for (id, checksum) in shipped_ladder() {
+            assert!(
+                !migration_checksum_mismatch(&ledger_row(id, checksum)),
+                "{id} at its shipped checksum must not read as tampered",
+            );
+            // The load-bearing direction: the `_ => false` catch-all silently accepts ANY checksum
+            // for an unarmed id, so a store whose migration body changed under it opens clean.
+            assert!(
+                migration_checksum_mismatch(&ledger_row(id, &format!("{checksum}-tampered"))),
+                "{id} has no `migration_checksum_mismatch` arm, so a changed migration body is \
+                 never detected",
+            );
+        }
+    }
+
+    #[test]
+    fn the_shipped_ladder_covers_every_version_up_to_latest() {
+        let armed: Vec<u32> =
+            shipped_ladder().iter().filter_map(|(id, _)| armed_version(id)).collect();
+        // Comparing the whole sequence — not just its length or its maximum — is what makes a
+        // reused number, a gap, an out-of-order entry, and a forgotten `LATEST_SCHEMA_VERSION`
+        // bump all one failure.
+        assert_eq!(
+            armed,
+            (1..=LATEST_SCHEMA_VERSION).collect::<Vec<u32>>(),
+            "the shipped ladder must be 1..=LATEST_SCHEMA_VERSION in order, with no gaps or reuse",
+        );
+    }
+}

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -329,6 +329,11 @@ mod tests {
             rw.connection().query_row(&format!("PRAGMA {name}"), [], |row| row.get(0)).unwrap()
         };
 
+        // #220: a write connection WAITS OUT another writer rather than failing SQLITE_BUSY — WAL
+        // admits one writer at a time, and every shared-store path (a second checkout, the watcher
+        // mid-pass, a lazy heal, the table-sync refold's IMMEDIATE transaction at store open)
+        // relies on this rather than on retry logic of its own.
+        assert_eq!(pragma("busy_timeout"), 5000, "a writer must wait out a concurrent writer");
         // #815: temp b-trees/tables must stay in memory (2 = MEMORY), never spill to /var/tmp
         // external-merge files, and the page cache is a bounded 64 MiB (negative form = KiB).
         assert_eq!(pragma("temp_store"), 2, "temp_store must be MEMORY");

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -266,6 +266,11 @@ fn stored_projector_version(conn: &Connection) -> anyhow::Result<Option<i64>> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
+    use rag_rat_base::test_scratch::ScratchDir;
+    use rag_rat_db::storage::IndexConnection;
+
     use super::*;
     use crate::table_sync::engine::{self, IngestOutcome, SyncCtx};
     use crate::table_sync::registry::{ColumnSpec, DefaultValue, ValueType};
@@ -1380,5 +1385,359 @@ mod tests {
             ],
             "a stored classification token moved, or a new variant is unpinned"
         );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Two openers of ONE database file.
+    //
+    // A store reached by binaries of different versions is a first-class configuration here —
+    // linked worktrees share one database — but every test above drives it from a single
+    // `Connection`, with the other binary simulated by hand-editing the stamp or an entry's
+    // `pending_projector_version`. That cannot show what a second opener changes: whether the
+    // pending mark, the projector stamp, and the unsent-local-edit guard are FILE state rather than
+    // connection state, and whether the refold's IMMEDIATE transaction really contends for the
+    // store's single write lock. The tests below open the same file twice, for real.
+
+    /// One database file, schema-applied once, plus the scratch dir that owns it.
+    struct SharedStore {
+        dir: ScratchDir,
+    }
+
+    impl SharedStore {
+        fn new(tag: &str) -> Self {
+            let store = Self { dir: ScratchDir::new(tag) };
+            let db = IndexConnection::open(&store.path()).unwrap();
+            rag_rat_db::schema::apply(db.connection(), &crate::test_hooks()).unwrap();
+            db.execute_batch(
+                "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT, later_col TEXT) STRICT;",
+            )
+            .unwrap();
+            store
+        }
+
+        fn path(&self) -> PathBuf {
+            self.dir.join("index.sqlite")
+        }
+
+        fn open(&self) -> Opener {
+            open_at(&self.path())
+        }
+    }
+
+    /// A production opener of `path`. [`IndexConnection::open`] is what pins the real write-path
+    /// pragmas — WAL plus `busy_timeout = 5000` — and those decide whether a contended IMMEDIATE
+    /// transaction waits or fails, so a hand-rolled `Connection::open` here would exercise a
+    /// configuration that does not ship.
+    fn open_at(path: &Path) -> Opener {
+        let db = IndexConnection::open(path).unwrap();
+        let local = crate::local_device(db.connection(), 0).unwrap();
+        Opener { db, local }
+    }
+
+    /// One opener of a [`SharedStore`]. Deliberately not a [`Device`]: `Device` OWNS its
+    /// connection, while an opener borrows one from the `IndexConnection` carrying the pragmas
+    /// above — so its write paths go through `Transaction::new_unchecked`, exactly as the
+    /// engine's own callers do.
+    struct Opener {
+        db: IndexConnection,
+        local: LocalDevice,
+    }
+
+    impl Opener {
+        fn conn(&self) -> &Connection {
+            self.db.connection()
+        }
+
+        fn fingerprint(&self) -> crate::op::DeviceFingerprint {
+            self.local.secret().public().fingerprint()
+        }
+
+        fn enroll(&self, fp: crate::op::DeviceFingerprint) {
+            self.conn()
+                .execute(
+                    "INSERT OR IGNORE INTO account_roster_history
+                         (roster_ref, account_id, device_fingerprint, role, effective_at, \
+                     closed_at)
+                     VALUES (?1, ?2, ?3, 'owner', 0, NULL)",
+                    params![fp.to_bytes().as_slice(), ACCOUNT.as_slice(), fp.to_bytes().as_slice()],
+                )
+                .unwrap();
+        }
+
+        /// Fallible, because the newer-projector refusal is one of the behaviors under test.
+        fn produce(&self, registry: &[TableSpec], repo_id: &str) -> anyhow::Result<Vec<Vec<u8>>> {
+            let tx = Transaction::new_unchecked(self.conn(), TransactionBehavior::Deferred)?;
+            let ctx = SyncCtx {
+                repo_id,
+                account_id: account(),
+                device: &self.local,
+                registry,
+                now_ms: 0,
+            };
+            let out = engine::produce_and_author(&tx, &ctx)?;
+            tx.commit()?;
+            Ok(out)
+        }
+
+        fn ingest(
+            &self,
+            registry: &[TableSpec],
+            repo_id: &str,
+            entries: &[Vec<u8>],
+            from: &crate::device::DevicePublic,
+        ) -> Vec<IngestOutcome> {
+            let tx =
+                Transaction::new_unchecked(self.conn(), TransactionBehavior::Deferred).unwrap();
+            let ctx = SyncCtx {
+                repo_id,
+                account_id: account(),
+                device: &self.local,
+                registry,
+                now_ms: 0,
+            };
+            let out = entries
+                .iter()
+                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap())
+                .collect();
+            tx.commit().unwrap();
+            out
+        }
+
+        fn refold(&self, registry: &[TableSpec]) -> anyhow::Result<bool> {
+            refold_stale_projections_against(self.conn(), registry)
+        }
+
+        fn row(&self) -> Option<(String, Option<String>)> {
+            self.conn()
+                .query_row("SELECT title, later_col FROM t_demo WHERE id = 'r1'", [], |r| {
+                    Ok((r.get(0)?, r.get(1)?))
+                })
+                .optional()
+                .unwrap()
+        }
+
+        fn pending_count(&self) -> i64 {
+            self.conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM table_sync_entries WHERE pending_reason IS NOT NULL",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        }
+    }
+
+    /// The complete r1 row the wide entry projects to once a NEW-registry binary understands it.
+    fn refolded_row() -> Option<(String, Option<String>)> {
+        Some(("v1".to_string(), Some("wide".to_string())))
+    }
+
+    /// Park one entry in `store`: an in-memory peer authors r1 under the NEW column set, and an
+    /// opener ingests it under the OLD one, which cannot project it. The opener is dropped, so the
+    /// parked state survives only in the file.
+    fn park_wide_entry(store: &SharedStore) {
+        let mut peer = Device::new();
+        let entries = author_wide_row(&mut peer);
+        let opener = store.open();
+        opener.enroll(peer.pubkey().fingerprint());
+        assert_eq!(opener.ingest(OLD_REGISTRY, "repo", &entries, &peer.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::NewerSpecVersion.as_db_str())
+        ]);
+        assert_eq!(opener.pending_count(), 1, "the fixture leaves exactly one entry parked");
+    }
+
+    #[test]
+    fn a_second_opener_refolds_what_the_first_one_parked() {
+        let store = SharedStore::new("table-sync-two-openers-refold");
+        park_wide_entry(&store);
+
+        let first = store.open();
+        let second = store.open();
+        assert_eq!(
+            first.fingerprint(),
+            second.fingerprint(),
+            "two openers of one file are one device identity, not two peers"
+        );
+        assert_eq!(
+            second.pending_count(),
+            1,
+            "the pending mark is file state, not connection state"
+        );
+        assert_eq!(second.row(), None, "and nothing was applied in part");
+
+        assert!(second.refold(NEW_REGISTRY).unwrap());
+        assert_eq!(second.row(), refolded_row());
+
+        // The other, still-open connection sees the committed result — including the stamp, so it
+        // does not redo the work, and the anti-echo hashes, so it emits nothing. Every
+        // single-connection test above assumes exactly this and cannot check it.
+        assert_eq!(first.row(), refolded_row());
+        assert_eq!(first.pending_count(), 0);
+        assert!(!first.refold(NEW_REGISTRY).unwrap(), "the refold is one-shot across openers");
+        assert!(first.produce(NEW_REGISTRY, "repo").unwrap().is_empty(), "and nothing echoes back");
+    }
+
+    #[test]
+    fn the_refold_contends_for_the_stores_single_write_lock() {
+        let store = SharedStore::new("table-sync-two-openers-busy");
+        park_wide_entry(&store);
+
+        let writer = store.open();
+        let refolder = store.open();
+        // A refold that will not wait, so the contention is observable rather than absorbed by the
+        // production timeout (the sibling test covers the waiting half).
+        refolder.conn().busy_timeout(std::time::Duration::ZERO).unwrap();
+
+        // WAL admits exactly one writer, and the other opener is it.
+        let held =
+            Transaction::new_unchecked(writer.conn(), TransactionBehavior::Immediate).unwrap();
+        held.execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r9', 'held', NULL)", [])
+            .unwrap();
+
+        let err = refolder
+            .refold(NEW_REGISTRY)
+            .expect_err("the refold must not proceed without the store's write lock");
+        assert!(rag_rat_db::storage::is_busy(&err), "the refusal is SQLITE_BUSY, got: {err}");
+        assert_eq!(refolder.pending_count(), 1, "and the worklist is untouched");
+
+        // The same refold then succeeds, so the failure was contention rather than a worklist this
+        // opener could never redeem.
+        held.commit().unwrap();
+        assert!(refolder.refold(NEW_REGISTRY).unwrap());
+        assert_eq!(refolder.row(), refolded_row());
+    }
+
+    /// Set by [`note_blocked_then_retry`] the first time SQLite reports the write lock unavailable
+    /// — the only reliable proof that a refold actually BLOCKED rather than finding the lock
+    /// free. Read and reset by the single test below; nothing else touches it, so it is safe
+    /// under the shared-process `cargo test` runner as well as under nextest.
+    static REFOLD_BLOCKED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    /// Stands in for the production `busy_timeout` (pinned separately by
+    /// `setup_pins_the_write_path_pragmas` in `rag-rat-db`), because `sqlite3_busy_handler` gives a
+    /// callback and the timeout pragma does not: the hand-off below has to be CAUSAL, not timed. A
+    /// sleep-based hand-off fails both ways — the holder commits before the refold reaches `BEGIN`
+    /// (the test passes without contending), or the holder is descheduled past the timeout (the
+    /// test fails for scheduling reasons).
+    ///
+    /// The ~30s ceiling is a HANG-STOP, not a timeout under test: the holder releases the lock
+    /// within its own 5s watchdog, so patience an order of magnitude past that cannot be reached by
+    /// a correct run — and matching the production 5s here would just reintroduce the spurious
+    /// failure the causal hand-off exists to remove.
+    fn note_blocked_then_retry(attempts: i32) -> bool {
+        REFOLD_BLOCKED.store(true, std::sync::atomic::Ordering::SeqCst);
+        if attempts > 3_000 {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        true
+    }
+
+    #[test]
+    fn the_refold_blocks_on_a_concurrent_writer_and_completes_once_it_commits() {
+        use std::sync::atomic::Ordering;
+
+        let store = SharedStore::new("table-sync-two-openers-wait");
+        park_wide_entry(&store);
+        REFOLD_BLOCKED.store(false, Ordering::SeqCst);
+
+        // Opened BEFORE the write lock is taken: `IndexConnection::open` writes pragmas of its own,
+        // and this test is about the refold's contention, not the opener's.
+        let refolder = store.open();
+        refolder.conn().busy_handler(Some(note_blocked_then_retry)).unwrap();
+
+        let path = store.path();
+        let (holding, lock_held) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let opener = open_at(&path);
+            let tx =
+                Transaction::new_unchecked(opener.conn(), TransactionBehavior::Immediate).unwrap();
+            tx.execute(
+                "INSERT INTO t_demo(id, title, later_col) VALUES ('r9', 'concurrent', NULL)",
+                [],
+            )
+            .unwrap();
+            holding.send(()).unwrap();
+            // Hold until the refolder is provably blocked, so the release is caused by the
+            // contention rather than by a clock. The deadline is only a watchdog: if the refold
+            // never blocks, this returns and the assertion below reports it instead of hanging.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while !REFOLD_BLOCKED.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            tx.commit().unwrap();
+        });
+
+        lock_held.recv().unwrap();
+        assert!(refolder.refold(NEW_REGISTRY).unwrap(), "the refold completes once the lock frees");
+        writer.join().unwrap();
+        assert!(
+            REFOLD_BLOCKED.load(Ordering::SeqCst),
+            "the refold must have contended for the write lock, not found it free"
+        );
+
+        // And neither write was lost to the other.
+        assert_eq!(refolder.row(), refolded_row());
+        let concurrent: String = refolder
+            .conn()
+            .query_row("SELECT title FROM t_demo WHERE id = 'r9'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(concurrent, "concurrent");
+    }
+
+    #[test]
+    fn an_opener_refuses_to_write_a_store_the_other_folded_with_a_newer_projector() {
+        let store = SharedStore::new("table-sync-two-openers-newer");
+        let newer = store.open();
+        let older = store.open();
+
+        // One process has one `TABLE_SYNC_PROJECTOR_VERSION`, so the newer binary can only be
+        // modelled by the stamp it leaves behind — but the stamp CROSSING two connections is real,
+        // and that crossing is what the refusal depends on in the field.
+        newer
+            .conn()
+            .execute("INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)", params![
+                TABLE_SYNC_PROJECTOR_VERSION_KEY,
+                (TABLE_SYNC_PROJECTOR_VERSION + 1).to_string()
+            ])
+            .unwrap();
+        older
+            .conn()
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'v', NULL)", [])
+            .unwrap();
+
+        let err = older
+            .produce(OLD_REGISTRY, "repo")
+            .expect_err("an older projector must not author into a store a newer one folded");
+        assert!(
+            err.to_string().contains("newer rag-rat"),
+            "the refusal names the cause, got: {err}"
+        );
+        assert!(!older.refold(NEW_REGISTRY).unwrap(), "nor fold the stamp back down");
+    }
+
+    #[test]
+    fn the_unsent_local_edit_guard_sees_the_other_openers_committed_write() {
+        // The guard that keeps the refold from destroying a change no peer has seen must read the
+        // STORE, not one connection's view of it: on a shared file the local edit routinely arrives
+        // through a different opener than the one that refolds at open.
+        let store = SharedStore::new("table-sync-two-openers-unsent");
+        park_wide_entry(&store);
+
+        let editor = store.open();
+        editor
+            .conn()
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'unsent', NULL)", [])
+            .unwrap();
+
+        let refolder = store.open();
+        assert!(refolder.refold(NEW_REGISTRY).unwrap());
+        assert_eq!(
+            refolder.row().unwrap().0,
+            "unsent",
+            "the other opener's unsent edit survives the refold"
+        );
+        assert_eq!(refolder.pending_count(), 1, "and the entry stays outstanding rather than lost");
     }
 }


### PR DESCRIPTION
Two test-only gates that get harder to add once a table registers in `SYNCABLE_TABLES`.

## Migration arming (#1018)

Registering a migration takes six coordinated edits: the `MIGRATION_0NN_{ID,CHECKSUM,DESCRIPTION}`
consts, the `ADDITIVE_MIGRATIONS` entry, `LATEST_SCHEMA_VERSION`, and three separate recognizers in
`migrations.rs` (`known_version`, `known_migration`, `migration_checksum_mismatch`). Only the consts
and the ladder entry fail to compile when forgotten.

A missing `known_migration` arm was the invisible one: `status` reports `Newer` while
`current_version` still reads correctly, so a per-migration `current_version == LATEST_SCHEMA_VERSION`
assertion passes and only a broad integration test notices.

`schema::migration_arming` now ranges over the shipped ladder itself — the baseline plus
`ADDITIVE_MIGRATIONS` — so a new migration is checked without touching the tests. Each id must have a
`known_version` arm, appear in `known_migration`, and have a checksum arm that flags a tampered
checksum rather than falling through the `_ => false` catch-all. A fourth test compares the whole
armed sequence against `1..=LATEST_SCHEMA_VERSION`, which makes a gap, a reused number, an
out-of-order entry, and a forgotten version bump one failure.

## Two openers of one database file (#1019)

A store reached by binaries of different versions is a first-class configuration — linked worktrees
share one database — but every existing test drove it from a single `Connection`, with the other
binary simulated by hand-editing the projector stamp or an entry's `pending_projector_version`.

Five tests now open the same file twice through `IndexConnection`, so they carry the real write-path
pragmas rather than a configuration that does not ship:

- a parked entry survives in the file and is refolded by a second opener; the first, still-open
  connection then sees the projected row, the cleared mark, and the current stamp, so it neither
  redoes the work nor echoes the row back;
- the refold's IMMEDIATE transaction genuinely contends for the store's single write lock — with the
  wait disabled it fails `SQLITE_BUSY` and leaves the worklist untouched, and succeeds once the other
  opener commits;
- it blocks on a concurrent writer and completes when that writer commits, with neither write lost;
- the newer-projector refusal fires across connections, on stamp state one opener wrote and the other
  read;
- the unsent-local-edit guard sees a raw write committed by a different opener, which is how that
  edit normally arrives on a shared file.

The concurrent-writer hand-off is causal rather than timed: the holder releases the write lock only
once SQLite has reported it busy to the refolding connection, via a busy handler that also records
that the block happened, so the test cannot pass without contending. A sleep-based hand-off fails
both ways — the holder commits before the refold reaches `BEGIN`, or the holder is descheduled past
the timeout and the test reds for scheduling reasons.

Because that test installs its own handler, the production `busy_timeout` it stands in for is pinned
where the other write-path pragmas already are, in `setup_pins_the_write_path_pragmas`.

## Verification

Every assertion was mutation-checked — the code under test was reverted and the test confirmed to
fail, and to fail for the stated reason:

| Mutation | Killed by |
|---|---|
| `known_version` / `known_migration` / checksum arm for 095 removed | the matching arming test |
| `DIRTY_MIGRATION_ID` dropped from `known_migration` | `every_shipped_migration_is_a_known_migration` |
| `LATEST_SCHEMA_VERSION` moved up, and down | `the_shipped_ladder_covers_every_version_up_to_latest` |
| `row_has_unsent_local_change` always false | `the_unsent_local_edit_guard_sees_the_other_openers_committed_write` |
| `assert_projector_not_newer` no-op'd | `an_opener_refuses_to_write_a_store_the_other_folded_with_a_newer_projector` |
| a busy `BEGIN` swallowed as "no work" | `the_refold_contends_for_the_stores_single_write_lock` |
| the holder commits without waiting | `the_refold_blocks_on_a_concurrent_writer_and_completes_once_it_commits` |
| `busy_timeout` dropped to 0 | `setup_pins_the_write_path_pragmas` |

Gates: `cargo +nightly fmt --all --check`, clippy on both feature legs
(`--no-default-features` and `--all-features`, `--all-targets`, `-D warnings`),
`cargo nextest run --workspace --no-default-features` (4346 passed), and `cargo test` for the two
touched crates — the coverage job's shared-process runner, which the new `static AtomicBool` has to
be safe under.

Fixes #1018
Fixes #1019