### PR TITLE
refactor(oracle): declare coverage and authority, unify languages, drop dead declarations

### DIFF
--- a/crates/rag-rat-cli/src/init/wizard/steps/oracle.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/oracle.rs
@@ -27,10 +27,10 @@ pub(super) fn render_oracle(f: &mut Frame, area: Rect, state: &WizardState) {
         chunks[0],
     );
 
-    let detected: Vec<&str> = Language::all()
+    let detected: Vec<Language> = Language::all()
         .iter()
-        .filter(|&&l| state.scan.language_counts().get(&l).copied().unwrap_or(0) > 0)
-        .map(|&l| l.as_str())
+        .copied()
+        .filter(|l| state.scan.language_counts().get(l).copied().unwrap_or(0) > 0)
         .collect();
 
     let mut lines = vec![
@@ -72,7 +72,13 @@ pub(super) fn render_oracle(f: &mut Frame, area: Rect, state: &WizardState) {
             .replace("ScipJava", "scip-java");
         lines.push(Line::from(vec![
             Span::styled(format!(" {} {} ", if relevant { "▶" } else { " " }, name), style),
-            Span::styled(format!("— {}", m.languages.join(", ")), theme::muted()),
+            Span::styled(
+                format!(
+                    "— {}",
+                    m.languages.iter().map(|l| l.as_str()).collect::<Vec<_>>().join(", ")
+                ),
+                theme::muted(),
+            ),
         ]));
     }
     f.render_widget(
@@ -106,10 +112,10 @@ pub(super) fn handle_oracle(key: KeyEvent, state: &mut WizardState) -> Outcome {
 }
 
 fn tools_for_scan(state: &WizardState) -> Vec<OracleTool> {
-    let detected: Vec<&str> = Language::all()
+    let detected: Vec<Language> = Language::all()
         .iter()
-        .filter(|&&l| state.scan.language_counts().get(&l).copied().unwrap_or(0) > 0)
-        .map(|&l| l.as_str())
+        .copied()
+        .filter(|l| state.scan.language_counts().get(l).copied().unwrap_or(0) > 0)
         .collect();
     OracleTool::ALL
         .iter()

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -277,8 +277,8 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_base::config::Config) {
         // e.g. scip-python installed but no Python target: it would index nothing, fail,
         // the error would be swallowed with no `oracle_runs` row recorded, and the loop
         // would retry the doomed run every poll.
-        let configured_languages: std::collections::HashSet<&str> =
-            config.targets.iter().map(|target| target.language.as_str()).collect();
+        let configured_languages: std::collections::HashSet<_> =
+            config.targets.iter().map(|target| target.language).collect();
         for &tool in OracleTool::ALL {
             // Live-only backends (`ra-lsp`) are driven by the watcher, never by the batch
             // auto-run loop (#534).

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -103,8 +103,8 @@ impl IndexDatabase {
             // No oracle run for this checkout — nothing to surface, all hops stay heuristic.
             return Ok(false);
         }
-        // Stable sort: batch tools (`batch_capable`) first, preserving their ALL order.
-        runs.sort_by_key(|(tool, _)| !tool.batch_capable());
+        // Stable sort by declared AUTHORITY: canonical tools first, preserving their ALL order.
+        runs.sort_by_key(|(tool, _)| tool.authority());
         let edge_ids = hops.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();
         let mut verdicts = std::collections::HashMap::new();
         for (tool, tool_version) in &runs {
@@ -490,8 +490,8 @@ impl IndexDatabase {
             &self.active_commit_sha,
             &self.active_worktree_id,
         )?;
-        // Stable sort: batch tools (`batch_capable`) first, preserving their ALL order.
-        runs.sort_by_key(|(tool, _)| !tool.batch_capable());
+        // Stable sort by declared AUTHORITY: canonical tools first, preserving their ALL order.
+        runs.sort_by_key(|(tool, _)| tool.authority());
         let mut summary = rag_rat_query::graph::CompareGraphScipSummary::default();
         let mut contradictions = Vec::new();
         // Edge ids already reported as contradicted (batch-first dedupe, #534).
@@ -517,10 +517,10 @@ impl IndexDatabase {
         // Batch-wins precedence (#534): reserve EVERY edge a batch tool has a verdict on (any
         // kind — Confirm/Upgrade/ResolvedExternal/Contradict) BEFORE emitting any live
         // contradiction. `runs` is sorted batch-first, so by the time a live tool is examined
-        // `batch_covered` holds all batch-covered edges. A live `Contradict` on a batch-covered
+        // `canonical_covered` holds all batch-covered edges. A live `Contradict` on a batch-covered
         // edge is suppressed: the batch pass is canonical, so surfacing a live disagreement the
         // authoritative tool doesn't share would be a false "compiler disagrees with the graph".
-        let mut batch_covered = std::collections::HashSet::new();
+        let mut canonical_covered = std::collections::HashSet::new();
         for (tool, version) in &runs {
             let comparisons = rag_rat_oracle::current_oracle_comparisons(
                 conn,
@@ -530,12 +530,12 @@ impl IndexDatabase {
                 &self.active_worktree_id,
             )?;
             summary.verdicts_examined += u64::try_from(comparisons.len()).unwrap_or(u64::MAX);
-            let is_batch = tool.batch_capable();
+            let is_canonical = tool.authority() == rag_rat_oracle::Authority::Canonical;
             for comparison in comparisons {
-                if is_batch {
-                    batch_covered.insert(comparison.edge_id);
-                } else if batch_covered.contains(&comparison.edge_id) {
-                    // A batch tool already spoke for this edge — its verdict wins.
+                if is_canonical {
+                    canonical_covered.insert(comparison.edge_id);
+                } else if canonical_covered.contains(&comparison.edge_id) {
+                    // A canonical tool already spoke for this edge — its verdict wins.
                     continue;
                 }
                 if comparison.kind != rag_rat_oracle::OracleResolutionKind::Contradict {

--- a/crates/rag-rat-core/src/index/query_api/importance.rs
+++ b/crates/rag-rat-core/src/index/query_api/importance.rs
@@ -418,12 +418,12 @@ impl IndexDatabase {
             return Ok(None);
         }
         let mut effects: Option<std::collections::HashMap<i64, EdgeOracleEffect>> = None;
-        // BATCH tools first (#534): batch verdict sets are disjoint across languages, but a live
-        // tool (`ra-lsp`) overlaps its batch counterpart on the same Rust edges. The batch pass
-        // is canonical, so first-writer-wins per edge_id gives batch-wins-on-overlap —
-        // deterministically, not via ALL's declaration order.
+        // CANONICAL tools first (#534): canonical verdict sets are disjoint across languages, but a
+        // patch tool (`ra-lsp`) overlaps its canonical counterpart on the same Rust edges. So
+        // first-writer-wins per edge_id gives batch-wins-on-overlap — deterministically, off the
+        // declared authority rather than `ALL`'s declaration order.
         let mut tools = rag_rat_oracle::OracleTool::ALL.to_vec();
-        tools.sort_by_key(|tool| !tool.batch_capable());
+        tools.sort_by_key(|tool| tool.authority());
         for tool in tools {
             let Some(version) = self.latest_oracle_run_version(tool)? else {
                 continue;

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -583,7 +583,7 @@ fn every_live_backend_copies_monikers_from_a_batch_tool_for_its_own_language() {
         let batch_languages = crate::ToolManifest::for_tool(source).languages;
         for language in backend.languages {
             assert!(
-                batch_languages.contains(&language.as_str()),
+                batch_languages.contains(language),
                 "{} resolves {language} but copies monikers from {}, which indexes \
                  {batch_languages:?}",
                 backend.tool.as_db_str(),

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -768,11 +768,59 @@ impl OracleTool {
         value.parse().ok()
     }
 
-    /// Whether this tool produces/consumes whole-checkout `.scip` indexes — the batch paths:
-    /// `oracle run`, the background auto-run loop, the init-wizard tool listing, and
-    /// [`produce_scip_with_tool`]. `false` ONLY for the live LSP tools, which write per-pass
-    /// verdicts from the watcher and have no `scip_command`; every batch driver must skip them
-    /// rather than try to invoke them as indexers.
+    /// How much of the checkout one of this tool's runs speaks for.
+    ///
+    /// DECLARED per tool rather than derived from [`Self::batch_capable`], because the two are
+    /// independent questions that only happen to coincide today. Coverage is what gives
+    /// `oracle_runs.tool_version` its opposite meanings — a whole-checkout run treats a version
+    /// bump as *discard* (`clear_edge_oracle_for_tool` is `(tool, tool_version)`-scoped) while a
+    /// changed-paths run treats it as *copy-forward* (`migrate_live_verdicts_to_version`). A future
+    /// whole-checkout LSP sweep would be `WholeCheckout` on a tool that is not `batch_capable`, and
+    /// deriving this from the driver kind is what would make that unrepresentable.
+    ///
+    /// The match is exhaustive on purpose: a new tool must state its coverage rather than inherit a
+    /// default.
+    pub fn coverage(self) -> Coverage {
+        match self {
+            Self::RustAnalyzer
+            | Self::ScipClang
+            | Self::ScipPython
+            | Self::ScipTypescript
+            | Self::ScipJava => Coverage::WholeCheckout,
+            Self::RaLsp | Self::TsLsp | Self::ClangdLsp => Coverage::ChangedPaths,
+        }
+    }
+
+    /// Whose verdict stands when two tools speak for the SAME edge.
+    ///
+    /// Batch verdict sets are disjoint across languages, but a live tool overlaps its batch
+    /// counterpart on the same edges — so every read-side merge needs a total order, and it must
+    /// not be `ALL`'s declaration order. Sorting by this and taking first-writer-wins gives
+    /// batch-wins-on-overlap deterministically.
+    ///
+    /// DECLARED per tool, and exhaustively, for the same reason as [`Self::coverage`]: read-side
+    /// authority is not the same question as whether a batch driver can invoke the tool, and a new
+    /// tool must state its answer. Deriving it from [`Self::batch_capable`] is how a merge site
+    /// ends up silently ordering a new backend by accident.
+    pub fn authority(self) -> Authority {
+        match self {
+            Self::RustAnalyzer
+            | Self::ScipClang
+            | Self::ScipPython
+            | Self::ScipTypescript
+            | Self::ScipJava => Authority::Canonical,
+            Self::RaLsp | Self::TsLsp | Self::ClangdLsp => Authority::Patch,
+        }
+    }
+
+    /// Whether a BATCH DRIVER can invoke this tool as an indexer — `oracle run`, the background
+    /// auto-run loop, the init-wizard tool listing, and [`produce_scip_with_tool`]. `false` ONLY
+    /// for the live LSP tools, which write per-pass verdicts from the watcher and have no
+    /// `scip_command`.
+    ///
+    /// This is DISPATCH ONLY. It used to answer read-side precedence and run coverage as well;
+    /// those are [`Self::authority`] and [`Self::coverage`] now, because a tool can be a
+    /// whole-checkout measurement without being a `.scip` producer.
     pub fn batch_capable(self) -> bool {
         !matches!(self, Self::RaLsp | Self::TsLsp | Self::ClangdLsp)
     }
@@ -862,6 +910,26 @@ impl OracleResolutionKind {
     }
 }
 
+/// How much of the checkout one run of a backend speaks for. See [`OracleTool::coverage`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Coverage {
+    /// The run measures the whole checkout: absent verdicts are a statement, and a `tool_version`
+    /// bump discards the previous set.
+    WholeCheckout,
+    /// The run patches the paths that changed: absent verdicts mean "not visited yet", and a
+    /// `tool_version` bump carries the previous set forward.
+    ChangedPaths,
+}
+
+/// Whose verdict stands when two backends speak for the same edge. `Canonical` sorts FIRST, so
+/// `sort_by_key(|tool| tool.authority())` plus first-writer-wins is batch-wins-on-overlap.
+/// See [`OracleTool::authority`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Authority {
+    Canonical,
+    Patch,
+}
+
 /// Outcome of an oracle pass, mirroring `ReconcileReport`'s shape (counts + a status string). One
 /// per `run()`; persisted opaquely as `oracle_runs.stats_json` and surfaced via [`OracleStatus`].
 #[derive(Debug, Clone, Default, Serialize)]
@@ -895,8 +963,6 @@ pub struct OracleReport {
     /// verdict (#81 finding 2). A non-zero count means `eval` should warn that some documents
     /// were out of sync.
     pub skipped_drifted: u64,
-    /// `local N` occurrences skipped (function-local, no cross-file meaning).
-    pub skipped_local: u64,
     /// Candidates whose callee position fell outside any occurrence (no oracle data).
     pub no_occurrence: u64,
     /// `edge_oracle` rows written this pass.
@@ -911,12 +977,4 @@ pub struct OracleReport {
     /// contract `check_library_usage` reads.
     pub external_symbols_written: u64,
     pub status: String,
-}
-
-/// An oracle backend: produces (or consumes) a SCIP index for a checkout. Phase 1 implements only
-/// the consume-existing-`.scip` path; the trait is the seam phase 2 (#69) fills with indexer
-/// invocation. Kept minimal on purpose.
-pub trait Oracle {
-    fn tool(&self) -> OracleTool;
-    fn tool_version(&self) -> &str;
 }

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -11,6 +11,7 @@
 use std::path::Path;
 use std::process::Command;
 
+use rag_rat_base::language::Language;
 use serde::Serialize;
 
 use super::OracleTool;
@@ -29,8 +30,12 @@ pub struct ToolManifest {
     /// to the registry entry, not the client. Empty for batch tools, which build their whole
     /// invocation in [`ToolManifest::scip_command`].
     pub live_args: &'static [&'static str],
-    /// Languages this backend resolves, for status/diagnostics.
-    pub languages: &'static [&'static str],
+    /// Languages this backend resolves, for status/diagnostics and for gating the auto-run loop.
+    ///
+    /// The SAME encoding `LiveBackend::languages` and `ResolvedTarget.language` use. It was once a
+    /// list of lowercase registry tokens, which meant every consumer round-tripped through
+    /// `Language::as_str()` and a test had to reconcile the two spellings.
+    pub languages: &'static [Language],
     /// A one-line install hint surfaced when the tool is absent (the `Blocked` UX).
     pub install_hint: &'static str,
 }
@@ -60,7 +65,7 @@ impl ToolManifest {
                 tool,
                 program: "rust-analyzer",
                 live_args: &[],
-                languages: &["rust"],
+                languages: &[Language::Rust],
                 install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
                                component add rust-analyzer`) or pass a pre-built index with \
                                `--scip <path>`.",
@@ -69,7 +74,7 @@ impl ToolManifest {
                 tool,
                 program: "scip-clang",
                 live_args: &[],
-                languages: &["c", "cpp"],
+                languages: &[Language::C, Language::Cpp],
                 install_hint: "scip-clang not found on PATH. Install it from \
                                github.com/sourcegraph/scip-clang and generate a \
                                compile_commands.json for the checkout (e.g. `bear -- make`, CMake \
@@ -81,7 +86,7 @@ impl ToolManifest {
                 tool,
                 program: "scip-python",
                 live_args: &[],
-                languages: &["python"],
+                languages: &[Language::Python],
                 install_hint: "scip-python not found on PATH. Install it (e.g. `npm install -g \
                                @sourcegraph/scip-python`) AND install the project's dependencies \
                                (e.g. into a virtualenv) so imports resolve, or pass a pre-built \
@@ -91,7 +96,7 @@ impl ToolManifest {
                 tool,
                 program: "scip-typescript",
                 live_args: &[],
-                languages: &["typescript"],
+                languages: &[Language::TypeScript],
                 install_hint: "scip-typescript not found on PATH. Install it (e.g. `npm install \
                                -g @sourcegraph/scip-typescript`) AND install the project's \
                                dependencies (`npm install`) so cross-package references resolve, \
@@ -104,7 +109,7 @@ impl ToolManifest {
                 tool,
                 program: "scip-java",
                 live_args: &[],
-                languages: &["kotlin"],
+                languages: &[Language::Kotlin],
                 install_hint: "scip-java not found on PATH. Install it (e.g. `cs install \
                                --contrib scip-java`, needs a JVM) — it indexes Kotlin through the \
                                project's Gradle build (Maven Kotlin is unsupported), so the build \
@@ -117,7 +122,7 @@ impl ToolManifest {
                 tool,
                 program: "rust-analyzer",
                 live_args: &[],
-                languages: &["rust"],
+                languages: &[Language::Rust],
                 install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
                                component add rust-analyzer`) so the live oracle (`[oracle.live] \
                                enabled`) can spawn it as a language server.",
@@ -129,7 +134,7 @@ impl ToolManifest {
                 tool,
                 program: "typescript-language-server",
                 live_args: &["--stdio"],
-                languages: &["typescript"],
+                languages: &[Language::TypeScript],
                 install_hint: "typescript-language-server not found on PATH. Install it (e.g. \
                                `npm install -g typescript-language-server typescript`) so the \
                                live oracle (`[oracle.live] enabled`) can spawn it as a language \
@@ -146,7 +151,7 @@ impl ToolManifest {
                 tool,
                 program: "clangd",
                 live_args: &["--background-index"],
-                languages: &["c", "cpp"],
+                languages: &[Language::C, Language::Cpp],
                 install_hint: "clangd not found on PATH. Install it (e.g. `apt install clangd`, \
                                or a release from github.com/clangd/clangd) so the live oracle \
                                (`[oracle.live] enabled`) can spawn it as a language server.",
@@ -291,7 +296,18 @@ impl ToolManifest {
             // server. `checkout_can_signal_readiness` is the same search the warm-up uses, so the
             // gate and the warm-up cannot disagree.
             OracleTool::ClangdLsp | OracleTool::TsLsp => {
-                let backend = super::backend::LiveBackend::for_tool(self.tool)?;
+                // `None` from this function means READY, so a missing registry entry must NOT
+                // short-circuit with `?`: a progress-signalled tool with no `LiveBackend` would
+                // then report the checkout ready and the driver would spawn a server it has no
+                // argv, readiness policy, or language set for. Absent means blocked, and says so.
+                let Some(backend) = super::backend::LiveBackend::for_tool(self.tool) else {
+                    return Some(format!(
+                        "{} is registered as a live backend but has no `LiveBackend` entry, so \
+                         the oracle has no argv, readiness policy, or language set for it. This \
+                         is a registry gap, not a checkout problem.",
+                        self.tool.as_db_str(),
+                    ));
+                };
                 let resolved;
                 let layout = match layout {
                     Some(layout) => layout,
@@ -578,7 +594,7 @@ mod tests {
             tool: OracleTool::ScipClang,
             program: "cargo",
             live_args: &[],
-            languages: &["c"],
+            languages: &[Language::C],
             install_hint: "install hint",
         };
         assert!(
@@ -616,7 +632,7 @@ mod tests {
             tool: OracleTool::ScipClang,
             program: "rag-rat-no-such-tool-xyzzy",
             live_args: &[],
-            languages: &["c"],
+            languages: &[Language::C],
             install_hint: "install scip-clang",
         };
         match absent.probe_runnable_in(&crate::test_support::every_path_scope(&dir)) {
@@ -633,7 +649,7 @@ mod tests {
         let manifest = ToolManifest::for_tool(OracleTool::ClangdLsp);
         assert_eq!(manifest.program, "clangd");
         assert_eq!(manifest.live_args, ["--background-index"]);
-        assert_eq!(manifest.languages, ["c", "cpp"], "one server, both dialects");
+        assert_eq!(manifest.languages, [Language::C, Language::Cpp], "one server, both dialects");
 
         // The compilation database is what clangd builds that index from — the same file the
         // batch scip-clang backend requires, for its own reasons.

--- a/crates/rag-rat-oracle/src/report.rs
+++ b/crates/rag-rat-oracle/src/report.rs
@@ -333,7 +333,6 @@ mod tests {
             oracle_only_calls: 4,
             covered_calls: 16,
             skipped_drifted: 5,
-            skipped_local: 0,
             no_occurrence: 0,
             rows_written: 13,
             monikers_written: monikers,

--- a/crates/rag-rat-oracle/src/tests/tool_defaults.rs
+++ b/crates/rag-rat-oracle/src/tests/tool_defaults.rs
@@ -80,3 +80,53 @@ fn live_tools_are_gated_out_of_the_batch_paths() {
         }
     }
 }
+
+/// Sorting by declared `Authority` reproduces the batch-first order the read-side merge sites used
+/// to get from `!batch_capable()`, and every canonical tool precedes every patch tool.
+///
+/// This is the behaviour-preservation pin for splitting that one predicate into three. It does NOT
+/// assert that authority and `batch_capable` agree tool-for-tool — they are independent questions
+/// that merely coincide today, and a whole-checkout LSP sweep would separate them. What must hold
+/// is the ORDER the merge sites depend on.
+#[test]
+fn sorting_by_authority_reproduces_the_batch_first_merge_order() {
+    let mut by_authority = OracleTool::ALL.to_vec();
+    by_authority.sort_by_key(|tool| tool.authority());
+
+    let mut by_old_predicate = OracleTool::ALL.to_vec();
+    by_old_predicate.sort_by_key(|tool| !tool.batch_capable());
+
+    assert_eq!(
+        by_authority, by_old_predicate,
+        "the declared authority must order the merge sites exactly as the predicate did",
+    );
+
+    let last_canonical = by_authority
+        .iter()
+        .rposition(|tool| tool.authority() == Authority::Canonical)
+        .expect("some tool is canonical");
+    assert!(
+        by_authority[..=last_canonical].iter().all(|tool| tool.authority() == Authority::Canonical),
+        "no patch tool may sort before a canonical one — that is the whole guarantee",
+    );
+}
+
+/// Coverage and authority are DECLARED, so every tool has an answer and a new variant cannot
+/// inherit one. The exhaustive matches make that a compile error; this pins that they are also
+/// reachable and that today every whole-checkout tool is canonical.
+///
+/// The pairing is asserted as a fact about TODAY, not a rule: a whole-checkout LSP sweep would be
+/// `WholeCheckout` + `Patch`, and this test should then be updated rather than treated as a veto.
+#[test]
+fn every_tool_declares_its_coverage_and_authority() {
+    for &tool in OracleTool::ALL {
+        let (coverage, authority) = (tool.coverage(), tool.authority());
+        assert_eq!(
+            coverage == Coverage::WholeCheckout,
+            authority == Authority::Canonical,
+            "{} pairs coverage {coverage:?} with authority {authority:?}; if that is intentional, \
+             update this test — it records today's coincidence, not a constraint",
+            tool.as_db_str(),
+        );
+    }
+}


### PR DESCRIPTION
Stage 1 of #1042. **No behaviour change** — 4341 tests pass, both clippy configurations and `fmt --check` clean.

## Splitting one predicate that answered three questions

`OracleTool::batch_capable` was doing three independent jobs: *can a batch driver invoke this tool*, *whose verdict wins when two tools speak for the same edge*, and *how much of the checkout does a run speak for*. Two are now separate declared facts, with exhaustive matches so a new backend must state its answer rather than inherit one.

- **`Coverage`** — whole-checkout measurement versus changed-paths patch. This is the axis that gives `oracle_runs.tool_version` its opposite meanings: a whole-checkout run treats a version bump as *discard* (`clear_edge_oracle_for_tool` is `(tool, tool_version)`-scoped), a changed-paths run as *copy-forward* (`migrate_live_verdicts_to_version`). Deriving it from the driver kind is what would make a future whole-checkout LSP sweep unrepresentable.
- **`Authority`** — canonical versus patch, ordered so canonical sorts first. The four read-side merge sites (`enrich_hops_with_oracle`, the tier surfacing, `compare_graph_to_scip`, `symbol_importance_oracle_effects`) now sort by it instead of `!batch_capable()`.

Batch-wins-on-overlap used to be a convention every merge site had to remember — the recorded invariant says as much: *"when adding a NEW live backend or NEW verdict-merge site, replicate batch-first sort"*. It is now a property each backend declares once.

`batch_capable` keeps dispatch only, and its doc says so.

## One encoding for `languages`

`ToolManifest.languages` was `&'static [&'static str]` while `LiveBackend::languages` and `ResolvedTarget.language` were `Language`, so every consumer round-tripped through `Language::as_str()` on both sides of a comparison, and a test existed to reconcile the two spellings. It is `&'static [Language]` now: the auto-run language gate and the wizard's tool list compare `Language` to `Language`, and the reconciliation compares directly.

## A fail-open closed

In `prerequisite_blocked_with`, `None` means READY. A `?` on a missing `LiveBackend` entry therefore reported a progress-signalled tool as ready, and the driver would spawn a server it has no argv, readiness policy, or language set for. Absent now blocks and names the registry gap rather than the checkout.

## Deletions

- `pub trait Oracle` — zero implementors, no `dyn` uses. Its doc describes a phase-1 seam that concrete drivers filled instead.
- `OracleReport::skipped_local` — never incremented; its only read was a literal `0`.

## Tests

Two pins for the split:

- `sorting_by_authority_reproduces_the_batch_first_merge_order` — the behaviour-preservation guarantee, asserted as an order equivalence against the old predicate plus the invariant that no patch tool sorts before a canonical one.
- `every_tool_declares_its_coverage_and_authority` — records today's coverage/authority coincidence explicitly **as a fact to update, not a constraint**. A whole-checkout LSP sweep would be `WholeCheckout` + `Patch`, and that is the point of declaring them apart.

The two spellings of `languages` no longer need reconciling, so that assertion in `every_live_backend_copies_monikers_from_a_batch_tool_for_its_own_language` becomes a direct comparison — the test keeps its genuine cross-field invariant.

## Not in this PR

Stages 2–4 of #1042: the merged registry record with a `DriverSpec` payload, `ProjectModel` (the stage that unblocks #536 and #637), and the behaviour changes. Also noted there: persisting run refusals is **not** safe as an `oracle_runs` status string, because `latest_run_tool_version` and `latest_run_started_at` are `ORDER BY id DESC` with no `status` filter.