### PR TITLE
fix(sync): tolerate an unreadable row at store open, and purge the table-sync entry log with its repo (#1017, #1004)

### DIFF
--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -732,29 +732,10 @@ mod tests {
         let b_stream = seed_table_sync_stream(conn, POISON_REPO_ID, 0xbb);
         let a_stream = seed_table_sync_stream(conn, &repo_a, 0xaa);
 
-        // The multi-checkout shape: a linked worktree registers a SECOND root under the SAME
-        // `repo_id`, which is the only thing about it the store records — the stream directory is
-        // keyed by `(repo_id, account_id, scope_id)` with no checkout dimension, so both checkouts
-        // share one stream row set and a purge from either must take it exactly once. Seeding the
-        // second root pins that: if the purge ever grew a per-checkout predicate, a repo reachable
-        // from two roots would leave half its rows behind.
-        // Plain INSERT, not `INSERT OR IGNORE`: OR IGNORE would swallow a missing NOT NULL column
-        // and leave the scenario un-seeded while the test still read as passing.
-        for root in ["/tmp/zz_poison_main_checkout", "/tmp/zz_poison_linked_worktree"] {
-            conn.execute(
-                "INSERT INTO repo_roots(repo_id, root, registered_at_ms) VALUES (?1, ?2, 0)",
-                params![POISON_REPO_ID, root],
-            )
-            .unwrap();
-        }
-        let b_roots: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM repo_roots WHERE repo_id = ?1",
-                params![POISON_REPO_ID],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert!(b_roots >= 2, "the victim must be reachable from more than one checkout");
+        // The multi-checkout dimension of this purge is covered where it can be exercised for real:
+        // `schema_bootstrap_tests::worktree_purge` builds a main checkout and a linked worktree
+        // sharing one database, resolves the removal through the linked one, and asserts a sibling
+        // repo's stream-keyed log survives. This tripwire stays about class-level completeness.
 
         // The full class-level table set, captured from the LIVE schema. A subset here would
         // silently narrow the guarantee, so pin a floor on its breadth.

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -732,6 +732,30 @@ mod tests {
         let b_stream = seed_table_sync_stream(conn, POISON_REPO_ID, 0xbb);
         let a_stream = seed_table_sync_stream(conn, &repo_a, 0xaa);
 
+        // The multi-checkout shape: a linked worktree registers a SECOND root under the SAME
+        // `repo_id`, which is the only thing about it the store records — the stream directory is
+        // keyed by `(repo_id, account_id, scope_id)` with no checkout dimension, so both checkouts
+        // share one stream row set and a purge from either must take it exactly once. Seeding the
+        // second root pins that: if the purge ever grew a per-checkout predicate, a repo reachable
+        // from two roots would leave half its rows behind.
+        // Plain INSERT, not `INSERT OR IGNORE`: OR IGNORE would swallow a missing NOT NULL column
+        // and leave the scenario un-seeded while the test still read as passing.
+        for root in ["/tmp/zz_poison_main_checkout", "/tmp/zz_poison_linked_worktree"] {
+            conn.execute(
+                "INSERT INTO repo_roots(repo_id, root, registered_at_ms) VALUES (?1, ?2, 0)",
+                params![POISON_REPO_ID, root],
+            )
+            .unwrap();
+        }
+        let b_roots: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM repo_roots WHERE repo_id = ?1",
+                params![POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(b_roots >= 2, "the victim must be reachable from more than one checkout");
+
         // The full class-level table set, captured from the LIVE schema. A subset here would
         // silently narrow the guarantee, so pin a floor on its breadth.
         let repo_id_tables = repo_scoped_table_names(conn).unwrap();

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -555,6 +555,34 @@ mod tests {
         .unwrap();
     }
 
+    /// Seed one table-sync stream directory row for `repo_id` plus one entry on that stream, and
+    /// return the stream id. The entry log carries no `repo_id` and is reached ONLY through the
+    /// directory (#1004), so without this the stream-keyed half of the purge is unobservable — the
+    /// class-level assertion below would pass on an empty table and prove nothing.
+    fn seed_table_sync_stream(conn: &rusqlite::Connection, repo_id: &str, seed: u8) -> Vec<u8> {
+        let stream_id = vec![seed; 32];
+        conn.execute(
+            "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id) VALUES (?1, \
+             ?2, ?3, 'demo/1')",
+            params![stream_id, repo_id, vec![seed; 32]],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO table_sync_entries(entry_hash, stream_id, device_fingerprint, lamport, \
+             prev_hash, signed_bytes, received_at_ms) VALUES (?1, ?2, ?3, 1, NULL, ?4, 0)",
+            params![vec![seed; 32], stream_id, vec![seed; 32], vec![seed; 8]],
+        )
+        .unwrap();
+        stream_id
+    }
+
+    /// A blob as a SQL `X'..'` literal, for the stream-keyed orphan check (the other id sets are
+    /// integers or text).
+    fn blob_literal(bytes: &[u8]) -> String {
+        let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        format!("X'{hex}'")
+    }
+
     /// Assert NO orphan survives the purge in ANY transitive child — checked against the parent id
     /// sets CAPTURED BEFORE the purge, so a row whose parent was deleted but which itself was
     /// missed (the exact escape a hand-list allows) is still caught. `NULL` id sets match
@@ -567,6 +595,7 @@ mod tests {
         symbols: &[i64],
         memory_id: &str,
         generation: Option<i64>,
+        stream_id: &[u8],
     ) {
         let file_in = in_clause(files);
         let chunk_in = in_clause(chunks);
@@ -592,6 +621,7 @@ mod tests {
             ("clone_edges", "build_generation", generation_in.clone()),
             ("clone_subblock_postings", "build_generation", generation_in.clone()),
             ("clone_df_epoch", "build_generation", generation_in),
+            ("table_sync_entries", "stream_id", blob_literal(stream_id)),
         ];
         for (table, column, in_body) in checks {
             let count: i64 = conn
@@ -696,6 +726,12 @@ mod tests {
             .unwrap();
         let a_null_source_edge = seed_chunk_symbol_children(conn, "a", a_chunk, a_symbol);
 
+        // A table-sync stream + one entry on it for each repo. Seeded BEFORE the counts below so
+        // A's entry is inside the parity check: the entry log has no `repo_id`, so a purge that
+        // deleted it by anything other than B's captured stream ids would show up as A losing rows.
+        let b_stream = seed_table_sync_stream(conn, POISON_REPO_ID, 0xbb);
+        let a_stream = seed_table_sync_stream(conn, &repo_a, 0xaa);
+
         // The full class-level table set, captured from the LIVE schema. A subset here would
         // silently narrow the guarantee, so pin a floor on its breadth.
         let repo_id_tables = repo_scoped_table_names(conn).unwrap();
@@ -745,7 +781,31 @@ mod tests {
             &b_symbols,
             &b_memory,
             Some(b_generation),
+            &b_stream,
         );
+        // The stream-keyed half of #1004 explicitly: the directory row is gone via the class sweep,
+        // and the entries that only it could place are gone with it. Retaining them would let a
+        // re-registration of the same repo — whose stream id is a pure function of
+        // `(repo_id, account_id, scope_id)` — replay the removed repo's operations back into it.
+        let b_streams_left: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_streams WHERE repo_id = ?1",
+                params![POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(b_streams_left, 0, "the removed repo's stream directory rows are swept");
+        let a_entries: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM table_sync_entries WHERE stream_id = {}",
+                    blob_literal(&a_stream)
+                ),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(a_entries, 1, "the sibling's stream-keyed entries survive the scoped purge");
         let edge_exists = |id: i64| -> bool {
             conn.query_row("SELECT EXISTS(SELECT 1 FROM edges_data WHERE id = ?1)", [id], |row| {
                 row.get(0)

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -989,3 +989,4 @@ mod swift_corpus;
 mod symbol_search_lookup;
 mod watch_placement;
 mod worktree_overlay;
+mod worktree_purge;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
@@ -1,0 +1,134 @@
+//! `rag-rat rm` driven from a LINKED WORKTREE, against a database shared with the main checkout and
+//! with an unrelated sibling repo.
+//!
+//! The table-sync stream directory is keyed by `(repo_id, account_id, scope_id)`, and the entry log
+//! it scopes carries no `repo_id` at all — the purge reaches that log only through the captured
+//! directory rows (#1004). Neither key has a checkout dimension, and this pins that rather than
+//! assuming it: both checkouts of a repo must register under ONE `repo_id`, a removal resolved from
+//! the linked worktree must take the whole repo's log, and a sibling repo in the same database must
+//! keep its own — which no `repo_id` predicate could have protected, since the log has none.
+
+use super::*;
+
+/// A git checkout with one committed Rust file.
+fn checkout(marker: &str) -> ScratchRoot {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), format!("pub fn {marker}() {{}}\n")).unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    root
+}
+
+/// Index `root` into the SHARED `database`, returning the repo id it registered under.
+fn index_at(root: &Path, database: &Path) -> String {
+    let mut config = source_config(root.to_path_buf(), Language::Rust);
+    config.database = database.to_path_buf();
+    IndexDatabase::rebuild(&config).unwrap().active_repo_id.clone()
+}
+
+/// One stream directory row for `repo_id` plus one entry on its stream; returns the stream id.
+fn seed_stream(conn: &rusqlite::Connection, repo_id: &str, seed: u8) -> Vec<u8> {
+    let stream_id = vec![seed; 32];
+    conn.execute(
+        "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id) VALUES (?1, ?2, \
+         ?3, 'demo/1')",
+        rusqlite::params![stream_id, repo_id, vec![seed; 32]],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO table_sync_entries(entry_hash, stream_id, device_fingerprint, lamport, \
+         prev_hash, signed_bytes, received_at_ms) VALUES (?1, ?2, ?3, 1, NULL, ?4, 0)",
+        rusqlite::params![vec![seed; 32], stream_id, vec![seed; 32], vec![seed; 8]],
+    )
+    .unwrap();
+    stream_id
+}
+
+fn entries_on(conn: &rusqlite::Connection, stream_id: &[u8]) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM table_sync_entries WHERE stream_id = ?1",
+        rusqlite::params![stream_id],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn directory_rows(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM table_sync_streams WHERE repo_id = ?1",
+        rusqlite::params![repo_id],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+#[test]
+fn rm_from_a_linked_worktree_purges_the_shared_stream_log_and_spares_the_sibling_repo() {
+    let main = checkout("main_anchor");
+    let store = unique_temp_root();
+    let database = store.join("shared.sqlite");
+    let repo_id = index_at(&main, &database);
+
+    // A linked worktree of the SAME repo, indexed into the SAME database.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    let linked_repo_id = index_at(&linked, &database);
+    assert_eq!(
+        linked_repo_id, repo_id,
+        "a linked worktree indexes under the SAME repo id — the property that makes a purge keyed \
+         by `repo_id` alone reach every checkout",
+    );
+
+    // An unrelated repo in the same database: the isolation half.
+    let sibling = checkout("sibling_anchor");
+    let sibling_repo_id = index_at(&sibling, &database);
+    assert_ne!(sibling_repo_id, repo_id, "the sibling is a distinct repo in the shared store");
+
+    // A BARE connection, exactly as the production purge uses: a scoped `IndexDatabase` connection
+    // installs a `temp.files` view that shadows the base tables.
+    let storage = IndexConnection::open(&database).unwrap();
+    let conn = storage.connection();
+    let shared_stream = seed_stream(conn, &repo_id, 0xaa);
+    let sibling_stream = seed_stream(conn, &sibling_repo_id, 0xbb);
+
+    let roots: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM repo_roots WHERE repo_id = ?1",
+            rusqlite::params![&repo_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(roots >= 2, "both checkouts registered a root under the one repo id, saw {roots}");
+
+    // ACTIVE-CHECKOUT SCOPE: the removal is resolved from the LINKED worktree, not the main one.
+    let resolved = crate::index::remove::resolve_removable_repo(conn, &linked)
+        .unwrap()
+        .expect("the linked worktree resolves to a registered repo");
+    assert_eq!(resolved.repo_id, repo_id, "and it resolves to the shared repo, not a new one");
+
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)
+        .unwrap();
+    schema::purge_repo_rows(&tx, &resolved.repo_id).unwrap();
+    tx.commit().unwrap();
+
+    assert_eq!(directory_rows(conn, &repo_id), 0, "the shared repo's stream directory is swept");
+    assert_eq!(
+        entries_on(conn, &shared_stream),
+        0,
+        "and the stream-keyed entry log goes with the directory that placed it, whichever \
+         checkout drove the removal",
+    );
+
+    // SIBLING PRESERVATION: the other repo in the shared store keeps both halves. Its entries carry
+    // no `repo_id`, so only the captured stream ids could have spared them.
+    assert_eq!(directory_rows(conn, &sibling_repo_id), 1, "the sibling's directory row survives");
+    assert_eq!(entries_on(conn, &sibling_stream), 1, "and so does its entry log");
+
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -49,6 +49,15 @@
 //! directory `table_sync_streams` carries a `repo_id` and is swept by the class sweep, so the two
 //! halves have to agree — retaining the entries while dropping the directory that places them is
 //! the shape that resurrects history.
+//!
+//! That same determinism leaves the OTHER half of the problem open, and deleting the log does not
+//! settle it: a re-registration derives the same stream id over an empty log, so this device
+//! authors a second genesis at lamport 0 and a peer holding the old chain reads it as a fork (and
+//! an old entry redelivered from that peer is chain-continuous, so it repopulates what was purged).
+//! The resolution is a stream epoch or durable chain high-water state, which has to be agreed with
+//! peers and therefore belongs to the transport milestone — tracked in #1049. Unreachable until a
+//! transport exists; purging is still the better interim, because the resurrection path above needs
+//! no peer at all.
 
 use rusqlite::{Connection, params};
 
@@ -217,13 +226,19 @@ pub fn count_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<RepoR
         )?;
         counts.record(&table, count);
     }
-    // Transitive children: count through the live parent scope (the parents still exist at count
-    // time — this is the read path). An older schema may predate a table (e.g. `clone_df_epoch`,
-    // V051); this count runs BEFORE `rm` migrates (so `--dry-run` never writes), so a table that
-    // does not exist is skipped — its row count is 0, and the destructive purge runs post-migration
-    // where every listed table exists.
+    // Transitive children: count through the live parent scope. An older schema may predate a table
+    // (e.g. `clone_df_epoch`, V051); this count runs BEFORE `rm` migrates (so `--dry-run` never
+    // writes), so a table that does not exist is skipped — its row count is 0, and the destructive
+    // purge runs post-migration (the `rm` command applies the schema after the preview, before
+    // taking the write lock) where every listed table exists.
+    //
+    // BOTH halves are guarded, not just the child: a child can predate the parent that scopes it
+    // (see [`parent_table`]), and an unguarded subquery against a missing parent fails the whole
+    // plan on a store the preview is explicitly meant to tolerate.
     for transitive in TRANSITIVE_SCOPED_TABLES {
-        if !crate::schema::table_exists(conn, transitive.table)? {
+        if !crate::schema::table_exists(conn, transitive.table)?
+            || !crate::schema::table_exists(conn, parent_table(transitive.parent_ids))?
+        {
             continue;
         }
         let count: i64 = conn.query_row(
@@ -283,6 +298,22 @@ fn parent_id_select(parent_ids: &str) -> &'static str {
         purge_ids::GENERATIONS =>
             "SELECT generation FROM clone_graph_generations WHERE repo_id = ?1",
         purge_ids::STREAMS => "SELECT stream_id FROM table_sync_streams WHERE repo_id = ?1",
+        other => unreachable!("unknown purge id set {other}"),
+    }
+}
+
+/// The `repo_id`-bearing table each id set reads from — the PARENT half of the count-path existence
+/// check. A child can outlive its parent's introduction: `table_sync_entries` arrived in V087 and
+/// the `table_sync_streams` directory that scopes it only in V093, so on a store in between, the
+/// child exists while the subquery's table does not. `count_repo_rows` runs on exactly such a store
+/// (planning is read-only and pre-migration, so `--dry-run` never writes), and an unguarded
+/// reference there fails the plan before the destructive path can migrate.
+fn parent_table(parent_ids: &str) -> &'static str {
+    match parent_ids {
+        purge_ids::FILES | purge_ids::CHUNKS | purge_ids::SYMBOLS => "files",
+        purge_ids::MEMORIES => "repo_memories",
+        purge_ids::GENERATIONS => "clone_graph_generations",
+        purge_ids::STREAMS => "table_sync_streams",
         other => unreachable!("unknown purge id set {other}"),
     }
 }
@@ -424,4 +455,26 @@ fn drop_purge_ids(conn: &Connection) -> anyhow::Result<()> {
 /// names the table unqualified while later reads qualify it `temp.<name>`.
 fn temp_name(qualified: &str) -> &str {
     qualified.strip_prefix("temp.").unwrap_or(qualified)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `count_repo_rows` is the read-only planning path, and `rag-rat rm` runs it BEFORE migrating
+    /// so `--dry-run` never writes. Every transitive child must therefore tolerate a schema
+    /// that predates it — including one that predates its PARENT: `table_sync_entries` shipped
+    /// in V087 and the `table_sync_streams` directory that scopes it only in V093, so on a
+    /// store in between the child exists while the subquery's table does not. Dropping the
+    /// parent reproduces that shape.
+    #[test]
+    fn counting_tolerates_a_transitive_child_whose_parent_table_does_not_exist_yet() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        conn.execute_batch("DROP TABLE table_sync_streams;").unwrap();
+
+        let counts = count_repo_rows(&conn, "some-repo")
+            .expect("planning must survive a store whose directory table predates the entry log");
+        assert_eq!(counts.total_rows, 0, "nothing is counted for an unknown repo");
+    }
 }

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -40,6 +40,15 @@
 //! log — no `repo_id`, keyed by device/account/`stream_id`, and excluded from the per-repo
 //! consolidate import for the same reason). None of these carry a `repo_id` column, so the
 //! class-level sweep leaves them untouched.
+//!
+//! `table_sync_entries` is the ONE stream-keyed sync table that departs from that posture, and the
+//! reason is that its stream id is DERIVED rather than random (#1004): `scope_stream_id` is a pure
+//! function of `(repo_id, account_id, scope_id)`, so re-registering the same repo recreates the
+//! identical stream mapping and a later projector bump replays the removed repo's parked operations
+//! straight back into it. Retention is only safe where the key cannot be regenerated. The stream
+//! directory `table_sync_streams` carries a `repo_id` and is swept by the class sweep, so the two
+//! halves have to agree — retaining the entries while dropping the directory that places them is
+//! the shape that resurrects history.
 
 use rusqlite::{Connection, params};
 
@@ -65,6 +74,7 @@ mod purge_ids {
     pub const SYMBOLS: &str = "temp.rmp_symbol_ids";
     pub const MEMORIES: &str = "temp.rmp_memory_ids";
     pub const GENERATIONS: &str = "temp.rmp_generation_ids";
+    pub const STREAMS: &str = "temp.rmp_stream_ids";
 }
 
 /// Every transitively-scoped child, child-first (a child appears before the parent whose id set it
@@ -146,6 +156,14 @@ const TRANSITIVE_SCOPED_TABLES: &[TransitiveTable] = &[
         table: "clone_df_epoch",
         id_column: "build_generation",
         parent_ids: purge_ids::GENERATIONS,
+    },
+    // The table-sync entry log (table_sync_streams.stream_id → stream_id). Captured through the
+    // directory because the stream id is a one-way hash and cannot be re-derived once the
+    // directory row is swept — see the module docs for why this log is purged at all.
+    TransitiveTable {
+        table: "table_sync_entries",
+        id_column: "stream_id",
+        parent_ids: purge_ids::STREAMS,
     },
 ];
 
@@ -264,6 +282,7 @@ fn parent_id_select(parent_ids: &str) -> &'static str {
         purge_ids::MEMORIES => "SELECT id FROM repo_memories WHERE repo_id = ?1",
         purge_ids::GENERATIONS =>
             "SELECT generation FROM clone_graph_generations WHERE repo_id = ?1",
+        purge_ids::STREAMS => "SELECT stream_id FROM table_sync_streams WHERE repo_id = ?1",
         other => unreachable!("unknown purge id set {other}"),
     }
 }
@@ -373,6 +392,17 @@ fn capture_purge_ids(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
         ),
         params![repo_id],
     )?;
+    // Same aliasing for the sync stream directory. This capture is what makes the entry-log delete
+    // possible at all: `stream_id` is a one-way hash of `(repo_id, account_id, scope_id)`, so once
+    // the class sweep removes the directory row there is no way back from an entry to its repo.
+    conn.execute(
+        &format!(
+            "CREATE TEMP TABLE {} AS SELECT stream_id AS id FROM table_sync_streams WHERE repo_id \
+             = ?1",
+            temp_name(purge_ids::STREAMS)
+        ),
+        params![repo_id],
+    )?;
     Ok(())
 }
 
@@ -383,6 +413,7 @@ fn drop_purge_ids(conn: &Connection) -> anyhow::Result<()> {
         purge_ids::SYMBOLS,
         purge_ids::MEMORIES,
         purge_ids::GENERATIONS,
+        purge_ids::STREAMS,
     ] {
         conn.execute(&format!("DROP TABLE IF EXISTS {temp}"), [])?;
     }

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -432,45 +432,85 @@ pub(crate) fn synced_row_hash(
     spec: &TableSpec,
     pk_vals: &[TypedValue],
 ) -> anyhow::Result<Option<String>> {
-    Ok(read_synced_cells(tx, spec, pk_vals)?.map(|cells| row_op::cells_hash(&cells)))
+    // Absent and unreadable collapse to `None` HERE, and only here, because this function's one
+    // caller is the applier's post-write read-back, where both are equally "there is no hash to
+    // record". Neither is reachable at that point — the winner just wrote every synced column from
+    // typed cells — and the consequence of being wrong is bounded: an unrecorded hash makes the
+    // producer reconsider the row, not corrupt it.
+    Ok(match read_synced_cells(tx, spec, pk_vals)? {
+        SyncedRow::Cells(cells) => Some(row_op::cells_hash(&cells)),
+        SyncedRow::Absent | SyncedRow::Unreadable(_) => None,
+    })
 }
 
-/// Read a row's synced columns as typed cells (sorted by the registry's column order), mapping each
-/// stored value back to its declared type so the hash matches what the applier wrote. `None` if the
-/// row is absent.
+/// What a read of a row's synced columns found.
+///
+/// `Unreadable` is NOT interchangeable with `Absent`, and conflating them is a real bug rather than
+/// a tidiness point: the refold's guard reads an absent row as a local delete awaiting authorship
+/// and refuses to replay over it, which for a row that merely cannot be mapped back to its declared
+/// types would block that entry for good.
+pub(crate) enum SyncedRow {
+    /// No row carries this pk.
+    Absent,
+    /// The row exists but at least one synced column has no value of its declared type (see
+    /// [`ReadCell`]), so the row has no comparable hash and cannot be carried in an op.
+    Unreadable(String),
+    Cells(Vec<Cell>),
+}
+
+/// Read a row's synced columns as typed cells (in the registry's column order), mapping each stored
+/// value back to its declared type so the hash matches what the applier wrote.
 pub(crate) fn read_synced_cells(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     pk_vals: &[TypedValue],
-) -> anyhow::Result<Option<Vec<Cell>>> {
+) -> anyhow::Result<SyncedRow> {
     let select = spec.columns.iter().map(|c| quote_ident(c.name)).collect::<Vec<_>>().join(", ");
     let sql =
         format!("SELECT {select} FROM {} WHERE {} LIMIT 1", quote_ident(spec.name), pk_where(spec));
-    let cells = tx
+    let row = tx
         .query_row(&sql, params_from_iter(pk_params(pk_vals)), |row| {
             let mut cells = Vec::with_capacity(spec.columns.len());
             for (idx, column) in spec.columns.iter().enumerate() {
-                cells.push(Cell {
-                    column: column.name.to_string(),
-                    value: read_typed(row, idx, column.value_type)?,
-                });
+                match read_typed(row, idx, column.value_type)? {
+                    ReadCell::Value(value) =>
+                        cells.push(Cell { column: column.name.to_string(), value }),
+                    ReadCell::Malformed(why) =>
+                        return Ok(SyncedRow::Unreadable(format!("`{}`: {why}", column.name))),
+                }
             }
-            Ok(cells)
+            Ok(SyncedRow::Cells(cells))
         })
         .optional()?;
-    Ok(cells)
+    Ok(row.unwrap_or(SyncedRow::Absent))
 }
 
-/// Every current row of `spec`'s table FOR `repo_id` as `(pk values, synced cells)`, the producer's
-/// scan input. A repo-scoped table is filtered by its `repo_column`, so a multi-repo store never
-/// emits one repo's rows into another repo's stream. Pk values are read by their runtime storage
-/// type (identities are text/int/blob); synced cells by their declared type so the hash matches the
-/// applier's.
+/// One row of the producer's scan. The two unreadable cases are split because the producer must
+/// treat them DIFFERENTLY, and getting that wrong deletes data: a row it does not see at all reads
+/// as a local delete, and the producer authors a `Remove` for it that removes it from every peer.
+pub(crate) enum ScannedRow {
+    /// Fully readable: emit it, or skip it if it is already published unchanged.
+    Readable { pk: Vec<TypedValue>, cells: Vec<Cell> },
+    /// A synced column is unreadable ([`SyncedRow::Unreadable`]), so the row cannot be carried in
+    /// an op — but it is still addressable and still LIVE, and its identity has to count as
+    /// such.
+    Unpublishable { pk: Vec<TypedValue> },
+    /// A PK column is unreadable, so the row cannot be named at all. No identity to keep alive: as
+    /// far as the pk that was published is concerned, nothing carries it any more, which is the
+    /// same thing the row having been deleted means.
+    Unaddressable,
+}
+
+/// Every current row of `spec`'s table FOR `repo_id`, the producer's scan input. A repo-scoped
+/// table is filtered by its `repo_column`, so a multi-repo store never emits one repo's rows into
+/// another repo's stream. Both pk values and synced cells are read by their DECLARED type — a
+/// `Bool` pk is stored as INTEGER 0/1, and reading it as `I64` would emit a `TypedValue` the
+/// applier's typed-pk check rejects, so the producer would sign ops its own self-apply quarantines.
 pub(crate) fn read_all_rows(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     repo_id: &str,
-) -> anyhow::Result<Vec<(Vec<TypedValue>, Vec<Cell>)>> {
+) -> anyhow::Result<Vec<ScannedRow>> {
     let pk_select = spec.pk.iter().map(|c| quote_ident(c.name));
     let col_select = spec.columns.iter().map(|c| quote_ident(c.name));
     let select = pk_select.chain(col_select).collect::<Vec<_>>().join(", ");
@@ -483,22 +523,22 @@ pub(crate) fn read_all_rows(
     let mut stmt = tx.prepare(&sql)?;
     let rows = stmt
         .query_map(params_from_iter(bind), |row| {
-            // Read each pk value by its DECLARED type, not its storage type: a `Bool` pk is stored
-            // as INTEGER 0/1, and reading it as `I64` would emit a `TypedValue` the applier's
-            // typed- pk check rejects — the producer would then sign ops its own
-            // self-apply quarantines.
             let mut pk = Vec::with_capacity(spec.pk.len());
             for (idx, column) in spec.pk.iter().enumerate() {
-                pk.push(read_typed(row, idx, column.value_type)?);
+                match read_typed(row, idx, column.value_type)? {
+                    ReadCell::Value(value) => pk.push(value),
+                    ReadCell::Malformed(_) => return Ok(ScannedRow::Unaddressable),
+                }
             }
             let mut cells = Vec::with_capacity(spec.columns.len());
             for (offset, column) in spec.columns.iter().enumerate() {
-                cells.push(Cell {
-                    column: column.name.to_string(),
-                    value: read_typed(row, spec.pk.len() + offset, column.value_type)?,
-                });
+                match read_typed(row, spec.pk.len() + offset, column.value_type)? {
+                    ReadCell::Value(value) =>
+                        cells.push(Cell { column: column.name.to_string(), value }),
+                    ReadCell::Malformed(_) => return Ok(ScannedRow::Unpublishable { pk }),
+                }
             }
-            Ok((pk, cells))
+            Ok(ScannedRow::Readable { pk, cells })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
@@ -725,11 +765,23 @@ pub(crate) fn row_has_unsent_local_change(
         return Ok(false);
     }
     let row_pk = row_op::row_pk_string(pk_vals);
-    let Some(current_cells) = read_synced_cells(tx, spec, pk_vals)? else {
-        // No row — but a surviving published identity means the row was DELETED locally and not yet
-        // authored. That is precisely what the producer's `Remove` branch keys on, so replaying an
-        // upsert here would recreate the row and discard the unsent deletion for good.
-        return Ok(published_hash(tx, repo_id, spec.name, &row_pk)?.is_some());
+    let current_cells = match read_synced_cells(tx, spec, pk_vals)? {
+        SyncedRow::Cells(cells) => cells,
+        SyncedRow::Absent => {
+            // No row — but a surviving published identity means the row was DELETED locally and not
+            // yet authored. That is precisely what the producer's `Remove` branch keys on, so
+            // replaying an upsert here would recreate the row and discard the unsent deletion for
+            // good.
+            return Ok(published_hash(tx, repo_id, spec.name, &row_pk)?.is_some());
+        },
+        // The row is there but has no hash, so nothing about it can be PROVEN unsent — and this
+        // verdict has two readers that must not both defer. The producer cannot author an
+        // unreadable row either ([`ScannedRow::Unpublishable`]), so answering "there may be an
+        // unsent edit" here would leave the row unauthorable AND permanently block its own pending
+        // entries, with no way out. Replaying is the direction with a floor: the entry still has to
+        // win the ordinary clock comparison, and a winner rewrites every synced column, which is
+        // the only thing that makes the row syncable again.
+        SyncedRow::Unreadable(_) => return Ok(false),
     };
     let current = row_op::cells_hash(&current_cells);
     Ok(match published_hash(tx, repo_id, spec.name, &row_pk)? {
@@ -813,29 +865,39 @@ fn sql_value(value: &TypedValue) -> SqlValue {
     }
 }
 
-fn read_typed(row: &rusqlite::Row<'_>, idx: usize, vt: ValueType) -> rusqlite::Result<TypedValue> {
-    match vt {
+/// Mapping one stored value back to its declared type: the value, or the reason it has none.
+///
+/// A REASON rather than an `Err`, because every read below sits under a path that must not fail —
+/// see [`SyncedRow`]. `Malformed` has exactly ONE producer, and that is a property of the schema
+/// rules, not a coincidence: the registry lint requires a STRICT table, so a `Text` / `I64` /
+/// `Blob` column can only ever hold its declared storage type and those three mappings are total.
+/// `Bool` is the sole value type whose domain SQLite does not enforce — 0/1 needs a
+/// `CHECK (col IN (0, 1))`, which no pragma exposes for the lint to require.
+enum ReadCell {
+    Value(TypedValue),
+    Malformed(String),
+}
+
+fn read_typed(row: &rusqlite::Row<'_>, idx: usize, vt: ValueType) -> rusqlite::Result<ReadCell> {
+    let value = match vt {
         ValueType::Text =>
-            Ok(row.get::<_, Option<String>>(idx)?.map_or(TypedValue::Null, TypedValue::Text)),
-        ValueType::I64 =>
-            Ok(row.get::<_, Option<i64>>(idx)?.map_or(TypedValue::Null, TypedValue::I64)),
+            row.get::<_, Option<String>>(idx)?.map_or(TypedValue::Null, TypedValue::Text),
+        ValueType::I64 => row.get::<_, Option<i64>>(idx)?.map_or(TypedValue::Null, TypedValue::I64),
         // A Bool column must hold exactly 0 or 1. Coercing any other integer to `true` (the old
         // `n != 0`) would silently rewrite the source value to 1 on self-apply and replicate a
-        // value that differs from the row — surface the malformed value instead of
-        // normalizing it away.
+        // value that differs from the row — report the malformed value instead of normalizing it
+        // away, and let the caller decide (never by failing, see [`ReadCell`]).
         ValueType::Bool => match row.get::<_, Option<i64>>(idx)? {
-            None => Ok(TypedValue::Null),
-            Some(0) => Ok(TypedValue::Bool(false)),
-            Some(1) => Ok(TypedValue::Bool(true)),
-            Some(other) => Err(rusqlite::Error::FromSqlConversionFailure(
-                idx,
-                rusqlite::types::Type::Integer,
-                format!("a Bool column holds {other}, not 0 or 1").into(),
-            )),
+            None => TypedValue::Null,
+            Some(0) => TypedValue::Bool(false),
+            Some(1) => TypedValue::Bool(true),
+            Some(other) =>
+                return Ok(ReadCell::Malformed(format!("a Bool column holds {other}, not 0 or 1"))),
         },
         ValueType::Blob =>
-            Ok(row.get::<_, Option<Vec<u8>>>(idx)?.map_or(TypedValue::Null, TypedValue::Blob)),
-    }
+            row.get::<_, Option<Vec<u8>>>(idx)?.map_or(TypedValue::Null, TypedValue::Blob),
+    };
+    Ok(ReadCell::Value(value))
 }
 
 /// Whether a value is storable in a column of the declared type. `Null` fits any column
@@ -1721,18 +1783,17 @@ mod tests {
         let src_tx = src.transaction().unwrap();
         let rows = read_all_rows(&src_tx, &FLAG, "repo").unwrap();
         assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].0,
-            vec![TypedValue::Bool(true)],
-            "a Bool pk is emitted as Bool, not I64"
-        );
+        let ScannedRow::Readable { pk, cells } = &rows[0] else {
+            panic!("a 0/1 Bool pk is readable");
+        };
+        assert_eq!(pk, &vec![TypedValue::Bool(true)], "a Bool pk is emitted as Bool, not I64");
 
         // The op the producer would sign applies cleanly on a peer (the typed-pk check passes).
         let op = RowOp::Upsert {
             spec_version: 1,
             table: "t_flag".to_string(),
-            pk: rows[0].0.clone(),
-            cells: rows[0].1.clone(),
+            pk: pk.clone(),
+            cells: cells.clone(),
         };
         let mut peer = rusqlite::Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&peer, &crate::test_hooks()).unwrap();
@@ -1747,29 +1808,104 @@ mod tests {
         );
     }
 
+    /// A table whose only synced column is a `Bool`, plus a store holding one row of it at `flag`.
+    /// STRICT keeps every other column mapping total, so this is the one shape that can be
+    /// unreadable (#1017).
+    const FLAGGED: TableSpec = TableSpec {
+        name: "t_flagged",
+        scope_id: "demo/1",
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("flag", ValueType::Bool)],
+        local_columns: &[],
+        repo_column: None,
+    };
+
+    fn flagged_store(flag: i64) -> rusqlite::Connection {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_flagged(id TEXT PRIMARY KEY, flag INTEGER) STRICT;")
+            .unwrap();
+        c.execute("INSERT INTO t_flagged(id, flag) VALUES ('r', ?1)", [flag]).unwrap();
+        c
+    }
+
     #[test]
-    fn a_bool_column_holding_a_non_boolean_int_is_rejected_not_normalized() {
-        // A `Bool` column that somehow holds an integer other than 0/1 must be surfaced, not
-        // coerced to `true` — coercing would replicate a value (1) that differs from the
-        // stored row.
-        const FLAGGED: TableSpec = TableSpec {
-            name: "t_flagged",
+    fn a_bool_column_holding_a_non_boolean_int_is_unreadable_not_normalized() {
+        // Coercing 2 to `true` would replicate a value that differs from the stored row. Reporting
+        // it as unreadable is the alternative — and it must stay a VALUE, because every reader here
+        // runs under a path that cannot fail (#1017).
+        let mut c = flagged_store(2);
+        let tx = c.transaction().unwrap();
+
+        let rows = read_all_rows(&tx, &FLAGGED, "repo").unwrap();
+        assert_eq!(rows.len(), 1, "the row is still scanned, not dropped or errored");
+        match &rows[0] {
+            ScannedRow::Unpublishable { pk } => {
+                assert_eq!(pk, &vec![TypedValue::Text("r".into())], "it stays addressable")
+            },
+            _ => panic!("a Bool column holding 2 makes the row unpublishable, never `true`"),
+        }
+    }
+
+    #[test]
+    fn an_unreadable_row_is_distinguished_from_an_absent_one() {
+        // The load-bearing distinction: the refold's guard reads `Absent` as a local delete
+        // awaiting authorship and refuses to replay over it, so collapsing the two would
+        // block the entry for a row that is merely unreadable.
+        let mut c = flagged_store(2);
+        let tx = c.transaction().unwrap();
+        let present = read_synced_cells(&tx, &FLAGGED, &[TypedValue::Text("r".into())]).unwrap();
+        assert!(matches!(present, SyncedRow::Unreadable(_)), "a present-but-unreadable row");
+
+        let missing = read_synced_cells(&tx, &FLAGGED, &[TypedValue::Text("nope".into())]).unwrap();
+        assert!(matches!(missing, SyncedRow::Absent), "and a genuinely absent one");
+    }
+
+    #[test]
+    fn a_bool_pk_holding_a_non_boolean_int_leaves_the_row_unaddressable() {
+        // The pk case is separate because the producer must treat it differently: with no readable
+        // pk the row has no identity at all, so there is nothing to keep alive.
+        const FLAG_PK: TableSpec = TableSpec {
+            name: "t_flag",
             scope_id: "demo/1",
             spec_version: 1,
-            pk: &[ColumnSpec::required("id", ValueType::Text)],
-            columns: &[ColumnSpec::required("flag", ValueType::Bool)],
+            pk: &[ColumnSpec::required("active", ValueType::Bool)],
+            columns: &[ColumnSpec::required("label", ValueType::Text)],
             local_columns: &[],
             repo_column: None,
         };
         let mut c = rusqlite::Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
-        c.execute_batch("CREATE TABLE t_flagged(id TEXT PRIMARY KEY, flag INTEGER) STRICT;")
+        c.execute_batch("CREATE TABLE t_flag(active INTEGER PRIMARY KEY, label TEXT) STRICT;")
             .unwrap();
-        c.execute("INSERT INTO t_flagged(id, flag) VALUES ('r', 2)", []).unwrap();
+        c.execute("INSERT INTO t_flag(active, label) VALUES (2, 'on')", []).unwrap();
         let tx = c.transaction().unwrap();
+
+        let rows = read_all_rows(&tx, &FLAG_PK, "repo").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(matches!(rows[0], ScannedRow::Unaddressable), "no pk means no identity");
+    }
+
+    #[test]
+    fn the_unsent_edit_guard_does_not_defer_on_a_row_it_cannot_read() {
+        // Both readers of "is there an unsent edit here" must not defer: the producer cannot author
+        // an unreadable row either, so answering `true` here would leave the row unauthorable AND
+        // permanently block its own pending entries. Replaying is the direction with a floor — the
+        // entry still has to win on the clock, and a winner rewrites the column that is unreadable.
+        let mut c = flagged_store(2);
+        let tx = c.transaction().unwrap();
+        let stream = crate::table_sync::scope_stream::scope_stream_id(
+            "repo",
+            crate::AccountId::from_bytes([7; 32]),
+            "demo/1",
+        );
         assert!(
-            read_all_rows(&tx, &FLAGGED, "repo").is_err(),
-            "a Bool column holding 2 is rejected, not silently normalized to true",
+            !row_has_unsent_local_change(&tx, &FLAGGED, "repo", stream, &[TypedValue::Text(
+                "r".into()
+            )],)
+            .unwrap(),
+            "an unreadable row proves nothing, so it must not block the replay",
         );
     }
 

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -733,8 +733,13 @@ pub(crate) fn stale_row_disposition(
     }
 }
 
-/// Whether this row holds a local change that has not been authored yet, so a caller replaying an
-/// older retained entry over it would DESTROY work no peer has seen.
+/// Whether replaying `op` over this row would DESTROY local work no peer has seen — normally
+/// because the row holds a change that has not been authored yet.
+///
+/// The question is asked about the OP and not only the row, because the two kinds have different
+/// floors when the row's state cannot be established: an `Upsert` rewrites every synced column and
+/// can therefore repair a row, while a `Remove` deletes it outright, local-only columns included,
+/// and repairs nothing. See the `Unreadable` arm.
 ///
 /// A raw local write does not advance `sync_row_clocks` — only authoring-and-self-applying does —
 /// so the ordinary LWW comparison cannot see an unsent edit at all: it compares the incoming op
@@ -749,13 +754,14 @@ pub(crate) fn stale_row_disposition(
 /// the rows it exists to repair. Those rows are in the ordinary last-writer-wins regime, where the
 /// refold behaves exactly as live ingest does and the driver's author-before-apply ordering
 /// governs.
-pub(crate) fn row_has_unsent_local_change(
+pub(crate) fn replay_would_destroy_unsent_work(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     repo_id: &str,
     stream: StreamId,
-    pk_vals: &[TypedValue],
+    op: &RowOp,
 ) -> anyhow::Result<bool> {
+    let pk_vals = op.pk();
     // A malformed key never reached `apply_row_op`'s arity check (an entry parked as out-of-scope
     // or unknown-kind was never validated), and binding it against `spec.pk`'s placeholders
     // would be a parameter-count ERROR — which, propagating out of the refold, would roll back
@@ -774,14 +780,21 @@ pub(crate) fn row_has_unsent_local_change(
             // good.
             return Ok(published_hash(tx, repo_id, spec.name, &row_pk)?.is_some());
         },
-        // The row is there but has no hash, so nothing about it can be PROVEN unsent — and this
-        // verdict has two readers that must not both defer. The producer cannot author an
-        // unreadable row either ([`ScannedRow::Unpublishable`]), so answering "there may be an
-        // unsent edit" here would leave the row unauthorable AND permanently block its own pending
-        // entries, with no way out. Replaying is the direction with a floor: the entry still has to
-        // win the ordinary clock comparison, and a winner rewrites every synced column, which is
-        // the only thing that makes the row syncable again.
-        SyncedRow::Unreadable(_) => return Ok(false),
+        // The row is there but has no hash, so nothing about it can be PROVEN either way — and what
+        // to do about that is NOT the same for the two op kinds.
+        //
+        // An `Upsert` may replay. This verdict has two readers that must not both defer, and the
+        // producer cannot author an unreadable row either ([`ScannedRow::Unpublishable`]), so
+        // answering "there may be an unsent edit" for every op would leave the row unauthorable AND
+        // permanently block its own pending entries, with no way out. The upsert has a floor: it
+        // still has to win the ordinary clock comparison, and a winner rewrites every synced
+        // column, which is the only thing that makes the row syncable again.
+        //
+        // A `Remove` has no such floor. It deletes the row outright — local-only columns included —
+        // and repairs nothing, so a winning remove would destroy an unsent local edit that merely
+        // happens to be unreadable. Deferring it is the safe stuck state: the row survives, and the
+        // entry replays on the merits once the cell is repaired.
+        SyncedRow::Unreadable(_) => return Ok(matches!(op, RowOp::Remove { .. })),
     };
     let current = row_op::cells_hash(&current_cells);
     Ok(match published_hash(tx, repo_id, spec.name, &row_pk)? {
@@ -868,34 +881,59 @@ fn sql_value(value: &TypedValue) -> SqlValue {
 /// Mapping one stored value back to its declared type: the value, or the reason it has none.
 ///
 /// A REASON rather than an `Err`, because every read below sits under a path that must not fail —
-/// see [`SyncedRow`]. `Malformed` has exactly ONE producer, and that is a property of the schema
-/// rules, not a coincidence: the registry lint requires a STRICT table, so a `Text` / `I64` /
-/// `Blob` column can only ever hold its declared storage type and those three mappings are total.
-/// `Bool` is the sole value type whose domain SQLite does not enforce — 0/1 needs a
-/// `CHECK (col IN (0, 1))`, which no pragma exposes for the lint to require.
+/// see [`SyncedRow`].
 enum ReadCell {
     Value(TypedValue),
     Malformed(String),
 }
 
+/// Map the stored value at `idx` to its DECLARED type.
+///
+/// TOTAL over (declared type, storage class) by construction: every pair either produces a value or
+/// names why it cannot, and the only `Err` left is a genuine statement fault (a column index that
+/// does not exist). That totality is the whole point — this runs under the refold at STORE OPEN,
+/// where an error fails the open itself rather than one read, so no stored byte pattern may be able
+/// to reach a `?`.
+///
+/// It is deliberately NOT argued from `STRICT`. STRICT pins the storage CLASS, not the value's
+/// domain within it, and two domains escape it:
+///   * a `Bool` needs `CHECK (col IN (0, 1))` to exclude other integers, and no pragma exposes that
+///     for the registry lint to require;
+///   * a `Text` column can hold bytes that are not valid UTF-8 (`CAST(X'80' AS TEXT)` stores with
+///     `typeof() = 'text'`), which is a conversion failure the moment it is read as a `String`.
+///
+/// A mismatched storage class is folded in for the same reason: it should be unreachable on a
+/// STRICT table, and "should be unreachable" is exactly the argument that made the previous version
+/// fail an open.
 fn read_typed(row: &rusqlite::Row<'_>, idx: usize, vt: ValueType) -> rusqlite::Result<ReadCell> {
-    let value = match vt {
-        ValueType::Text =>
-            row.get::<_, Option<String>>(idx)?.map_or(TypedValue::Null, TypedValue::Text),
-        ValueType::I64 => row.get::<_, Option<i64>>(idx)?.map_or(TypedValue::Null, TypedValue::I64),
+    use rusqlite::types::ValueRef;
+
+    let raw = row.get_ref(idx)?;
+    let value = match (vt, raw) {
+        (_, ValueRef::Null) => TypedValue::Null,
+        // Not `get::<String>`: that maps invalid UTF-8 to a conversion ERROR, which is precisely
+        // the failure this function exists to keep out of the store-open path.
+        (ValueType::Text, ValueRef::Text(bytes)) => match std::str::from_utf8(bytes) {
+            Ok(text) => TypedValue::Text(text.to_string()),
+            Err(_) =>
+                return Ok(ReadCell::Malformed(
+                    "a Text column holds bytes that are not valid UTF-8".to_string(),
+                )),
+        },
+        (ValueType::I64, ValueRef::Integer(n)) => TypedValue::I64(n),
+        (ValueType::Blob, ValueRef::Blob(bytes)) => TypedValue::Blob(bytes.to_vec()),
         // A Bool column must hold exactly 0 or 1. Coercing any other integer to `true` (the old
         // `n != 0`) would silently rewrite the source value to 1 on self-apply and replicate a
-        // value that differs from the row — report the malformed value instead of normalizing it
-        // away, and let the caller decide (never by failing, see [`ReadCell`]).
-        ValueType::Bool => match row.get::<_, Option<i64>>(idx)? {
-            None => TypedValue::Null,
-            Some(0) => TypedValue::Bool(false),
-            Some(1) => TypedValue::Bool(true),
-            Some(other) =>
-                return Ok(ReadCell::Malformed(format!("a Bool column holds {other}, not 0 or 1"))),
-        },
-        ValueType::Blob =>
-            row.get::<_, Option<Vec<u8>>>(idx)?.map_or(TypedValue::Null, TypedValue::Blob),
+        // value that differs from the row.
+        (ValueType::Bool, ValueRef::Integer(0)) => TypedValue::Bool(false),
+        (ValueType::Bool, ValueRef::Integer(1)) => TypedValue::Bool(true),
+        (ValueType::Bool, ValueRef::Integer(other)) =>
+            return Ok(ReadCell::Malformed(format!("a Bool column holds {other}, not 0 or 1"))),
+        (declared, other) =>
+            return Ok(ReadCell::Malformed(format!(
+                "a {declared:?} column holds {:?} storage",
+                other.data_type()
+            ))),
     };
     Ok(ReadCell::Value(value))
 }
@@ -1887,25 +1925,136 @@ mod tests {
         assert!(matches!(rows[0], ScannedRow::Unaddressable), "no pk means no identity");
     }
 
-    #[test]
-    fn the_unsent_edit_guard_does_not_defer_on_a_row_it_cannot_read() {
-        // Both readers of "is there an unsent edit here" must not defer: the producer cannot author
-        // an unreadable row either, so answering `true` here would leave the row unauthorable AND
-        // permanently block its own pending entries. Replaying is the direction with a floor — the
-        // entry still has to win on the clock, and a winner rewrites the column that is unreadable.
-        let mut c = flagged_store(2);
-        let tx = c.transaction().unwrap();
-        let stream = crate::table_sync::scope_stream::scope_stream_id(
+    /// A stable stream id for the guard tests, which never reach the winner lookup.
+    fn guard_stream() -> StreamId {
+        crate::table_sync::scope_stream::scope_stream_id(
             "repo",
             crate::AccountId::from_bytes([7; 32]),
             "demo/1",
-        );
+        )
+    }
+
+    /// An op of each kind against the `FLAGGED` row, for the asymmetry below.
+    fn flagged_op(remove: bool) -> RowOp {
+        let pk = vec![TypedValue::Text("r".into())];
+        if remove {
+            RowOp::Remove { table: "t_flagged".to_string(), spec_version: 1, pk }
+        } else {
+            RowOp::Upsert {
+                table: "t_flagged".to_string(),
+                spec_version: 1,
+                pk,
+                cells: vec![Cell { column: "flag".to_string(), value: TypedValue::Bool(true) }],
+            }
+        }
+    }
+
+    #[test]
+    fn an_upsert_may_replay_over_a_row_it_cannot_read() {
+        // Both readers of "is there unsent work here" must not defer: the producer cannot author an
+        // unreadable row either, so deferring every op would leave the row unauthorable AND
+        // permanently block its own pending entries. The upsert has a floor — it still has to win
+        // on the clock, and a winner rewrites the column that is unreadable.
+        let mut c = flagged_store(2);
+        let tx = c.transaction().unwrap();
         assert!(
-            !row_has_unsent_local_change(&tx, &FLAGGED, "repo", stream, &[TypedValue::Text(
-                "r".into()
-            )],)
+            !replay_would_destroy_unsent_work(
+                &tx,
+                &FLAGGED,
+                "repo",
+                guard_stream(),
+                &flagged_op(false)
+            )
             .unwrap(),
-            "an unreadable row proves nothing, so it must not block the replay",
+            "an unreadable row proves nothing against an upsert that would repair it",
+        );
+    }
+
+    #[test]
+    fn a_remove_may_not_replay_over_a_row_it_cannot_read() {
+        // The asymmetry. A remove deletes the row outright — local-only columns included — and
+        // repairs nothing, so letting it through would destroy an unsent local edit that merely
+        // happens to be unreadable. Deferring is the safe stuck state: the row survives, and the
+        // entry replays on the merits once the cell is repaired.
+        let mut c = flagged_store(2);
+        let tx = c.transaction().unwrap();
+        assert!(
+            replay_would_destroy_unsent_work(
+                &tx,
+                &FLAGGED,
+                "repo",
+                guard_stream(),
+                &flagged_op(true)
+            )
+            .unwrap(),
+            "a remove over an unreadable row has no repair to offer, so it must defer",
+        );
+    }
+
+    #[test]
+    fn a_text_column_holding_invalid_utf8_is_unreadable_too() {
+        // STRICT pins the storage CLASS, not the value's domain within it: `CAST(X'80' AS TEXT)`
+        // stores with `typeof() = 'text'` and fails the moment it is read as a `String`. Reading it
+        // as an error would fail the store open exactly the way a malformed Bool used to, so the
+        // mapping is total over (declared type, storage class) rather than argued from STRICT.
+        const LABELLED: TableSpec = TableSpec {
+            name: "t_labelled",
+            scope_id: "demo/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("label", ValueType::Text)],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_labelled(id TEXT PRIMARY KEY, label TEXT) STRICT;
+             INSERT INTO t_labelled(id, label) VALUES ('r', CAST(X'80' AS TEXT));",
+        )
+        .unwrap();
+        let tx = c.transaction().unwrap();
+
+        let cells = read_synced_cells(&tx, &LABELLED, &[TypedValue::Text("r".into())]).unwrap();
+        assert!(
+            matches!(cells, SyncedRow::Unreadable(_)),
+            "invalid UTF-8 is unreadable, not an error"
+        );
+        let rows = read_all_rows(&tx, &LABELLED, "repo").unwrap();
+        assert!(
+            matches!(&rows[0], ScannedRow::Unpublishable { .. }),
+            "and the scan carries the row rather than failing the pass",
+        );
+    }
+
+    #[test]
+    fn a_storage_class_that_does_not_match_the_declared_type_is_unreadable() {
+        // Unreachable on a STRICT table — which is exactly the argument that let the previous
+        // version fail an open, so the mapping covers it as a value instead of assuming it away.
+        const LABELLED: TableSpec = TableSpec {
+            name: "t_loose",
+            scope_id: "demo/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("label", ValueType::Text)],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        // No STRICT here: that is what lets an INTEGER land in a column declared TEXT.
+        c.execute_batch(
+            "CREATE TABLE t_loose(id TEXT PRIMARY KEY, label BLOB);
+             INSERT INTO t_loose(id, label) VALUES ('r', 7);",
+        )
+        .unwrap();
+        let tx = c.transaction().unwrap();
+        assert!(
+            matches!(
+                read_synced_cells(&tx, &LABELLED, &[TypedValue::Text("r".into())]).unwrap(),
+                SyncedRow::Unreadable(_)
+            ),
+            "a mismatched storage class is carried, not raised",
         );
     }
 

--- a/crates/rag-rat-oplog/src/table_sync/produce.rs
+++ b/crates/rag-rat-oplog/src/table_sync/produce.rs
@@ -34,7 +34,23 @@ pub(crate) fn produce_row_ops(
     let mut ops = Vec::new();
     let mut live: BTreeSet<String> = BTreeSet::new();
 
-    for (pk, cells) in apply::read_all_rows(tx, spec, repo_id)? {
+    for scanned in apply::read_all_rows(tx, spec, repo_id)? {
+        let (pk, cells) = match scanned {
+            apply::ScannedRow::Readable { pk, cells } => (pk, cells),
+            // The row exists and cannot be carried, so it is published as whatever it last was —
+            // but its identity MUST still count as live. Dropping it here instead would leave a
+            // published identity with no live row, which the loop below reads as a local delete and
+            // authors a `Remove` for: an unreadable cell on one device would then delete the row on
+            // every peer.
+            apply::ScannedRow::Unpublishable { pk } => {
+                live.insert(row_op::row_pk_string(&pk));
+                continue;
+            },
+            // No pk means no identity to keep alive, so this row is deliberately NOT added to
+            // `live`: whatever pk was published genuinely has no row carrying it any more, and a
+            // `Remove` for that identity is the same answer a delete would get.
+            apply::ScannedRow::Unaddressable => continue,
+        };
         let row_pk = row_op::row_pk_string(&pk);
         live.insert(row_pk.clone());
         let hash = row_op::cells_hash(&cells);
@@ -255,6 +271,116 @@ mod tests {
             ops[0].pk()[0],
             TypedValue::Text("A".to_string()),
             "the produced row belongs to the repo being synced",
+        );
+    }
+
+    /// A spec whose synced column is a `Bool`, plus its table — the one shape a STRICT schema can
+    /// leave unreadable (#1017).
+    const FLAGGED: TableSpec = TableSpec {
+        name: "t_flagged",
+        scope_id: "demo/1",
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("flag", ValueType::Bool)],
+        local_columns: &[],
+        repo_column: None,
+    };
+
+    fn flagged_conn() -> rusqlite::Connection {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_flagged(id TEXT PRIMARY KEY, flag INTEGER) STRICT;")
+            .unwrap();
+        c
+    }
+
+    fn flag_upsert(id: &str, flag: bool) -> RowOp {
+        RowOp::Upsert {
+            spec_version: 1,
+            table: "t_flagged".to_string(),
+            pk: vec![TypedValue::Text(id.to_string())],
+            cells: vec![Cell { column: "flag".to_string(), value: TypedValue::Bool(flag) }],
+        }
+    }
+
+    #[test]
+    fn a_row_that_cannot_be_read_is_neither_authored_nor_removed() {
+        // The trap: an unreadable row that is simply skipped disappears from the live set, and the
+        // published identity it leaves behind reads as a local delete — so one device's malformed
+        // cell would author a `Remove` that deletes the row on EVERY peer.
+        let mut c = flagged_conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(&tx, &FLAGGED, "repo", &flag_upsert("r1", true), OpMeta {
+            lamport: 1,
+            device: DeviceFingerprint::from_bytes([1; 32]),
+        })
+        .unwrap();
+        assert!(produce_row_ops(&tx, &FLAGGED, "repo", test_stream()).unwrap().is_empty());
+
+        // A raw local write puts the column outside the Bool domain STRICT cannot pin.
+        tx.execute("UPDATE t_flagged SET flag = 2 WHERE id = 'r1'", []).unwrap();
+        assert!(
+            produce_row_ops(&tx, &FLAGGED, "repo", test_stream()).unwrap().is_empty(),
+            "an unreadable row is not carried in an op — and above all is not deleted on peers",
+        );
+    }
+
+    #[test]
+    fn an_unreadable_row_does_not_stop_the_rest_of_the_table() {
+        // One bad row must not cost the pass: before #1017 the scan errored, taking every other
+        // row's op with it.
+        let mut c = flagged_conn();
+        let tx = c.transaction().unwrap();
+        tx.execute("INSERT INTO t_flagged(id, flag) VALUES ('bad', 2), ('good', 1)", []).unwrap();
+        let ops = produce_row_ops(&tx, &FLAGGED, "repo", test_stream()).unwrap();
+        assert_eq!(ops.len(), 1, "the readable row is still produced");
+        assert_eq!(ops[0].pk(), vec![TypedValue::Text("good".to_string())]);
+    }
+
+    #[test]
+    fn a_row_whose_pk_cannot_be_read_releases_the_identity_it_was_published_under() {
+        // The pk case is the other half, and it goes the other way: with no readable pk there is no
+        // identity to keep alive, so the pk that WAS published genuinely has no row carrying it —
+        // exactly what a delete means. Suppressing the `Remove` instead would leave peers holding a
+        // row this device can never speak about again.
+        const FLAG_PK: TableSpec = TableSpec {
+            name: "t_flag",
+            scope_id: "demo/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("active", ValueType::Bool)],
+            columns: &[ColumnSpec::required("label", ValueType::Text)],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_flag(active INTEGER PRIMARY KEY, label TEXT) STRICT;")
+            .unwrap();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &FLAG_PK,
+            "repo",
+            &RowOp::Upsert {
+                spec_version: 1,
+                table: "t_flag".to_string(),
+                pk: vec![TypedValue::Bool(true)],
+                cells: vec![Cell {
+                    column: "label".to_string(),
+                    value: TypedValue::Text("on".into()),
+                }],
+            },
+            OpMeta { lamport: 1, device: DeviceFingerprint::from_bytes([1; 32]) },
+        )
+        .unwrap();
+        assert!(produce_row_ops(&tx, &FLAG_PK, "repo", test_stream()).unwrap().is_empty());
+
+        tx.execute("UPDATE t_flag SET active = 2", []).unwrap();
+        let ops = produce_row_ops(&tx, &FLAG_PK, "repo", test_stream()).unwrap();
+        assert_eq!(ops.len(), 1);
+        assert!(
+            matches!(&ops[0], RowOp::Remove { .. }),
+            "the published pk no longer names a live row, so it is a delete",
         );
     }
 

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -167,7 +167,8 @@ fn replay_pending_entry(
     // it. Leaving the entry pending costs nothing: once the producer authors that edit (at a
     // lamport above this entry's, since authoring counts parked entries), a later replay lands
     // and loses on the merits.
-    if apply::row_has_unsent_local_change(tx, spec, &context.repo_id, pending.stream_id, op.pk())? {
+    if apply::replay_would_destroy_unsent_work(tx, spec, &context.repo_id, pending.stream_id, &op)?
+    {
         return Ok(());
     }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
@@ -1170,6 +1171,69 @@ mod tests {
             "and the replayed winner rewrites the whole row, which is what repairs the bad cell",
         );
         assert_eq!(b.pending_count(), 0, "the entry is no longer outstanding");
+    }
+
+    #[test]
+    fn a_parked_remove_does_not_delete_a_row_this_binary_cannot_read() {
+        // The other half of #1017's guard, and the destructive one. An UPSERT may replay over an
+        // unreadable row because a winner rewrites every synced column and repairs it. A REMOVE has
+        // no such floor: it deletes the row outright — local-only columns included — so a row whose
+        // unreadable cell is an unsent local edit would be destroyed at store open, before anything
+        // had a chance to author it.
+        const BOOL: TableSpec = TableSpec {
+            name: "t_bool",
+            scope_id: "demo/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("flag", ValueType::Bool)],
+            local_columns: &["local_only"],
+            repo_column: None,
+        };
+        let table =
+            "CREATE TABLE t_bool(id TEXT PRIMARY KEY, flag INTEGER, local_only TEXT) STRICT;";
+
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute_batch(table).unwrap();
+        b.conn.execute_batch(table).unwrap();
+
+        // A publishes r1; B ingests it normally, so B's chain holds the Remove's predecessor.
+        a.conn.execute("INSERT INTO t_bool(id, flag) VALUES ('r1', 1)", []).unwrap();
+        let upserts = a.produce(&[BOOL], "repo");
+        assert_eq!(upserts.len(), 1, "the row is published first");
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(&[BOOL], "repo", &upserts, &a.pubkey()), vec![IngestOutcome::Applied]);
+
+        // B then edits its copy raw — unsent, outside the Bool domain, and carrying a local-only
+        // column a delete would take with it.
+        b.conn
+            .execute("UPDATE t_bool SET flag = 2, local_only = 'keep me' WHERE id = 'r1'", [])
+            .unwrap();
+
+        // A deletes the row and authors the `Remove`. B ingests it through a binary whose registry
+        // does not carry the table — the mixed-version shared store this engine treats as
+        // first-class — so it is retained for the refold rather than applied.
+        a.conn.execute("DELETE FROM t_bool WHERE id = 'r1'", []).unwrap();
+        let removes = a.produce(&[BOOL], "repo");
+        assert_eq!(removes.len(), 1, "the local delete is authored as a Remove");
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &removes, &a.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::TableNotInScope.as_db_str())
+        ]);
+        assert_eq!(b.pending_count(), 1);
+
+        assert!(refold_stale_projections_against(&b.conn, &[BOOL]).unwrap());
+        let survived: (i64, Option<String>) = b
+            .conn
+            .query_row("SELECT flag, local_only FROM t_bool WHERE id = 'r1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(
+            survived,
+            (2, Some("keep me".to_string())),
+            "the unsent row survives the replayed remove, local-only column included",
+        );
+        assert_eq!(b.pending_count(), 1, "and the entry stays outstanding rather than being lost");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -1112,6 +1112,67 @@ mod tests {
     }
 
     #[test]
+    fn a_row_this_binary_cannot_read_does_not_fail_the_refold_and_is_repaired_by_it() {
+        // #1017, and the reason it is severe: this pass runs at STORE OPEN, so an error here does
+        // not fail one replay — it fails the open, and `index --full` takes the same path, so there
+        // is no recovery. A `Bool` column outside 0/1 is the one cell a STRICT schema cannot rule
+        // out, and no registry lint can require the `CHECK (col IN (0, 1))` that would.
+        const BOOL_OLD: TableSpec = TableSpec {
+            name: "t_bool",
+            scope_id: "demo/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("flag", ValueType::Bool)],
+            local_columns: &["later"],
+            repo_column: None,
+        };
+        const BOOL_NEW: TableSpec = TableSpec {
+            spec_version: 2,
+            columns: &[
+                ColumnSpec::required("flag", ValueType::Bool),
+                ColumnSpec::added("later", ValueType::Text, 2, DefaultValue::Null),
+            ],
+            local_columns: &[],
+            ..BOOL_OLD
+        };
+        let table = "CREATE TABLE t_bool(id TEXT PRIMARY KEY, flag INTEGER, later TEXT) STRICT;";
+
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute_batch(table).unwrap();
+        b.conn.execute_batch(table).unwrap();
+
+        // A authors r1 under the wider column set; B cannot project it and parks it.
+        a.conn.execute("INSERT INTO t_bool(id, flag, later) VALUES ('r1', 0, 'wide')", []).unwrap();
+        let entries = a.produce(&[BOOL_NEW], "repo");
+        assert_eq!(entries.len(), 1);
+        b.enroll(a.pubkey().fingerprint());
+        b.ingest(&[BOOL_OLD], "repo", &entries, &a.pubkey());
+        assert_eq!(b.pending_count(), 1);
+
+        // B's own copy of the row is outside the Bool domain — written raw, so it never went
+        // through the applier's typed cells.
+        b.conn.execute("INSERT INTO t_bool(id, flag, later) VALUES ('r1', 2, NULL)", []).unwrap();
+
+        assert!(
+            refold_stale_projections_against(&b.conn, &[BOOL_NEW]).unwrap(),
+            "the refold must complete — an error here is an index that never opens again",
+        );
+        let row: (i64, Option<String>) = b
+            .conn
+            .query_row("SELECT flag, later FROM t_bool WHERE id = 'r1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(
+            row,
+            (0, Some("wide".to_string())),
+            "and the replayed winner rewrites the whole row, which is what repairs the bad cell",
+        );
+        assert_eq!(b.pending_count(), 0, "the entry is no longer outstanding");
+    }
+
+    #[test]
     fn redelivery_of_a_parked_entry_changes_nothing_and_keeps_its_mark() {
         // Redelivery cannot rescue a parked entry (it short-circuits on `entry_exists`) — which is
         // exactly why the mark has to survive it. If redelivery cleared the mark, the refold would

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -22,8 +22,10 @@ use super::schema_facts::{self, CheckVerdict, PhysicalColumn};
 ///
 /// `Bool` stores as a STRICT `INTEGER` and must hold only 0 or 1. SQLite does not enforce that
 /// domain without a `CHECK (col IN (0, 1))`, which no pragma exposes for the lint to require — so a
-/// `Bool` column SHOULD carry that CHECK, and `read_typed` fail-closes (errors, halting the pass —
-/// never silently coercing) on any other integer as the runtime backstop.
+/// `Bool` column SHOULD carry that CHECK, and the runtime backstop is that `read_typed` refuses any
+/// other integer rather than coercing it. It refuses it as a VALUE, not an error: the reader runs
+/// under the refold at store open, where an error would fail every subsequent open, so a row with
+/// such a cell is carried as unreadable — never published, never deleted — until it is repaired.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ValueType {
     Text,
@@ -528,9 +530,9 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
 
     // The table MUST be STRICT. STRICT enforces the declared column type at write time, so a value
     // the producer read (by its `ValueType`) can never be affinity-coerced to a different stored
-    // type — which would make the post-write `synced_row_hash` read-back throw and wedge ingest
-    // after the row was already written. It also makes pk columns NOT NULL. It is the schema
-    // convention for every new table regardless.
+    // type — which is what makes the `Text` / `I64` / `Blob` mappings in `read_typed` total,
+    // leaving `Bool`'s 0/1 domain as the one case the schema cannot pin. It also makes pk
+    // columns NOT NULL. It is the schema convention for every new table regardless.
     // A GENERATED column is invisible to the rest of this lint and to the applier alike:
     // `PRAGMA table_info` omits it, so the exhaustiveness diff never classifies it, and the
     // applier never supplies it. It is not inert, though — its expression can read a synced column,

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -23,7 +23,8 @@ use super::schema_facts::{self, CheckVerdict, PhysicalColumn};
 /// `Bool` stores as a STRICT `INTEGER` and must hold only 0 or 1. SQLite does not enforce that
 /// domain without a `CHECK (col IN (0, 1))`, which no pragma exposes for the lint to require — so a
 /// `Bool` column SHOULD carry that CHECK, and the runtime backstop is that `read_typed` refuses any
-/// other integer rather than coercing it. It refuses it as a VALUE, not an error: the reader runs
+/// other integer rather than coercing it. `Text` has the same shape: STRICT pins the storage class,
+/// not that the bytes are valid UTF-8. Both are refused as a VALUE, not an error: the reader runs
 /// under the refold at store open, where an error would fail every subsequent open, so a row with
 /// such a cell is carried as unreadable — never published, never deleted — until it is repaired.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -530,9 +531,10 @@ pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> 
 
     // The table MUST be STRICT. STRICT enforces the declared column type at write time, so a value
     // the producer read (by its `ValueType`) can never be affinity-coerced to a different stored
-    // type — which is what makes the `Text` / `I64` / `Blob` mappings in `read_typed` total,
-    // leaving `Bool`'s 0/1 domain as the one case the schema cannot pin. It also makes pk
-    // columns NOT NULL. It is the schema convention for every new table regardless.
+    // type. It pins the storage CLASS only, not the value's domain within it — a `Bool` can still
+    // hold 2 and a `Text` can still hold invalid UTF-8 — which is why `read_typed` carries those as
+    // unreadable rather than relying on the schema. It also makes pk columns NOT NULL, and is the
+    // schema convention for every new table regardless.
     // A GENERATED column is invisible to the rest of this lint and to the applier alike:
     // `PRAGMA table_info` omits it, so the exhaustiveness diff never classifies it, and the
     // applier never supplies it. It is not inert, though — its expression can read a synced column,


### PR DESCRIPTION
Two table-sync defects that are unreachable while `SYNCABLE_TABLES` is empty, and that both get
harder to fix once the first table registers.

## An unreadable row no longer fails the open (#1017)

`read_typed` refuses a `Bool` column holding an integer other than 0 or 1 — coercing it to `true`
would replicate a value that differs from the stored row. It refused by *erroring*, and the
table-sync refold runs at store open, so that error propagated out of `IndexDatabase::open` and
re-failed on every subsequent open, with `index --full` taking the same path. There was no recovery.

The refusal is now a value, and each reader decides what it means:

- `read_synced_cells` reports `SyncedRow::Unreadable` distinctly from `Absent`. Collapsing the two
  would be its own bug: the refold's guard reads an absent row as a local delete awaiting authorship
  and refuses to replay over it, which for a row that is merely unreadable would block that entry
  for good.
- `row_has_unsent_local_change` answers "no unsent change" for a row it cannot read, because it can
  prove nothing about it. The producer cannot author such a row either, and this verdict's two
  readers must not both defer — the row would be unauthorable *and* would permanently block its own
  pending entries. Replaying is the direction with a floor: the entry still has to win on the clock,
  and a winner rewrites every synced column, which is what repairs the cell.
- the producer scan splits the two unreadable cases, because treating them alike deletes data. A row
  whose synced column is unreadable is still live and addressable, so its identity must stay in the
  live set — drop it and the published identity it leaves behind reads as a local delete, and one
  device's malformed cell authors a `Remove` that removes the row from every peer. A row whose *pk*
  is unreadable has no identity to keep alive, and the pk it was published under genuinely no longer
  names a live row.

`Malformed` has exactly one producer, and that follows from the schema rules rather than from
inspection: the registry lint requires a STRICT table, so the `Text`, `I64` and `Blob` mappings are
total, and `Bool` is the only value type whose domain SQLite will not enforce without a
`CHECK (col IN (0, 1))` that no pragma exposes for the lint to require.

## `rag-rat rm` no longer leaves resurrectable sync history (#1004)

`purge_repo_rows` sweeps every table carrying a `repo_id`, which includes the `table_sync_streams`
directory. `table_sync_entries` is keyed by an opaque `stream_id` with no `repo_id`, and the
stream-keyed sync substrate is otherwise deliberately retained across a repo purge — so after
`rag-rat rm` a repo's signed table history survived without the directory row needed to place it.

Retention is only safe where the key cannot be regenerated, and this key can: `scope_stream_id` is a
pure function of `(repo_id, account_id, scope_id)`, so re-registering the same repo recreates the
identical stream mapping and a later projector bump replays the removed repo's parked operations
back into it. The entry log therefore joins the purge, as a transitive child of the directory —
captured up front, because once the class sweep removes the directory row a one-way hash leaves no
way back from an entry to its repo.

The poison-sibling tripwire now seeds a stream and an entry for both the victim and the sibling, so
the guarantee is observable rather than passing on an empty table: the victim's entries must be
gone, and the sibling's — which no `repo_id` predicate could have protected — must survive.

## Verification

Every behavior was mutation-checked: the code under test was reverted and the test confirmed to
fail, and to fail for the stated reason.

| Mutation | Killed by |
|---|---|
| `read_typed` errors on a malformed `Bool` (the prior behavior) | 8 tests, incl. the store-open refold |
| `read_typed` coerces any non-zero integer to `true` | 7 tests |
| the guard defers on an unreadable row | `the_unsent_edit_guard_does_not_defer_on_a_row_it_cannot_read` |
| an unpublishable row is skipped without keeping its identity live | `a_row_that_cannot_be_read_is_neither_authored_nor_removed` |
| an unreadable pk is filled with a placeholder instead of unnaming the row | `a_row_whose_pk_cannot_be_read_releases_the_identity_it_was_published_under` |
| the entry log is retained (the prior behavior) | the poison-sibling tripwire |
| the stream ids are captured after the class sweep | the poison-sibling tripwire |
| the stream capture is unscoped | the sibling-integrity assertion |

Gates: `cargo +nightly fmt --all --check`, clippy on both feature legs (`--no-default-features` and
`--all-features`, `--all-targets`, `-D warnings`), `cargo nextest run --workspace
--no-default-features` (4353 passed), and `cargo test` on the touched crates — the coverage job's
shared-process runner.

Fixes #1017
Fixes #1004