### PR TITLE
refactor(oracle): split the batch declaration off the shared tool registry

### DIFF
--- a/crates/rag-rat-oracle/src/backend/mod.rs
+++ b/crates/rag-rat-oracle/src/backend/mod.rs
@@ -8,6 +8,7 @@
 //! manifest entry — not new protocol code.
 //!
 //! - `registry.rs` — the [`LiveBackend`] entries and every question the live driver asks of one.
+//! - `spec.rs` — the [`spec::BatchSpec`] entries: what a BATCH driver asks, and nothing else.
 //! - `layout.rs` — the whole-checkout project-marker search and the [`ProjectLayout`] it produces.
 //! - `documents.rs` — the searches that find a document whose open would warm a session.
 
@@ -15,9 +16,11 @@ mod documents;
 mod layout;
 mod registry;
 mod scope;
+mod spec;
 #[cfg(test)]
 mod tests;
 
 pub use layout::{LAYOUT_MAX_AGE, ProjectLayout};
 pub use registry::LiveBackend;
 pub use scope::{CheckoutScope, IndexedCorpus};
+pub(crate) use spec::BatchSpec;

--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -25,6 +25,14 @@ pub struct LiveBackend {
     /// `languages`, whose entries are the lowercase registry tokens (`c`, `cpp`) — joining those
     /// renders "the live c/cpp oracle" in a hint a human reads.
     pub(crate) display_name: &'static str,
+    /// Arguments this server is spawned with. Language servers disagree on how the stdio transport
+    /// is selected — `rust-analyzer` speaks LSP on stdio by default, while
+    /// `typescript-language-server` prints usage and exits without `--stdio` — so the argv belongs
+    /// to the backend, not the client.
+    ///
+    /// It lives HERE rather than on the shared tool registry, where five batch entries had to
+    /// carry an empty one and a test had to assert they did.
+    pub(crate) stdio_args: &'static [&'static str],
     /// How this server announces that it is ready to answer definitions.
     pub(crate) readiness: ReadinessPolicy,
     /// LSP `languageId` per file extension, first match wins; the last entry is the fallback for
@@ -79,6 +87,8 @@ impl LiveBackend {
             OracleTool::RaLsp => Some(Self {
                 tool,
                 languages: &[Language::Rust],
+                // rust-analyzer speaks LSP on stdio with no flag.
+                stdio_args: &[],
                 display_name: "Rust",
                 // rust-analyzer reports load/index quiescence explicitly, for any checkout.
                 readiness: ReadinessPolicy::ServerStatus,
@@ -88,6 +98,9 @@ impl LiveBackend {
             OracleTool::TsLsp => Some(Self {
                 tool,
                 languages: &[Language::TypeScript],
+                // Without a transport flag the program prints usage and exits, so the spawn would
+                // fail with an opaque EOF instead of yielding a session.
+                stdio_args: &["--stdio"],
                 display_name: "TypeScript",
                 // typescript-language-server has no quiescence notification. The only warm-up
                 // signal it emits is the work-done progress cycle bracketing a project load —
@@ -110,6 +123,10 @@ impl LiveBackend {
             OracleTool::ClangdLsp => Some(Self {
                 tool,
                 languages: &[Language::C, Language::Cpp],
+                // clangd's own default, PINNED because it is load-bearing: it is what resolves a
+                // call across translation units. With it off clangd answers with the header
+                // declaration instead, and emits no project-load progress at all.
+                stdio_args: &["--background-index"],
                 display_name: "C/C++",
                 // clangd brackets its indexing in a work-done progress cycle and, like
                 // typescript-language-server, emits nothing until a document is opened.
@@ -307,12 +324,8 @@ impl LiveBackend {
     /// invisible to it. Passing the directory we found makes every layout behave the same, and
     /// keeps the prerequisite gate honest: it accepts a database wherever it sits precisely
     /// because the session is then told where that is.
-    pub(crate) fn spawn_args(
-        &self,
-        static_args: &[&'static str],
-        layout: &ProjectLayout,
-    ) -> Vec<OsString> {
-        let mut args: Vec<OsString> = static_args.iter().map(OsString::from).collect();
+    pub(crate) fn spawn_args(&self, layout: &ProjectLayout) -> Vec<OsString> {
+        let mut args: Vec<OsString> = self.stdio_args.iter().map(OsString::from).collect();
         if let Some(dir) = layout.sole_marker_dir() {
             // Built as an OsString, never through `Path::display()`: on Unix a path is bytes, and
             // formatting a non-UTF-8 component would substitute replacement characters and hand

--- a/crates/rag-rat-oracle/src/backend/spec.rs
+++ b/crates/rag-rat-oracle/src/backend/spec.rs
@@ -1,0 +1,191 @@
+//! What a BATCH backend declares: how to invoke it, how to prove it can emit SCIP, and the two
+//! reader facts its `.scip` output implies.
+//!
+//! The live half of the registry is [`super::registry::LiveBackend`]. Keeping the two kinds'
+//! declarations in separate records is what makes their impossible states unrepresentable. A batch
+//! backend has no stdio argv; a live backend has no whole-checkout invocation. While both lived on
+//! one struct, each carried the other's questions as a lie: `live_args: &[]` on five batch entries,
+//! an `unreachable!` arm in `scip_command` for the three live tools, and vacuous "exists only for
+//! exhaustiveness" arms in the capability check and the position-encoding default.
+//!
+//! `BatchSpec::for_tool` returning `None` IS the statement "this tool is not a batch backend", and
+//! it is the one place that fact is declared — [`crate::OracleTool::batch_capable`] reads it.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::OracleTool;
+
+/// Everything a batch driver needs from a backend, and nothing a live driver would ask for.
+pub(crate) struct BatchSpec {
+    /// Builds the whole-checkout invocation that writes a `.scip` to the output path.
+    ///
+    /// A function per backend rather than a `match` in the driver: the invocations have nothing in
+    /// common beyond the program name — a subcommand here, a cwd there, flags that are pinned for
+    /// reasons documented at each one — and a `match` over them is what needed an `unreachable!`
+    /// arm for the tools that have no invocation at all.
+    pub(crate) command: fn(program: &str, root: &Path, output: &Path) -> Command,
+    /// How to prove a versioned binary can actually emit SCIP.
+    pub(crate) capability: ScipCapability,
+    /// Whether a NON-ZERO exit reflects source diagnostics rather than an indexing failure — i.e.
+    /// whether the tool can exit non-zero while still having written a complete, valid index. Only
+    /// such tools get the diagnostic-exit tolerance; for every other backend a non-zero exit is a
+    /// genuine failure and bails, so a crashed or killed indexer is never read as success.
+    pub(crate) exit_code_reflects_diagnostics: bool,
+    /// The encoding to assume when this tool's `.scip` leaves `position_encoding` unset.
+    ///
+    /// scip-typescript and scip-java (JVM/semanticdb) both emit UTF-16 columns with the field
+    /// unset — empirically confirmed: a token after an astral character lands at the UTF-16 count.
+    /// Reading them as the UTF-32 fallback mis-converts past astral characters.
+    pub(crate) assumed_position_encoding: ::scip::types::PositionEncoding,
+}
+
+/// How to prove a versioned binary can emit a SCIP index. Distinct from "is it installed", which
+/// the version probe already answered: a stripped build can be present and unable to index.
+pub(crate) enum ScipCapability {
+    /// The binary IS the emitter — it has no indexing subcommand, so a successful `--version`
+    /// (already detected) is the capability signal.
+    VersionSuffices,
+    /// An indexing subcommand must exist: `<program> <subcommand> --help` exiting 0 is the check.
+    SubcommandHelpSucceeds(&'static str),
+}
+
+impl ScipCapability {
+    pub(crate) fn holds_for(&self, program: &str) -> bool {
+        match self {
+            Self::VersionSuffices => true,
+            Self::SubcommandHelpSucceeds(subcommand) => Command::new(program)
+                .arg(subcommand)
+                .arg("--help")
+                .output()
+                .is_ok_and(|output| output.status.success()),
+        }
+    }
+}
+
+impl BatchSpec {
+    /// The batch declaration for `tool`, or `None` when it is not a batch backend at all.
+    pub(crate) fn for_tool(tool: OracleTool) -> Option<Self> {
+        use ::scip::types::PositionEncoding::{
+            UTF16CodeUnitOffsetFromLineStart as Utf16, UnspecifiedPositionEncoding as Unspecified,
+        };
+        let spec = match tool {
+            OracleTool::RustAnalyzer => Self {
+                command: rust_analyzer_command,
+                capability: ScipCapability::SubcommandHelpSucceeds("scip"),
+                exit_code_reflects_diagnostics: false,
+                assumed_position_encoding: Unspecified,
+            },
+            OracleTool::ScipClang => Self {
+                command: scip_clang_command,
+                capability: ScipCapability::VersionSuffices,
+                exit_code_reflects_diagnostics: false,
+                assumed_position_encoding: Unspecified,
+            },
+            OracleTool::ScipPython => Self {
+                command: scip_python_command,
+                capability: ScipCapability::SubcommandHelpSucceeds("index"),
+                // scip-python exits non-zero on unresolved imports while still writing a usable
+                // index, which is the ordinary state of a checkout whose deps are partly installed.
+                exit_code_reflects_diagnostics: true,
+                assumed_position_encoding: Unspecified,
+            },
+            OracleTool::ScipTypescript => Self {
+                command: scip_typescript_command,
+                capability: ScipCapability::SubcommandHelpSucceeds("index"),
+                exit_code_reflects_diagnostics: false,
+                assumed_position_encoding: Utf16,
+            },
+            OracleTool::ScipJava => Self {
+                command: scip_java_command,
+                capability: ScipCapability::SubcommandHelpSucceeds("index"),
+                exit_code_reflects_diagnostics: false,
+                assumed_position_encoding: Utf16,
+            },
+            // The live backends drive their program as an LSP server and never produce a `.scip`.
+            // `None` is not a gap to paper over with defaults — it is the declaration.
+            OracleTool::RaLsp | OracleTool::TsLsp | OracleTool::ClangdLsp => return None,
+        };
+        Some(spec)
+    }
+}
+
+/// `rust-analyzer scip <root> --output <path>` writes the index to a deterministic path so the
+/// caller (a temp file) can consume it.
+fn rust_analyzer_command(program: &str, root: &Path, output: &Path) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.arg("scip").arg(root).arg("--output").arg(output);
+    cmd
+}
+
+/// scip-clang consumes the compilation database, not a source root, and emits the index directly
+/// (no subcommand). cwd = root so the compdb's relative paths resolve, pointed at
+/// `root/compile_commands.json` (prerequisite-checked).
+fn scip_clang_command(program: &str, root: &Path, output: &Path) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.current_dir(root)
+        .arg(format!("--compdb-path={}", root.join("compile_commands.json").display()))
+        .arg(format!("--index-output-path={}", output.display()));
+    cmd
+}
+
+/// scip-python indexes a working directory (not a source-root argument) via its `index` subcommand.
+/// `--cwd <root>` is where it resolves the project and its installed deps; `--project-name` (the
+/// root's directory name) becomes the package component of in-corpus monikers, so a non-empty name
+/// is what lets `count_symbols_with_moniker` see them.
+///
+/// `--project-version _` is PINNED: scip-python otherwise defaults the version to the checkout's
+/// git revision, which is embedded in every SCIP symbol string, so every commit would churn all
+/// Python monikers — breaking moniker-anchored memory relocation, which resolves by exact moniker
+/// per tool. A constant version keeps a symbol's moniker stable across commits, and sidesteps
+/// scip-python's crash on a non-git checkout where the git-rev default is undefined. `--output` is
+/// absolute, so it is unaffected by `--cwd`.
+fn scip_python_command(program: &str, root: &Path, output: &Path) -> Command {
+    let project_name = root.file_name().and_then(|name| name.to_str()).unwrap_or("project");
+    let mut cmd = Command::new(program);
+    cmd.arg("index")
+        .arg("--project-name")
+        .arg(project_name)
+        .arg("--project-version")
+        .arg("_")
+        .arg("--cwd")
+        .arg(root)
+        .arg("--output")
+        .arg(output);
+    cmd
+}
+
+/// scip-typescript indexes the working dir via its `index` subcommand, reading the project's
+/// `tsconfig.json` (prerequisite-checked — `--infer-tsconfig` is deliberately NOT passed, because
+/// it WRITES a tsconfig into the source tree, breaking read-only-on-source).
+///
+/// No `--project-name` / `--project-version`: the package name and version come from
+/// `package.json`. That version is embedded in every local moniker and has no CLI override, so it
+/// is normalized downstream at moniker-write time (`scip::stabilize_moniker_version`), not here.
+/// `--output` is absolute, unaffected by `--cwd`.
+fn scip_typescript_command(program: &str, root: &Path, output: &Path) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.arg("index").arg("--cwd").arg(root).arg("--output").arg(output);
+    cmd
+}
+
+/// scip-java indexes THROUGH the build (running it with the semanticdb-kotlinc plugin), so cwd =
+/// root. `--build-tool Gradle` is PINNED: the prerequisite only proved Gradle is present, but a
+/// checkout that ALSO carries a `pom.xml` (a Maven→Gradle migration, a parent Maven descriptor)
+/// makes scip-java's auto-detection see multiple build tools and abort with "Multiple build tools
+/// detected" instead of indexing. Forcing Gradle — this backend's only supported Kotlin path —
+/// skips that ambiguity; the value is matched case-insensitively upstream.
+///
+/// No `--project-version` need, unlike scip-python: scip-java emits `.` placeholders for the local
+/// project's package and version regardless of the build's `group`/`version`, so monikers are
+/// already commit-stable. `--output` is absolute.
+fn scip_java_command(program: &str, root: &Path, output: &Path) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.current_dir(root)
+        .arg("index")
+        .arg("--build-tool")
+        .arg("Gradle")
+        .arg("--output")
+        .arg(output);
+    cmd
+}

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -853,7 +853,7 @@ fn clangd_is_told_where_a_compilation_database_it_could_not_find_lives() {
     std::fs::create_dir_all(dir.join("out")).unwrap();
     std::fs::write(dir.join("out/compile_commands.json"), COMPDB).unwrap();
 
-    let args = clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir)));
+    let args = clangd.spawn_args(&clangd.resolve_layout(&scope(&dir)));
     assert_eq!(args[0], "--background-index", "the static argv comes first");
     assert!(
         args.contains(&compdb_arg(&dir.join("out"))),
@@ -1016,7 +1016,7 @@ fn a_broken_second_database_still_disqualifies_global_pinning() {
 
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "a second database disqualifies pinning even when it is unusable",
     );
@@ -1029,7 +1029,7 @@ fn a_broken_second_database_still_disqualifies_global_pinning() {
     // Remove the broken one and the checkout is genuinely single-database again.
     std::fs::remove_file(dir.join("sub/build/compile_commands.json")).unwrap();
     let layout = clangd.resolve_layout(&scope(&dir));
-    assert!(clangd.spawn_args(&["--background-index"], &layout).contains(&compdb_arg(&dir)));
+    assert!(clangd.spawn_args(&layout).contains(&compdb_arg(&dir)));
     assert!(clangd.session_can_resolve(&scope(&dir), "sub/main.c", &layout));
 }
 
@@ -1380,7 +1380,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     std::os::unix::fs::symlink(dir.join("out"), dir.join("current-build")).unwrap();
 
     let layout = clangd.resolve_layout(&scope(&dir));
-    let args = clangd.spawn_args(&["--background-index"], &layout);
+    let args = clangd.spawn_args(&layout);
     assert!(
         args.contains(&compdb_arg(&dir.join("out")))
             || args.contains(&compdb_arg(&dir.join("current-build"))),
@@ -1397,7 +1397,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     std::fs::write(dir.join("other/build/compile_commands.json"), COMPDB).unwrap();
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "two distinct databases are still two",
     );
@@ -1406,7 +1406,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     std::fs::write(dir.join("other/build/compile_commands.json"), "[]").unwrap();
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "an unusable second database disqualifies pinning too",
     );
@@ -1436,9 +1436,7 @@ fn a_nested_checkout_makes_the_layout_unprovable_rather_than_simply_smaller() {
     // Control FIRST: with no nested checkout the scan is complete, so this pins.
     let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
-        clangd
-            .spawn_args(&["--background-index"], &layout)
-            .contains(&compdb_arg(&dir.join("build"))),
+        clangd.spawn_args(&layout).contains(&compdb_arg(&dir.join("build"))),
         "a checkout with one database and nothing hidden is pinned",
     );
 
@@ -1454,7 +1452,7 @@ fn a_nested_checkout_makes_the_layout_unprovable_rather_than_simply_smaller() {
 
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "a hidden nested checkout makes global pinning unprovable, so it is declined",
     );
@@ -1481,9 +1479,7 @@ fn a_scan_that_could_not_look_everywhere_never_reports_a_sole_database() {
     // A shallow database alone pins.
     let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
-        clangd
-            .spawn_args(&["--background-index"], &layout)
-            .contains(&compdb_arg(&dir.join("build"))),
+        clangd.spawn_args(&layout).contains(&compdb_arg(&dir.join("build"))),
         "the control must pin, or this test proves nothing about truncation",
     );
 
@@ -1495,7 +1491,7 @@ fn a_scan_that_could_not_look_everywhere_never_reports_a_sole_database() {
 
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "a scan that hit its depth bound cannot claim the database it found is the only one",
     );
@@ -1690,7 +1686,7 @@ fn a_key_outside_the_modelled_format_is_uncertainty_rather_than_acceptance() {
 
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "a database clangd would refuse must not be pinned",
     );
@@ -1712,7 +1708,7 @@ fn a_key_outside_the_modelled_format_is_uncertainty_rather_than_acceptance() {
     let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
         clangd
-            .spawn_args(&["--background-index"], &layout)
+            .spawn_args(&layout)
             .iter()
             .any(|arg| arg.to_string_lossy().starts_with("--compile-commands-dir=")),
         "`output` is part of the format and must stay loadable",
@@ -1747,7 +1743,7 @@ fn a_database_this_crate_cannot_parse_is_not_trusted_but_does_not_block_the_back
         "a database this crate cannot read must not report the whole backend blocked",
     );
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "…but it is not proof of anything either, so the session is not pinned to it",
     );
@@ -1820,9 +1816,7 @@ fn the_marker_search_does_not_follow_a_symlink_out_of_the_checkout() {
 
     let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
-        clangd
-            .spawn_args(&["--background-index"], &layout)
-            .contains(&compdb_arg(&dir.join("build"))),
+        clangd.spawn_args(&layout).contains(&compdb_arg(&dir.join("build"))),
         "the checkout has exactly one database; a link out of it must not make that two",
     );
 
@@ -1832,7 +1826,7 @@ fn the_marker_search_does_not_follow_a_symlink_out_of_the_checkout() {
     std::fs::write(dir.join("inside/build/compile_commands.json"), COMPDB).unwrap();
     let layout = clangd.resolve_layout(&scope(&dir));
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &layout),
+        clangd.spawn_args(&layout),
         vec![OsString::from("--background-index")],
         "a second database inside the checkout still counts",
     );
@@ -1941,7 +1935,7 @@ fn a_hidden_build_directory_still_counts_as_a_compilation_database() {
     );
     assert!(
         clangd
-            .spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir)))
+            .spawn_args(&clangd.resolve_layout(&scope(&dir)))
             .contains(&compdb_arg(&dir.join(".build"))),
     );
     // The warm-up document still comes from the visible tree.
@@ -1968,7 +1962,7 @@ fn a_vendored_or_vcs_database_is_never_mistaken_for_the_checkouts_own() {
 
     assert!(
         clangd
-            .spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir)))
+            .spawn_args(&clangd.resolve_layout(&scope(&dir)))
             .contains(&OsString::from(format!("--compile-commands-dir={}", dir.display()))),
         "the checkout's own database is still the single unambiguous one",
     );
@@ -1990,7 +1984,7 @@ fn several_compilation_databases_are_left_to_the_servers_own_per_file_lookup() {
         std::fs::write(dir.join(project).join("main.c"), "int main(void){return 0;}\n").unwrap();
     }
     assert_eq!(
-        clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&dir))),
+        clangd.spawn_args(&clangd.resolve_layout(&scope(&dir))),
         vec![OsString::from("--background-index")],
         "no database may be forced globally when several exist",
     );
@@ -2021,18 +2015,15 @@ fn a_backend_with_no_checkout_scoped_marker_gets_only_its_static_argv() {
     let dir = rag_rat_base::test_scratch::ScratchDir::new("static-argv");
     std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
-    assert_eq!(ts.spawn_args(&["--stdio"], &ts.resolve_layout(&scope(&dir))), vec![
-        OsString::from("--stdio")
-    ]);
+    assert_eq!(ts.spawn_args(&ts.resolve_layout(&scope(&dir))), vec![OsString::from("--stdio")]);
     let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
-    assert!(rust.spawn_args(&[], &rust.resolve_layout(&scope(&dir))).is_empty());
+    assert!(rust.spawn_args(&rust.resolve_layout(&scope(&dir))).is_empty());
     // And with no database anywhere, clangd gets no directory to point at either.
     let empty = rag_rat_base::test_scratch::ScratchDir::new("static-argv-empty");
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    assert_eq!(
-        clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&empty))),
-        vec![OsString::from("--background-index")],
-    );
+    assert_eq!(clangd.spawn_args(&clangd.resolve_layout(&scope(&empty))), vec![OsString::from(
+        "--background-index"
+    )],);
 }
 
 #[test]

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -311,10 +311,11 @@ pub fn produce_scip_with_tool(
     scip_output: &Path,
 ) -> anyhow::Result<ScipProduction> {
     let manifest = ToolManifest::for_tool(tool);
-    // A live-only tool (`ra-lsp`) has no `scip_command` — it writes verdicts from the watcher's
-    // maintenance pass, not a whole-checkout index. Block with that explanation rather than
-    // probing/spawning anything (#534).
-    if !tool.batch_capable() {
+    // The batch declaration's ABSENCE is what says this tool is live-only — it writes verdicts from
+    // the watcher's maintenance pass, not a whole-checkout index. Taking it here rather than gating
+    // on `batch_capable()` separately is what lets the invocation below be infallible: there is no
+    // second place that could disagree about whether this tool has one (#534).
+    let Some(batch) = crate::backend::BatchSpec::for_tool(tool) else {
         return Ok(ScipProduction::Blocked {
             tool: tool.as_db_str().to_string(),
             program: manifest.program.to_string(),
@@ -324,7 +325,7 @@ pub fn produce_scip_with_tool(
                 tool.as_db_str()
             ),
         });
-    }
+    };
     let version = match manifest.probe() {
         ToolAvailability::Available { version, .. } => version,
         ToolAvailability::Blocked { tool, program, hint } => {
@@ -340,7 +341,7 @@ pub fn produce_scip_with_tool(
             hint,
         });
     }
-    let mut command = manifest.scip_command(checkout_root, scip_output);
+    let mut command = (batch.command)(manifest.program, checkout_root, scip_output);
     // Forward the tool's stdout to OUR stderr, never inherit it onto our stdout: the CLI emits the
     // run's JSON report on stdout, and a tool that prints progress to stdout (scip-clang's
     // `[N/M] Indexed …`) would otherwise corrupt that JSON. A piped child + a copy thread keeps
@@ -816,13 +817,13 @@ impl OracleTool {
     /// Whether a BATCH DRIVER can invoke this tool as an indexer — `oracle run`, the background
     /// auto-run loop, the init-wizard tool listing, and [`produce_scip_with_tool`]. `false` ONLY
     /// for the live LSP tools, which write per-pass verdicts from the watcher and have no
-    /// `scip_command`.
+    /// its `BatchSpec` invocation builder.
     ///
     /// This is DISPATCH ONLY. It used to answer read-side precedence and run coverage as well;
     /// those are [`Self::authority`] and [`Self::coverage`] now, because a tool can be a
     /// whole-checkout measurement without being a `.scip` producer.
     pub fn batch_capable(self) -> bool {
-        !matches!(self, Self::RaLsp | Self::TsLsp | Self::ClangdLsp)
+        crate::backend::BatchSpec::for_tool(self).is_some()
     }
 
     /// The batch tool whose `logical_symbol_monikers` rows a LIVE tool copies into its own
@@ -852,8 +853,11 @@ impl OracleTool {
     /// `scip-python` (pyright) exits 1 whenever the analyzed project has type errors — true of most
     /// real-world Python. Restricted to this one verified case; broaden (e.g. scip-typescript, also
     /// a compiler frontend) only with evidence a real corpus needs it.
+    /// Declared on the backend's [`crate::backend::BatchSpec`], so a tool with no batch declaration
+    /// answers `false` without needing an arm.
     pub(crate) fn exit_code_reflects_diagnostics(self) -> bool {
-        matches!(self, Self::ScipPython)
+        crate::backend::BatchSpec::for_tool(self)
+            .is_some_and(|spec| spec.exit_code_reflects_diagnostics)
     }
     /// The position encoding to assume for SCIP documents this tool emits **without** an explicit
     /// `position_encoding` (the protobuf default `Unspecified`). scip-typescript reports ranges in
@@ -861,23 +865,15 @@ impl OracleTool {
     /// reading it as the generic UTF-32 fallback mis-converts columns after any astral
     /// character. The other backends either set the field or are unaffected, so they keep the
     /// conservative `Unspecified` (UTF-32-equivalent) default.
+    /// Declared on the backend's [`crate::backend::BatchSpec`]. A tool with no batch declaration
+    /// produces no `.scip`, so this is never consulted for one — `Unspecified` is the neutral
+    /// element rather than a claim about a live backend, and the six "exists only for
+    /// exhaustiveness" arms this used to carry are gone.
     pub(crate) fn default_position_encoding(self) -> ::scip::types::PositionEncoding {
-        use ::scip::types::PositionEncoding;
-        match self {
-            // scip-typescript and scip-java (JVM/semanticdb) both emit UTF-16 columns with the
-            // field unset — empirically confirmed (a token after an astral char lands at the
-            // UTF-16 count). Reading them as the UTF-32 fallback mis-converts past astral chars.
-            Self::ScipTypescript | Self::ScipJava =>
-                PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
-            // The live tools never parse a `.scip` (the live client negotiates its own LSP
-            // encoding per session); their arms exist only for exhaustiveness.
-            Self::RustAnalyzer
-            | Self::ScipClang
-            | Self::ScipPython
-            | Self::RaLsp
-            | Self::TsLsp
-            | Self::ClangdLsp => PositionEncoding::UnspecifiedPositionEncoding,
-        }
+        crate::backend::BatchSpec::for_tool(self)
+            .map_or(::scip::types::PositionEncoding::UnspecifiedPositionEncoding, |spec| {
+                spec.assumed_position_encoding
+            })
     }
 }
 

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -168,7 +168,7 @@ impl LiveOracleSession {
         };
         let mut client = LspClient::spawn(
             manifest.program,
-            &backend.spawn_args(manifest.live_args, &layout),
+            &backend.spawn_args(&layout),
             checkout.root(),
             backend.readiness,
         )

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -24,12 +24,6 @@ pub struct ToolManifest {
     pub tool: OracleTool,
     /// The executable to invoke (looked up on `PATH`).
     pub program: &'static str,
-    /// Arguments the LIVE backends spawn the program with. Language servers disagree on how the
-    /// stdio transport is selected — `rust-analyzer` speaks LSP on stdio by default, while
-    /// `typescript-language-server` prints usage and exits without `--stdio` — so the argv belongs
-    /// to the registry entry, not the client. Empty for batch tools, which build their whole
-    /// invocation in [`ToolManifest::scip_command`].
-    pub live_args: &'static [&'static str],
     /// Languages this backend resolves, for status/diagnostics and for gating the auto-run loop.
     ///
     /// The SAME encoding `LiveBackend::languages` and `ResolvedTarget.language` use. It was once a
@@ -64,7 +58,6 @@ impl ToolManifest {
             OracleTool::RustAnalyzer => ToolManifest {
                 tool,
                 program: "rust-analyzer",
-                live_args: &[],
                 languages: &[Language::Rust],
                 install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
                                component add rust-analyzer`) or pass a pre-built index with \
@@ -73,7 +66,6 @@ impl ToolManifest {
             OracleTool::ScipClang => ToolManifest {
                 tool,
                 program: "scip-clang",
-                live_args: &[],
                 languages: &[Language::C, Language::Cpp],
                 install_hint: "scip-clang not found on PATH. Install it from \
                                github.com/sourcegraph/scip-clang and generate a \
@@ -85,7 +77,6 @@ impl ToolManifest {
             OracleTool::ScipPython => ToolManifest {
                 tool,
                 program: "scip-python",
-                live_args: &[],
                 languages: &[Language::Python],
                 install_hint: "scip-python not found on PATH. Install it (e.g. `npm install -g \
                                @sourcegraph/scip-python`) AND install the project's dependencies \
@@ -95,7 +86,6 @@ impl ToolManifest {
             OracleTool::ScipTypescript => ToolManifest {
                 tool,
                 program: "scip-typescript",
-                live_args: &[],
                 languages: &[Language::TypeScript],
                 install_hint: "scip-typescript not found on PATH. Install it (e.g. `npm install \
                                -g @sourcegraph/scip-typescript`) AND install the project's \
@@ -108,7 +98,6 @@ impl ToolManifest {
             OracleTool::ScipJava => ToolManifest {
                 tool,
                 program: "scip-java",
-                live_args: &[],
                 languages: &[Language::Kotlin],
                 install_hint: "scip-java not found on PATH. Install it (e.g. `cs install \
                                --contrib scip-java`, needs a JVM) — it indexes Kotlin through the \
@@ -121,7 +110,6 @@ impl ToolManifest {
             OracleTool::RaLsp => ToolManifest {
                 tool,
                 program: "rust-analyzer",
-                live_args: &[],
                 languages: &[Language::Rust],
                 install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
                                component add rust-analyzer`) so the live oracle (`[oracle.live] \
@@ -133,7 +121,6 @@ impl ToolManifest {
             OracleTool::TsLsp => ToolManifest {
                 tool,
                 program: "typescript-language-server",
-                live_args: &["--stdio"],
                 languages: &[Language::TypeScript],
                 install_hint: "typescript-language-server not found on PATH. Install it (e.g. \
                                `npm install -g typescript-language-server typescript`) so the \
@@ -150,7 +137,6 @@ impl ToolManifest {
             OracleTool::ClangdLsp => ToolManifest {
                 tool,
                 program: "clangd",
-                live_args: &["--background-index"],
                 languages: &[Language::C, Language::Cpp],
                 install_hint: "clangd not found on PATH. Install it (e.g. `apt install clangd`, \
                                or a release from github.com/clangd/clangd) so the live oracle \
@@ -228,27 +214,12 @@ impl ToolManifest {
     /// exit 0; a stripped build without it is `Blocked`, #82 P3). `scip-clang` IS the SCIP
     /// emitter — it has no subcommand — so a successful `--version` (already detected) is the
     /// capability signal and this is a no-op `true`.
+    /// Whether a versioned binary can actually emit a SCIP index — declared per backend as
+    /// [`crate::backend::spec::ScipCapability`]. A tool with no batch declaration is never asked to
+    /// emit one, so it trivially can.
     fn can_emit_scip(&self) -> bool {
-        match self.tool {
-            OracleTool::RustAnalyzer => Command::new(self.program)
-                .arg("scip")
-                .arg("--help")
-                .output()
-                .is_ok_and(|output| output.status.success()),
-            OracleTool::ScipClang => true,
-            // scip-python/typescript/java emit via an `index` subcommand; `index --help` exiting 0
-            // is the analog of rust-analyzer's `scip --help` capability check.
-            OracleTool::ScipPython | OracleTool::ScipTypescript | OracleTool::ScipJava =>
-                Command::new(self.program)
-                    .arg("index")
-                    .arg("--help")
-                    .output()
-                    .is_ok_and(|output| output.status.success()),
-            // The live clients drive their program as an LSP server (no `.scip` subcommand
-            // needed); a successful `--version` (already detected by `probe`) is the capability
-            // signal.
-            OracleTool::RaLsp | OracleTool::TsLsp | OracleTool::ClangdLsp => true,
-        }
+        crate::backend::BatchSpec::for_tool(self.tool)
+            .is_none_or(|spec| spec.capability.holds_for(self.program))
     }
 
     /// A tool-specific prerequisite that must hold before a tool-driven run, beyond the binary
@@ -426,97 +397,6 @@ impl ToolManifest {
             OracleTool::ClangdLsp | OracleTool::TsLsp => None,
         }
     }
-
-    /// Build the command that produces a `.scip` index at `output` for the checkout rooted at
-    /// `root`. `rust-analyzer scip <root> --output <path>` writes the SCIP index to a deterministic
-    /// path so the caller (a temp file) can consume it.
-    pub fn scip_command(&self, root: &Path, output: &Path) -> Command {
-        match self.tool {
-            OracleTool::RustAnalyzer => {
-                let mut cmd = Command::new(self.program);
-                cmd.arg("scip").arg(root).arg("--output").arg(output);
-                cmd
-            },
-            // scip-clang consumes the compilation database, not a source root, and emits the index
-            // directly (no subcommand). Run with cwd = root so the compdb's relative paths
-            // resolve, and point it at `root/compile_commands.json` (prerequisite-checked).
-            OracleTool::ScipClang => {
-                let mut cmd = Command::new(self.program);
-                cmd.current_dir(root)
-                    .arg(format!("--compdb-path={}", root.join("compile_commands.json").display()))
-                    .arg(format!("--index-output-path={}", output.display()));
-                cmd
-            },
-            // scip-python indexes a working directory (not a source root arg) via its `index`
-            // subcommand. `--cwd <root>` is where it resolves the project + its installed deps;
-            // `--project-name` (the root's dir name) becomes the package component of in-corpus
-            // monikers, so a non-empty name is what lets `count_symbols_with_moniker` see them.
-            // `--project-version _` is PINNED (Codex on #176): scip-python otherwise defaults the
-            // version to the checkout's git revision, which is embedded in every SCIP symbol
-            // string, so every commit would churn all Python monikers — breaking
-            // moniker-anchored memory relocation (which resolves by exact moniker per
-            // tool). A constant version keeps a symbol's moniker stable across commits
-            // (and sidesteps scip-python's crash on a non-git checkout, where the
-            // git-rev default is undefined). `--output` is absolute, so it's unaffected
-            // by `--cwd`.
-            OracleTool::ScipPython => {
-                let project_name = root.file_name().and_then(|n| n.to_str()).unwrap_or("project");
-                let mut cmd = Command::new(self.program);
-                cmd.arg("index")
-                    .arg("--project-name")
-                    .arg(project_name)
-                    .arg("--project-version")
-                    .arg("_")
-                    .arg("--cwd")
-                    .arg(root)
-                    .arg("--output")
-                    .arg(output);
-                cmd
-            },
-            // scip-typescript indexes the working dir via its `index` subcommand (like
-            // scip-python), reading the project's `tsconfig.json` (prerequisite-checked — we
-            // deliberately do NOT pass `--infer-tsconfig`, which WRITES a tsconfig into the source
-            // tree, breaking read-only-on-source). No `--project-name` / `--project-version`:
-            // package name + version come from `package.json`. That version is embedded in every
-            // local moniker and has no CLI override, so it's normalized downstream at
-            // moniker-write time (`scip::stabilize_moniker_version`), not here. `--output` is
-            // absolute, unaffected by `--cwd`.
-            OracleTool::ScipTypescript => {
-                let mut cmd = Command::new(self.program);
-                cmd.arg("index").arg("--cwd").arg(root).arg("--output").arg(output);
-                cmd
-            },
-            // scip-java indexes through the build (running it with the semanticdb-kotlinc plugin),
-            // so cwd = root. `--build-tool Gradle` is PINNED: the prerequisite only proved Gradle
-            // is present, but a checkout that ALSO carries a `pom.xml` (Maven→Gradle
-            // migration, parent Maven descriptor) makes scip-java's auto-detection see
-            // multiple build tools and abort with "Multiple build tools detected"
-            // instead of indexing. Forcing Gradle (this backend's only supported Kotlin
-            // path) skips that ambiguity (Codex on #193); the value is matched
-            // case-insensitively upstream. No `--project-version` need (unlike
-            // scip-python): scip-java emits `.` placeholders for the local project's
-            // package/version regardless of the build's `group`/`version`, so monikers
-            // are already commit-stable. `--output` is absolute.
-            OracleTool::ScipJava => {
-                let mut cmd = Command::new(self.program);
-                cmd.current_dir(root)
-                    .arg("index")
-                    .arg("--build-tool")
-                    .arg("Gradle")
-                    .arg("--output")
-                    .arg(output);
-                cmd
-            },
-            // Unreachable: every batch driver gates live-only tools out BEFORE building a command
-            // (`produce_scip_with_tool` returns `Blocked`, the auto-run loop and the wizard filter
-            // on `batch_capable`). A live tool has no whole-checkout index invocation.
-            tool @ (OracleTool::RaLsp | OracleTool::TsLsp | OracleTool::ClangdLsp) => unreachable!(
-                "{} is a live oracle backend with no scip_command — the caller must gate on \
-                 OracleTool::batch_capable()",
-                tool.as_db_str()
-            ),
-        }
-    }
 }
 
 /// Whether `root` has a Gradle build that scip-java can index Kotlin through. The sentinel set
@@ -558,30 +438,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn live_backends_declare_their_stdio_argv_and_batch_tools_declare_none() {
-        // A live backend is spawned as `program live_args…`; batch tools build their whole
-        // invocation in `scip_command`, so a stray `live_args` there would be silently ignored
-        // and mislead the next reader.
-        let ts = ToolManifest::for_tool(OracleTool::TsLsp);
-        assert_eq!(ts.program, "typescript-language-server");
-        assert_eq!(
-            ts.live_args,
-            ["--stdio"],
-            "without a transport flag the program prints usage and exits, so the spawn fails with \
-             an opaque EOF instead of a session"
-        );
-        // rust-analyzer speaks LSP on stdio with no flag — the two backends genuinely differ.
-        assert!(ToolManifest::for_tool(OracleTool::RaLsp).live_args.is_empty());
-        for tool in OracleTool::ALL.iter().filter(|tool| tool.batch_capable()) {
-            assert!(
-                ToolManifest::for_tool(*tool).live_args.is_empty(),
-                "{} is batch-only and must declare no live argv",
-                tool.as_db_str()
-            );
-        }
-    }
-
-    #[test]
     fn a_runnable_probe_reports_an_unmet_prerequisite_instead_of_available() {
         // "installed" is not "can run here". A tool reported Available while its checkout
         // prerequisite is unmet says nothing is wrong about a backend that can never produce a
@@ -593,7 +449,6 @@ mod tests {
         let installed_but_unprepared = ToolManifest {
             tool: OracleTool::ScipClang,
             program: "cargo",
-            live_args: &[],
             languages: &[Language::C],
             install_hint: "install hint",
         };
@@ -631,7 +486,6 @@ mod tests {
         let absent = ToolManifest {
             tool: OracleTool::ScipClang,
             program: "rag-rat-no-such-tool-xyzzy",
-            live_args: &[],
             languages: &[Language::C],
             install_hint: "install scip-clang",
         };
@@ -648,7 +502,6 @@ mod tests {
         // header declaration instead, and emits no project-load progress at all.
         let manifest = ToolManifest::for_tool(OracleTool::ClangdLsp);
         assert_eq!(manifest.program, "clangd");
-        assert_eq!(manifest.live_args, ["--background-index"]);
         assert_eq!(manifest.languages, [Language::C, Language::Cpp], "one server, both dialects");
 
         // The compilation database is what clangd builds that index from — the same file the

--- a/crates/rag-rat-oracle/src/tests/tool_defaults.rs
+++ b/crates/rag-rat-oracle/src/tests/tool_defaults.rs
@@ -64,7 +64,7 @@ fn live_tools_are_gated_out_of_the_batch_paths() {
     }
 
     // `produce_scip_with_tool` on a live tool returns the documented Blocked hint and never
-    // builds a `scip_command` (which would be an unreachable! panic).
+    // builds an invocation — a live tool has no `BatchSpec`, so there is none to build.
     for (tool, program) in
         [(OracleTool::RaLsp, "rust-analyzer"), (OracleTool::TsLsp, "typescript-language-server")]
     {


### PR DESCRIPTION
Stage 2a of #1042. **No behaviour change** — one test deleted (4356 vs 4357 total), all passing; both clippy configurations and `fmt --check` clean.

## The problem

`ToolManifest` served both backend kinds from one struct, so each carried the other's questions as a lie:

- five batch entries declared `live_args: &[]`;
- three live tools reached an `unreachable!` arm in `scip_command`;
- the SCIP capability check and the position-encoding default each carried arms documented as existing *"only for exhaustiveness"* — six in total;
- and a test existed to assert that batch entries declare no live argv, a reconciliation only needed because the field was there to get wrong.

## The change

The batch half moves to `backend/spec.rs` as `BatchSpec`, sitting alongside `LiveBackend` in the same module. It carries the invocation builder, the SCIP capability check, the diagnostic-exit tolerance, and the assumed position encoding.

Two shape notes:

- **The invocation is a function per backend, not a match.** The five invocations share nothing but the program name — a subcommand here, a cwd there, flags pinned for reasons documented at each one. A match over them is exactly what needed an `unreachable!` arm for the tools that have no invocation at all.
- **The capability check is declared, not matched.** `ScipCapability::VersionSuffices` for the tool that *is* the emitter, `SubcommandHelpSucceeds("scip" | "index")` for the rest.

**`BatchSpec::for_tool` returning `None` IS the statement "not a batch backend"**, and it is now the only place that fact is declared:

- `produce_scip_with_tool` takes the spec first, so its absence is the live-only refusal it already returned — which makes the invocation below infallible rather than gated by a separate predicate that could disagree with it;
- `OracleTool::batch_capable` derives from it;
- `exit_code_reflects_diagnostics` and `default_position_encoding` read it, so the six vacuous live arms are gone.

The stdio argv moves to `LiveBackend` as `stdio_args`, next to the readiness policy it belongs with, with each live entry documenting its own value where a reader will find it — including why `--stdio` and `--background-index` are load-bearing rather than incidental.

`ToolManifest` is left with what both kinds genuinely share: the persisted tool id, the program, the languages, and the install hint.

## Tests

The reconciliation test is **deleted rather than fixed**: batch entries have no live argv field to assert about. That is the intended shape of this stage — impossible states stop being representable, so the tests that policed them stop being necessary.

## Scope note

#1042 framed Stage 2 as the full merged record with a `DriverSpec` payload. This PR is the half that removes the impossible states; folding the two records into one `Backend` is mostly mechanical renaming across 50+ call sites and is better reviewed on its own, which is the natural Stage 2b. Everything here stands on its own if that never happens.