### PR TITLE
fix(index): canonicalize fixture config roots so the suite matches Config::load

### DIFF
--- a/crates/rag-rat-base/src/logging/mod.rs
+++ b/crates/rag-rat-base/src/logging/mod.rs
@@ -128,14 +128,15 @@ mod tests {
     use crate::config::{Config, LogConfig};
 
     fn test_config(dir: &std::path::Path, enabled: bool) -> Config {
+        let config_root = crate::test_scratch::canonical_config_root(dir.to_path_buf());
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: dir.to_path_buf(),
-            database: dir.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: Vec::new(),
             llm: Default::default(),
             watch: Default::default(),

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -331,6 +331,11 @@ pub fn scratch_dir(tag: &str) -> PathBuf {
 /// Name of the self-referential symlink inside the namespace that makes every handed-out scratch
 /// path NON-CANONICAL on Unix (see [`aliased_root`]). Not a valid scratch dir name itself —
 /// [`scratch_dir`] always appends `-<pid>-<seq>` — so it can never collide with a `tag`.
+///
+/// Gated with its only reader: [`aliased_root`]'s link-creating branch is Unix-only, so an
+/// ungated const here would be `dead_code` on Windows, where the cross-platform legs deny
+/// warnings.
+#[cfg(unix)]
 const NON_CANONICAL_ALIAS: &str = "via-symlink";
 
 /// `root`, reached through a symlinked ancestor so the paths this module hands out are NOT
@@ -351,8 +356,29 @@ const NON_CANONICAL_ALIAS: &str = "via-symlink";
 /// no attack surface, and [`sweep_stale`] skips symlink entries so it is never followed or swept.
 ///
 /// Unix-only: creating a symlink on Windows needs developer mode or elevation, and Windows has its
-/// own non-canonical spelling anyway. Falls back to `root` unchanged if the link cannot be made,
-/// so a restricted filesystem degrades to the old behavior rather than failing the suite.
+/// own non-canonical spelling anyway — the tripwire tests are gated the same way, so nothing on
+/// Windows depends on this branch.
+///
+/// On Unix it returns `root` unchanged when the link cannot be made (a mount or policy that denies
+/// symlink creation). That is NOT a graceful degradation: the divergence the tripwires assert
+/// disappears with it, so
+/// `scratch_paths_are_not_canonical_so_linux_covers_the_macos_root_divergence` and the per-fixture
+/// `*_diverges_from_its_scratch_spelling` probes fail. Failing loudly is the intended outcome — a
+/// suite that stayed green while silently dropping this coverage is how the class reached the
+/// cross-platform legs in the first place (#1027).
+///
+/// # What it does NOT cover
+///
+/// The alias only reaches paths handed out by [`scratch_dir`] / [`ScratchDir`]. A fixture that
+/// rolls its own root — `std::env::temp_dir().join(...)`, `tempfile::tempdir()` — opts out: that
+/// root is already canonical on Linux, [`canonical_config_root`] degenerates to a no-op, and the
+/// root-spelling class stops being covered on the per-PR matrix. Build index `Config` fixtures on
+/// [`ScratchDir`] for that reason (the roots not on it today are synthetic paths, explicitly
+/// canonicalized ones, and the bench corpus, none of which carry a scratch spelling at all).
+///
+/// It is also only an approximation of Windows: `std::fs::canonicalize` there returns a `\\?\`
+/// verbatim path and expands 8.3 names, neither of which a Unix symlink produces. A root-spelling
+/// bug specific to those two shapes still surfaces first on the cross-platform legs.
 fn aliased_root(root: &Path) -> PathBuf {
     #[cfg(unix)]
     {

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -405,19 +405,37 @@ fn aliased_root(root: &Path) -> PathBuf {
 ///
 /// Fixtures hand roots over before creating them (a `git worktree add` destination must not
 /// exist), which plain `canonicalize()` rejects, so this canonicalizes the longest EXISTING
-/// ancestor and re-joins the remainder. For a root that exists it is exactly `canonicalize()`;
-/// with no existing ancestor at all it returns `root` unchanged.
+/// ancestor and re-joins the remainder. For a root that exists it is exactly `canonicalize()`.
+///
+/// A root with NO existing ancestor below the filesystem root comes back UNCHANGED, and that is
+/// load-bearing rather than a degenerate case. Placement and event-classification tests reason over
+/// SYNTHETIC paths (`/repo`, `/main/.git/worktrees`, `/checkout/packages`) that are never on disk;
+/// `Config::load` rejects such a root outright (`normalize_existing_dir` requires the directory to
+/// exist), so there is no production spelling to match and inventing one would only introduce a
+/// divergence. Windows is where that bites: `canonicalize()` on the bare root yields the current
+/// drive's `\\?\C:\` verbatim prefix, so a canonicalized `/repo` would stop matching the sibling
+/// literals the same test compares it against — a mismatch the Linux legs can never see (#1027).
 pub fn canonical_config_root(root: impl Into<PathBuf>) -> PathBuf {
     let root = root.into();
+    resolve_through_existing_ancestor(&root).unwrap_or(root)
+}
+
+/// `path` resolved through its deepest EXISTING ancestor: that ancestor canonicalized, with the
+/// components below it re-joined verbatim. `None` when the ascent reaches a filesystem root or
+/// prefix without finding one.
+///
+/// The ascent deliberately stops ABOVE the filesystem root instead of resolving it. A path with no
+/// existing ancestor at all names nothing on this machine, so there is no spelling to normalize
+/// toward — and on Windows `canonicalize()` of the bare root returns the current drive's `\\?\C:\`
+/// verbatim form, which would rewrite the path into one none of its siblings match.
+fn resolve_through_existing_ancestor(path: &Path) -> Option<PathBuf> {
     let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
-    let mut probe = root.as_path();
+    let mut probe = path;
     loop {
+        let (parent, name) = (probe.parent()?, probe.file_name()?);
         if let Ok(canonical) = probe.canonicalize() {
-            return tail.iter().rev().fold(canonical, |acc, part| acc.join(part));
+            return Some(tail.iter().rev().fold(canonical, |acc, part| acc.join(part)));
         }
-        let (Some(parent), Some(name)) = (probe.parent(), probe.file_name()) else {
-            return root;
-        };
         tail.push(name);
         probe = parent;
     }
@@ -711,6 +729,35 @@ mod tests {
         // Once it exists, plain canonicalization agrees.
         std::fs::create_dir_all(&absent).unwrap();
         assert_eq!(canonical_config_root(&absent), absent.canonicalize().unwrap());
+    }
+
+    /// The ancestor search stops ABOVE the filesystem root, so a SYNTHETIC path — one with no
+    /// existing ancestor at all — resolves to nothing and [`canonical_config_root`] hands it back
+    /// untouched.
+    ///
+    /// The placement and event-classification tests reason over paths that are never on disk
+    /// (`/repo`, `/main/.git/worktrees`, `/checkout/packages`) and compare `config.root` against
+    /// sibling literals spelled the same way. Resolving the bare root would rewrite one side of
+    /// every one of those comparisons and neither of the others — on Windows into the current
+    /// drive's `\\?\C:\` verbatim form (#1027). The search is asserted directly because on Unix
+    /// canonicalizing `/` is the identity, so `canonical_config_root` alone cannot tell the two
+    /// behaviours apart here.
+    #[test]
+    fn the_existing_ancestor_search_stops_above_the_filesystem_root() {
+        let synthetic = PathBuf::from("/rag-rat-no-such-root/packages/crate");
+        assert!(!synthetic.exists(), "the probe must not exist: {synthetic:?}");
+        assert!(
+            resolve_through_existing_ancestor(&synthetic).is_none(),
+            "a path with no existing ancestor must not resolve through the filesystem root",
+        );
+        assert_eq!(canonical_config_root(&synthetic), synthetic);
+
+        // The contrast: an absent leaf whose ancestor DOES exist still resolves through it.
+        let dir = ScratchDir::new("ancestor-search");
+        assert_eq!(
+            resolve_through_existing_ancestor(&dir.join("absent/leaf")),
+            Some(dir.path().canonicalize().unwrap().join("absent/leaf")),
+        );
     }
 
     #[test]

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -658,7 +658,14 @@ mod tests {
         let dir = ScratchDir::new("normal-tag");
         // The parent is the namespace, reached through the non-canonical alias on Unix.
         assert_eq!(dir.path().parent(), Some(aliased_root(&scratch_root()).as_path()));
-        assert_eq!(canonical_config_root(dir.path()).parent(), Some(scratch_root().as_path()));
+        // Both sides canonical: [`scratch_root`] is `std::env::temp_dir()`-derived and therefore
+        // NOT canonical itself on macOS (`/var` → `/private/var`) or Windows (`\\?\` verbatim, 8.3
+        // expansion). Comparing a canonicalized left against a raw right is the very defect #1027
+        // exists to remove — it would pass only on a Linux box with a canonical `$TMPDIR`.
+        assert_eq!(
+            canonical_config_root(dir.path()).parent(),
+            Some(canonical_config_root(scratch_root()).as_path()),
+        );
         let name = dir.path().file_name().and_then(|n| n.to_str()).unwrap_or_default();
         assert!(name.starts_with("normal-tag-"), "unexpected scratch name {name:?}");
     }
@@ -681,7 +688,12 @@ mod tests {
         // Same directory, two spellings: a file written through one is visible through the other.
         std::fs::write(dir.path().join("probe"), "payload").unwrap();
         assert_eq!(std::fs::read_to_string(canonical.join("probe")).unwrap(), "payload");
-        assert!(canonical.starts_with(scratch_root()), "the canonical form stays in the namespace");
+        // Canonical against canonical: a raw `scratch_root()` here would carry the system temp's
+        // own non-canonical spelling on macOS/Windows and never match (#1027).
+        assert!(
+            canonical.starts_with(canonical_config_root(scratch_root())),
+            "the canonical form stays in the namespace",
+        );
     }
 
     /// [`canonical_config_root`] must match `Config::load`'s `canonicalize()` for an EXISTING root

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -44,6 +44,16 @@
 //!     `0700`; ownership verification is Unix-only (see the fn). A poisoned namespace fails the
 //!     suite loudly; it is never swept.
 //!
+//! # Why the handed-out paths are deliberately NOT canonical
+//!
+//! Production's `Config::load` canonicalizes its root, and index/overlay code depends on that. On
+//! macOS the system temp is already non-canonical (`/var` → `/private/var`) and on Windows it
+//! carries 8.3 names (`RUNNER~1`), so a fixture that keeps its own copy of the scratch path is
+//! holding a second spelling of the root production never sees — the mis-scoping that produces is
+//! invisible on Linux, where the two spellings used to coincide. [`aliased_root`] hands scratch
+//! paths out through a symlink inside the namespace so Linux carries that divergence too, and
+//! [`canonical_config_root`] is what a fixture's hand-built `Config` normalizes its root with.
+//!
 //! Not `#[cfg(test)]`: that gate does not propagate across crates, and fixtures in sibling crates
 //! (`rag-rat-core`, `rag-rat-cli`, …) consume this helper. It is not part of the semver-stable API
 //! surface. Matches the existing `rag_rat_oracle::test_support` convention.
@@ -313,9 +323,78 @@ pub fn scratch_dir(tag: &str) -> PathBuf {
     SWEEP.call_once(|| sweep_stale(&root));
 
     let name = format!("{tag}-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed));
-    let dir = root.join(name);
+    let dir = aliased_root(&root).join(name);
     let _ = std::fs::remove_dir_all(&dir);
     dir
+}
+
+/// Name of the self-referential symlink inside the namespace that makes every handed-out scratch
+/// path NON-CANONICAL on Unix (see [`aliased_root`]). Not a valid scratch dir name itself —
+/// [`scratch_dir`] always appends `-<pid>-<seq>` — so it can never collide with a `tag`.
+const NON_CANONICAL_ALIAS: &str = "via-symlink";
+
+/// `root`, reached through a symlinked ancestor so the paths this module hands out are NOT
+/// canonical.
+///
+/// Production's `Config::load` normalizes its root through `canonicalize()`, and index/overlay
+/// code depends on that (the worktree overlay derives `config.root`'s subdir by stripping it
+/// against a canonicalized repo workdir). On macOS the system temp is already non-canonical
+/// (`/var` → `/private/var`) and on Windows it expands 8.3 names like `RUNNER~1`, so a fixture that
+/// keeps its own copy of the scratch path is comparing against a root production never sees.
+/// Linux was the one platform where the two spellings coincided — which is exactly why that class
+/// of bug reached the macOS/Windows legs instead of the per-PR Linux matrix (#1027).
+///
+/// `<namespace>/via-symlink` is a symlink to the namespace itself, so `<namespace>/via-symlink/x`
+/// and `<namespace>/x` are the same directory under two spellings — the Linux stand-in for the
+/// divergence the other platforms hand over for free. It lives INSIDE the namespace
+/// [`ensure_secure_root`] has already verified (a real, euid-owned, `0700` directory), so it adds
+/// no attack surface, and [`sweep_stale`] skips symlink entries so it is never followed or swept.
+///
+/// Unix-only: creating a symlink on Windows needs developer mode or elevation, and Windows has its
+/// own non-canonical spelling anyway. Falls back to `root` unchanged if the link cannot be made,
+/// so a restricted filesystem degrades to the old behavior rather than failing the suite.
+fn aliased_root(root: &Path) -> PathBuf {
+    #[cfg(unix)]
+    {
+        let alias = root.join(NON_CANONICAL_ALIAS);
+        // Racy by construction (every test process runs this): tolerate an already-created link.
+        if std::fs::symlink_metadata(&alias).is_err() {
+            let _ = std::os::unix::fs::symlink(".", &alias);
+        }
+        if std::fs::symlink_metadata(&alias).is_ok_and(|meta| meta.file_type().is_symlink()) {
+            return alias;
+        }
+    }
+    root.to_path_buf()
+}
+
+/// `root` in the canonical form a `Config` loaded from disk would carry.
+///
+/// `Config::load` normalizes its root through `canonicalize()`, and index/overlay code depends on
+/// that: the worktree overlay derives `config.root`'s subdir by stripping it against a
+/// canonicalized repo workdir, so a hand-built `Config` holding a non-canonical root strips to
+/// nothing and scopes the refresh at the repo root instead of the config root. A fixture that
+/// builds its `Config` by hand must therefore canonicalize the same way — otherwise it exercises a
+/// configuration production can never produce, and the mis-scoping stays invisible (#1027).
+///
+/// Fixtures hand roots over before creating them (a `git worktree add` destination must not
+/// exist), which plain `canonicalize()` rejects, so this canonicalizes the longest EXISTING
+/// ancestor and re-joins the remainder. For a root that exists it is exactly `canonicalize()`;
+/// with no existing ancestor at all it returns `root` unchanged.
+pub fn canonical_config_root(root: impl Into<PathBuf>) -> PathBuf {
+    let root = root.into();
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut probe = root.as_path();
+    loop {
+        if let Ok(canonical) = probe.canonicalize() {
+            return tail.iter().rev().fold(canonical, |acc, part| acc.join(part));
+        }
+        let (Some(parent), Some(name)) = (probe.parent(), probe.file_name()) else {
+            return root;
+        };
+        tail.push(name);
+        probe = parent;
+    }
 }
 
 /// One uniquely owned scratch directory, removed on drop.
@@ -551,9 +630,49 @@ mod tests {
     #[test]
     fn accepts_normal_single_component_tag() {
         let dir = ScratchDir::new("normal-tag");
-        assert_eq!(dir.path().parent(), Some(scratch_root().as_path()));
+        // The parent is the namespace, reached through the non-canonical alias on Unix.
+        assert_eq!(dir.path().parent(), Some(aliased_root(&scratch_root()).as_path()));
+        assert_eq!(canonical_config_root(dir.path()).parent(), Some(scratch_root().as_path()));
         let name = dir.path().file_name().and_then(|n| n.to_str()).unwrap_or_default();
         assert!(name.starts_with("normal-tag-"), "unexpected scratch name {name:?}");
+    }
+
+    /// The scratch paths this module hands out must NOT be canonical on Unix, so a Linux run
+    /// exercises the same root divergence macOS (`/var` → `/private/var`) and Windows (8.3
+    /// `RUNNER~1`) produce by default — the divergence that let a mis-scoped worktree overlay
+    /// reach the cross-platform legs unnoticed (#1027). Bites if [`aliased_root`] is neutered:
+    /// the class would silently stop being covered on the per-PR matrix.
+    #[cfg(unix)]
+    #[test]
+    fn scratch_paths_are_not_canonical_so_linux_covers_the_macos_root_divergence() {
+        let dir = ScratchDir::new("alias-probe");
+        let canonical = canonical_config_root(dir.path());
+        assert_ne!(
+            canonical,
+            dir.path(),
+            "scratch paths must reach the directory through a symlinked ancestor",
+        );
+        // Same directory, two spellings: a file written through one is visible through the other.
+        std::fs::write(dir.path().join("probe"), "payload").unwrap();
+        assert_eq!(std::fs::read_to_string(canonical.join("probe")).unwrap(), "payload");
+        assert!(canonical.starts_with(scratch_root()), "the canonical form stays in the namespace");
+    }
+
+    /// [`canonical_config_root`] must match `Config::load`'s `canonicalize()` for an EXISTING root
+    /// and still resolve the symlinked ancestors of a root that does not exist yet — fixtures hand
+    /// over `git worktree add` destinations before creating them.
+    #[cfg(unix)]
+    #[test]
+    fn canonical_config_root_resolves_an_absent_leaf_through_its_symlinked_ancestors() {
+        let dir = ScratchDir::new("absent-leaf-probe");
+        let existing = canonical_config_root(dir.path());
+        assert_eq!(existing, dir.path().canonicalize().unwrap());
+
+        let absent = dir.path().join("not-created-yet/nested");
+        assert_eq!(canonical_config_root(&absent), existing.join("not-created-yet/nested"));
+        // Once it exists, plain canonicalization agrees.
+        std::fs::create_dir_all(&absent).unwrap();
+        assert_eq!(canonical_config_root(&absent), absent.canonicalize().unwrap());
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -268,14 +268,15 @@ mod tests {
         std::fs::write(root.join("src/a.rs"), &clone_body).unwrap();
         std::fs::write(root.join("src/b.rs"), &clone_body).unwrap();
 
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -790,14 +790,15 @@ mod tests {
         let root = rag_rat_base::test_scratch::ScratchDir::new("cli-vacuum");
         std::fs::create_dir_all(root.join("docs")).unwrap();
         std::fs::write(root.join("docs/a.md"), "# Title\nalpha token\n").unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "markdown".to_string(),
                 language: Language::Markdown,
@@ -846,14 +847,15 @@ mod tests {
         git(&main, &["config", "user.name", "t"]);
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "base"]);
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(main.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: main.clone(),
-            database: main.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
@@ -924,14 +926,15 @@ mod tests {
         git(&main, &["config", "user.name", "t"]);
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "base"]);
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(main.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: main.clone(),
-            database: main.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
@@ -999,14 +1002,15 @@ mod tests {
         git(&root, &["config", "user.name", "t"]);
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-qm", "base"]);
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
@@ -1066,14 +1070,15 @@ mod tests {
         git(&root, &["config", "user.name", "t"]);
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-qm", "base"]);
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
@@ -1136,14 +1141,15 @@ mod tests {
         let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-coalesce");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
@@ -1207,14 +1213,15 @@ mod tests {
             "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
         )
         .unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
@@ -1285,6 +1292,7 @@ mod papertrail_hook_tests {
     use rag_rat_core::IndexDatabase;
 
     fn config_with_unreachable_tracker(root: &std::path::Path) -> Config {
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         Config {
             trackers: vec![TrackerConfig {
                 provider: Tracker::Github,
@@ -1300,8 +1308,8 @@ mod papertrail_hook_tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -487,14 +487,15 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n")
             .unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -61,7 +61,7 @@ pub fn bench_config(subdir: &str) -> (Config, rag_rat_base::test_scratch::Scratc
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: corpus_dir(),
+        root: rag_rat_base::test_scratch::canonical_config_root(corpus_dir()),
         database: scratch.join("bench.sqlite"),
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -194,14 +194,15 @@ mod tests {
     }
 
     fn source_config(root: PathBuf, language: Language) -> Config {
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![ResolvedTarget {
                 name: language.as_str().to_string(),
                 language,

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -165,36 +165,33 @@ pub struct EmptyIndexRefused {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
     use rag_rat_base::language::Language;
+    use rag_rat_base::test_scratch::{self, ScratchDir};
 
     use super::*;
 
-    // `schema_bootstrap_tests::source_config` / `unique_temp_root` are private to that module and
-    // not reachable from here (a sibling of `index`, not a descendant of `schema_bootstrap_tests`)
-    // — build the fixtures inline instead of widening their visibility just for this test.
-    /// A temp root unique across BOTH test runners. pid + millisecond is not: `cargo test` (what
-    /// the coverage job runs) executes tests as THREADS IN ONE PROCESS, so two tests entering
-    /// within the same millisecond derive the SAME path — and one test's `remove_dir_all` then
-    /// races the other's `git init`, which fails with a bare "git [\"init\"] failed". nextest
-    /// hides the race by giving each test its own process (its own pid). The atomic counter
-    /// makes the name unique regardless of runner.
-    fn unique_temp_root() -> PathBuf {
-        static NEXT_ROOT: AtomicUsize = AtomicUsize::new(0);
-        let mut root = std::env::temp_dir();
-        root.push(format!(
-            "rag-rat-adoption-hints-test-{}-{}-{}",
-            std::process::id(),
-            rag_rat_base::time::now_ms(),
-            NEXT_ROOT.fetch_add(1, Ordering::Relaxed),
-        ));
-        root
+    // `schema_bootstrap_tests::source_config` is private to that module and not reachable from
+    // here (a sibling of `index`, not a descendant of `schema_bootstrap_tests`) — build the
+    // fixture `Config` inline instead of widening its visibility just for this test.
+    /// A created, uniquely owned scratch root that is removed on drop.
+    ///
+    /// [`ScratchDir`] rather than a hand-rolled `std::env::temp_dir()` join, for two reasons. It
+    /// names the dir from the pid AND a process-wide counter, so it is unique under both runners
+    /// (`cargo test`, which the coverage job runs, executes tests as THREADS IN ONE PROCESS, where
+    /// a pid+millisecond name collides and one test's cleanup races another's `git init`). And it
+    /// hands the path out through a symlinked ancestor, so `canonical_config_root` in
+    /// [`source_config`] is a real normalization here — a bare `temp_dir()` root is already
+    /// canonical on Linux, which would leave these fixtures outside the per-PR coverage of
+    /// root-spelling bugs and only redden the cross-platform legs (#1027). The guard also brings
+    /// them under the scratch namespace's stale sweep (#726).
+    fn unique_temp_root(tag: &str) -> ScratchDir {
+        ScratchDir::new(tag)
     }
 
     fn source_config(root: PathBuf, language: Language) -> Config {
-        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
+        let config_root = test_scratch::canonical_config_root(root);
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
@@ -225,23 +222,21 @@ mod tests {
 
     #[test]
     fn would_discover_any_file_is_false_when_targets_are_empty() {
-        let root = unique_temp_root();
+        let root = unique_temp_root("adopt-no-targets");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
-        let mut config = source_config(root.clone(), Language::Rust);
+        let mut config = source_config(root.to_path_buf(), Language::Rust);
         config.targets.clear(); // no [target_bindings] → nothing to walk
         assert!(!would_discover_any_file(&config).unwrap());
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
     fn would_discover_any_file_is_true_when_a_target_matches() {
-        let root = unique_temp_root();
+        let root = unique_temp_root("adopt-target-match");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
-        let config = source_config(root.clone(), Language::Rust);
+        let config = source_config(root.to_path_buf(), Language::Rust);
         assert!(would_discover_any_file(&config).unwrap());
-        let _ = std::fs::remove_dir_all(root);
     }
 
     // Run a git command in `root`, panicking on failure — models
@@ -253,6 +248,13 @@ mod tests {
         rag_rat_base::test_git::run(root, args);
     }
 
+    /// Clone `source` into the already-created scratch dir `dest` — a second physical checkout
+    /// sharing `source`'s portable identity. `git clone` accepts an existing EMPTY destination, so
+    /// the clone can land in a guarded scratch dir instead of an unguarded sibling path.
+    fn clone_into(source: &ScratchDir, dest: &ScratchDir) {
+        git(source, &["clone", "-q", ".", dest.path().to_str().unwrap()]);
+    }
+
     /// A clone sharing a checkout's portable (root-commit-derived) identity, pointed at the SAME
     /// database (the consolidated-DB shape the #427 join hint targets), fires the note naming the
     /// original checkout; the original checkout re-indexing itself, and a config whose DB doesn't
@@ -262,13 +264,13 @@ mod tests {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return; // no git on PATH — skip rather than fail.
         }
-        let root_a = unique_temp_root();
+        let root_a = unique_temp_root("adopt-join-a");
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
         git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
-        let config_a = source_config(root_a.clone(), Language::Rust);
+        let config_a = source_config(root_a.to_path_buf(), Language::Rust);
 
         // No DB yet at all — nothing to join.
         assert!(same_identity_join_note(&config_a).unwrap().is_none());
@@ -281,20 +283,18 @@ mod tests {
         // A full clone of A shares its portable (root-commit) identity but is a NEW checkout,
         // pointed at A's SAME database (config_b keeps config_a's `database`, only the `root`
         // moves) — the consolidated-DB shape the hint exists for.
-        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
-        let _ = std::fs::remove_dir_all(&root_b);
-        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let root_b = unique_temp_root("adopt-join-b");
+        clone_into(&root_a, &root_b);
         let mut config_b = config_a.clone();
-        config_b.root = root_b.clone();
+        config_b.root = test_scratch::canonical_config_root(root_b.path());
 
         let expected_repo_id =
             rag_rat_base::repo_identity::resolve_repo_identity(&root_a, None).unwrap().repo_id;
         let note = same_identity_join_note(&config_b).unwrap().unwrap();
         assert_eq!(note.repo_id, expected_repo_id);
-        assert_eq!(note.existing_root, root_a);
-
-        let _ = std::fs::remove_dir_all(&root_a);
-        let _ = std::fs::remove_dir_all(&root_b);
+        // The recorded root is the spelling A's `Config` carries — canonical, as `Config::load`
+        // produces — never the scratch spelling of the same directory (#1027).
+        assert_eq!(note.existing_root, config_a.root);
     }
 
     /// A garbage/non-DB file at `config.database` must yield `Ok(None)` (no hint), NEVER `Err`:
@@ -304,8 +304,8 @@ mod tests {
     /// failure mode the generous-`None` contract exists to prevent.
     #[test]
     fn same_identity_join_note_is_none_on_a_garbage_db_file() {
-        let root = unique_temp_root();
-        let config = source_config(root.clone(), Language::Rust);
+        let root = unique_temp_root("adopt-garbage-db");
+        let config = source_config(root.to_path_buf(), Language::Rust);
         std::fs::create_dir_all(config.database.parent().unwrap()).unwrap();
         std::fs::write(&config.database, b"not a sqlite database at all\x00\xff").unwrap();
         assert!(config.database.exists());
@@ -313,7 +313,6 @@ mod tests {
         let result = same_identity_join_note(&config);
         assert!(result.is_ok(), "a garbage DB must not abort the index: {result:?}");
         assert!(result.unwrap().is_none(), "a garbage DB yields no join hint");
-        let _ = std::fs::remove_dir_all(root);
     }
 
     /// `is_root_already_indexed` is `false` before indexing (no DB / fresh) and `true` after a
@@ -327,13 +326,13 @@ mod tests {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return; // no git on PATH — skip rather than fail.
         }
-        let root_a = unique_temp_root();
+        let root_a = unique_temp_root("adopt-indexed-a");
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
         git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
-        let config_a = source_config(root_a.clone(), Language::Rust);
+        let config_a = source_config(root_a.to_path_buf(), Language::Rust);
 
         // No database yet → not indexed.
         assert!(!is_root_already_indexed(&config_a).unwrap());
@@ -345,18 +344,14 @@ mod tests {
 
         // A full clone of A shares A's portable identity but its root is NOT recorded — it must NOT
         // count as already-indexed, or an empty clone could prune A's shared scope (#427 review).
-        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
-        let _ = std::fs::remove_dir_all(&root_b);
-        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let root_b = unique_temp_root("adopt-indexed-b");
+        clone_into(&root_a, &root_b);
         let mut config_b = config_a.clone();
-        config_b.root = root_b.clone();
+        config_b.root = test_scratch::canonical_config_root(root_b.path());
         assert!(
             !is_root_already_indexed(&config_b).unwrap(),
             "a same-identity clone with an unrecorded root is NOT already-indexed"
         );
-
-        let _ = std::fs::remove_dir_all(root_a);
-        let _ = std::fs::remove_dir_all(root_b);
     }
 
     /// An identity-less (NON-git) root gets NO `repo_roots` entry — `adopt_repo_from_config` falls
@@ -366,11 +361,10 @@ mod tests {
     /// first-time instead of pruning its stale rows.
     #[test]
     fn is_root_already_indexed_recognizes_an_indexed_non_git_root() {
-        let root = unique_temp_root();
-        let _ = std::fs::remove_dir_all(&root);
+        let root = unique_temp_root("adopt-non-git");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
-        let config = source_config(root.clone(), Language::Rust); // NOT a git repo
+        let config = source_config(root.to_path_buf(), Language::Rust); // NOT a git repo
 
         // Fresh: not indexed.
         assert!(!is_root_already_indexed(&config).unwrap());
@@ -385,8 +379,6 @@ mod tests {
         // And so a now-empty re-index is NOT treated as first-time (it would prune, not refuse).
         std::fs::remove_file(root.join("src/a.rs")).unwrap();
         assert!(!is_first_time_empty(&config).unwrap());
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     /// #427 review (comment 4): a READ-ONLY open (`doctor` / MCP / query via `open_config`) adopts
@@ -402,25 +394,25 @@ mod tests {
         }
         // Repo A: a committed git repo, actually indexed into a shared DB (persists A's
         // source_root).
-        let root_a = unique_temp_root();
+        let root_a = unique_temp_root("adopt-readonly-a");
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
         git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
-        let config_a = source_config(root_a.clone(), Language::Rust);
+        let config_a = source_config(root_a.to_path_buf(), Language::Rust);
         crate::index::IndexDatabase::rebuild(&config_a).unwrap();
 
         // Repo B: a DISTINCT git repo (own init → own root commit → own identity), pointed at A's
         // SAME database but with NO discoverable target files. A read-only `open_config` registers
         // B's identity WITHOUT indexing anything and WITHOUT recording its root.
-        let root_b = unique_temp_root();
+        let root_b = unique_temp_root("adopt-readonly-b");
         std::fs::create_dir_all(root_b.join("src")).unwrap();
         std::fs::write(root_b.join("keep.txt"), "not a rust file\n").unwrap();
         git(&root_b, &["init", "-q", "-b", "main"]);
         git(&root_b, &["add", "-A"]);
         git(&root_b, &["commit", "-q", "-m", "init"]);
-        let mut config_b = source_config(root_b.clone(), Language::Rust);
+        let mut config_b = source_config(root_b.to_path_buf(), Language::Rust);
         config_b.database = config_a.database.clone(); // shared DB
 
         let _ = crate::index::IndexDatabase::open_config(&config_b).unwrap();
@@ -432,7 +424,10 @@ mod tests {
             let recorded: i64 = conn
                 .query_row(
                     "SELECT count(*) FROM repo_roots WHERE root = ?1",
-                    [root_b.to_string_lossy()],
+                    // The recorded spelling would be the one B's `Config` carries (canonical), so
+                    // that is what must be absent — asserting on the scratch spelling could pass
+                    // for the wrong reason.
+                    [config_b.root.to_string_lossy()],
                     |r| r.get(0),
                 )
                 .unwrap();
@@ -443,9 +438,6 @@ mod tests {
             "a read-only open must not make an unindexed repo look already-indexed"
         );
         assert!(is_first_time_empty(&config_b).unwrap());
-
-        let _ = std::fs::remove_dir_all(root_a);
-        let _ = std::fs::remove_dir_all(root_b);
     }
 
     /// #427 review ("Gate Older schemas on registry availability"): a LEGACY index predating the
@@ -456,8 +448,8 @@ mod tests {
     /// `Err`.
     #[test]
     fn a_pre_registry_legacy_schema_does_not_fault_the_readonly_probes() {
-        let root = unique_temp_root();
-        let config = source_config(root.clone(), Language::Rust);
+        let root = unique_temp_root("adopt-legacy-schema");
+        let config = source_config(root.to_path_buf(), Language::Rust);
         std::fs::create_dir_all(config.database.parent().unwrap()).unwrap();
         // A legacy index: a `files` table makes `schema::status` report `Older` (not `Missing`),
         // but there is no repo registry — exactly a pre-V038 database.
@@ -472,8 +464,6 @@ mod tests {
         let join = same_identity_join_note(&config);
         assert!(join.is_ok(), "a pre-registry DB must not fault the join hint: {join:?}");
         assert!(join.unwrap().is_none());
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     /// #427 review ("Recognize legacy placeholder indexes before refusing empties"): a LEGACY index
@@ -487,10 +477,10 @@ mod tests {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return; // needs git for the (unregistered) identity; skip rather than fail.
         }
-        let root = unique_temp_root();
+        let root = unique_temp_root("adopt-placeholder");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
-        let config = source_config(root.clone(), Language::Rust);
+        let config = source_config(root.to_path_buf(), Language::Rust);
 
         // Index while NON-git: `adopt_repo_from_config` sees an ABSENT identity and adopts the sole
         // `__unassigned__` placeholder, persisting `source_root` under it — a pre-adoption-style
@@ -510,8 +500,6 @@ mod tests {
         // So a delete-to-empty prunes rather than being refused as first-time-empty.
         std::fs::remove_file(root.join("src/a.rs")).unwrap();
         assert!(!is_first_time_empty(&config).unwrap());
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     /// #427 review ("Warn even when a read open touched the checkout"): a read-only `open_config`
@@ -524,21 +512,20 @@ mod tests {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return;
         }
-        let root_a = unique_temp_root();
+        let root_a = unique_temp_root("adopt-join-read-a");
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
         git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
-        let config_a = source_config(root_a.clone(), Language::Rust);
+        let config_a = source_config(root_a.to_path_buf(), Language::Rust);
         crate::index::IndexDatabase::rebuild(&config_a).unwrap(); // registers A into the shared DB
 
         // Clone B shares A's identity, pointed at A's SAME database.
-        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
-        let _ = std::fs::remove_dir_all(&root_b);
-        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let root_b = unique_temp_root("adopt-join-read-b");
+        clone_into(&root_a, &root_b);
         let mut config_b = config_a.clone();
-        config_b.root = root_b.clone();
+        config_b.root = test_scratch::canonical_config_root(root_b.path());
 
         // A read-only open registers B's identity but records no root and indexes nothing.
         let _ = crate::index::IndexDatabase::open_config(&config_b).unwrap();
@@ -549,10 +536,7 @@ mod tests {
             note.is_some(),
             "a read-only-opened clone must still warn it joins the shared scope"
         );
-        assert_eq!(note.unwrap().existing_root, root_a);
-
-        let _ = std::fs::remove_dir_all(root_a);
-        let _ = std::fs::remove_dir_all(root_b);
+        assert_eq!(note.unwrap().existing_root, config_a.root);
     }
 
     /// #427 review ("Preserve pruning for earlier same-identity checkouts"): when checkout A has
@@ -567,22 +551,21 @@ mod tests {
             return;
         }
         // A: committed git repo, indexed into a shared DB.
-        let root_a = unique_temp_root();
+        let root_a = unique_temp_root("adopt-sibling-a");
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
         git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
-        let config_a = source_config(root_a.clone(), Language::Rust);
+        let config_a = source_config(root_a.to_path_buf(), Language::Rust);
         crate::index::IndexDatabase::rebuild(&config_a).unwrap();
         assert!(is_root_already_indexed(&config_a).unwrap(), "A is indexed after its rebuild");
 
         // B: a same-identity clone of A, pointed at the SAME DB, INDEXED too (has its own file).
-        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
-        let _ = std::fs::remove_dir_all(&root_b);
-        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let root_b = unique_temp_root("adopt-sibling-b");
+        clone_into(&root_a, &root_b);
         let mut config_b = config_a.clone();
-        config_b.root = root_b.clone();
+        config_b.root = test_scratch::canonical_config_root(root_b.path());
         crate::index::IndexDatabase::index_discover(&config_b).unwrap();
 
         // B's index overwrote the shared `source_root` to B — but A's `repo_roots` row survives, so
@@ -597,8 +580,30 @@ mod tests {
             !is_first_time_empty(&config_a).unwrap(),
             "A going empty must be allowed to prune, not refused as first-time-empty"
         );
+    }
 
-        let _ = std::fs::remove_dir_all(root_a);
-        let _ = std::fs::remove_dir_all(root_b);
+    /// The scratch spelling and `config.root` must be two names for ONE directory — the shape
+    /// `Config::load` produces wherever the system temp is reached through a symlink (macOS
+    /// `/var` → `/private/var`) or an 8.3 alias (Windows `RUNNER~1`). Rooting these fixtures at a
+    /// bare `temp_dir()` join degenerates `canonical_config_root` to a no-op on Linux, and the
+    /// recorded
+    /// root the probes above compare against would then be indistinguishable from the raw fixture
+    /// path on the only platform the per-PR matrix runs (#1027).
+    #[cfg(unix)]
+    #[test]
+    fn the_fixture_config_root_diverges_from_its_scratch_spelling() {
+        let root = unique_temp_root("adopt-root-spelling");
+        let config = source_config(root.to_path_buf(), Language::Rust);
+        assert_ne!(
+            config.root,
+            root.path(),
+            "the fixture must reach its root through a symlinked ancestor, or root-spelling bugs \
+             stay invisible on the per-PR matrix",
+        );
+        assert_eq!(
+            config.root,
+            root.path().canonicalize().unwrap(),
+            "both spellings name the same directory",
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/corpus.rs
+++ b/crates/rag-rat-core/src/index/corpus.rs
@@ -124,6 +124,13 @@ mod tests {
 
     /// A checkout with `src` bound as a Rust target, a gitignored `generated/`, and the usual
     /// machine-written trees.
+    ///
+    /// Assert against `config.root`, NEVER the guard's own spelling. `Config::load` canonicalizes
+    /// its root and [`ConfiguredCorpus`] strips exactly that root off the path it is asked about,
+    /// while a scratch path reaches its directory through a symlinked ancestor — so a test holding
+    /// the guard's spelling asks about a root production never produces, and every answer comes
+    /// back `false` for the wrong reason. Non-canonical temp roots are what macOS (`/var` →
+    /// `/private/var`) and Windows (8.3 `RUNNER~1`) hand over by default (#1027).
     fn fixture(tag: &str) -> (rag_rat_base::test_scratch::ScratchDir, Config) {
         let dir = rag_rat_base::test_scratch::ScratchDir::new(tag);
         for relative in ["src", "vendor", "node_modules", "generated", "build"] {
@@ -143,14 +150,59 @@ mod tests {
         (dir, config)
     }
 
+    /// The guard's spelling of the root and `config.root` must be two names for ONE directory —
+    /// the shape `Config::load` produces wherever the system temp is reached through a symlink
+    /// (macOS `/var` → `/private/var`) or an 8.3 alias (Windows `RUNNER~1`). Without the
+    /// divergence every assertion in this module would pass whether it derived its paths from
+    /// `config.root` or from the guard, and the root-spelling class would only redden the
+    /// cross-platform legs (#1027).
+    #[cfg(unix)]
     #[test]
-    fn a_bound_source_is_in_the_corpus_and_an_unbound_sibling_is_not() {
-        let (dir, config) = fixture("corpus-bound-target");
+    fn the_fixture_config_root_diverges_from_its_scratch_spelling() {
+        let (scratch, config) = fixture("corpus-root-spelling");
+        assert_ne!(
+            config.root,
+            scratch.path(),
+            "the fixture must reach its root through a symlinked ancestor",
+        );
+        assert_eq!(
+            config.root,
+            scratch.path().canonicalize().unwrap(),
+            "both spellings name the same directory",
+        );
+    }
+
+    /// Corpus membership answers about the CONFIG-ROOT spelling and no other, and an alias of an
+    /// indexed file is refused rather than resolved.
+    ///
+    /// Deliberate: this predicate mirrors what `walk_target` yields, and the walk yields paths
+    /// under the canonical root. Resolving an alias here would have to canonicalize the path's
+    /// ancestors, which is exactly what the symlink rules above must see un-resolved — a file
+    /// under a symlinked ancestor would come back rebased onto its target and be admitted. The
+    /// caller's fallback for a refusal is to treat a compilation database as governing nothing,
+    /// which declines analysis rather than trusting the wrong flags (#1008).
+    #[cfg(unix)]
+    #[test]
+    fn an_aliased_spelling_of_an_indexed_file_is_refused_not_resolved() {
+        let (scratch, config) = fixture("corpus-aliased-spelling");
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(corpus.indexes_file(&dir.join("src/main.rs")), "a bound target's source");
+        assert!(corpus.indexes_file(&config.root.join("src/main.rs")), "the control");
         assert!(
-            !corpus.indexes_file(&dir.join("vendor/dep.rs")),
+            !corpus.indexes_file(&scratch.join("src/main.rs")),
+            "the same file spelled through a symlinked ancestor is not answered for",
+        );
+    }
+
+    #[test]
+    fn a_bound_source_is_in_the_corpus_and_an_unbound_sibling_is_not() {
+        let (_scratch, config) = fixture("corpus-bound-target");
+        let root = config.root.clone();
+        let corpus = ConfiguredCorpus::new(&config);
+
+        assert!(corpus.indexes_file(&root.join("src/main.rs")), "a bound target's source");
+        assert!(
+            !corpus.indexes_file(&root.join("vendor/dep.rs")),
             "a Rust file no target binds is not this checkout's corpus — which is exactly the \
              vendored-database case (#1008)",
         );
@@ -167,19 +219,21 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn a_source_reached_through_a_symlink_is_not_in_the_corpus() {
-        let (dir, config) = fixture("corpus-symlinked-source");
-        std::fs::write(dir.join("vendor/real.rs"), "pub fn real() {}\n").unwrap();
-        std::os::unix::fs::symlink(dir.join("vendor/real.rs"), dir.join("src/linked.rs")).unwrap();
-        std::os::unix::fs::symlink(dir.join("vendor"), dir.join("src/linked_dir")).unwrap();
+        let (_scratch, config) = fixture("corpus-symlinked-source");
+        let root = config.root.clone();
+        std::fs::write(root.join("vendor/real.rs"), "pub fn real() {}\n").unwrap();
+        std::os::unix::fs::symlink(root.join("vendor/real.rs"), root.join("src/linked.rs"))
+            .unwrap();
+        std::os::unix::fs::symlink(root.join("vendor"), root.join("src/linked_dir")).unwrap();
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(corpus.indexes_file(&dir.join("src/main.rs")), "the control: a real bound source");
+        assert!(corpus.indexes_file(&root.join("src/main.rs")), "the control: a real bound source");
         assert!(
-            !corpus.indexes_file(&dir.join("src/linked.rs")),
+            !corpus.indexes_file(&root.join("src/linked.rs")),
             "a symlinked LEAF under a bound target is not indexed, so it is not in the corpus",
         );
         assert!(
-            !corpus.indexes_file(&dir.join("src/linked_dir/real.rs")),
+            !corpus.indexes_file(&root.join("src/linked_dir/real.rs")),
             "nor is a path crossing a symlinked ancestor",
         );
     }
@@ -190,17 +244,18 @@ mod tests {
     /// entry's flags inferred for the files that do exist.
     #[test]
     fn a_path_that_is_not_a_regular_file_is_not_in_the_corpus() {
-        let (dir, config) = fixture("corpus-not-a-regular-file");
+        let (_scratch, config) = fixture("corpus-not-a-regular-file");
+        let root = config.root.clone();
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(corpus.indexes_file(&dir.join("src/main.rs")), "the control: a real bound source");
+        assert!(corpus.indexes_file(&root.join("src/main.rs")), "the control: a real bound source");
         assert!(
-            !corpus.indexes_file(&dir.join("src/deleted.rs")),
+            !corpus.indexes_file(&root.join("src/deleted.rs")),
             "a path the database still names but the checkout no longer has",
         );
-        std::fs::create_dir_all(dir.join("src/looks_like.rs")).unwrap();
+        std::fs::create_dir_all(root.join("src/looks_like.rs")).unwrap();
         assert!(
-            !corpus.indexes_file(&dir.join("src/looks_like.rs")),
+            !corpus.indexes_file(&root.join("src/looks_like.rs")),
             "a DIRECTORY with a source-shaped name is not a translation unit either",
         );
     }
@@ -227,17 +282,22 @@ mod tests {
         let corpus = ConfiguredCorpus::new(&config);
 
         assert!(
-            corpus.indexes_file(&dir.join("src/main.rs")),
+            corpus.indexes_file(&config.root.join("src/main.rs")),
             "the walk starts AT the target, so the target's own link is not a crossing",
         );
     }
 
     #[test]
     fn a_gitignored_source_is_not_in_the_corpus() {
-        let (dir, config) = fixture("corpus-gitignored");
+        let (_scratch, config) = fixture("corpus-gitignored");
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(!corpus.indexes_file(&dir.join("generated/out.rs")));
+        assert!(
+            corpus.indexes_file(&config.root.join("src/main.rs")),
+            "the control: without it the gitignore assertion below would also hold for a path the \
+             corpus simply failed to recognize",
+        );
+        assert!(!corpus.indexes_file(&config.root.join("generated/out.rs")));
     }
 
     /// The floor removes `.cache/clangd` SPECIFICALLY, not all of `.cache` — so a checkout whose
@@ -260,14 +320,15 @@ mod tests {
         )
         .unwrap();
         let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let root = config.root.clone();
         let corpus = ConfiguredCorpus::new(&config);
 
         assert!(
-            corpus.indexes_file(&dir.join(".cache/generated/gen.rs")),
+            corpus.indexes_file(&root.join(".cache/generated/gen.rs")),
             "a hidden directory bound as a target is an ordinary source location",
         );
         assert!(
-            !corpus.may_hold_indexed_files(&dir.join(".cache/clangd")),
+            !corpus.may_hold_indexed_files(&root.join(".cache/clangd")),
             "clangd's own index never holds this checkout's source",
         );
     }
@@ -292,17 +353,18 @@ mod tests {
         )
         .unwrap();
         let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let root = config.root.clone();
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(corpus.may_hold_indexed_files(&dir), "the root is on the way to every target");
-        assert!(corpus.may_hold_indexed_files(&dir.join("src")), "a target subtree");
+        assert!(corpus.may_hold_indexed_files(&root), "the root is on the way to every target");
+        assert!(corpus.may_hold_indexed_files(&root.join("src")), "a target subtree");
         assert!(
-            corpus.may_hold_indexed_files(&dir.join("deep")),
+            corpus.may_hold_indexed_files(&root.join("deep")),
             "an ancestor of a target must be entered to reach it",
         );
-        assert!(corpus.may_hold_indexed_files(&dir.join("deep/nested/gen")));
+        assert!(corpus.may_hold_indexed_files(&root.join("deep/nested/gen")));
         assert!(
-            !corpus.may_hold_indexed_files(&dir.join(".cache/big")),
+            !corpus.may_hold_indexed_files(&root.join(".cache/big")),
             "unignored but unreachable by any target — no indexed file can live here",
         );
     }
@@ -320,24 +382,29 @@ mod tests {
         )
         .unwrap();
         let config = Config::load(dir.join("rag-rat.toml")).unwrap();
+        let root = config.root.clone();
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(corpus.may_hold_indexed_files(&dir.join("anywhere/deep")));
+        assert!(corpus.may_hold_indexed_files(&root.join("anywhere/deep")));
         assert!(
-            !corpus.may_hold_indexed_files(&dir.join("node_modules")),
+            !corpus.may_hold_indexed_files(&root.join("node_modules")),
             "the floor still applies"
         );
     }
 
     #[test]
     fn a_floored_directory_holds_no_indexed_files() {
-        let (dir, config) = fixture("corpus-floored-dirs");
+        let (_scratch, config) = fixture("corpus-floored-dirs");
+        let root = config.root.clone();
         let corpus = ConfiguredCorpus::new(&config);
 
-        assert!(corpus.may_hold_indexed_files(&dir.join("src")), "an ordinary source directory");
-        assert!(!corpus.may_hold_indexed_files(&dir.join("node_modules")), "vendored dependencies");
+        assert!(corpus.may_hold_indexed_files(&root.join("src")), "an ordinary source directory");
         assert!(
-            !corpus.may_hold_indexed_files(&dir.join("build")),
+            !corpus.may_hold_indexed_files(&root.join("node_modules")),
+            "vendored dependencies"
+        );
+        assert!(
+            !corpus.may_hold_indexed_files(&root.join("build")),
             "a build tree is floored — which is why the MARKER search must not use this \
              predicate: it is where compilation databases live",
         );

--- a/crates/rag-rat-core/src/index/papertrail_autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail_autosync.rs
@@ -668,14 +668,15 @@ mod tests {
     }
 
     fn test_config(root: &Path) -> Config {
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join("db/index.sqlite"),
+            database: config_root.join("db/index.sqlite"),
+            root: config_root,
             targets: Vec::new(),
             llm: Default::default(),
             watch: Default::default(),

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -205,25 +205,10 @@ pub(crate) fn explicit_index_files_and_changes(
     let mut manifest_in_change_set = false;
     for path in paths {
         let raw_relative = if path.is_absolute() {
-            match path.strip_prefix(&config.root) {
-                Ok(relative) => relative.to_path_buf(),
-                // A LEXICAL strip fails when the caller spells the path (or the checkout root)
-                // through a DIFFERENT symlink than `config.root` (macOS `/tmp` vs `/private/tmp`,
-                // a symlinked editor `$PWD`), even for a file genuinely inside the checkout. Retry
-                // against the CANONICAL root before giving up, so the valid edit is not silently
-                // dropped; a strip that still fails is a real outside / linked-worktree path the
-                // caller routes elsewhere (#659 review).
-                Err(_) => {
-                    let Some(relative) =
-                        canonicalize_nearest_ancestor(path).and_then(|canonical| {
-                            canonical.strip_prefix(&canonical_root).ok().map(Path::to_path_buf)
-                        })
-                    else {
-                        continue;
-                    };
-                    relative
-                },
-            }
+            let Some(relative) = root_relative_path(path, &config.root, &canonical_root) else {
+                continue; // a real outside / linked-worktree path the caller routes elsewhere
+            };
+            relative
         } else {
             path.clone()
         };
@@ -356,13 +341,42 @@ pub(crate) fn path_crosses_symlink(root: &Path, relative: &Path) -> bool {
     })
 }
 
+/// An ABSOLUTE `path`'s `root`-relative spelling: a lexical strip against `root`, retried against
+/// `canonical_root` when the caller spells the path (or the checkout root) through a DIFFERENT
+/// symlink than `root` (macOS `/tmp` vs `/private/tmp`, a symlinked editor `$PWD`, a Windows 8.3
+/// alias) — without the retry a file genuinely inside the checkout is silently dropped. `None` when
+/// the path is really outside the root (a linked-worktree edit the caller routes elsewhere).
+///
+/// The retry canonicalizes only the path's ANCESTORS and re-appends the LEAF verbatim. The leaf is
+/// the indexed row's IDENTITY, so resolving it rewrites the caller's path into a different file:
+/// `src/a.rs` REPLACED by a symlink to `src/b.rs` would come back as `src/b.rs`, leaving the stale
+/// row for `src/a.rs` un-tombstoned while `src/b.rs` is re-indexed in its place, and an ESCAPING
+/// link would
+/// resolve outside the root and drop the path before the deletion branch ever ran. Whether the leaf
+/// is INDEXABLE is decided afterwards by [`resolves_within_root`] / [`path_crosses_symlink`]; this
+/// only fixes the root SPELLING. Shared by the base explicit flow and the path-scoped linked
+/// overlay so both rebase identically (#659/#679/#1027).
+pub(crate) fn root_relative_path(
+    path: &Path,
+    root: &Path,
+    canonical_root: &Path,
+) -> Option<PathBuf> {
+    if let Ok(relative) = path.strip_prefix(root) {
+        return Some(relative.to_path_buf());
+    }
+    let leaf = path.file_name()?;
+    let canonical_parent = canonicalize_nearest_ancestor(path.parent()?)?;
+    canonical_parent.join(leaf).strip_prefix(canonical_root).ok().map(Path::to_path_buf)
+}
+
 /// Canonicalize `path` by canonicalizing its nearest EXISTING ancestor (the file — or even its
 /// parent dir — may be gone in a deletion, or not yet created) and re-appending the missing suffix,
 /// so the result is SYMLINK-RESOLVED even for a path that doesn't exist. `None` when nothing on the
 /// ancestor chain canonicalizes (effectively unreachable for a real absolute path — the filesystem
-/// root always resolves). Shared by containment ([`resolves_within_root`]), the absolute-path
-/// rebase in [`explicit_index_files_and_changes`] (a symlinked checkout-root spelling must compare
-/// canonically or a valid in-repo edit is dropped), and the worktree routing in `watch::overlay`.
+/// root always resolves). Shared by containment ([`resolves_within_root`]), the root-spelling
+/// rebase in [`root_relative_path`] (which passes the PARENT — the leaf must not be resolved
+/// there), and the worktree routing in `watch::overlay`. Every other caller wants the leaf
+/// resolved: containment must see where a symlinked leaf actually points.
 pub(crate) fn canonicalize_nearest_ancestor(path: &Path) -> Option<PathBuf> {
     let mut ancestor = path;
     loop {

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -670,14 +670,15 @@ mod tests {
             "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
         )
         .unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
                 language: rag_rat_base::language::Language::Rust,
@@ -783,15 +784,16 @@ mod tests {
             "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
         )
         .unwrap();
-        let db_path = root.join(".rag-rat/index.sqlite");
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
+        let db_path = config_root.join(".rag-rat/index.sqlite");
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
             database: db_path.clone(),
+            root: config_root,
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
                 language: rag_rat_base::language::Language::Rust,
@@ -851,14 +853,15 @@ mod tests {
              } }\n",
         )
         .unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
                 language: rag_rat_base::language::Language::Rust,
@@ -952,14 +955,15 @@ mod tests {
             exclude: Vec::new(),
             kind: rag_rat_base::config::TargetKind::Source,
         };
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.to_path_buf(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![
                 target("rust", rag_rat_base::language::Language::Rust, "src"),
                 target("python", rag_rat_base::language::Language::Python, "py"),

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute/tests.rs
@@ -64,14 +64,15 @@ pub(in super::super) fn clone_fixture_config(tag: &str) -> CloneFixture {
          } t + 1 }\n",
     )
     .unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = rag_rat_base::config::Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![rag_rat_base::config::ResolvedTarget {
             name: "rust".to_string(),
             language: rag_rat_base::language::Language::Rust,

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -185,14 +185,15 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
     let root = rag_rat_base::test_scratch::ScratchDir::new("rag-rat-nan-test");
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = rag_rat_base::config::Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![rag_rat_base::config::ResolvedTarget {
             name: "rust".to_string(),
             language: rag_rat_base::language::Language::Rust,
@@ -764,14 +765,15 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
          } t + 1 }\n",
     )
     .unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = rag_rat_base::config::Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![rag_rat_base::config::ResolvedTarget {
             name: "rust".to_string(),
             language: rag_rat_base::language::Language::Rust,

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -355,14 +355,15 @@ mod tests {
         let root = scratch.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn health_probe() -> i32 { 1 }\n").unwrap();
+        let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
-            database: root.join(".rag-rat/index.sqlite"),
+            database: config_root.join(".rag-rat/index.sqlite"),
+            root: config_root,
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
                 language: rag_rat_base::language::Language::Rust,

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1750,7 +1750,9 @@ fn indexed_config() -> (tempfile::TempDir, Config) {
     fs::write(root.join(UNICODE_PATH), UNICODE_SOURCE).unwrap();
     fs::write(root.join(FOLDED_PATH), FOLDED_SOURCE).unwrap();
     fs::write(root.join(COMPOSED_PATH), COMPOSED_SOURCE).unwrap();
-    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root);
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root);
+    let mut config =
+        Config::minimal_for_database(config_root.join("index.sqlite"), config_root.clone());
     config.database_key_pinned = true;
     config.targets = vec![ResolvedTarget {
         name: "rust".into(),

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
 use rag_rat_base::language::Language;
+use rag_rat_base::test_scratch::{self, ScratchDir};
 use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
 use rusqlite::params;
 
@@ -1739,8 +1740,15 @@ fn rust_source_config(source: &str) -> (tempfile::TempDir, Config) {
     (temp, config)
 }
 
-fn indexed_config() -> (tempfile::TempDir, Config) {
-    let temp = tempfile::tempdir().unwrap();
+/// A fully indexed single-crate fixture, returning the scratch guard and its `Config`.
+///
+/// The root comes from [`test_scratch::ScratchDir`], not `tempfile`: scratch paths are handed out
+/// through a symlinked ancestor, so `canonical_config_root` below is a real normalization on every
+/// platform rather than a no-op that only bites on macOS/Windows (#1027). A `tempfile` root is
+/// already canonical on Linux, which would leave this fixture — and the Lens chunk/search paths it
+/// drives — outside the per-PR coverage of root-spelling bugs.
+fn indexed_config() -> (ScratchDir, Config) {
+    let temp = ScratchDir::new("lens-indexed");
     let root = temp.path().to_path_buf();
     fs::create_dir(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), SOURCE).unwrap();
@@ -1750,7 +1758,7 @@ fn indexed_config() -> (tempfile::TempDir, Config) {
     fs::write(root.join(UNICODE_PATH), UNICODE_SOURCE).unwrap();
     fs::write(root.join(FOLDED_PATH), FOLDED_SOURCE).unwrap();
     fs::write(root.join(COMPOSED_PATH), COMPOSED_SOURCE).unwrap();
-    let config_root = rag_rat_base::test_scratch::canonical_config_root(root);
+    let config_root = test_scratch::canonical_config_root(root);
     let mut config =
         Config::minimal_for_database(config_root.join("index.sqlite"), config_root.clone());
     config.database_key_pinned = true;
@@ -1768,8 +1776,10 @@ fn indexed_config() -> (tempfile::TempDir, Config) {
 
 #[test]
 fn per_file_answers_name_the_exact_bytes_they_were_computed_from() {
-    let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().to_path_buf();
+    // `ScratchDir` + `canonical_config_root`, not `tempfile`: a fixture rooted at a raw temp path
+    // is already canonical on Linux, so it opts out of the root-spelling coverage entirely (#1027).
+    let temp = ScratchDir::new("lens-verbatim");
+    let root = test_scratch::canonical_config_root(temp.path().to_path_buf());
     fs::create_dir(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), SOURCE).unwrap();
     // Verbatim disk bytes: a UTF-8 BOM and CRLF endings. The client compares against this hash, so
@@ -1889,5 +1899,28 @@ fn a_file_answer_and_its_content_hash_come_from_one_snapshot() {
                 .get::<_, String>(0))
             .unwrap(),
         "reindexed"
+    );
+}
+
+/// The fixture root and `config.root` must be two spellings of ONE directory — the shape
+/// `Config::load` produces wherever the system temp is reached through a symlink (macOS `/var` →
+/// `/private/var`) or an 8.3 alias (Windows `RUNNER~1`). A fixture rooted at a `tempfile` /
+/// `temp_dir()` path is already canonical on Linux, so `canonical_config_root` degenerates to a
+/// no-op and a one-sided `strip_prefix(config.root)` regression on the Lens chunk/search paths
+/// would pass the per-PR matrix and redden only the tag-triggered cross-platform legs (#1027).
+#[cfg(unix)]
+#[test]
+fn the_lens_fixture_config_root_diverges_from_its_scratch_spelling() {
+    let (temp, config) = indexed_config();
+    assert_ne!(
+        config.root,
+        temp.path(),
+        "the fixture must reach its root through a symlinked ancestor, or root-spelling bugs stay \
+         invisible on the per-PR matrix",
+    );
+    assert_eq!(
+        config.root,
+        temp.path().canonicalize().unwrap(),
+        "both spellings must name the same directory",
     );
 }

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -20,14 +20,15 @@ fn temp_root() -> rag_rat_base::test_scratch::ScratchDir {
 }
 
 fn rust_config(root: PathBuf) -> Config {
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -1271,14 +1272,15 @@ fn deleted_and_generated_paths_counted_in_skipped() {
     fs::write(root.join("src/doomed.rs"), "pub fn doomed() {}\n").unwrap();
     fs::write(root.join("gen/out.rs"), "pub fn generated_fn() {}\n").unwrap();
     // A config with a Generated target for `gen/` so `out.rs` indexes generated.
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![
             ResolvedTarget {
                 name: "rust".to_string(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/fingerprints.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/fingerprints.rs
@@ -476,14 +476,15 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
     )
     .unwrap();
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![
             ResolvedTarget {
                 name: "rust".to_string(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/ranking.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/ranking.rs
@@ -34,14 +34,15 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     )
     .unwrap();
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -306,14 +306,15 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
     for name in &["a.rs", "b.rs", "c.rs"] {
         fs::write(root.join("src/pkg/inner/deep").join(name), "pub fn f() {}\n").unwrap();
     }
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -541,14 +542,15 @@ fn dir_tree_truncates_at_max_nodes() {
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join("lib.rs"), "pub fn f() {}\n").unwrap();
     }
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -693,14 +695,15 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         fs::write(root.join("top/mid/x").join(name), "pub fn fx() {}\n").unwrap();
         fs::write(root.join("top/mid/y").join(name), "pub fn fy() {}\n").unwrap();
     }
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -1124,7 +1124,12 @@ fn concurrent_create_or_migrate_applies_the_schema_exactly_once() {
 /// with the pointer, and the retry publishes files + history together.
 #[test]
 fn a_tail_failure_leaves_git_meta_and_history_cursors_on_the_old_state() {
-    let (root, config) = generation_fixture(&[("a.rs", "pub fn a() -> u32 { 1 }\n")]);
+    let (_scratch, config) = generation_fixture(&[("a.rs", "pub fn a() -> u32 { 1 }\n")]);
+    // Drive production calls and assertions through the root the `Config` carries: the fixture
+    // canonicalizes it exactly as `Config::load` does, so the scratch spelling is a SECOND,
+    // non-canonical name for the same directory wherever the system temp is reached through a
+    // symlink or an 8.3 alias (#1027).
+    let root = config.root.clone();
     IndexDatabase::rebuild(&config).unwrap();
     let db_path = config.database.clone();
     let repo_id = resolve_repo_id(&db_path, &root);
@@ -1279,7 +1284,12 @@ fn gc_reclaims_abandoned_staged_generations_from_failed_rebuilds() {
 /// the new root together with the flip.
 #[test]
 fn a_tail_failure_leaves_source_root_on_the_old_checkout() {
-    let (root, config) = generation_fixture(&[("a.rs", "pub fn a() -> u32 { 1 }\n")]);
+    let (_scratch, config) = generation_fixture(&[("a.rs", "pub fn a() -> u32 { 1 }\n")]);
+    // Drive production calls and assertions through the root the `Config` carries: the fixture
+    // canonicalizes it exactly as `Config::load` does, so the scratch spelling is a SECOND,
+    // non-canonical name for the same directory wherever the system temp is reached through a
+    // symlink or an 8.3 alias (#1027).
+    let root = config.root.clone();
     IndexDatabase::rebuild(&config).unwrap();
     let db_path = config.database.clone();
     let repo_id = resolve_repo_id(&db_path, &root);
@@ -1295,7 +1305,7 @@ fn a_tail_failure_leaves_source_root_on_the_old_checkout() {
     let _ = fs::remove_dir_all(&root2);
     run_git(&root, &["clone", "-q", ".", root2.to_str().unwrap()]);
     let mut config2 = config.clone();
-    config2.root = root2.clone();
+    config2.root = test_scratch::canonical_config_root(root2.clone());
 
     {
         let conn = rusqlite::Connection::open(&db_path).unwrap();
@@ -1319,7 +1329,7 @@ fn a_tail_failure_leaves_source_root_on_the_old_checkout() {
     IndexDatabase::rebuild(&config2).unwrap();
     assert_eq!(
         persisted_root(&db_path).as_deref(),
-        Some(root2.display().to_string().as_str()),
+        Some(config2.root.display().to_string().as_str()),
         "the retry publishes the new root together with the flip"
     );
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -1,10 +1,25 @@
 use super::*;
 
+/// The two-commit git-history fixture: its scratch guard, the repo root, and the `Config`.
+///
+/// The returned root is the spelling the `Config` CARRIES, not the raw scratch path. Fixture
+/// `Config`s canonicalize their root exactly as `Config::load` does, so where the system temp is
+/// reached through a symlink (macOS `/var` → `/private/var`) or an 8.3 alias (Windows `RUNNER~1`)
+/// the scratch path is a second, non-canonical name for the same directory. The git-history
+/// cursor/plan helpers below (`prepare_plan`, `apply_prepared_deferring_cursors`,
+/// `is_history_current`) resolve the repo scope from the root they are handed, so a test driving
+/// them through the scratch spelling asks about a root the index never recorded (#1027).
+fn git_history_fixture() -> (ScratchRoot, PathBuf, Config) {
+    let scratch = unique_temp_root();
+    let _ = fs::remove_dir_all(&scratch);
+    let config = git_history_test_config(&scratch);
+    let root = config.root.clone();
+    (scratch, root, config)
+}
+
 #[test]
 fn git_history_appends_after_a_new_commit() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -38,9 +53,7 @@ fn git_history_appends_after_a_new_commit() {
 
 #[test]
 fn git_history_append_rebuilds_desynced_commit_fts() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let repo_id = db.active_repo_id.clone();
@@ -78,9 +91,7 @@ fn git_history_append_rebuilds_desynced_commit_fts() {
 
 #[test]
 fn history_import_materializes_coupling_and_bumps_lens_once() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
 
@@ -233,9 +244,7 @@ fn history_import_materializes_coupling_and_bumps_lens_once() {
 
 #[test]
 fn git_history_falls_back_when_append_rows_are_already_present() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -273,9 +282,7 @@ fn git_history_falls_back_when_append_rows_are_already_present() {
 
 #[test]
 fn git_history_append_plan_falls_back_for_non_git_or_other_root() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
@@ -332,9 +339,7 @@ fn git_history_prepare_plan_fails_closed_on_incomplete_or_shallow_cursors() {
         CursorCase::CompleteFalse,
         CursorCase::CompleteBad,
     ] {
-        let root = unique_temp_root();
-        let _ = fs::remove_dir_all(&root);
-        let config = git_history_test_config(&root);
+        let (_scratch, root, config) = git_history_fixture();
         let db = IndexDatabase::rebuild(&config).unwrap();
         match case {
             CursorCase::MissingHead => {
@@ -431,9 +436,7 @@ fn git_history_prepare_plan_fails_closed_on_incomplete_or_shallow_cursors() {
 
 #[test]
 fn incomplete_git_history_cursor_forces_full_reload_before_fast_forward_append() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -472,9 +475,7 @@ fn incomplete_git_history_cursor_forces_full_reload_before_fast_forward_append()
 
 #[test]
 fn stale_prepared_append_is_noop_after_another_pass_catches_up() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
@@ -505,9 +506,7 @@ fn stale_prepared_append_is_noop_after_another_pass_catches_up() {
 
 #[test]
 fn stale_prepared_append_clears_when_root_loses_git_dir() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
@@ -543,9 +542,7 @@ fn stale_prepared_append_clears_when_root_loses_git_dir() {
 
 #[test]
 fn stale_prepared_append_is_noop_when_db_cursor_is_ahead() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
@@ -645,9 +642,7 @@ fn git_history_append_records_new_head_for_out_of_scope_fast_forward_commit() {
 
 #[test]
 fn git_history_append_reports_commit_fts_prepare_errors() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
@@ -672,9 +667,7 @@ fn git_history_append_reports_commit_fts_prepare_errors() {
 
 #[test]
 fn repo_generation_file_count_reports_sql_errors() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     let db = IndexDatabase::rebuild(&config).unwrap();
     db.storage.connection().execute("DROP TABLE main.files", []).unwrap();
     let err = db.repo_generation_file_count(true).expect_err("missing files table must error");
@@ -685,9 +678,7 @@ fn repo_generation_file_count_reports_sql_errors() {
 
 #[test]
 fn repo_generation_file_count_ignores_foreign_worktree_overlays() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     let db = IndexDatabase::rebuild(&config).unwrap();
     let scoped = db.indexed_file_count().unwrap();
     assert_eq!(db.repo_generation_file_count(true).unwrap(), scoped);
@@ -746,9 +737,7 @@ fn repo_generation_file_count_ignores_foreign_worktree_overlays() {
 
 #[test]
 fn discovered_empty_active_commit_does_not_promote_changed_mode() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     let db = IndexDatabase::rebuild(&config).unwrap();
     assert!(db.indexed_file_count().unwrap() > 0);
 
@@ -791,9 +780,7 @@ fn discovered_empty_active_commit_does_not_promote_changed_mode() {
 
 #[test]
 fn changed_mode_discovers_when_target_fingerprint_is_stale() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     fs::create_dir_all(root.join("examples")).unwrap();
     fs::write(root.join("examples/guide.md"), "# Guide\nnew target token\n").unwrap();
     run_git(&root, &["add", "."]);
@@ -846,9 +833,7 @@ fn changed_mode_discovers_when_target_fingerprint_is_stale() {
 
 #[test]
 fn base_scope_marker_is_absent_without_commit_or_worktree_scope() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     let mut db = IndexDatabase::rebuild(&config).unwrap();
     db.active_commit_sha.clear();
     db.active_worktree_id.clear();
@@ -867,9 +852,7 @@ fn base_scope_marker_is_absent_without_commit_or_worktree_scope() {
 
 #[test]
 fn watch_shutdown_marker_clear_is_idempotent() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     assert!(
@@ -890,9 +873,7 @@ fn watch_shutdown_marker_clear_is_idempotent() {
 
 #[test]
 fn git_history_appends_after_a_merge_commit() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -924,9 +905,7 @@ fn git_history_appends_after_a_merge_commit() {
 
 #[test]
 fn git_history_appends_after_a_squash_commit() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -959,9 +938,7 @@ fn git_history_appends_after_a_squash_commit() {
 
 #[test]
 fn git_history_reloads_after_a_history_rewrite() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -984,9 +961,7 @@ fn git_history_reloads_after_a_history_rewrite() {
 
 #[test]
 fn git_history_reloads_after_a_non_fast_forward_branch_switch() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     insert_sentinel_commit(&db);
@@ -1007,9 +982,7 @@ fn git_history_reloads_after_a_non_fast_forward_branch_switch() {
 
 #[test]
 fn git_history_reloads_after_squashing_indexed_commits() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     let before = db.status(&config.database).unwrap().git_history.commit_count;
@@ -1097,9 +1070,7 @@ fn git_history_reload_is_not_skipped_on_a_shallow_clone() {
 
 #[test]
 fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
     // Stamp a non-numeric sentinel so any spurious timestamp write is unmistakable. Under the
@@ -1141,9 +1112,7 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
 
 #[test]
 fn index_discover_reporting_flags_content_changes() {
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    let config = git_history_test_config(&root);
+    let (_scratch, root, config) = git_history_fixture();
     IndexDatabase::rebuild(&config).unwrap();
 
     // No change → reports false, so the watch loop skips the reconcile / memory-validate tail.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
@@ -8,9 +8,16 @@ use rag_rat_base::hash::hex_sha256;
 
 use super::*;
 
-/// A repo with two committed rust files, returning `(root, config)`. `keep.rs` stays unchanged
-/// across every HEAD move in these tests; `edit.rs` is the file the moves modify.
-fn head_move_repo(tag: &str) -> (ScratchRoot, Config) {
+/// A repo with two committed rust files, returning `(scratch guard, root, config)`. `keep.rs`
+/// stays unchanged across every HEAD move in these tests; `edit.rs` is the file the moves modify.
+///
+/// The root is the spelling the `Config` CARRIES, not the raw scratch path: fixture `Config`s
+/// canonicalize their root exactly as `Config::load` does, so on a filesystem where the system
+/// temp is reached through a symlink (macOS `/var` → `/private/var`) or an 8.3 alias (Windows
+/// `RUNNER~1`) the scratch path is a second, non-canonical name for the same directory. Carry-mode
+/// discovery keys its scopes off the recorded root, so a test that drives it — or asserts against
+/// it — through the scratch spelling is comparing with a root the index never stored (#1027).
+fn head_move_repo(tag: &str) -> (ScratchRoot, PathBuf, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -24,7 +31,8 @@ fn head_move_repo(tag: &str) -> (ScratchRoot, Config) {
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-q", "-m", "seed"]);
     let config = source_config(root.clone(), Language::Rust);
-    (root, config)
+    let config_root = config.root.clone();
+    (root, config_root, config)
 }
 
 /// The raw `main.files` rows `(id, commit_sha, sha256)` for `path` in the ACTIVE repo's base
@@ -117,7 +125,7 @@ fn scope_row_modified_at_ms_reads_the_scoped_disk_mtime() {
 
 #[test]
 fn a_head_move_carries_unchanged_rows_and_rederives_only_the_diff() {
-    let (root, config) = head_move_repo("carry");
+    let (_scratch, root, config) = head_move_repo("carry");
     let db = IndexDatabase::rebuild(&config).unwrap();
     let old_head = head_sha(&root);
     let keep_id = active_row_id(&db, "src/keep.rs").expect("keep.rs indexed");
@@ -181,7 +189,7 @@ fn a_head_move_carries_unchanged_rows_and_rederives_only_the_diff() {
 
 #[test]
 fn a_branch_switch_back_carries_everything_with_no_rederive() {
-    let (root, config) = head_move_repo("swback");
+    let (_scratch, root, config) = head_move_repo("swback");
     let db = IndexDatabase::rebuild(&config).unwrap();
     let main_head = head_sha(&root);
     let keep_id = active_row_id(&db, "src/keep.rs").unwrap();
@@ -221,7 +229,7 @@ fn a_branch_switch_back_carries_everything_with_no_rederive() {
 
 #[test]
 fn carry_requires_matching_language_and_kind() {
-    let (root, config) = head_move_repo("drift");
+    let (_scratch, root, config) = head_move_repo("drift");
     let db = IndexDatabase::rebuild(&config).unwrap();
     // A forged retained row at a stale commit whose sha256 matches the file about to appear,
     // but under a different language — the target-drift twin of discovery's sha check. Carry
@@ -271,7 +279,7 @@ fn carry_requires_matching_language_and_kind() {
 
 #[test]
 fn dirty_paths_keep_their_overlay_and_are_not_carried() {
-    let (root, config) = head_move_repo("dirty");
+    let (_scratch, root, config) = head_move_repo("dirty");
     let db = IndexDatabase::rebuild(&config).unwrap();
     let old_head = head_sha(&root);
     drop(db);
@@ -319,7 +327,7 @@ fn a_pull_after_a_branch_round_trip_still_carries_despite_stale_higher_id_rows()
     // main → feat (edit.rs re-derived there, HIGHER row id) → main → commit on main. The pull's
     // carry must adopt the OLD-main row that matches disk, not give up because the stale feat
     // row (higher id, different sha) shadows it for the same path.
-    let (root, config) = head_move_repo("multiret");
+    let (_scratch, root, config) = head_move_repo("multiret");
     let db = IndexDatabase::rebuild(&config).unwrap();
     let keep_id = active_row_id(&db, "src/keep.rs").unwrap();
     let edit_id = active_row_id(&db, "src/edit.rs").unwrap();
@@ -368,7 +376,7 @@ fn discovery_status_surfaces_a_pending_carry_instead_of_reporting_clean() {
     // carry-only scope must not read as "everything indexed": the scope view misses the rows
     // until a discover pass applies the re-stamps, so status reports the pending carry and
     // names the remedy.
-    let (root, config) = head_move_repo("status");
+    let (_scratch, root, config) = head_move_repo("status");
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
@@ -396,7 +404,7 @@ fn an_untracked_recreation_of_old_content_is_not_carried_into_the_committed_scop
     // retained row on sha — but the committed tree at the new HEAD does not contain it, and
     // committed rows are shared with every linked worktree's base view. It must be indexed as
     // this worktree's OVERLAY row, never re-stamped into the committed scope.
-    let (root, config) = head_move_repo("untracked");
+    let (_scratch, root, config) = head_move_repo("untracked");
     let db = IndexDatabase::rebuild(&config).unwrap();
     let old_head = head_sha(&root);
     drop(db);
@@ -438,7 +446,7 @@ fn a_dirty_revert_to_old_content_is_not_carried_into_the_committed_scope() {
     // to the OLD commit's bytes without committing. The path is dirty, so its true committed
     // content at the new HEAD is the edited version — the old-content retained row must not be
     // re-stamped as committed; the dirty bytes belong to the overlay scope.
-    let (root, config) = head_move_repo("dirtyrevert");
+    let (_scratch, root, config) = head_move_repo("dirtyrevert");
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -299,6 +299,74 @@ fn reindex_paths_does_not_index_a_symlinked_linked_path() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+/// #1027: the path-scoped linked overlay rebases a supplied path spelled through a DIFFERENT
+/// symlink than the resolved source root (macOS `/var` vs `/private/var`, a symlinked editor
+/// `$PWD`, a watcher event carrying the watched spelling) — and that rebase must keep the LEAF
+/// verbatim. A branch-only file REPLACED by a symlink still has to lose its stale overlay row;
+/// resolving the leaf hands the pass the link's TARGET instead, so the replaced file is never
+/// classified at all and its row survives indefinitely (this pass skips the global prune).
+#[cfg(unix)]
+#[test]
+fn overlay_paths_rebases_a_symlink_replaced_branch_file_without_following_its_leaf() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Two BRANCH-ONLY files (absent from base), so each carries an overlay row with no base row
+    // behind it — the removal branch, not the tombstone branch.
+    fs::write(linked.join("src/branch.rs"), "pub fn branch_fn() {}\n").unwrap();
+    fs::write(linked.join("src/other.rs"), "pub fn other_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        overlay_rows(&config, "src/branch.rs"),
+        1,
+        "the branch-only file is overlay-indexed"
+    );
+
+    // Replace the branch-only file with a symlink to its sibling, then supply it through an ALIAS
+    // spelling of the worktree — the second spelling of one directory that macOS and Windows hand
+    // over for free.
+    fs::remove_file(linked.join("src/branch.rs")).unwrap();
+    std::os::unix::fs::symlink(linked.join("src/other.rs"), linked.join("src/branch.rs")).unwrap();
+    let alias = unique_temp_root();
+    let _ = fs::remove_dir_all(&alias);
+    std::os::unix::fs::symlink(linked.as_path(), alias.as_path()).unwrap();
+
+    db.index_worktree_overlay_paths(
+        &config,
+        &linked,
+        &[alias.join("src/branch.rs")],
+        crate::index::OverlayLogicalRebuild::Inline,
+        &mut |_| {},
+    )
+    .unwrap();
+
+    assert_eq!(
+        overlay_rows(&config, "src/branch.rs"),
+        0,
+        "the symlink-replaced branch-only file's stale overlay row is removed, not left behind",
+    );
+    assert_eq!(
+        overlay_rows(&config, "src/other.rs"),
+        1,
+        "the link's target is untouched — it was never the supplied path",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 /// #679 review: a BRANCH-ONLY file (absent from base) that was overlay-indexed and is then deleted
 /// must have its stale overlay row REMOVED by a path-scoped pass — there is no base row to shadow
 /// (so a tombstone is wrong) and this pass skips the global prune, so it must remove the row per
@@ -1201,13 +1269,13 @@ fn index_paths_tombstones_a_regular_file_replaced_by_a_symlink() {
     // to true — the exact case a sha/is_file check would mis-treat as "restored").
     fs::remove_file(root.join("src/a.rs")).unwrap();
     std::os::unix::fs::symlink(root.join("src/b.rs"), root.join("src/a.rs")).unwrap();
-    // Supply the path spelled from `config.root`: the fixture canonicalizes its root like
-    // `Config::load`, and a supplied path spelled from the raw scratch root is a DIFFERENT
-    // (non-canonical) name for the same file wherever temp is symlinked. `index --paths`
-    // re-resolves such a path by canonicalizing it, which for a symlink leaf follows to its
-    // TARGET — so the raw spelling would silently supply `src/b.rs` and this test would stop
-    // exercising the tombstone path at all (#1027).
-    let db = IndexDatabase::index_paths(&config, &[config.root.join("src/a.rs")]).unwrap();
+    // Spelled from the RAW scratch root, which is a different (non-canonical) name for the same
+    // directory than the canonicalized `config.root` — exactly what a caller hands over on macOS
+    // (`/var` vs `/private/var`) or through a symlinked `$PWD`. That drives the non-canonical-root
+    // retry in `explicit_index_files_and_changes`, which must rebase the path WITHOUT resolving
+    // the symlink LEAF: resolving it would turn this into `src/b.rs` and the stale row for
+    // `src/a.rs` would never be tombstoned (#1027).
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
 
     assert_eq!(
         db.indexed_file_count().unwrap(),
@@ -1289,10 +1357,11 @@ fn index_paths_tombstones_a_regular_file_replaced_by_an_escaping_symlink() {
     fs::remove_file(root.join("src/a.rs")).unwrap();
     std::os::unix::fs::symlink(outside.join("evil.rs"), root.join("src/a.rs")).unwrap();
 
-    // Spelled from `config.root` for the same reason as the in-repo symlink case above: the raw
-    // scratch spelling would be re-resolved by following the symlink LEAF, landing outside the
-    // root, and the path would be dropped before the deletion branch ran (#1027).
-    let db = IndexDatabase::index_paths(&config, &[config.root.join("src/a.rs")]).unwrap();
+    // Spelled from the RAW scratch root for the same reason as the in-repo symlink case above:
+    // the non-canonical spelling drives the rebase retry, which must not follow the symlink LEAF —
+    // following it lands OUTSIDE the root and the path is dropped before the deletion branch ever
+    // runs, silently leaving the stale row behind (#1027).
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
     // Count 1 proves BOTH: a.rs's stale row is tombstoned AND the external evil.rs is not indexed
     // (an external read would have reindexed src/a.rs, keeping the count at 2).
     assert_eq!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -1201,7 +1201,13 @@ fn index_paths_tombstones_a_regular_file_replaced_by_a_symlink() {
     // to true — the exact case a sha/is_file check would mis-treat as "restored").
     fs::remove_file(root.join("src/a.rs")).unwrap();
     std::os::unix::fs::symlink(root.join("src/b.rs"), root.join("src/a.rs")).unwrap();
-    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    // Supply the path spelled from `config.root`: the fixture canonicalizes its root like
+    // `Config::load`, and a supplied path spelled from the raw scratch root is a DIFFERENT
+    // (non-canonical) name for the same file wherever temp is symlinked. `index --paths`
+    // re-resolves such a path by canonicalizing it, which for a symlink leaf follows to its
+    // TARGET — so the raw spelling would silently supply `src/b.rs` and this test would stop
+    // exercising the tombstone path at all (#1027).
+    let db = IndexDatabase::index_paths(&config, &[config.root.join("src/a.rs")]).unwrap();
 
     assert_eq!(
         db.indexed_file_count().unwrap(),
@@ -1283,7 +1289,10 @@ fn index_paths_tombstones_a_regular_file_replaced_by_an_escaping_symlink() {
     fs::remove_file(root.join("src/a.rs")).unwrap();
     std::os::unix::fs::symlink(outside.join("evil.rs"), root.join("src/a.rs")).unwrap();
 
-    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    // Spelled from `config.root` for the same reason as the in-repo symlink case above: the raw
+    // scratch spelling would be re-resolved by following the symlink LEAF, landing outside the
+    // root, and the path would be dropped before the deletion branch ran (#1027).
+    let db = IndexDatabase::index_paths(&config, &[config.root.join("src/a.rs")]).unwrap();
     // Count 1 proves BOTH: a.rs's stale row is tombstoned AND the external evil.rs is not indexed
     // (an external read would have reindexed src/a.rs, keeping the count at 2).
     assert_eq!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -8,6 +8,7 @@ use rag_rat_base::embedding_models::{
     FASTEMBED_DISPLAY_MODEL, FASTEMBED_EMBEDDING_DIM, FASTEMBED_MODEL_ID, HASH_EMBEDDING_DIM,
     HASH_MODEL_ID,
 };
+use rag_rat_base::test_scratch;
 
 use super::*;
 
@@ -71,14 +72,15 @@ fn git_history_targets() -> Vec<ResolvedTarget> {
 }
 
 fn rag_rat_config(root: &Path) -> Config {
+    let root = test_scratch::canonical_config_root(root);
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
+        root,
         targets: git_history_targets(),
         llm: Default::default(),
         watch: Default::default(),
@@ -229,14 +231,15 @@ fn markdown_config(text: &str) -> (ScratchRoot, Config) {
 }
 
 fn markdown_config_for_root(root: PathBuf) -> Config {
+    let root = test_scratch::canonical_config_root(root);
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
+        root,
         targets: vec![ResolvedTarget {
             name: "markdown".to_string(),
             language: Language::Markdown,
@@ -388,14 +391,15 @@ fn source_config(root: PathBuf, language: Language) -> Config {
 /// `source_config` for a layout that isn't `src/` — SwiftPM puts first-party code under `Sources/`
 /// and its test targets under `Tests/`.
 fn source_config_dirs(root: PathBuf, language: Language, dirs: &[&str]) -> Config {
+    let root = test_scratch::canonical_config_root(root);
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
+        root,
         targets: vec![ResolvedTarget {
             name: language.as_str().to_string(),
             language,
@@ -779,14 +783,15 @@ fn git_fixture_for_overlay_tests() -> (ScratchRoot, Config) {
     fs::write(root.join("src/extra.rs"), "pub fn extra() -> i32 { 2 }\n").unwrap();
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "init"]);
+    let canonical_root = test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: canonical_root.join(".rag-rat/index.sqlite"),
+        root: canonical_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -913,14 +918,15 @@ fn write_four_renamed_clones(root: &Path) -> IndexDatabase {
 /// shared with tests that write their own four-member variant (e.g. the #275 differing-callee
 /// fixture) before rebuilding.
 fn four_clone_config(root: &Path) -> Config {
+    let root = test_scratch::canonical_config_root(root);
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
+        root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -672,6 +672,10 @@ fn orientation_pins_the_fork_repo_over_a_shared_root_sibling() {
     // Index the fork under a PINNED id (records root → fork-pin).
     let mut config = source_config(root.clone(), Language::Rust);
     config.repo_id_override = Some("fork-pin".to_string());
+    // The owner mirror matches the recorded root against the queried one, and the fixture
+    // canonicalizes its root like `Config::load` — so the identity/orientation calls below must be
+    // driven through `config.root`, not the raw scratch spelling of the same directory (#1027).
+    let root = config.root.clone();
     let db = IndexDatabase::rebuild(&config).unwrap();
     assert_eq!(db.active_repo_id, "fork-pin", "the fork indexes under its pinned id");
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -163,14 +163,15 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "init"]);
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -541,14 +541,15 @@ fn parser_failures_report_paths() {
     let src = root.join("src");
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("broken.rs"), "pub fn broken(").unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -730,14 +730,15 @@ fn policy_skip_summary_recomputes_exactly_for_a_non_default_char_cap() {
     let big =
         "// generated data line with sufficient length to matter for the cap xxxxx\n".repeat(80);
     fs::write(root.join("gen/bindings.rs"), &big).unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "generated".to_string(),
             language: Language::Rust,
@@ -980,14 +981,15 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "Refresh beta docs"]);
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![
             ResolvedTarget {
                 name: "markdown".to_string(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/diagnostics.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/diagnostics.rs
@@ -420,14 +420,15 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         run_git(&root, &["commit", "-m", "Iterate hot module"]);
     }
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -510,14 +511,15 @@ fn repo_clusters_groups_cotouched_files() {
         run_git(&root, &["commit", "-m", "Iterate sync modules"]);
     }
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/bootstrap.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/bootstrap.rs
@@ -7,14 +7,15 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
     let docs = root.join("docs");
     fs::create_dir_all(&docs).unwrap();
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "markdown".to_string(),
             language: Language::Markdown,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -781,14 +781,15 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
 "#,
     )
     .unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "c".to_string(),
             language: Language::C,
@@ -1561,14 +1562,15 @@ where
         "# task_spawn\nLocal task_spawn notes explain spawn_blocking.\n",
     )
     .unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![
             ResolvedTarget {
                 name: "rust".to_string(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod config_root;
 mod delta_refresh;
 mod lens_handles;
 mod lifecycle;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+// Every fixture in `config_root` spells its root through a symlink, which needs developer mode or
+// elevation on Windows. Gating the module — rather than each item inside it — keeps its helpers
+// from becoming `dead_code` on a platform where none of its tests compile in.
+#[cfg(unix)]
 mod config_root;
 mod delta_refresh;
 mod lens_handles;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
@@ -1,0 +1,187 @@
+//! The overlay's scoping contract for `config.root` (#1027).
+//!
+//! `Config::load` normalizes its root through `canonicalize()`, and the overlay derives
+//! `config.root`'s subdir by stripping it against the repo's canonicalized workdir. A root spelled
+//! any other way — a symlinked `$PWD`, macOS's `/var` for `/private/var`, a Windows 8.3 alias —
+//! used to strip to nothing: the refresh then scoped itself at the repo root, matched no target
+//! path, wrote nothing, invalidated no client, and still returned `Ok(())`.
+//!
+//! These tests pin the two halves of the fix: the overlay normalizes the root it is handed, and
+//! refuses (loudly) to run when no subdir can be derived at all.
+
+use super::*;
+
+/// The refresh's observable freshness token — what a connected editor polls. A refresh that
+/// scopes itself at the wrong directory leaves this untouched while still reporting success, which
+/// is exactly the silent failure this file exists to catch.
+fn lens_revision(db: &IndexDatabase) -> String {
+    db.lens_version().unwrap().revision
+}
+
+/// A `crate/`-in-repo fixture reached through a SYMLINKED root: `alias` points at the real scratch
+/// dir, and the `Config` deliberately keeps the alias spelling. Returns the guards (kept alive for
+/// the test), the config, and the linked worktree path.
+///
+/// `config.root` is set back to the alias spelling ON PURPOSE, after the fixture canonicalized it:
+/// a `Config` assembled in-process (a fixture, an embedding caller, a hand-edited root) carries
+/// whatever spelling it was given, and the overlay must scope correctly regardless.
+#[cfg(unix)]
+fn symlinked_root_fixture() -> (ScratchRoot, ScratchRoot, ScratchRoot, Config, PathBuf) {
+    let real = unique_temp_root();
+    let _ = fs::remove_dir_all(&real);
+    fs::create_dir_all(real.join("crate/src")).unwrap();
+    fs::write(real.join("crate/src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&real);
+    run_git(&real, &["add", "."]);
+    run_git(&real, &["commit", "-q", "-m", "base"]);
+
+    let alias = unique_temp_root();
+    let _ = fs::remove_dir_all(&alias);
+    std::os::unix::fs::symlink(real.as_path(), alias.as_path()).unwrap();
+
+    let mut config = source_config(alias.join("crate"), Language::Rust);
+    config.root = alias.join("crate");
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&real, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    let linked_path = linked.to_path_buf();
+    (real, alias, linked, config, linked_path)
+}
+
+/// A linked-worktree refresh scoped through a NON-CANONICAL `config.root` must index the branch's
+/// files and move the Lens revision. Before the fix the subdir stripped to nothing, every
+/// candidate kept its `crate/` prefix, no target matched, and the pass reported `Ok(())` having
+/// written nothing — a connected editor was never invalidated.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_config_root_still_scopes_the_overlay_to_the_config_subdir() {
+    let (_real, _alias, _linked, config, linked_path) = symlinked_root_fixture();
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(
+        path_in_scope(&db, "src/a.rs"),
+        "the base index is scoped to `crate/`, so its paths are config-root-relative",
+    );
+
+    fs::write(linked_path.join("crate/src/b.rs"), "pub fn branch_fn() {}\n").unwrap();
+    run_git(&linked_path, &["add", "."]);
+    run_git(&linked_path, &["commit", "-q", "-m", "branch"]);
+
+    let before = lens_revision(&db);
+    let report = db.index_worktree_overlay(&config, &linked_path, &mut |_| {}).unwrap();
+
+    assert_eq!(report.indexed, 1, "the branch-only file is indexed into the overlay");
+    assert!(path_in_scope(&db, "src/b.rs"), "the overlay row is keyed relative to `config.root`");
+    assert_eq!(names_in_scope(&db, "src/b.rs"), vec!["branch_fn".to_string()]);
+    assert_ne!(before, lens_revision(&db), "a refresh that indexed rows must invalidate clients");
+}
+
+/// Sibling isolation under the same non-canonical root: a SECOND linked worktree's refresh must
+/// not disturb the first one's overlay rows, and the base scope must stay on its own content.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_config_root_keeps_sibling_worktree_overlays_isolated() {
+    let (real, _alias, _linked, config, first_path) = symlinked_root_fixture();
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    fs::write(first_path.join("crate/src/first.rs"), "pub fn first_fn() {}\n").unwrap();
+    run_git(&first_path, &["add", "."]);
+    run_git(&first_path, &["commit", "-q", "-m", "first"]);
+    let first = db.index_worktree_overlay(&config, &first_path, &mut |_| {}).unwrap();
+    assert_eq!(first.indexed, 1);
+
+    let second = unique_temp_root();
+    let _ = fs::remove_dir_all(&second);
+    run_git(&real, &["worktree", "add", "-q", "-b", "other", second.to_str().unwrap()]);
+    fs::write(second.join("crate/src/second.rs"), "pub fn second_fn() {}\n").unwrap();
+    run_git(&second, &["add", "."]);
+    run_git(&second, &["commit", "-q", "-m", "second"]);
+    let report = db.index_worktree_overlay(&config, &second, &mut |_| {}).unwrap();
+    assert_eq!(report.indexed, 1, "the sibling's branch-only file is indexed into its own overlay");
+
+    // Active scope = the SECOND worktree: it sees its own file, never the sibling's.
+    assert!(path_in_scope(&db, "src/second.rs"));
+    assert!(!path_in_scope(&db, "src/first.rs"), "a sibling worktree's overlay is not visible");
+
+    // Back to the FIRST worktree: its overlay survived the sibling's refresh.
+    db.set_context(&first.worktree_id.clone(), &first.worktree_id).ok();
+    let scoped = db.storage.connection();
+    let rows: Vec<String> = scoped
+        .prepare("SELECT path FROM main.files WHERE worktree_id = ?1 AND commit_sha = ''")
+        .unwrap()
+        .query_map([&first.worktree_id], |row| row.get::<_, String>(0))
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(rows, vec!["src/first.rs".to_string()], "the first overlay is intact and isolated");
+}
+
+/// A root that resolves OUTSIDE its repository's working tree cannot be scoped at all — the
+/// overlay must say so instead of silently scoping at the repo root and reporting success. The
+/// pre-fix fallback made this indistinguishable from an unchanged worktree.
+#[cfg(unix)]
+#[test]
+fn a_config_root_resolving_outside_the_repo_fails_loudly_instead_of_mis_scoping() {
+    let repo = unique_temp_root();
+    let _ = fs::remove_dir_all(&repo);
+    fs::create_dir_all(repo.join("src")).unwrap();
+    fs::write(repo.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&repo);
+    run_git(&repo, &["add", "."]);
+    run_git(&repo, &["commit", "-q", "-m", "base"]);
+
+    let config = source_config(repo.to_path_buf(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&repo, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/b.rs"), "pub fn branch_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    // An in-repo directory that is really a link to somewhere outside it: lexically inside the
+    // working tree (so the repo still discovers), but it resolves elsewhere, so no subdir of the
+    // working tree describes it.
+    let outside = unique_temp_root();
+    let _ = fs::remove_dir_all(&outside);
+    fs::create_dir_all(&outside).unwrap();
+    std::os::unix::fs::symlink(outside.as_path(), repo.join("escape").as_path()).unwrap();
+    let mut escaping = config.clone();
+    escaping.root = repo.join("escape");
+
+    let err = db
+        .index_worktree_overlay(&escaping, &linked, &mut |_| {})
+        .expect_err("an unscopable root must not report a successful, empty refresh");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("cannot scope a worktree overlay"),
+        "the failure must name the scoping problem, got: {message}",
+    );
+}
+
+/// The fixture `Config` must carry a CANONICAL root, exactly as `Config::load` does. Without this
+/// the whole suite exercises a configuration production can never produce, and root-spelling bugs
+/// stay invisible on the platform the per-PR matrix runs on.
+#[cfg(unix)]
+#[test]
+fn the_fixture_config_canonicalizes_its_root_like_config_load() {
+    let real = unique_temp_root();
+    let _ = fs::remove_dir_all(&real);
+    fs::create_dir_all(real.join("crate/src")).unwrap();
+
+    let alias = unique_temp_root();
+    let _ = fs::remove_dir_all(&alias);
+    std::os::unix::fs::symlink(real.as_path(), alias.as_path()).unwrap();
+
+    let config = source_config(alias.join("crate"), Language::Rust);
+    assert_eq!(
+        config.root,
+        alias.join("crate").canonicalize().unwrap(),
+        "a fixture Config must normalize its root the way `Config::load` does",
+    );
+    assert!(
+        config.database.starts_with(&config.root),
+        "the fixture database path follows the canonical root",
+    );
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
@@ -103,8 +103,10 @@ fn a_symlinked_config_root_keeps_sibling_worktree_overlays_isolated() {
     assert!(path_in_scope(&db, "src/second.rs"));
     assert!(!path_in_scope(&db, "src/first.rs"), "a sibling worktree's overlay is not visible");
 
-    // Back to the FIRST worktree: its overlay survived the sibling's refresh.
-    db.set_context(&first.worktree_id.clone(), &first.worktree_id).ok();
+    // The FIRST worktree's overlay rows survived the sibling's refresh. Read them by their own
+    // `(worktree_id, commit_sha)` key rather than through the connection's installed scope — the
+    // connection is still scoped to the SECOND worktree, and re-scoping it would only re-test what
+    // `path_in_scope` above already covers.
     let scoped = db.storage.connection();
     let rows: Vec<String> = scoped
         .prepare("SELECT path FROM main.files WHERE worktree_id = ?1 AND commit_sha = ''")

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
@@ -8,6 +8,10 @@
 //!
 //! These tests pin the two halves of the fix: the overlay normalizes the root it is handed, and
 //! refuses (loudly) to run when no subdir can be derived at all.
+//!
+//! Every fixture here spells its root through a symlink, so the whole module is Unix-only and is
+//! gated at its `mod` declaration rather than item by item — a helper added below would otherwise
+//! be `dead_code` on Windows, where the cross-platform legs deny warnings.
 
 use super::*;
 
@@ -25,7 +29,6 @@ fn lens_revision(db: &IndexDatabase) -> String {
 /// `config.root` is set back to the alias spelling ON PURPOSE, after the fixture canonicalized it:
 /// a `Config` assembled in-process (a fixture, an embedding caller, a hand-edited root) carries
 /// whatever spelling it was given, and the overlay must scope correctly regardless.
-#[cfg(unix)]
 fn symlinked_root_fixture() -> (ScratchRoot, ScratchRoot, ScratchRoot, Config, PathBuf) {
     let real = unique_temp_root();
     let _ = fs::remove_dir_all(&real);
@@ -53,7 +56,6 @@ fn symlinked_root_fixture() -> (ScratchRoot, ScratchRoot, ScratchRoot, Config, P
 /// files and move the Lens revision. Before the fix the subdir stripped to nothing, every
 /// candidate kept its `crate/` prefix, no target matched, and the pass reported `Ok(())` having
 /// written nothing — a connected editor was never invalidated.
-#[cfg(unix)]
 #[test]
 fn a_symlinked_config_root_still_scopes_the_overlay_to_the_config_subdir() {
     let (_real, _alias, _linked, config, linked_path) = symlinked_root_fixture();
@@ -78,7 +80,6 @@ fn a_symlinked_config_root_still_scopes_the_overlay_to_the_config_subdir() {
 
 /// Sibling isolation under the same non-canonical root: a SECOND linked worktree's refresh must
 /// not disturb the first one's overlay rows, and the base scope must stay on its own content.
-#[cfg(unix)]
 #[test]
 fn a_symlinked_config_root_keeps_sibling_worktree_overlays_isolated() {
     let (real, _alias, _linked, config, first_path) = symlinked_root_fixture();
@@ -121,7 +122,6 @@ fn a_symlinked_config_root_keeps_sibling_worktree_overlays_isolated() {
 /// A root that resolves OUTSIDE its repository's working tree cannot be scoped at all — the
 /// overlay must say so instead of silently scoping at the repo root and reporting success. The
 /// pre-fix fallback made this indistinguishable from an unchanged worktree.
-#[cfg(unix)]
 #[test]
 fn a_config_root_resolving_outside_the_repo_fails_loudly_instead_of_mis_scoping() {
     let repo = unique_temp_root();
@@ -165,7 +165,6 @@ fn a_config_root_resolving_outside_the_repo_fails_loudly_instead_of_mis_scoping(
 /// The fixture `Config` must carry a CANONICAL root, exactly as `Config::load` does. Without this
 /// the whole suite exercises a configuration production can never produce, and root-spelling bugs
 /// stay invisible on the platform the per-PR matrix runs on.
-#[cfg(unix)]
 #[test]
 fn the_fixture_config_canonicalizes_its_root_like_config_load() {
     let real = unique_temp_root();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/relink.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/relink.rs
@@ -337,6 +337,11 @@ fn a_body_only_base_edit_pass_relinks_without_a_rebuild() {
     run_git(&main, &["add", "."]);
     run_git(&main, &["commit", "-q", "-m", "base"]);
     let config = source_config(main.clone(), Language::Rust);
+    // Supply paths spelled from the root the `Config` carries: the fixture canonicalizes it like
+    // `Config::load`, so the scratch spelling is a second, non-canonical name for the same
+    // directory wherever temp is symlinked. This test is about the relink tail, not about
+    // `index --paths`' non-canonical-spelling retry (#1027).
+    let main = config.root.clone();
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
@@ -427,14 +427,15 @@ fn worktree_overlay_reads_uncommitted_linked_edit_not_head() {
 /// binding `rag-rat init` produces for a repo with no conventional source subdirectory. A
 /// `src`-only binding never walks a checkout-root `.cache/`, so it says nothing about the floor.
 fn whole_root_c_config(root: PathBuf) -> Config {
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: Language::C.as_str().to_string(),
             language: Language::C,

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -61,6 +61,12 @@ pub struct WorktreeOverlayReport {
 /// `/private/var`, a Windows 8.3 name. Normalizing here is a no-op for a root that already holds
 /// the invariant and repairs one that does not.
 ///
+/// `ignore_rules::base_under_worktree` solves the same representation mismatch for the gitignore
+/// base, but deliberately returns the ancestor in the ROOT's own spelling (its callers need a
+/// textual prefix of the paths they strip). This one wants the CANONICAL subdir instead: the subdir
+/// is re-joined onto the LINKED checkout's workdir, and git reports that checkout's tree-diff and
+/// status paths in their real form — a symlinked segment of the base root has no meaning there.
+///
 /// ERRORS rather than falling back when the subdir still cannot be derived (#1027). The former
 /// fallback — an empty subdir, the linked workdir as the source root — makes the whole refresh
 /// scope the repo root instead of the config root: every candidate path keeps a `crate/` prefix

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -52,30 +52,56 @@ pub struct WorktreeOverlayReport {
 /// equivalent of `config.root`. The subdir is derived from the BASE workdir (both worktrees share
 /// the same layout); the linked root is the linked WORKDIR joined with that subdir — NOT the raw
 /// `linked_path`, which may be a subdir of the checkout (e.g. `--worktree .` from `/wt/src`) or the
-/// git dir (a hook). Falls back to the linked workdir / `linked_path` when the subdir can't be
-/// derived. Shared by the delta computation (path rebasing) and the read step (source root) so the
-/// two can't drift (#219 review).
+/// git dir (a hook). Shared by the delta computation (path rebasing) and the read step (source
+/// root) so the two can't drift (#219 review).
+///
+/// BOTH sides of the strip are canonicalized first. `Config::load` guarantees a canonical root, but
+/// gix's `workdir()` makes no such promise, and a `Config` assembled in-process (a fixture, an
+/// embedding caller) can carry any spelling of the root — a symlinked `$PWD`, macOS's `/var` for
+/// `/private/var`, a Windows 8.3 name. Normalizing here is a no-op for a root that already holds
+/// the invariant and repairs one that does not.
+///
+/// ERRORS rather than falling back when the subdir still cannot be derived (#1027). The former
+/// fallback — an empty subdir, the linked workdir as the source root — makes the whole refresh
+/// scope the repo root instead of the config root: every candidate path keeps a `crate/` prefix
+/// the targets don't match, the delta comes out empty, nothing is written, no client is
+/// invalidated, and `index_worktree_overlay` still returns `Ok(())`. A caller cannot tell that
+/// from a genuinely unchanged worktree, which is what made the original report expensive to
+/// localize. There is no correct scope to fall back to here, so say so.
 fn linked_config_subdir_and_root(
     config_root: &Path,
     base_repo: &gix::Repository,
     linked_repo: &gix::Repository,
     linked_path: &Path,
-) -> (PathBuf, PathBuf) {
+) -> anyhow::Result<(PathBuf, PathBuf)> {
     let linked_workdir =
         linked_repo.workdir().map(Path::to_path_buf).unwrap_or_else(|| linked_path.to_path_buf());
-    // `config.root` is canonicalized (by `Config::load`'s `normalize_existing_dir`), but gix's
-    // `workdir()` may not be; canonicalize the base workdir so the subdir prefix strips cleanly.
-    let config_subdir = base_repo
-        .workdir()
-        .map(|base_workdir| {
-            base_workdir.canonicalize().unwrap_or_else(|_| base_workdir.to_path_buf())
-        })
-        .and_then(|base_workdir| {
-            config_root.strip_prefix(&base_workdir).ok().map(Path::to_path_buf)
-        })
-        .unwrap_or_default();
+    let base_workdir = base_repo.workdir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot scope a worktree overlay for {}: its repository has no working tree",
+            config_root.display(),
+        )
+    })?;
+    let base_workdir = canonical_or_raw(base_workdir);
+    let config_subdir = canonical_or_raw(config_root)
+        .strip_prefix(&base_workdir)
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "cannot scope a worktree overlay: the index root {} does not resolve to a path \
+                 inside its repository's working tree {}",
+                config_root.display(),
+                base_workdir.display(),
+            )
+        })?
+        .to_path_buf();
     let linked_config_root = linked_workdir.join(&config_subdir);
-    (config_subdir, linked_config_root)
+    Ok((config_subdir, linked_config_root))
+}
+
+/// `path` canonicalized, or `path` itself when it cannot be resolved (a vanished directory) — the
+/// caller then fails on the strip rather than on the canonicalization.
+fn canonical_or_raw(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub(crate) fn linked_source_root(
@@ -84,7 +110,7 @@ pub(crate) fn linked_source_root(
 ) -> anyhow::Result<PathBuf> {
     let base_repo = rag_rat_base::repo_discover::discover_repo(config_root)?;
     let linked_repo = rag_rat_base::repo_discover::discover_repo(linked_path)?;
-    Ok(linked_config_subdir_and_root(config_root, &base_repo, &linked_repo, linked_path).1)
+    Ok(linked_config_subdir_and_root(config_root, &base_repo, &linked_repo, linked_path)?.1)
 }
 
 /// A linked-worktree overlay's resolved identity plus the opened repositories it was resolved
@@ -119,7 +145,7 @@ pub(super) fn resolve_overlay_scope(
     let base_repo = rag_rat_base::repo_discover::discover_repo(&config.root)?;
     let linked_repo = rag_rat_base::repo_discover::discover_repo(linked_path)?;
     let (config_subdir, source_root) =
-        linked_config_subdir_and_root(&config.root, &base_repo, &linked_repo, linked_path);
+        linked_config_subdir_and_root(&config.root, &base_repo, &linked_repo, linked_path)?;
     Ok(Some(ResolvedOverlayScope {
         base_sha,
         worktree_id,

--- a/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
@@ -239,19 +239,14 @@ impl IndexDatabase {
         let mut removal_candidates = Vec::new();
         for path in paths {
             // Rebase to the config-root-relative key (the spelling every overlay row + target match
-            // uses), retrying against the CANONICAL source root for a symlinked spelling; then
-            // reject a `..`-escape. A path not under the source root is dropped
+            // uses) through the SHARED `root_relative_path`, which retries a failed lexical strip
+            // against the CANONICAL source root for a symlinked spelling while keeping the LEAF
+            // verbatim — resolving the leaf would rewrite a symlink-replaced file into its target,
+            // so the tombstone / removal branches below would never see the path they must
+            // shadow. Then reject a `..`-escape. A path not under the source root is dropped
             // (defensive).
-            let raw = match path.strip_prefix(&source_root) {
-                Ok(rel) => rel.to_path_buf(),
-                Err(_) => {
-                    let Some(rel) = canonicalize_nearest_ancestor(path).and_then(|canonical| {
-                        canonical.strip_prefix(&canonical_source).ok().map(Path::to_path_buf)
-                    }) else {
-                        continue;
-                    };
-                    rel
-                },
+            let Some(raw) = root_relative_path(path, &source_root, &canonical_source) else {
+                continue;
             };
             let Some(rel) = lexically_normalized_within_root(&raw) else { continue };
             let full = source_root.join(&rel);

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -73,10 +73,20 @@ fn placement_counters() -> WatchPlacementCounters {
 
 /// A single-Rust-target `Config` rooted at `root` watching `target_dirs` — the inline builder
 /// the real-watcher placement tests share so they can call `watch_created_dirs` (which needs a
-/// `&Config` for the target-relation gate, #332).
-fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
+/// `&Config` for the target-relation gate, #332) — paired with the CANONICAL spelling of that
+/// root the returned `Config` actually carries.
+///
+/// Handing the canonical root back is the point of the pair, not a convenience. `Config::load`
+/// canonicalizes its root, and the watcher classifies an event by stripping `config.root` off the
+/// event path, so a fixture that keeps deriving event paths, ignore matchers and expectations from
+/// its OWN spelling of the root is comparing against a root production never produces: the strip
+/// misses and no pass is ever dispatched. Linux was the one platform where the two spellings
+/// coincided — macOS resolves `/var` → `/private/var`, Windows expands 8.3 names, and the scratch
+/// namespace now hands paths out through a symlinked ancestor so Linux carries the divergence too
+/// (#1027). Bind the second element and derive every other path in the test from it.
+fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> (Config, PathBuf) {
     let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
-    Config {
+    let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
@@ -101,7 +111,53 @@ fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
         log: Default::default(),
         source_root_reanchored_from: None,
         allow_empty: false,
-    }
+    };
+    let canonical_root = config.root.clone();
+    (config, canonical_root)
+}
+
+/// The prologue almost every event-loop test shares: a scratch checkout holding one Rust source
+/// file under `src/`, its single-target [`whole_root_config`], and the CANONICAL root spelling
+/// that `Config` carries. The scratch guard comes back so the caller can keep the directory alive;
+/// nothing hands the caller the fixture's own spelling of the root, which is the point.
+///
+/// Rooted on the scratch guard rather than `tempfile::TempDir` deliberately. A `tempfile` root is
+/// already canonical on Linux, so a test that keeps its own copy of the root compares against the
+/// same string `Config::load` would produce and stays green — while the identical fixture on macOS
+/// (`/var` → `/private/var`) or Windows (8.3 names) diverges and the watcher's `config.root` strip
+/// never matches the event path. Scratch paths reach their directory through a symlinked ancestor,
+/// so the per-PR Linux matrix carries that divergence too (#1027).
+fn src_checkout_config(tag: &str) -> (ScratchRoot, Config, PathBuf) {
+    let scratch = scratch_root(tag);
+    std::fs::create_dir_all(scratch.join("src")).unwrap();
+    std::fs::write(scratch.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let (config, root) = whole_root_config(&scratch, &[PathBuf::from("src")]);
+    (scratch, config, root)
+}
+
+/// The fixture's own spelling of the root and `config.root` must be two names for ONE directory —
+/// the shape `Config::load` produces wherever the system temp is reached through a symlink (macOS
+/// `/var` → `/private/var`) or an 8.3 alias (Windows `RUNNER~1`). Rooting the event-loop fixtures
+/// at a bare `tempfile::TempDir` degenerates the canonicalization to a no-op on Linux, and a test
+/// that kept its own copy of the root would then be indistinguishable from one deriving every path
+/// from `config.root` on the only platform the per-PR matrix runs — which is how a mis-scoped
+/// root reached the cross-platform legs unnoticed (#1027).
+#[cfg(unix)]
+#[test]
+fn the_watch_fixture_config_root_diverges_from_its_scratch_spelling() {
+    let (scratch, config, root) = src_checkout_config("watch-root-spelling");
+    assert_ne!(
+        config.root,
+        scratch.as_path(),
+        "the fixture must reach its root through a symlinked ancestor, or root-spelling bugs stay \
+         invisible on the per-PR matrix",
+    );
+    assert_eq!(
+        config.root,
+        scratch.as_path().canonicalize().unwrap(),
+        "both spellings name the same directory",
+    );
+    assert_eq!(root, config.root, "the returned root is the one the Config carries");
 }
 
 /// #427: a maintenance/watch pass on a first-time-empty config DEFERS — the core refuses the
@@ -111,9 +167,10 @@ fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
 /// coverage).
 #[test]
 fn maintenance_pass_defers_on_a_first_time_empty_config() {
-    let tmp = tempfile::TempDir::new().unwrap();
+    let scratch = scratch_root("watch-empty-first-time");
+    std::fs::create_dir_all(scratch.as_path()).unwrap();
     // A single rust target with NO directories → discovers nothing → first-time-empty.
-    let config = whole_root_config(tmp.path(), &[]);
+    let (config, _) = whole_root_config(&scratch, &[]);
     let result = maintenance_pass(&config, false);
     assert!(result.is_ok(), "an empty first-time config must defer, not error: {result:?}");
     assert!(!config.database.exists(), "deferring must register no empty index");
@@ -296,11 +353,7 @@ fn a_watch_failure_on_an_absent_directory_is_not_counted() {
 /// `watcher_main` uses the real notify watcher and isn't unit-drivable).
 #[test]
 fn shutdown_flush_persists_watch_placement_failures() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, config, root) = src_checkout_config("watch-shutdown-flush");
     IndexDatabase::rebuild(&config).unwrap();
 
     // A fresh index has recorded nothing; a flush with zero failures stays a no-op.
@@ -333,11 +386,7 @@ fn shutdown_flush_persists_watch_placement_failures() {
 /// and that it routes through the lightweight config-scoped persist (no `open_config` heals).
 #[test]
 fn a_nonblocking_flush_persists_the_count_when_the_write_lock_is_free() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, config, root) = src_checkout_config("watch-nonblocking-flush");
     IndexDatabase::rebuild(&config).unwrap();
 
     let counters = WatchPlacementCounters::default();
@@ -362,13 +411,9 @@ fn a_nonblocking_flush_persists_the_count_when_the_write_lock_is_free() {
 /// (#658 review).
 #[test]
 fn a_flush_on_a_checkout_without_an_index_creates_no_db_file() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
     // A source file exists (so the later rebuild has something to index), but no index has been
     // built yet — a source file on disk does not create the `.rag-rat/index.sqlite`.
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, config, root) = src_checkout_config("watch-flush-no-index");
     assert!(!config.database.exists(), "precondition: no index file yet");
 
     // Record real placement failures, then flush — as the shutdown path would.
@@ -406,11 +451,7 @@ fn a_flush_on_a_checkout_without_an_index_creates_no_db_file() {
 /// consolidated DB; `busy_timeout = 0` turns the contended write into an immediate SKIP.
 #[test]
 fn a_nonblocking_flush_skips_a_busy_database_instead_of_blocking() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, config, root) = src_checkout_config("watch-busy-flush");
     IndexDatabase::rebuild(&config).unwrap();
 
     // Persist an initial count (lock free) so we can prove a later busy flush does NOT overwrite
@@ -472,11 +513,7 @@ fn a_nonblocking_flush_skips_a_busy_database_instead_of_blocking() {
 /// resync would, after the pass persisted), wakes the loop, and asserts the drain persisted it.
 #[test]
 fn the_event_loop_drain_persists_a_placement_failure_while_running() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, root) = src_checkout_config("watch-drain-flush");
     config.watch.periodic_sweep_secs = 0; // the exact case the drain must cover.
     IndexDatabase::rebuild(&config).unwrap();
 
@@ -767,7 +804,7 @@ fn maintenance_pass_or_skip_runs_when_lock_is_available() {
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn maintenance_target() {}\n").unwrap();
     let root = root.canonicalize().unwrap();
-    let config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
 
     assert!(
         maintenance_pass_or_skip(&config, false).unwrap(),
@@ -799,7 +836,7 @@ fn startup_catchup_retries_existing_base_embedding_backlog() {
     .unwrap();
     let root = root.canonicalize().unwrap();
 
-    let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (mut config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -862,7 +899,7 @@ fn overlay_only_pass_skips_base_tail_but_still_validates_memories() {
     git(&main, &["worktree", "add", "-q", "-b", "feature", &linked_arg]);
 
     let main_root = main.canonicalize().unwrap();
-    let config = whole_root_config(&main_root, &[PathBuf::from("src")]);
+    let (config, main_root) = whole_root_config(&main_root, &[PathBuf::from("src")]);
     let db = IndexDatabase::rebuild(&config).unwrap();
     let created = db
         .memory_create(RepoMemoryCreate {
@@ -945,7 +982,7 @@ fn startup_catchup_skips_ephemeral_backlog_scan_without_query_endpoint() {
     .unwrap();
     let root = root.canonicalize().unwrap();
 
-    let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (mut config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     config.llm.embedding.backend = FASTEMBED_MODEL_ID.parse().unwrap();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -991,7 +1028,7 @@ fn startup_catchup_reconciles_shutdown_discovered_content() {
     .unwrap();
     let root = root.canonicalize().unwrap();
 
-    let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (mut config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -1062,7 +1099,7 @@ fn startup_catchup_keeps_shutdown_marker_when_reconcile_is_blocked() {
     .unwrap();
     let root = root.canonicalize().unwrap();
 
-    let config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     let db = IndexDatabase::rebuild(&config).unwrap();
     db.mark_watch_shutdown_reconcile_pending().unwrap();
     drop(db);
@@ -1096,7 +1133,7 @@ fn wal_checkpoint_runs_at_every_pass_terminal_gated_by_size_alone() {
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/a.rs"), "pub fn wal_probe() -> i32 { 1 }\n").unwrap();
-    let config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // Put frames in the WAL so there is something to truncate (any meta write serves).
@@ -1131,7 +1168,7 @@ fn initial_watch_state_places_base_gitignore_and_fleet_surfaces() {
     std::fs::create_dir_all(root.join("bin")).unwrap();
     let root = root.canonicalize().unwrap();
 
-    let config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     let target_dirs = config.target_directories();
     let ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
@@ -1182,7 +1219,7 @@ fn event_maintenance_helpers_place_dirs_recompile_and_refresh_linked_state() {
     std::fs::create_dir_all(root.join("src/fresh")).unwrap();
     let root = root.canonicalize().unwrap();
 
-    let config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     let target_dirs = config.target_directories();
     let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut linked_worktrees = LinkedWorktreeWatches::default();
@@ -1248,7 +1285,7 @@ fn event_maintenance_helper_requests_pass_for_relevant_and_registry_events() {
     std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
     let root = root.canonicalize().unwrap();
 
-    let config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     let target_dirs = config.target_directories();
     let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut linked_worktrees = LinkedWorktreeWatches::default();
@@ -1313,7 +1350,7 @@ fn initial_watch_state_places_worktree_registry() {
     git(&main, &["worktree", "add", "-q", "-b", "feature", &linked_arg]);
 
     let main = main.canonicalize().unwrap();
-    let config = whole_root_config(&main, &[PathBuf::from("src")]);
+    let (config, main) = whole_root_config(&main, &[PathBuf::from("src")]);
     let target_dirs = config.target_directories();
     let ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
@@ -1348,7 +1385,7 @@ fn initial_watch_state_places_worktree_registry() {
 fn watch_created_dirs_ignores_non_appearance_events() {
     let root = PathBuf::from("/repo");
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let access = Event::new(EventKind::Access(AccessKind::Any)).add_path(root.join("src/fresh"));
@@ -1399,7 +1436,7 @@ fn missing_config_root_bootstrap_dirs_use_existing_ancestor_chain() {
 fn created_dir_placement_classifies_target_ancestors_and_subtrees() {
     let root = PathBuf::from("/repo");
     let nested = vec![PathBuf::from("src/generated")];
-    let config = whole_root_config(&root, &nested);
+    let (config, root) = whole_root_config(&root, &nested);
 
     assert_eq!(
         created_dir_placement(&config, &nested, &PathBuf::from("/elsewhere/src"), None),
@@ -1427,7 +1464,7 @@ fn created_dir_placement_classifies_target_ancestors_and_subtrees() {
     );
 
     let whole_root = vec![PathBuf::from(".")];
-    let whole_config = whole_root_config(&root, &whole_root);
+    let (whole_config, root) = whole_root_config(&root, &whole_root);
     assert_eq!(
         created_dir_placement(&whole_config, &whole_root, &root.join("anything"), None),
         CreatedDirPlacement::TargetSubtree,
@@ -1435,7 +1472,7 @@ fn created_dir_placement_classifies_target_ancestors_and_subtrees() {
 
     let checkout = PathBuf::from("/checkout");
     let subdir_root = checkout.join("packages/crate");
-    let subdir_config = whole_root_config(&subdir_root, &nested);
+    let (subdir_config, subdir_root) = whole_root_config(&subdir_root, &nested);
     assert_eq!(
         created_dir_placement(&subdir_config, &nested, &checkout.join("packages"), Some(&checkout)),
         CreatedDirPlacement::TargetAncestor,
@@ -1559,7 +1596,7 @@ fn event_touches_worktree_attributes_the_touched_checkout_roots() {
     // #577: the hint names WHICH linked checkouts an event implicates, so the dispatched pass
     // refreshes those overlays instead of sweeping the fleet; registry changes and rescans are
     // unattributable and widen to AllWorktrees.
-    let config = whole_root_config(&PathBuf::from("/main"), &[PathBuf::from("src")]);
+    let (config, _) = whole_root_config(&PathBuf::from("/main"), &[PathBuf::from("src")]);
     let wt_a = PathBuf::from("/wt/a");
     let wt_b = PathBuf::from("/wt/b");
     let registry = PathBuf::from("/main/.git/worktrees");
@@ -1662,7 +1699,7 @@ fn linked_worktree_events_honor_its_ignore_rules() {
     let worktree = worktree.canonicalize().unwrap();
     std::fs::write(worktree.join(".gitignore"), "ignored_dir/\ntarget/\n").unwrap();
 
-    let config = whole_root_config(&worktree, &[PathBuf::from(".")]);
+    let (config, worktree) = whole_root_config(&worktree, &[PathBuf::from(".")]);
     let mut watcher = RecordingWatcher::default();
     let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         worktree.clone(),
@@ -1741,7 +1778,7 @@ fn linked_worktree_watch_placement_uses_configured_pruned_targets() {
     let worktree = worktree.canonicalize().unwrap();
     std::fs::write(worktree.join(".gitignore"), "src/ignored_dir/\ntarget/\n").unwrap();
 
-    let config = whole_root_config(&worktree, &[PathBuf::from("src")]);
+    let (config, worktree) = whole_root_config(&worktree, &[PathBuf::from("src")]);
     let mut watcher = RecordingWatcher::default();
     let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         worktree.clone(),
@@ -1787,8 +1824,8 @@ fn linked_worktree_watch_set_sync_rebuilds_existing_root_state() {
     std::fs::create_dir_all(worktree.join("extra")).unwrap();
     let worktree = worktree.canonicalize().unwrap();
 
-    let src_config = whole_root_config(&worktree, &[PathBuf::from("src")]);
-    let extra_config = whole_root_config(&worktree, &[PathBuf::from("extra")]);
+    let (src_config, worktree) = whole_root_config(&worktree, &[PathBuf::from("src")]);
+    let (extra_config, _) = whole_root_config(&worktree, &[PathBuf::from("extra")]);
     let mut watcher = RecordingWatcher::default();
     let mut worktrees = LinkedWorktreeWatches::default();
     worktrees.sync(&mut watcher, &placement_counters(), &src_config, vec![worktree.clone()]);
@@ -1815,7 +1852,7 @@ fn linked_worktree_watch_set_handles_created_dirs_and_recompile() {
     let worktree = worktree.canonicalize().unwrap();
     std::fs::write(worktree.join(".gitignore"), "").unwrap();
 
-    let config = whole_root_config(&worktree, &[PathBuf::from("src")]);
+    let (config, worktree) = whole_root_config(&worktree, &[PathBuf::from("src")]);
     let mut watcher = RecordingWatcher::default();
     let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         worktree.clone(),
@@ -1855,7 +1892,7 @@ fn linked_worktree_watch_set_handles_created_target_ancestors() {
     std::fs::write(worktree.join(".gitignore"), "").unwrap();
 
     let target_dirs = vec![PathBuf::from("src/generated")];
-    let config = whole_root_config(&worktree, &target_dirs);
+    let (config, worktree) = whole_root_config(&worktree, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         worktree.clone(),
@@ -1904,7 +1941,7 @@ fn linked_worktree_target_ancestor_gitignore_is_compiled() {
     std::fs::write(worktree.join("src/sibling/.gitignore"), "marker.rs\n").unwrap();
 
     let target_dirs = vec![PathBuf::from("src/generated")];
-    let config = whole_root_config(&worktree, &target_dirs);
+    let (config, worktree) = whole_root_config(&worktree, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         worktree.clone(),
@@ -1948,7 +1985,7 @@ fn linked_subdir_root_watch_placement_keeps_checkout_root_when_config_root_missi
     let checkout = checkout.canonicalize().unwrap();
     let config_root = repo.join("packages/crate").canonicalize().unwrap();
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&config_root, &target_dirs);
+    let (config, _) = whole_root_config(&config_root, &target_dirs);
 
     let mut watcher = RecordingWatcher::default();
     let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
@@ -1988,7 +2025,7 @@ fn watch_created_dirs_reinstalls_watches_for_recreated_config_root() {
     std::fs::write(root.join(".gitignore"), "").unwrap();
     let root = root.canonicalize().unwrap();
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(root.clone());
@@ -2037,7 +2074,7 @@ fn watch_created_dirs_bootstraps_missing_linked_subdir_root_ancestors() {
     let checkout = checkout.canonicalize().unwrap();
     let packages = checkout.join("packages");
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&packages.join("crate"), &target_dirs);
+    let (config, _) = whole_root_config(&packages.join("crate"), &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let create_packages =
@@ -2098,7 +2135,7 @@ fn linked_created_target_dir_requests_maintenance_when_directory_event_is_not_re
     std::fs::write(worktree.join(".gitignore"), "").unwrap();
 
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&worktree, &target_dirs);
+    let (config, worktree) = whole_root_config(&worktree, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         worktree.clone(),
@@ -2142,7 +2179,7 @@ fn linked_created_dir_watch_signal_does_not_short_circuit_state_updates() {
     let second = second.canonicalize().unwrap();
 
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&first, &target_dirs);
+    let (config, first) = whole_root_config(&first, &target_dirs);
     let mut watcher = RecordingWatcher::default();
     let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
         first.clone(),
@@ -2188,7 +2225,7 @@ fn watch_created_dirs_skips_dirs_ignored_before_or_after_recompile() {
     std::fs::write(root.join(".gitignore"), "src/already_ignored/\n").unwrap();
 
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
 
@@ -2751,14 +2788,10 @@ fn pass_worker_runs_requests_in_order_and_reports_completion() {
 /// the completion until the end.
 #[test]
 fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let (_scratch, mut config, root) = src_checkout_config("watch-pass-in-flight");
     let fleet_bin = root.join("rag-rat-506-test-bin");
     std::fs::write(&fleet_bin, b"binary").unwrap();
 
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
     config.watch.debounce_ms = 10;
     config.watch.max_latency_ms = 50;
     config.watch.periodic_sweep_secs = 0;
@@ -2853,12 +2886,8 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
 /// must wait it out (counted from pass COMPLETION) and then dispatch.
 #[test]
 fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let (_scratch, mut config, root) = src_checkout_config("watch-cooldown");
 
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
     config.watch.debounce_ms = 10;
     config.watch.max_latency_ms = 50;
     config.watch.periodic_sweep_secs = 0;
@@ -2946,12 +2975,8 @@ fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
 /// dispatches on time.
 #[test]
 fn a_due_periodic_sweep_overrides_the_pass_cooldown() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let (_scratch, mut config, _) = src_checkout_config("watch-sweep-cooldown");
 
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
     // No debounce fires (nothing event-driven); the sweep is due every second while the
     // cooldown would hold event-driven dispatch for an hour.
     config.watch.debounce_ms = 60_000;
@@ -3225,7 +3250,7 @@ fn watcher_main_routes_gitignore_mutations_through_central_helpers() {
     git(&root, &["commit", "-qm", "seed"]);
     let root = root.canonicalize().unwrap();
 
-    let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+    let (mut config, root) = whole_root_config(&root, &[PathBuf::from("src")]);
     config.watch.debounce_ms = 20;
     config.watch.max_latency_ms = 50;
     config.watch.periodic_sweep_secs = 0;
@@ -3363,7 +3388,7 @@ fn newly_created_non_ignored_dir_gets_watched() {
         return; // no watcher backend available (sandboxed CI) — nothing to assert.
     };
     let target_dirs = vec![PathBuf::from(".")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
 
@@ -3472,7 +3497,7 @@ fn a_directory_moved_into_a_target_is_watched() {
         return; // no watcher backend available (sandboxed CI) — nothing to assert.
     };
     let target_dirs = vec![PathBuf::from(".")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     // Simulate `mv` landing a directory into the target: create it, then feed a rename-To
@@ -3568,7 +3593,7 @@ fn a_symlink_to_a_directory_is_not_followed_into_watches() {
         return; // no watcher backend available (sandboxed CI) — nothing to assert.
     };
     let target_dirs = vec![PathBuf::from(".")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
 
@@ -3620,7 +3645,7 @@ fn a_non_target_top_level_dir_is_not_watched() {
         return; // no watcher backend available (sandboxed CI) — nothing to assert.
     };
     let target_dirs = vec![PathBuf::from("src")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     // Watch the target subtree + (mirroring watcher_main) config.root itself non-recursively,
     // so a top-level create is delivered here exactly as it would be in production.
@@ -3699,7 +3724,7 @@ fn a_moved_in_dir_with_a_nested_gitignore_prunes_against_it() {
         return; // no watcher backend available (sandboxed CI) — nothing to assert.
     };
     let target_dirs = vec![PathBuf::from(".")];
-    let config = whole_root_config(&root, &target_dirs);
+    let (config, root) = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     drain_until_quiet(&rx, 100, 1000);
@@ -3741,15 +3766,11 @@ fn a_moved_in_dir_with_a_nested_gitignore_prunes_against_it() {
 
 #[test]
 fn watcher_spawn_is_disabled_when_watch_is_off_or_env_opt_out_is_set() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, root) = src_checkout_config("watch-spawn-optout");
     config.watch.enabled = false;
     assert!(Watcher::spawn(config).is_none(), "disabled watch config must not spawn a thread");
 
-    let mut enabled = whole_root_config(root, &[PathBuf::from("src")]);
+    let (mut enabled, _) = whole_root_config(&root, &[PathBuf::from("src")]);
     enabled.watch.enabled = true;
     // SAFETY: this test is the only one touching RAG_RAT_NO_WATCH in this process.
     unsafe {
@@ -3763,11 +3784,7 @@ fn watcher_spawn_is_disabled_when_watch_is_off_or_env_opt_out_is_set() {
 
 #[test]
 fn event_loop_ignores_fs_errors_and_exits_on_disconnect() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, _) = src_checkout_config("watch-fs-errors");
     config.watch.debounce_ms = 50;
     config.watch.max_latency_ms = 200;
     config.watch.periodic_sweep_secs = 0;
@@ -3816,11 +3833,7 @@ fn event_loop_ignores_fs_errors_and_exits_on_disconnect() {
 
 #[test]
 fn periodic_sweep_dispatches_all_overlay_scope() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, _) = src_checkout_config("watch-sweep-scope");
     config.watch.debounce_ms = 60_000;
     config.watch.max_latency_ms = 60_000;
     config.watch.periodic_sweep_secs = 1;
@@ -3875,11 +3888,7 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
 
 #[test]
 fn live_oracle_deadline_dispatches_without_events_or_periodic_sweeps() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, _) = src_checkout_config("watch-oracle-deadline");
     config.watch.periodic_sweep_secs = 0;
     config.watch.pass_cooldown_secs = 3_600;
     let target_dirs = config.target_directories();
@@ -3937,11 +3946,7 @@ fn live_oracle_deadline_dispatches_without_events_or_periodic_sweeps() {
 
 #[test]
 fn shutdown_discover_skips_when_write_lock_is_held() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, config, _) = src_checkout_config("watch-shutdown-discover");
     let lock_repo = rag_rat_base::locks::write_lock_repo_id(&config);
     let holder_config = config.clone();
     let holder_repo = lock_repo.clone();
@@ -4011,9 +4016,8 @@ fn papertrail_scheduler_single_flights_and_coalesces_max_wins() {
 
 #[test]
 fn papertrail_tick_interval_requires_bindings_and_takes_the_tightest_cadence() {
-    let tmp = tempfile::TempDir::new().unwrap();
     // No `[[tracker]]` bindings and no git remote to auto-detect one from → disabled.
-    let mut config = whole_root_config(tmp.path(), &[PathBuf::from("src")]);
+    let (_scratch, mut config, _) = src_checkout_config("watch-papertrail-cadence");
     assert_eq!(papertrail_tick_interval(&config), None);
 
     config.trackers = vec![rag_rat_base::config::TrackerConfig {
@@ -4032,11 +4036,7 @@ fn papertrail_tick_interval_requires_bindings_and_takes_the_tightest_cadence() {
 
 #[test]
 fn idle_watcher_enqueues_papertrail_evaluation_without_filesystem_activity() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, _) = src_checkout_config("watch-idle-papertrail");
     config.watch.debounce_ms = 60_000;
     config.watch.max_latency_ms = 60_000;
     config.watch.periodic_sweep_secs = 0;
@@ -4088,11 +4088,7 @@ fn idle_watcher_enqueues_papertrail_evaluation_without_filesystem_activity() {
 
 #[test]
 fn papertrail_deadline_fires_during_an_in_flight_pass_and_ticks_coalesce() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let root = tmp.path();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    let (_scratch, mut config, root) = src_checkout_config("watch-papertrail-deadline");
     config.watch.debounce_ms = 10;
     config.watch.max_latency_ms = 50;
     config.watch.periodic_sweep_secs = 0;

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -75,14 +75,15 @@ fn placement_counters() -> WatchPlacementCounters {
 /// the real-watcher placement tests share so they can call `watch_created_dirs` (which needs a
 /// `&Config` for the target-relation gate, #332).
 fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -2302,14 +2303,15 @@ fn event_is_relevant_skips_gitignored_paths_consistently_with_walker() {
     std::fs::create_dir_all(root.join("crates")).unwrap();
     std::fs::write(root.join(".gitignore"), "gen/\n").unwrap();
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -2328,6 +2330,11 @@ fn event_is_relevant_skips_gitignored_paths_consistently_with_walker() {
         source_root_reanchored_from: None,
         allow_empty: false,
     };
+    // The classifier matches an event by stripping `config.root` off its path, and the
+    // fixture Config canonicalizes that root — so spell the fixture's paths and ignore
+    // rules through the SAME root, exactly as the live watcher (which subscribes under
+    // `config.root`) delivers them (#1027).
+    let root = config.root.clone();
     let ignore = IgnoreMatcher::compile(&root, &[]);
 
     // A real source edit under the target fires.
@@ -2369,14 +2376,15 @@ fn gitignore_edit_is_relevant_and_recompile_reflects_new_rules() {
     // Initially nothing is gitignored.
     std::fs::write(root.join(".gitignore"), "").unwrap();
 
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -2396,6 +2404,11 @@ fn gitignore_edit_is_relevant_and_recompile_reflects_new_rules() {
         allow_empty: false,
     };
 
+    // The classifier matches an event by stripping `config.root` off its path, and the
+    // fixture Config canonicalizes that root — so spell the fixture's paths and ignore
+    // rules through the SAME root, exactly as the live watcher (which subscribes under
+    // `config.root`) delivers them (#1027).
+    let root = config.root.clone();
     let ignore = IgnoreMatcher::compile(&root, &[]);
     let secret = root.join("crates/secret.rs");
     // Before the rule edit: a normal source edit fires.

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -991,7 +991,9 @@ fn test_config() -> (PathBuf, Config) {
         std::process::id(),
         NEXT.fetch_add(1, Ordering::Relaxed)
     ));
-    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root.clone());
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.clone());
+    let mut config =
+        Config::minimal_for_database(config_root.join("index.sqlite"), config_root.clone());
     config.database_key_pinned = true;
     config.targets = vec![ResolvedTarget {
         name: "rust".into(),

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -765,7 +765,7 @@ pub fn run() {
 /// reachable and says, in the response, that it covered two symbols at once.
 #[tokio::test]
 async fn hop_routes_prefer_the_symbol_handle_over_the_shared_qualified_name() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), OVERLOAD_SOURCE).unwrap();
     fs::write(root.join("src/cfg.rs"), CFG_VARIANT_SOURCE).unwrap();

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -984,16 +984,20 @@ async fn get_json(app: &axum::Router, uri: &str) -> Value {
     body
 }
 
+/// A fixture repo root plus a `Config` rooted at it. The returned root is the CANONICAL spelling
+/// the `Config` carries (`Config::load` canonicalizes, so a fixture must too): handing back the raw
+/// `temp_dir()` spelling alongside a canonical `config.root` would leave the caller writing its
+/// files through a second name for the same directory — the divergence that hides root-spelling
+/// bugs on the platforms where temp is symlinked (#1027).
 fn test_config() -> (PathBuf, Config) {
     static NEXT: AtomicU64 = AtomicU64::new(0);
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-http-test-{}-{}",
-        std::process::id(),
-        NEXT.fetch_add(1, Ordering::Relaxed)
-    ));
-    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.clone());
-    let mut config =
-        Config::minimal_for_database(config_root.join("index.sqlite"), config_root.clone());
+    let root =
+        rag_rat_base::test_scratch::canonical_config_root(std::env::temp_dir().join(format!(
+            "rag-rat-http-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        )));
+    let mut config = Config::minimal_for_database(root.join("index.sqlite"), root.clone());
     config.database_key_pinned = true;
     config.targets = vec![ResolvedTarget {
         name: "rust".into(),

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use axum::Json;
@@ -12,6 +12,7 @@ use axum::response::IntoResponse;
 use futures_util::StreamExt;
 use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
 use rag_rat_base::language::Language;
+use rag_rat_base::test_scratch::{self, ScratchDir};
 use rag_rat_core::IndexDatabase;
 use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
 use serde_json::Value;
@@ -33,7 +34,7 @@ async fn serve_control_observes_a_stop_that_precedes_the_waiter() {
 
 #[tokio::test]
 async fn non_loopback_serving_requires_authentication() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
     let error = serve(
         listener,
@@ -48,7 +49,7 @@ async fn non_loopback_serving_requires_authentication() {
 
 #[tokio::test]
 async fn health_is_available_without_opening_the_database() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let response = router(config, ServeOptions::default())
         .oneshot(Request::get("/api/health").body(Body::empty()).unwrap())
         .await
@@ -63,7 +64,7 @@ async fn health_is_available_without_opening_the_database() {
 
 #[tokio::test]
 async fn bearer_auth_and_exact_origin_are_enforced() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let app = router(config, ServeOptions {
         auth_token: Some("test-token".into()),
         allowed_origins: vec!["https://lens.example".into()],
@@ -109,7 +110,7 @@ async fn bearer_auth_and_exact_origin_are_enforced() {
 
 #[tokio::test]
 async fn an_allowed_origin_sees_cors_headers_on_auth_failure() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let app = router(config, ServeOptions {
         auth_token: Some("test-token".into()),
         allowed_origins: vec!["https://lens.example".into()],
@@ -138,7 +139,7 @@ async fn an_allowed_origin_sees_cors_headers_on_auth_failure() {
 /// emitted only for an exact-allowlisted origin, never by default.
 #[tokio::test]
 async fn cors_preflight_is_answered_before_auth_and_opts_into_private_network_access() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let app = router(config, ServeOptions {
         auth_token: Some("test-token".into()),
         allowed_origins: vec!["https://lens.example".into()],
@@ -211,7 +212,7 @@ async fn cors_preflight_is_answered_before_auth_and_opts_into_private_network_ac
 
 #[tokio::test]
 async fn events_emits_the_current_version_as_sse() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn current() {}\n").unwrap();
     drop(IndexDatabase::rebuild(&config).unwrap());
@@ -285,12 +286,11 @@ async fn events_emits_the_current_version_as_sse() {
         .await
         .expect("SSE shutdown must not wait for the polling interval");
     assert!(end.is_none(), "SSE body must end when serving stops");
-    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
 async fn events_ends_when_a_version_probe_can_no_longer_open_the_index() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn current() {}\n").unwrap();
     drop(IndexDatabase::rebuild(&config).unwrap());
@@ -312,12 +312,11 @@ async fn events_ends_when_a_version_probe_can_no_longer_open_the_index() {
         .await
         .expect("failed version probes must close the SSE stream");
     assert!(end.is_none(), "a failed version probe must disconnect the client");
-    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
 async fn clones_rejects_invalid_theta_and_paths() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let app = router(config, ServeOptions::default());
     for uri in [
         "/api/file/clones?path=src/a.rs&theta=nan",
@@ -333,7 +332,7 @@ async fn clones_rejects_invalid_theta_and_paths() {
 
 #[tokio::test]
 async fn new_routes_reject_missing_or_invalid_parameters() {
-    let (_root, config) = test_config();
+    let (_scratch, _root, config) = test_config();
     let app = router(config, ServeOptions::default());
     for uri in [
         "/api/file/symbols",
@@ -368,7 +367,7 @@ async fn new_routes_reject_missing_or_invalid_parameters() {
 
 #[tokio::test]
 async fn symbol_graph_hops_and_chunk_routes_preserve_endpoint_wrappers() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(
         root.join("src/lib.rs"),
@@ -511,12 +510,11 @@ pub fn handle(req: Req) {
         json_body(stale).await["error"].as_str().unwrap().contains("stale"),
         "stale chunk must report as a 404"
     );
-    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
 async fn clones_uses_the_native_lens_composition() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(
         root.join("src/a.rs"),
@@ -598,12 +596,11 @@ async fn clones_uses_the_native_lens_composition() {
     let body = json_body(response).await;
     assert_eq!(body["clone_regions"][0]["symbol"], "load_user");
     assert_eq!(body["clone_regions"][0]["partners"][0]["path"], "src/b.rs");
-    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
 async fn blocking_database_work_obeys_the_timeout() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
     drop(IndexDatabase::rebuild(&config).unwrap());
@@ -635,12 +632,11 @@ async fn blocking_database_work_obeys_the_timeout() {
     run_db(state, |_, _, _| Ok(()))
         .await
         .expect("a cooperatively cancelled request must release the sole worker permit");
-    let _ = fs::remove_dir_all(root);
 }
 
 #[tokio::test]
 async fn dropping_a_request_cancels_its_database_work() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
     drop(IndexDatabase::rebuild(&config).unwrap());
@@ -677,7 +673,6 @@ async fn dropping_a_request_cancels_its_database_work() {
     run_db(state, |_, _, _| Ok(()))
         .await
         .expect("cancelling the abandoned work releases the sole worker permit");
-    let _ = fs::remove_dir_all(root);
 }
 
 /// A clone read that is waiting its turn at the repository-wide graph must wait OUTSIDE the
@@ -686,7 +681,7 @@ async fn dropping_a_request_cancels_its_database_work() {
 /// graph, memory, coupling, and papertrail lane behind it for the length of the build.
 #[tokio::test]
 async fn a_queued_clone_read_holds_no_database_worker() {
-    let (root, config) = test_config();
+    let (_scratch, root, config) = test_config();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
     drop(IndexDatabase::rebuild(&config).unwrap());
@@ -726,7 +721,6 @@ async fn a_queued_clone_read_holds_no_database_worker() {
     let Json(clones) =
         queued.await.expect("the queued clone read completes once the build releases the graph");
     assert!(clones.answer.clone_regions.is_empty(), "a one-function corpus has no clone regions");
-    let _ = fs::remove_dir_all(root);
 }
 
 /// Two `run` overloads sharing `src/lib.rs::run`, each with its own caller and its own callee.
@@ -984,19 +978,20 @@ async fn get_json(app: &axum::Router, uri: &str) -> Value {
     body
 }
 
-/// A fixture repo root plus a `Config` rooted at it. The returned root is the CANONICAL spelling
-/// the `Config` carries (`Config::load` canonicalizes, so a fixture must too): handing back the raw
-/// `temp_dir()` spelling alongside a canonical `config.root` would leave the caller writing its
-/// files through a second name for the same directory — the divergence that hides root-spelling
-/// bugs on the platforms where temp is symlinked (#1027).
-fn test_config() -> (PathBuf, Config) {
-    static NEXT: AtomicU64 = AtomicU64::new(0);
-    let root =
-        rag_rat_base::test_scratch::canonical_config_root(std::env::temp_dir().join(format!(
-            "rag-rat-http-test-{}-{}",
-            std::process::id(),
-            NEXT.fetch_add(1, Ordering::Relaxed)
-        )));
+/// The scratch guard, the fixture repo root, and a `Config` rooted at it.
+///
+/// The root comes from [`ScratchDir`], not `std::env::temp_dir()`: scratch paths are handed out
+/// through a symlinked ancestor, so `canonical_config_root` is a real normalization on every
+/// platform instead of a no-op that only bites on macOS/Windows (#1027). A `temp_dir()` root is
+/// already canonical on Linux, which would leave the Lens HTTP chunk/search paths outside the
+/// per-PR coverage of root-spelling bugs. It also brings this fixture under the scratch
+/// namespace's stale sweep, so a killed run cannot strand it in the system temp (#726).
+///
+/// The returned root is the CANONICAL spelling the `Config` carries, so callers write their
+/// fixture files through the same name the index records.
+fn test_config() -> (ScratchDir, PathBuf, Config) {
+    let scratch = ScratchDir::new("rag-rat-http-test");
+    let root = test_scratch::canonical_config_root(scratch.path());
     let mut config = Config::minimal_for_database(root.join("index.sqlite"), root.clone());
     config.database_key_pinned = true;
     config.targets = vec![ResolvedTarget {
@@ -1007,5 +1002,25 @@ fn test_config() -> (PathBuf, Config) {
         exclude: Vec::new(),
         kind: TargetKind::Source,
     }];
-    (root, config)
+    (scratch, root, config)
+}
+
+/// The scratch spelling and `config.root` must be two names for ONE directory — the shape
+/// `Config::load` produces wherever the system temp is reached through a symlink (macOS `/var` →
+/// `/private/var`) or an 8.3 alias (Windows `RUNNER~1`). Rooting this fixture at a bare
+/// `temp_dir()` path degenerates `canonical_config_root` to a no-op on Linux, and a one-sided
+/// `strip_prefix(config.root)` regression on the routes below would then pass the per-PR matrix
+/// and redden only the tag-triggered cross-platform legs (#1027).
+#[cfg(unix)]
+#[test]
+fn the_http_fixture_config_root_diverges_from_its_scratch_spelling() {
+    let (scratch, root, config) = test_config();
+    assert_ne!(
+        root,
+        scratch.path(),
+        "the fixture must reach its root through a symlinked ancestor, or root-spelling bugs stay \
+         invisible on the per-PR matrix",
+    );
+    assert_eq!(config.root, root, "the Config carries the canonical spelling");
+    assert_eq!(root, scratch.path().canonicalize().unwrap(), "both spellings name one directory");
 }

--- a/crates/rag-rat-mcp/src/server/tests.rs
+++ b/crates/rag-rat-mcp/src/server/tests.rs
@@ -15,14 +15,15 @@ fn config_over_temp_repo() -> (rag_rat_base::test_scratch::ScratchDir, Config) {
     let root = rag_rat_base::test_scratch::ScratchDir::new("server-test");
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1036,14 +1036,15 @@ fn mixed_config() -> (rag_rat_base::test_scratch::ScratchDir, Config) {
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("docs/search.md"), "# Title\nalpha token\n").unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn alpha_symbol() {}\n").unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![
             ResolvedTarget {
                 name: "markdown".to_string(),
@@ -1079,14 +1080,15 @@ fn markdown_config(text: &str) -> (rag_rat_base::test_scratch::ScratchDir, Confi
     let root = unique_temp_root();
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::write(root.join("docs/search.md"), text).unwrap();
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "markdown".to_string(),
             language: Language::Markdown,
@@ -1109,14 +1111,15 @@ fn markdown_config(text: &str) -> (rag_rat_base::test_scratch::ScratchDir, Confi
 }
 
 fn rust_config(root: PathBuf) -> Config {
+    let config_root = rag_rat_base::test_scratch::canonical_config_root(root.to_path_buf());
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.to_path_buf(),
-        database: root.join(".rag-rat/index.sqlite"),
+        database: config_root.join(".rag-rat/index.sqlite"),
+        root: config_root,
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -1,15 +1,44 @@
 //! Registry, layout, and warm-up-document behaviour for the live backends.
 
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use rag_rat_base::language::Language;
+use rag_rat_base::test_scratch::{self, ScratchDir};
 
 use super::documents::enclosing_project_dir;
 use super::registry::LiveBackend;
 use crate::OracleTool;
 use crate::test_support::every_path_scope as scope;
+
+/// A scratch checkout, paired with the CANONICAL spelling of its root — the only spelling these
+/// tests may build paths from.
+///
+/// [`CheckoutScope::resolve`](super::CheckoutScope::resolve) canonicalizes the root it is handed
+/// (as `Config::load` does), so every path a layout, marker search or warm-up document comes back
+/// as is spelled through that root. Scratch paths reach their directory through a symlinked
+/// ancestor, so the guard's own spelling is a SECOND name for it — comparing against that name is
+/// the divergence macOS (`/var` → `/private/var`) and Windows (8.3 `RUNNER~1`) hand over by
+/// default, and it is why the guard is returned opaque here (#1027).
+fn checkout(tag: &str) -> (ScratchDir, PathBuf) {
+    let scratch = ScratchDir::new(tag);
+    let root = test_scratch::canonical_config_root(scratch.path());
+    (scratch, root)
+}
+
+/// The guard's spelling of a scratch root and the canonical one [`checkout`] hands back must be
+/// two names for ONE directory. Without the divergence every assertion in this module would pass
+/// whether it derived its paths from the canonical root or from the guard, and the root-spelling
+/// class would only redden the cross-platform legs (#1027).
+#[cfg(unix)]
+#[test]
+fn a_scratch_checkouts_canonical_root_diverges_from_the_guards_spelling() {
+    let (guard, root) = checkout("scope-root-spelling");
+    assert_ne!(root, guard.path(), "the guard must reach its root through a symlinked ancestor");
+    assert_eq!(root, guard.path().canonicalize().unwrap(), "both spellings name one directory");
+    assert_eq!(scope(&root).root(), root, "and the scope resolves to the canonical one");
+}
 
 /// A compilation database naming `files`, written at `dir/relative`.
 fn write_database(dir: &Path, relative: &str, files: &[&str]) {
@@ -37,7 +66,7 @@ fn write_database(dir: &Path, relative: &str, files: &[&str]) {
 #[test]
 fn a_database_that_governs_nothing_is_reported_apart_from_the_other_reasons() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-governs-nothing-reported");
+    let (_dir_guard, dir) = checkout("clangd-governs-nothing-reported");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("third_party")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
@@ -69,7 +98,7 @@ fn a_database_that_governs_nothing_is_reported_apart_from_the_other_reasons() {
 /// compilation database that none was found, and sends them to generate one.
 #[test]
 fn a_checkout_whose_database_governs_nothing_is_blocked_with_the_reason() {
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-blocked-governs-nothing");
+    let (_dir_guard, dir) = checkout("clangd-blocked-governs-nothing");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("third_party")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
@@ -98,7 +127,7 @@ fn a_checkout_whose_database_governs_nothing_is_blocked_with_the_reason() {
 #[test]
 fn an_empty_file_string_is_known_non_governance_not_an_unreadable_path() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-empty-file-string");
+    let (_dir_guard, dir) = checkout("clangd-empty-file-string");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
     std::fs::write(
@@ -131,7 +160,7 @@ fn an_empty_file_string_is_known_non_governance_not_an_unreadable_path() {
 #[test]
 fn a_database_written_through_a_symlinked_root_still_governs_the_checkout() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-aliased-root");
+    let (_dir_guard, dir) = checkout("clangd-aliased-root");
     let real = dir.join("real");
     std::fs::create_dir_all(real.join("src")).unwrap();
     std::fs::write(real.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
@@ -161,7 +190,7 @@ fn a_database_written_through_a_symlinked_root_still_governs_the_checkout() {
 #[test]
 fn an_ancestor_database_that_governs_nothing_does_not_configure_a_file() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-ancestor-governs-nothing");
+    let (_dir_guard, dir) = checkout("clangd-ancestor-governs-nothing");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
     std::fs::create_dir_all(checkout.join("other")).unwrap();
@@ -190,7 +219,7 @@ fn an_ancestor_database_that_governs_nothing_does_not_configure_a_file() {
 #[test]
 fn an_entry_that_configures_nothing_does_not_qualify_the_database() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-degenerate-indexed-entry");
+    let (_dir_guard, dir) = checkout("clangd-degenerate-indexed-entry");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("third_party")).unwrap();
     std::fs::create_dir_all(dir.join("build")).unwrap();
@@ -222,7 +251,7 @@ fn an_entry_that_configures_nothing_does_not_qualify_the_database() {
 #[test]
 fn a_database_naming_one_indexed_file_among_vendored_ones_is_pinned() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-mixed-database");
+    let (_dir_guard, dir) = checkout("clangd-mixed-database");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("third_party/foo")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
@@ -247,7 +276,7 @@ fn a_database_naming_one_indexed_file_among_vendored_ones_is_pinned() {
 #[test]
 fn an_absolute_path_database_governs_only_when_its_paths_land_in_this_checkout() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-absolute-paths");
+    let (_dir_guard, dir) = checkout("clangd-absolute-paths");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
     // `write_database` already emits absolute `file` paths rooted at the fixture.
@@ -282,7 +311,7 @@ fn an_absolute_path_database_governs_only_when_its_paths_land_in_this_checkout()
 #[test]
 fn a_symlinked_build_directory_inside_the_checkout_is_followed() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-symlink-sibling");
+    let (_dir_guard, dir) = checkout("clangd-symlink-sibling");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
     std::fs::create_dir_all(checkout.join("out")).unwrap();
@@ -308,7 +337,7 @@ fn a_symlinked_build_directory_inside_the_checkout_is_followed() {
 #[test]
 fn a_non_git_checkout_behaves_exactly_as_before() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-non-git");
+    let (_dir_guard, dir) = checkout("clangd-non-git");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
     write_database(&dir, "compile_commands.json", &["src/main.c"]);
@@ -331,7 +360,7 @@ fn a_non_git_checkout_behaves_exactly_as_before() {
 #[test]
 fn sources_under_a_hidden_directory_can_warm_the_session() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-hidden-sources");
+    let (_dir_guard, dir) = checkout("clangd-hidden-sources");
     std::fs::create_dir_all(dir.join(".cache/generated")).unwrap();
     std::fs::write(dir.join(".cache/generated/main.c"), "int main(void) { return 0; }\n").unwrap();
     write_database(&dir, "build/compile_commands.json", &[".cache/generated/main.c"]);
@@ -352,7 +381,7 @@ fn sources_under_a_hidden_directory_can_warm_the_session() {
 #[test]
 fn a_document_the_checkout_does_not_index_is_never_warmed_on() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-unindexed-documents");
+    let (_dir_guard, dir) = checkout("clangd-unindexed-documents");
     std::fs::create_dir_all(dir.join(".cache/clangd")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
     // Source-shaped files inside a machine-written tree, and one real source.
@@ -378,7 +407,7 @@ fn a_document_the_checkout_does_not_index_is_never_warmed_on() {
 #[test]
 fn a_database_governing_nothing_indexed_is_not_pinned() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-governs-nothing");
+    let (_dir_guard, dir) = checkout("clangd-governs-nothing");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("third_party/foo")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
@@ -406,7 +435,7 @@ fn a_database_governing_nothing_indexed_is_not_pinned() {
 #[test]
 fn a_build_directory_database_governing_indexed_sources_is_pinned() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-build-dir-governs");
+    let (_dir_guard, dir) = checkout("clangd-build-dir-governs");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
     write_database(&dir, "build/compile_commands.json", &["src/main.c"]);
@@ -441,7 +470,7 @@ fn a_build_directory_database_governing_indexed_sources_is_pinned() {
 #[test]
 fn a_database_above_the_index_root_is_found_by_the_ancestor_leg() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-db-above-index-root");
+    let (_dir_guard, dir) = checkout("clangd-db-above-index-root");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
     rag_rat_base::test_git::run(&checkout, &["init"]);
@@ -467,7 +496,7 @@ fn a_database_above_the_index_root_is_found_by_the_ancestor_leg() {
 #[test]
 fn a_file_resolves_through_a_database_above_the_index_root() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-resolve-above-root");
+    let (_dir_guard, dir) = checkout("clangd-resolve-above-root");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
     std::fs::create_dir_all(checkout.join("sub/other")).unwrap();
@@ -498,7 +527,7 @@ fn a_file_resolves_through_a_database_above_the_index_root() {
 /// for a checkout it could have served (#1008).
 #[test]
 fn the_ceiling_is_the_enclosing_checkout_not_the_index_root() {
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("scope-ceiling-subdir");
+    let (_dir_guard, dir) = checkout("scope-ceiling-subdir");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("sub")).unwrap();
     rag_rat_base::test_git::run(&checkout, &["init"]);
@@ -514,7 +543,7 @@ fn the_ceiling_is_the_enclosing_checkout_not_the_index_root() {
 /// would let a walk wander into unrelated trees.
 #[test]
 fn a_root_outside_a_git_checkout_is_its_own_ceiling() {
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("scope-ceiling-no-git");
+    let (_dir_guard, dir) = checkout("scope-ceiling-no-git");
     std::fs::create_dir_all(dir.join("plain")).unwrap();
     let root = dir.join("plain");
 
@@ -529,7 +558,7 @@ fn a_root_outside_a_git_checkout_is_its_own_ceiling() {
 /// per-checkout live sessions (#1010) will need, pinned now so it cannot regress before then.
 #[test]
 fn a_linked_worktree_is_its_own_ceiling_not_the_main_checkout() {
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("scope-ceiling-linked");
+    let (_dir_guard, dir) = checkout("scope-ceiling-linked");
     let main = dir.join("main");
     std::fs::create_dir_all(&main).unwrap();
     rag_rat_base::test_git::run(&main, &["init"]);
@@ -646,7 +675,7 @@ fn enclosing_tsconfig_walks_up_to_the_nearest_project_and_stops_at_the_root() {
     // This is how tsserver assigns a file to a project, and it decides whether opening the
     // file produces an observable load. A file under no project opens as an inferred project
     // SILENTLY, so warming on it teaches the session nothing.
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-enclosing");
+    let (_dir_guard, dir) = checkout("ts-lsp-enclosing");
     std::fs::create_dir_all(dir.join("packages/app/src")).unwrap();
     std::fs::create_dir_all(dir.join("scripts")).unwrap();
     std::fs::write(dir.join("packages/app/tsconfig.json"), "{}").unwrap();
@@ -668,7 +697,7 @@ fn a_warmup_document_is_found_at_any_depth_and_only_inside_a_project() {
     // A project can sit arbitrarily deep in a monorepo; a depth limit would silently disable
     // those checkouts entirely, which is worse than the walk it saves.
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-warmup-doc");
+    let (_dir_guard, dir) = checkout("ts-lsp-warmup-doc");
     std::fs::create_dir_all(dir.join("scripts")).unwrap();
     std::fs::write(dir.join("scripts/tool.ts"), "export function x() {}\n").unwrap();
     assert_eq!(
@@ -697,7 +726,7 @@ fn the_warmup_search_refuses_a_document_the_checkout_does_not_index() {
     // nothing. That is the point of the change — the indexer's own answer decides, so the warm-up
     // search cannot disagree with what the pass will actually resolve.
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-lsp-vendored-warmup");
+    let (_dir_guard, dir) = checkout("ts-lsp-vendored-warmup");
     write_project(&dir, "node_modules/some-dep");
     write_project(&dir, ".cache/tooling");
     let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
@@ -723,7 +752,7 @@ fn a_server_status_backend_needs_no_warmup_document_and_is_never_blocked_on_one(
     // rust-analyzer reports quiescence for any checkout, so the whole notion is TS-specific
     // and must not leak into the other backend's gating.
     let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("ra-lsp-warmup-doc");
+    let (_dir_guard, dir) = checkout("ra-lsp-warmup-doc");
     assert_eq!(rust.warmup_document(&scope(&dir), &rust.resolve_layout(&scope(&dir))), None);
     assert!(
         rust.checkout_can_signal_readiness(&scope(&dir), &rust.resolve_layout(&scope(&dir))),
@@ -767,7 +796,7 @@ fn clangd_opens_each_dialect_under_its_own_language_id() {
 fn a_backends_project_marker_is_the_file_its_prerequisite_looks_for() {
     // The warm-up search and the prerequisite gate must ask the SAME question, or a checkout
     // could pass the gate and still have nothing to warm on (or vice versa).
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-marker");
+    let (_dir_guard, dir) = checkout("clangd-marker");
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
     assert_eq!(clangd.project_marker.map(|m| m.file), Some("compile_commands.json"));
     assert!(
@@ -814,7 +843,7 @@ fn an_out_of_tree_compilation_database_still_counts_as_a_project() {
     // there just fine, so requiring the marker to be an ancestor would report an ordinary
     // CMake project as Blocked.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-out-of-tree");
+    let (_dir_guard, dir) = checkout("clangd-out-of-tree");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
@@ -849,7 +878,7 @@ fn clangd_is_told_where_a_compilation_database_it_could_not_find_lives() {
     // resolves calls to header declarations; with `--compile-commands-dir` it resolves across
     // translation units. Accepting the checkout is only honest because we pass the directory.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-compdb-dir");
+    let (_dir_guard, dir) = checkout("clangd-compdb-dir");
     std::fs::create_dir_all(dir.join("out")).unwrap();
     std::fs::write(dir.join("out/compile_commands.json"), COMPDB).unwrap();
 
@@ -868,7 +897,7 @@ fn a_file_whose_database_the_session_cannot_reach_is_not_resolvable() {
     // measured, that resolves a cross-unit call to the callee's HEADER DECLARATION. The live
     // pass must skip such files rather than persist the wrong answer.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-unreachable-db");
+    let (_dir_guard, dir) = checkout("clangd-unreachable-db");
     // `proj-a` keeps its database where clangd looks (`build/`); `proj-b` does not.
     std::fs::create_dir_all(dir.join("proj-a/build")).unwrap();
     std::fs::create_dir_all(dir.join("proj-b/out")).unwrap();
@@ -889,7 +918,7 @@ fn a_file_whose_database_the_session_cannot_reach_is_not_resolvable() {
 
     // With a SINGLE database the session is pointed at it, so every file is configured —
     // including one whose database is nowhere near it.
-    let single = rag_rat_base::test_scratch::ScratchDir::new("clangd-single-db");
+    let (_single_guard, single) = checkout("clangd-single-db");
     std::fs::create_dir_all(single.join("out")).unwrap();
     std::fs::create_dir_all(single.join("src")).unwrap();
     std::fs::write(single.join("out/compile_commands.json"), COMPDB).unwrap();
@@ -907,7 +936,7 @@ fn a_re_resolved_layout_reports_when_the_pinned_database_changed() {
     // the database leaves the server pointed at a directory that no longer exists, and gaining
     // one leaves the new project's files analysed with the old project's flags.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-relayout");
+    let (_dir_guard, dir) = checkout("clangd-relayout");
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
     let pinned = clangd.resolve_layout(&scope(&dir));
@@ -942,7 +971,7 @@ fn a_nearer_empty_database_does_not_make_a_file_configured() {
     // clangd picks up the NEAREST database — if that one is empty it configures nothing, and
     // the file must not count as resolvable merely because some other project has a real one.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-nearer-empty");
+    let (_dir_guard, dir) = checkout("clangd-nearer-empty");
     // THREE projects, so the checkout stays multi-database after one is hollowed out —
     // otherwise it would collapse to the single-database case, where the session pins the one
     // remaining database and every file is configured by it.
@@ -974,7 +1003,7 @@ fn a_databases_usability_is_read_once_per_layout() {
     // with the layout held, replacing the database with an unusable one cannot change the
     // answer, because the file is not read a second time.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-usability-memo");
+    let (_dir_guard, dir) = checkout("clangd-usability-memo");
     // Two databases, so the per-file discovery path is what decides — a single-database
     // checkout pins instead and never asks about a file's own database at all.
     for project in ["proj-a", "proj-b"] {
@@ -1007,7 +1036,7 @@ fn a_broken_second_database_still_disqualifies_global_pinning() {
     // resolve by stopping at their own nearer database. Both are wrong for those files, but
     // only pinning also makes them look configured.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-broken-second-db");
+    let (_dir_guard, dir) = checkout("clangd-broken-second-db");
     std::fs::write(dir.join("compile_commands.json"), COMPDB).unwrap();
     std::fs::create_dir_all(dir.join("sub/build")).unwrap();
     std::fs::write(dir.join("sub/build/compile_commands.json"), "[]").unwrap();
@@ -1038,7 +1067,7 @@ fn an_entry_missing_a_required_field_is_not_a_usable_database() {
     // clangd rejects an entry lacking `directory` or a compiler invocation and falls back to
     // generic flags, so a well-formed entry naming only a file is not a usable database.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-entry-fields");
+    let (_dir_guard, dir) = checkout("clangd-entry-fields");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     let incomplete = [
@@ -1075,7 +1104,7 @@ fn the_nearest_database_decides_even_when_it_is_unusable() {
     // unusable nearer database would declare the file configured by one clangd never
     // consults, and the pass would trust a fallback-flags answer.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-nearest-wins");
+    let (_dir_guard, dir) = checkout("clangd-nearest-wins");
     // A usable database at the root, plus a second project so the layout stays multi-database
     // (single-database checkouts pin instead of using per-file discovery).
     std::fs::write(dir.join("compile_commands.json"), COMPDB).unwrap();
@@ -1105,7 +1134,7 @@ fn a_database_is_parsed_not_pattern_matched() {
     // entries are larger than the window, and accepts a hollow one that merely contains the
     // token inside an unrelated string. Parsing the file settles both.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-db-shape");
+    let (_dir_guard, dir) = checkout("clangd-db-shape");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     // A database whose text merely MENTIONS the key names no translation unit.
@@ -1148,7 +1177,7 @@ fn one_malformed_entry_anywhere_makes_the_whole_database_unusable() {
     // first entry would call that database usable, pin the session to it, and persist
     // fallback-flag answers — which resolve a cross-unit call to the callee's header declaration.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-later-entry");
+    let (_dir_guard, dir) = checkout("clangd-later-entry");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     const GOOD: &str = r#"{"directory":"/x","file":"/x/a.c","command":"cc -c a.c"}"#;
@@ -1197,7 +1226,7 @@ fn an_entrys_shape_is_judged_the_way_clangd_judges_it() {
     // `--compile-commands-dir`; `Compile command from CDB` means loaded, `Failed to load
     // compilation database` / `Generic fallback command` means the whole file was discarded.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-entry-types");
+    let (_dir_guard, dir) = checkout("clangd-entry-types");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
 
@@ -1288,7 +1317,7 @@ fn a_realistically_large_compilation_database_is_validated_in_one_pass() {
     // an order of magnitude above that, so it documents the cost without failing on a loaded
     // machine; only a change that made validation super-linear would trip it.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-large-db");
+    let (_dir_guard, dir) = checkout("clangd-large-db");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
 
@@ -1348,7 +1377,7 @@ fn a_symlinked_build_directory_is_still_searched() {
     // `build -> cmake-build-debug` is an ordinary layout, and the database is reachable
     // through the checkout path — but a symlink is not a directory to `DirEntry::file_type`.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-symlinked-build");
+    let (_dir_guard, dir) = checkout("clangd-symlinked-build");
     std::fs::create_dir_all(dir.join("cmake-build-debug")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("cmake-build-debug/compile_commands.json"), COMPDB).unwrap();
@@ -1372,7 +1401,7 @@ fn one_database_reached_through_a_symlink_alias_is_not_two_databases() {
     // `--compile-commands-dir` is dropped, and a source outside clangd's own ancestor/`build/`
     // search stops being resolvable even though the checkout is perfectly ordinary.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-aliased-db");
+    let (_dir_guard, dir) = checkout("clangd-aliased-db");
     std::fs::create_dir_all(dir.join("out")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("out/compile_commands.json"), COMPDB).unwrap();
@@ -1427,7 +1456,7 @@ fn a_nested_checkout_makes_the_layout_unprovable_rather_than_simply_smaller() {
     // pinning is declined. clangd's own per-file lookup takes over, which is correct by
     // construction.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-nested-checkout");
+    let (_dir_guard, dir) = checkout("clangd-nested-checkout");
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
@@ -1474,7 +1503,7 @@ fn a_scan_that_could_not_look_everywhere_never_reports_a_sole_database() {
     // sources, and pinning would then hand them another project's flags. A truncated scan therefore
     // yields no sole database, whatever it happened to find.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-deep-tree");
+    let (_dir_guard, dir) = checkout("clangd-deep-tree");
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
 
@@ -1506,7 +1535,7 @@ fn a_scan_that_could_not_look_everywhere_never_reports_a_sole_database() {
 #[test]
 fn the_ancestor_leg_never_leaves_the_checkout() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-climb-stops-at-checkout");
+    let (_dir_guard, dir) = checkout("clangd-climb-stops-at-checkout");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("src")).unwrap();
     rag_rat_base::test_git::run(&checkout, &["init"]);
@@ -1538,7 +1567,7 @@ fn the_ancestor_leg_never_leaves_the_checkout() {
 #[test]
 fn a_real_linked_worktree_inside_the_checkout_is_not_this_checkouts_project() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-real-linked-worktree");
+    let (_dir_guard, dir) = checkout("clangd-real-linked-worktree");
     let main = dir.join("main");
     std::fs::create_dir_all(main.join("src")).unwrap();
     rag_rat_base::test_git::run(&main, &["init"]);
@@ -1597,7 +1626,7 @@ fn a_real_linked_worktree_inside_the_checkout_is_not_this_checkouts_project() {
 #[test]
 fn completeness_covers_the_ancestor_chain_and_ignores_sibling_subtrees() {
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-completeness-scope");
+    let (_dir_guard, dir) = checkout("clangd-completeness-scope");
     let checkout = dir.join("repo");
     std::fs::create_dir_all(checkout.join("sub/src")).unwrap();
     std::fs::create_dir_all(checkout.join("elsewhere/deep")).unwrap();
@@ -1636,7 +1665,7 @@ fn the_invocation_clangd_selects_is_the_one_that_must_configure_the_file() {
     // own would call that entry usable and let the checkout be pinned to a database that configures
     // nothing.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-invocation-choice");
+    let (_dir_guard, dir) = checkout("clangd-invocation-choice");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
 
@@ -1679,7 +1708,7 @@ fn a_key_outside_the_modelled_format_is_uncertainty_rather_than_acceptance() {
     // pinning and decline resolving through it, not enough to declare the checkout unwarmable on
     // the strength of a list that could be out of date.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-unmodelled-key");
+    let (_dir_guard, dir) = checkout("clangd-unmodelled-key");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     std::fs::write(
@@ -1730,7 +1759,7 @@ fn a_database_this_crate_cannot_parse_is_not_trusted_but_does_not_block_the_back
     // trailing commas, and block syntax that `serde_json` refuses (#1016). Such a file is therefore
     // UNKNOWN rather than bad: it must not be pinned or resolved through, and it must not block.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-unreadable-db");
+    let (_dir_guard, dir) = checkout("clangd-unreadable-db");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     // Valid YAML that clangd loads and `serde_json` cannot parse.
@@ -1768,7 +1797,7 @@ fn a_database_clangd_can_read_is_not_refused_over_a_bom_or_trailing_bytes() {
     // evidence — the expensive direction to be wrong in. A BOM is what a generator on Windows can
     // emit; trailing bytes are what a hand-edited file can end up with.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-db-syntax");
+    let (_dir_guard, dir) = checkout("clangd-db-syntax");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
 
@@ -1806,17 +1835,17 @@ fn the_marker_search_does_not_follow_a_symlink_out_of_the_checkout() {
     // repository write lock, and — worse — counts a database found out there as this checkout's,
     // which flips the pinning decision for files that have nothing to do with it.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let outside = rag_rat_base::test_scratch::ScratchDir::new("clangd-outside-tree");
+    let (_outside_guard, outside) = checkout("clangd-outside-tree");
     std::fs::create_dir_all(outside.join("vendor/build")).unwrap();
     std::fs::write(outside.join("vendor/build/compile_commands.json"), COMPDB).unwrap();
 
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-escaping-link");
+    let (_dir_guard, dir) = checkout("clangd-escaping-link");
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("build/compile_commands.json"), COMPDB).unwrap();
     std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
     // The escape: a link to a tree that holds its own database.
-    std::os::unix::fs::symlink(outside.path(), dir.join("sdk")).unwrap();
+    std::os::unix::fs::symlink(outside.as_path(), dir.join("sdk")).unwrap();
 
     let layout = clangd.resolve_layout(&scope(&dir));
     assert!(
@@ -1844,9 +1873,9 @@ fn a_symlink_cycle_cannot_hang_the_marker_search() {
     // Following directory symlinks is what makes the case above work, and it is also what
     // makes a cycle possible. The search must terminate rather than recurse forever.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-symlink-cycle");
+    let (_dir_guard, dir) = checkout("clangd-symlink-cycle");
     std::fs::create_dir_all(dir.join("nested")).unwrap();
-    std::os::unix::fs::symlink(dir.path(), dir.join("nested/loop")).unwrap();
+    std::os::unix::fs::symlink(dir.as_path(), dir.join("nested/loop")).unwrap();
     // Terminates; the checkout has no database, so it reports none.
     assert!(clangd.resolve_layout(&scope(&dir)).sole_marker_dir().is_none());
 }
@@ -1864,13 +1893,13 @@ fn two_symlink_cycles_cannot_make_the_marker_search_explode() {
     // No database anywhere, deliberately: the search stops at two sites, and a database
     // reachable through the links would supply the second one and mask the explosion.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-two-symlink-cycles");
-    std::os::unix::fs::symlink(dir.path(), dir.join("loop-a")).unwrap();
-    std::os::unix::fs::symlink(dir.path(), dir.join("loop-b")).unwrap();
+    let (_dir_guard, dir) = checkout("clangd-two-symlink-cycles");
+    std::os::unix::fs::symlink(dir.as_path(), dir.join("loop-a")).unwrap();
+    std::os::unix::fs::symlink(dir.as_path(), dir.join("loop-b")).unwrap();
 
     // Run the search off-thread with a bounded wait, so a regression fails this test in
     // seconds instead of hanging the suite for as long as CI allows.
-    let root = dir.path().to_path_buf();
+    let root = dir.as_path().to_path_buf();
     let (done, resolved) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let pinned = clangd.resolve_layout(&scope(&root)).sole_marker_dir().map(Path::to_path_buf);
@@ -1887,7 +1916,7 @@ fn a_hidden_build_under_dot_cache_is_still_a_database() {
     // Only clangd's OWN index is off-limits under `.cache` — excluding the whole subtree would
     // contradict supporting hidden build directories at all.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-dot-cache-build");
+    let (_dir_guard, dir) = checkout("clangd-dot-cache-build");
     std::fs::create_dir_all(dir.join(".cache/cmake-build")).unwrap();
     std::fs::create_dir_all(dir.join(".cache/clangd/index")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
@@ -1910,7 +1939,7 @@ fn an_empty_compilation_database_is_not_a_project() {
     // clangd emits no readiness cycle for it at all. Accepting it would report the backend
     // runnable while it could only ever sit in `Warming`.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-empty-db");
+    let (_dir_guard, dir) = checkout("clangd-empty-db");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void){return 0;}\n").unwrap();
     std::fs::write(dir.join("compile_commands.json"), "[]").unwrap();
@@ -1930,7 +1959,7 @@ fn a_hidden_build_directory_still_counts_as_a_compilation_database() {
     // real as one in `build/`. The DOCUMENT search still skips dot-directories — those hold
     // tooling state, not this checkout's sources — so the two searches differ on purpose.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-hidden-build");
+    let (_dir_guard, dir) = checkout("clangd-hidden-build");
     std::fs::create_dir_all(dir.join(".build")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join(".build/compile_commands.json"), COMPDB).unwrap();
@@ -1957,7 +1986,7 @@ fn a_vendored_or_vcs_database_is_never_mistaken_for_the_checkouts_own() {
     // single-database checkout into the multi-database mode and drop the flag that makes it
     // resolvable.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-vendored-db");
+    let (_dir_guard, dir) = checkout("clangd-vendored-db");
     std::fs::create_dir_all(dir.join("node_modules/dep")).unwrap();
     std::fs::create_dir_all(dir.join(".git/weird")).unwrap();
     std::fs::create_dir_all(dir.join("src")).unwrap();
@@ -1983,7 +2012,7 @@ fn several_compilation_databases_are_left_to_the_servers_own_per_file_lookup() {
     // unambiguous, and otherwise clangd's own per-file lookup (ancestors and their `build/`)
     // decides, which is correct by construction.
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("clangd-multi-db");
+    let (_dir_guard, dir) = checkout("clangd-multi-db");
     for project in ["proj-a", "proj-b"] {
         std::fs::create_dir_all(dir.join(project).join("build")).unwrap();
         std::fs::write(dir.join(project).join("build/compile_commands.json"), COMPDB).unwrap();
@@ -2018,7 +2047,7 @@ fn several_compilation_databases_are_left_to_the_servers_own_per_file_lookup() {
 fn a_backend_with_no_checkout_scoped_marker_gets_only_its_static_argv() {
     // The dynamic argument is clangd-shaped; the other backends must not acquire a stray flag
     // their server would reject.
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("static-argv");
+    let (_dir_guard, dir) = checkout("static-argv");
     std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
     assert_eq!(ts.spawn_args(&["--stdio"], &ts.resolve_layout(&scope(&dir))), vec![
@@ -2027,7 +2056,7 @@ fn a_backend_with_no_checkout_scoped_marker_gets_only_its_static_argv() {
     let rust = LiveBackend::for_tool(OracleTool::RaLsp).unwrap();
     assert!(rust.spawn_args(&[], &rust.resolve_layout(&scope(&dir))).is_empty());
     // And with no database anywhere, clangd gets no directory to point at either.
-    let empty = rag_rat_base::test_scratch::ScratchDir::new("static-argv-empty");
+    let (_empty_guard, empty) = checkout("static-argv-empty");
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
     assert_eq!(
         clangd.spawn_args(&["--background-index"], &clangd.resolve_layout(&scope(&empty))),
@@ -2041,7 +2070,7 @@ fn a_typescript_project_still_has_to_enclose_its_documents() {
     // of the sources governs nothing, because tsserver resolves a file's project by walking UP
     // from the file.
     let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
-    let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-sibling-config");
+    let (_dir_guard, dir) = checkout("ts-sibling-config");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::create_dir_all(dir.join("config")).unwrap();
     std::fs::write(dir.join("src/main.ts"), "export const x = 1;\n").unwrap();


### PR DESCRIPTION
## The problem

`Config::load` guarantees a canonical root: `normalize_existing_dir` calls `canonicalize()` on every
governing branch (main-governed, config-less-main, local). Test fixtures built their `Config` by hand
and skipped that step, so the suite was exercising a configuration production can never produce.

Several subsystems depend on the guarantee. The worktree overlay derives `config.root`'s subdir by
stripping the root against the repository's workdir. `ConfiguredCorpus` strips `config.root` off the
path it is asked about. `CheckoutScope::resolve` canonicalizes the root it is handed. The watcher
classifies a filesystem event by stripping `config.root` off the event path. Give any of them a
second spelling of the same directory and the strip fails — and the failures are silent:

- **The overlay reported success after scoping itself to the wrong directory.** When no subdir could
  be derived, `linked_config_subdir_and_root` fell back to an empty one, which scoped the whole
  refresh at the repository root. No candidate path matched a target, the delta came out empty,
  nothing was written, no connected client was invalidated — and `index_worktree_overlay` still
  returned `Ok(())`, indistinguishable from a genuinely unchanged worktree.
- **The watcher stopped dispatching passes.** Fixtures built event paths, ignore matchers and
  expectations from their own spelling of the root while `whole_root_config` canonicalized the one it
  put in the `Config`, so no event was ever classified as relevant.
- **Membership answers came back uniformly `false`.** Corpus and checkout-scope tests compared
  production's canonical answers against the scratch guard's spelling.

Linux is the one platform where this hides. `std::env::temp_dir()` and `tempfile` roots are already
canonical there, so `canonicalize()` is the identity and every fixture agreed with production by
accident. macOS reaches the system temp through `/var` -> `/private/var`; Windows expands 8.3 names
(`RUNNER~1`) and returns `\\?\` verbatim paths. The whole class could therefore only surface on the
tag-triggered cross-platform legs, long after the change that introduced it.

## The fix

**Fixture roots are canonicalized, the way `Config::load` does it.** A new
`test_scratch::canonical_config_root` resolves the longest existing ancestor and re-joins the rest, so
it also works for a root handed over before it exists (a `git worktree add` destination must not).
Every hand-built `Config` in the test suites goes through it.

**The scratch guard now hands paths out through a symlink inside its own namespace**, so the paths it
returns are deliberately *not* canonical and the per-PR Linux matrix carries the same divergence macOS
produces. The link lives inside the already-verified per-user namespace and the stale sweep skips
symlink entries, so namespace hardening and cleanup are unchanged.

**Fixtures hand back the canonical root, so the second spelling is unreachable from a test body.**
`whole_root_config` returns `(Config, PathBuf)`; a new `src_checkout_config` replaces the five-line
prologue the watch event-loop fixtures shared; the oracle backend tests take their root from a new
`checkout(tag)` that returns the guard opaque alongside the canonical root; corpus tests assert against
`config.root` with the guard bound as `_scratch`. This is a shape change rather than a set of per-site
corrections — there is no second spelling left to reach for.

**The overlay fails loudly instead of mis-scoping.** `linked_config_subdir_and_root` canonicalizes both
sides of the strip (gix's `workdir()` returns the spelling it was discovered with) and returns `Err`
when no subdir can be derived. The blast radius is bounded and was checked: the watcher's fleet loop
logs the per-worktree error, clears the overlay basis so the next pass retries, and continues; the CLI
surfaces it with context; the Lens chunk read turns it into an API error rather than serving text from
the wrong root. `index_worktree_overlay` can no longer return `Ok(())` after scoping itself to the
wrong directory.

**Rebasing a supplied path keeps the leaf verbatim.** `index --paths` and the path-scoped linked
overlay both retry against the canonical root when the lexical strip fails. That retry canonicalized
the *whole* path, leaf included, so a regular file replaced by a symlink came back as the link's
target: the stale row was never tombstoned (base flow) or pruned (overlay flow), and the target was
re-indexed in its place; when the link escaped the root, the resolved path failed the strip and was
dropped before the deletion branch ran at all — an `Ok` return having done nothing. Both sites now go
through one `prep::root_relative_path`, which canonicalizes only the ancestors. Indexability is still
decided afterwards by `resolves_within_root` / `path_crosses_symlink`, which is where a symlinked leaf
*should* be followed.

**The ancestor ascent stops above the filesystem root.** For a synthetic root (`/repo`, `/main`,
`/checkout/packages` — what the placement and event-classification fixtures reason over) the ascent
reached `/`, which always resolves, so the whole path was rebuilt from it. On Unix that is the
identity; on Windows `canonicalize()` of a bare root returns the current drive's `\\?\C:\` form, so
`config.root` would come back rewritten while the sibling literals the same test compares it against
stayed as written. A path with no existing ancestor is now returned untouched, matching `Config::load`,
which refuses such a root outright — there is no production spelling to normalize toward.

## Design decisions

**Patch the sites, or change the shape?** Shape, at every seam. A fixture hands back the guard opaque
plus the canonical root; the raw spelling is unreachable from the test body. `whole_root_config` already
did this with a `(Config, PathBuf)` tuple, and the same shape now covers the oracle backend (one
`checkout(tag)` applied mechanically to all 61 `ScratchDir::new` sites) and the corpus tests
(`config.root`, the authority already in scope). Per-site corrections would leave the next author free
to reintroduce the divergence.

**Should `ConfiguredCorpus::indexes_file` defend against an aliased path, the way the overlay now
does?** No — keep it lexical, and pin that as a contract with a test. The two cases pull opposite ways,
and the difference is which direction failure runs. The overlay's fallback produced a *wrong* scope
reported as success, so it must fail loudly. `indexes_file`'s refusal produces "this database governs
nothing", which declines analysis — the safe direction for #1008. A canonicalizing retry would
additionally break the symlink rule the predicate exists to enforce: resolving ancestors rebases a path
under a symlinked directory onto the link's target, admitting `src/linked_dir/real.rs`, which
`walk_target` never yields.

**Does canonicalizing the root conflict with #1031's deliberately-lexical `root_relative_within`?**
They compose; this was verified rather than assumed. `root_relative_within` governs the stored *target
directory* spelling, not the root's, and does its own filesystem containment check (canonicalizing both
sides for the accept/reject decision, keeping the lexical value only for storage). Its lexicality
matters because `walk_target` enters a target with `is_dir()`, which follows links, so a
`src -> real_sources` target yields paths under `src/`; rewriting the stored directory would leave
`target_for_path` and the oracle corpus unable to match the files actually indexed. `Config::load`
canonicalizes the root at all three governing branches *before* `resolve_targets` runs, and
`anchor_root_to_main_worktree` cannot break that (it canonicalizes `common_dir` first). This change
canonicalizes fixture roots only; it never canonicalizes a target directory.

**Keep the scratch alias, or make `ScratchDir::path()` canonical and remove the class outright?** Keep
the alias. A canonical `path()` makes fixtures agree with production trivially, but it also turns
`canonical_config_root` into a no-op everywhere and stops the overlay's canonicalizing strip and its
loud unscopable-root error from being exercised by anything. The alias keeps a symlinked spelling
flowing through the suite continuously. The cost is that fixture authors must derive from `config.root`;
the tripwire tests and doc comments now say so explicitly.

**How to make the synthetic-root rule testable where Linux cannot observe it?** Extract the ascent into
a named `resolve_through_existing_ancestor` and assert on it directly. `canonical_config_root("/repo")`
returns `/repo` both before and after the change on Unix, so a test through the public helper would have
passed against the unfixed state. Asserting `resolve_through_existing_ancestor(<synthetic>).is_none()`
discriminates — moving the `canonicalize` check above the `parent()?/file_name()?` guard makes it fail
on Linux, which was confirmed by mutation.

## Enumeration

Three sets, each enumerated in full rather than sampled.

**`whole_root_config` call sites** — 38 in `crates/rag-rat-core/src/watch/tests.rs` (54 before the
change; 15 moved into `src_checkout_config`). The tuple return forces every caller to acknowledge the
canonical root: 31 rebind it by shadowing, 7 discard it with `_`. Each of the 7 was checked — three root
at a path the test already canonicalized, two use only `config.root` afterwards, two are synthetic
(`/main`, `/repo`) where canonicalization must be the identity. That last pair is what drove the
filesystem-root change. Four hand-built `Config`s remain in that file (lines 1498, 2500, 3099, 3441):
1498 is deliberately synthetic, the other three take a root the test already canonicalized.

**Fixture helpers that now return or store a canonical root, and their callers** — 76 references to
`canonical_config_root` across 30 files. The helpers returning one: `whole_root_config` and
`src_checkout_config` (watch); `rag_rat_config`, `markdown_config_for_root`, `source_config`,
`source_config_dirs`, `four_clone_config`, `git_fixture_for_overlay_tests` (schema bootstrap);
`head_move_repo`, `git_history_fixture`, `indexed_config` (lens), `test_config` (mcp/http, mcp/server),
`mixed_config` / `markdown_config` / `rust_config` (mcp/tools), `whole_root_c_config`, `bench_config`,
`test_config` (logging, papertrail autosync), the CLI `index_ops` / `clones` / `oracle` fixtures, and
`source_config` in adoption hints. Every helper's callers were walked for a later comparison or strip
against the raw root: all 14 `indexed_config` callers bind `_temp` as a guard only; `head_move_repo`'s
8 callers and `git_history_fixture`'s 23 all take the canonical root as the second element;
`multi_repo_scope::orientation_pins_the_fork_repo_over_a_shared_root_sibling` and
`relink::a_body_only_base_edit_pass_relinks_without_a_rebuild` shadow `root` / `main` with `config.root`.
Two helpers were missing from the set and account for the 20 test failures fixed here:
`corpus::tests::fixture` and the `ScratchDir::new` sites in the oracle `backend/tests.rs`.

**Assertions comparing a canonical path against a raw one** — enumerated empirically, because that is
the only exhaustive method available. The scratch alias makes every `ScratchDir` / `ScratchRoot` path
non-canonical on Linux, so a full `cargo nextest run --workspace --no-fail-fast` is a complete detector
for the *failing* half of the class. It reported exactly 20, all in the two modules above, and is green
afterwards. For the half that passes for the wrong reason — a negative assertion satisfied because the
lookup failed rather than because the file was excluded — the suite is blind, so every assertion in
those two modules was read: two were found (`a_gitignored_source_is_not_in_the_corpus` and the symlink
test's negative arms) and both now carry a positive control. Every `root:` initializer of a `Config`
literal and every `Config::minimal_for_database` call site in the workspace was also checked; the
remaining uncanonicalized ones are the four justified watch cases, `config/tests.rs:3099` (never reads
`root`), the sync test's `/nonexistent`, `commands/oracle.rs:551` (`/x`), and the production
`configless_rm_config`, which is byte-identical to `main` and noted under *Outstanding*.

## Cross-platform evidence gathered from Linux, and its limits

**The macOS shape was reproduced.** Pointing `TMPDIR` at a *real* directory inside a *symlinked
ancestor* is the macOS shape (`/var` is the symlink; `$TMPDIR` itself is real). Making `$TMPDIR` itself
a link is not — that trips unrelated symlink guards and produces a simulation artifact, not a finding.

```
mkdir -p /tmp/rrreal/tmp && ln -s /tmp/rrreal /tmp/rralias   # then TMPDIR=/tmp/rralias/tmp
```

Before the watch fix, `cargo nextest run -p rag-rat-core watch:: --no-default-features --no-fail-fast`
under that `TMPDIR`: `papertrail_deadline_fires_during_an_in_flight_pass_and_ticks_coalesce` failed on
all three tries, and `a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger` and
`events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses` never completed (SLOW past 1680s
each; the run was killed at 30 minutes). After: exit 0, 110/110 in 5.6s. The full workspace under the
same `TMPDIR` is 4363/4363, identical to the stock `TMPDIR` result, so the simulation adds no false
positives.

**The Windows `-D warnings` dead-code leg was simulated by cfg flip.** A genuine
`--target x86_64-pc-windows-msvc` clippy dies in `aws-lc-sys`' cc build, so the 32 `#[cfg(unix)]` items
this branch adds or changes were rewritten to `#[cfg(windows)]` — leaving pre-existing `#[cfg(windows)]`
items alone so exactly one definition of each dual-platform function survives — and
`cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` was run against
that state: exit 0, no dead-code diagnostics. The simulation was first shown capable of failing:
deleting one gate reproduces `constant NON_CANONICAL_ALIAS is never used` (exit 101). Every `#[cfg(`
line was diffed against the pre-flip state afterwards; the branch adds exactly three `#[cfg(unix)]`
lines and changes none.

**What neither simulation covers.** Windows `canonicalize()` returns a `\\?\` verbatim path and expands
8.3 names; a Unix symlink produces neither. That is how the synthetic-root problem was found — no Linux
run can show it, because `canonicalize("/")` is the identity on Unix — and the fix is argued from
documented Windows semantics rather than executed.

## The real macOS and Windows legs, measured

`ci-cross-platform.yml` does not run on a pull request, so it was dispatched against both this branch
and `main` on 2026-07-30 to get a baseline rather than a bare result. Both `clippy` and `build` legs are
green on both platforms in both runs; the `test` legs are the interesting ones.

| `test` leg | `main` (run 30516413150) | this branch (run 30515336447) |
| --- | --- | --- |
| macOS | **20 failed** of 4340 | **green** — all pass |
| Windows | 18 failed of 4257 | 20 failed of 4258 |

**macOS is what this change is for, and it is fixed.** `main`'s 20 macOS failures are exactly the class
described above: 8 `index::corpus::tests` and 12 `rag-rat-oracle backend::tests`, each comparing
production's canonical answer against the fixture's own `/var` spelling. All 20 pass here. That is the
real-platform confirmation the `TMPDIR` simulation was standing in for.

**Windows is red before and after, and the failure set changes.** The branch clears 16 of `main`'s 18
(6 `index::corpus::tests`, 10 `rag-rat-oracle backend::tests` — the same class as macOS) and surfaces
18 the old fixtures hid. Those 18 are all git-driven fixtures —
`schema_bootstrap_tests::{head_move_carry, orientation_healing, reconcile_embeddings,
repo_memory::key_drift::refresh, worktree_overlay::delta_refresh, worktree_overlay::relink}`,
`query_api::oracle_surfacing_tests`, and the two linked-worktree `backend::tests` — and they fail
because the root they now carry is the one `Config::load` produces on Windows: a `\\?\` verbatim path.
`git worktree add \\?\C:\...` refuses it outright
(`could not create leading directories of '//?/C:/...': Invalid argument`), and gix's `workdir()`
reports the ordinary `C:\...` form, so the overlay subdir strip does not match and no overlay row is
written (`dirty edit creates the overlay row: left 0, right 1`).

That is a production defect on Windows, not one this change introduces: the linked-worktree overlay
does not work there for a `Config` loaded from disk, and it stayed invisible precisely because the
fixtures held a root production never produces. Fixing it means simplifying the canonical path on
Windows where that is safe (the `dunce::simplified` rule — strip the `\\?\` disk prefix, keep verbatim
form for long paths and UNC) in `normalize_existing_dir`, with `canonical_config_root` following. It
needs a Windows verification loop and its own review, so it is filed separately as #1048 rather than
folded in here. Two of the Windows failures (`test_git::tests::the_ambient_failure_mode_is_real` and
`ignore_rules::tests::the_clangd_index_floor_holds_in_a_real_linked_worktree`) predate both changes and
are untouched by either.

## Verification

All gates run on this branch, exit codes recorded:

| Gate | Exit |
| --- | --- |
| `cargo build --workspace --locked` | 0 |
| `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` | 0 |
| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | 0 |
| `cargo nextest run --workspace --no-default-features --locked --profile ci` | 0 — 4363 passed, 7 skipped |
| `cargo test --workspace --no-default-features --locked` (the coverage job's runner shape) | 0 |
| `cargo +nightly fmt --all --check` | 0 |

Both runners are exercised deliberately: nextest is one process per test, plain `cargo test` is threads
in one process, and process-global state can pass the first and fail the second.

New tests:

- `index::corpus::tests::the_fixture_config_root_diverges_from_its_scratch_spelling` — tripwire:
  `config.root != scratch.path()` and `config.root == scratch.path().canonicalize()`. Fails if the
  scratch alias is ever neutered, which is what would silently remove this class from the per-PR matrix.
  Sibling tripwires cover the oracle, lens, HTTP and adoption-hint fixtures.
- `index::corpus::tests::an_aliased_spelling_of_an_indexed_file_is_refused_not_resolved` — pins the
  lexical contract: the canonical spelling of `src/main.rs` is in the corpus, the guard's aliased
  spelling of the same file is not. Fails if a canonicalizing retry is ever added to `indexes_file`.
- `index::corpus::tests::a_gitignored_source_is_not_in_the_corpus` — gains the missing positive control,
  and was observed to fail for the right reason: reverting the probe to the guard's spelling panics on
  the control, not on the gitignore assertion.
- `rag-rat-oracle backend::tests::a_scratch_checkouts_canonical_root_diverges_from_the_guards_spelling`
  — tripwire for `checkout(tag)`, and asserts `scope(&root).root() == root` so the fixture and
  `CheckoutScope::resolve` cannot drift.
- `test_scratch::tests::the_existing_ancestor_search_stops_above_the_filesystem_root` — asserts the
  ascent gives up on a path with no existing ancestor, plus the contrast case (an absent leaf under an
  existing ancestor still resolves). Observed to fail for the right reason under mutation.
- `index::schema_bootstrap_tests::worktree_overlay::config_root` — drives a linked-worktree refresh
  through a symlinked `config.root` against one database with real `git worktree add` checkouts: the
  branch file is indexed, the Lens revision moves, sibling overlays stay isolated (read back by their
  own `(worktree_id, commit_sha)` key rather than a hand-inserted stand-in), and a root resolving
  outside the working tree errors instead of reporting an empty success. Reverting `discovery.rs` to
  `main` fails all three arms.
- `index_paths::overlay_paths_rebases_a_symlink_replaced_branch_file_without_following_its_leaf`, plus
  the two `index --paths` symlink-tombstone tests, which now supply the raw scratch spelling so the
  retry is actually exercised (spelling them from `config.root` makes the lexical strip succeed and the
  retry never runs). Reverting `prep::root_relative_path` fails all three on the exact stale-row counts.

Regression coverage for the 20 corpus and oracle-backend fixes is those 20 pre-existing tests themselves
— they were observed failing before the fix and passing after, so no duplicates were added.

## Outstanding

- **The Windows `test` leg is red, on this branch and on `main`.** It is not a required check (the
  cross-platform workflow is tag- and dispatch-triggered), and the numbers are in the section above:
  `main` 18 failures, this branch 20, with 16 of `main`'s cleared and 18 newly exposed. The exposed
  ones are a production defect on Windows — a `\\?\` verbatim `config.root` that git and gix do not
  match — tracked as #1048. macOS goes from 20 failures on `main` to green here. Do not read this PR
  as making Windows pass.
- **The synthetic-root rule is still only argued.** `resolve_through_existing_ancestor` returning
  `None` for a path with no existing ancestor is asserted directly, but the Windows consequence it
  exists to prevent (`canonicalize("/")` yielding `\\?\C:\`) has no Unix analogue and no test that
  observes it on the platform where it matters.
- `crates/rag-rat-cli/src/main.rs::configless_rm_config` builds a production `Config` whose root is
  `std::env::current_dir()`, never canonicalized. Harmless on Unix (`getcwd` returns the physical path)
  and confined to `rag-rat rm`, but it is now the only remaining production source of a non-canonical
  `config.root`. Pre-existing and byte-identical to `main`; deliberately left alone.
- The alias only reaches roots handed out by `ScratchDir` / `ScratchRoot`. A fixture that rolls its own
  `tempfile::tempdir()` root opts out of the coverage on Linux. This branch converted the index, lens,
  HTTP and adoption fixtures onto the guard; `config/tests.rs` and a handful of non-index fixtures still
  use `tempfile`, correctly — they never compare against a canonicalized root.
- The wrong-reason-pass half of the class is exhaustively covered only where every assertion was read
  (`corpus.rs`, oracle `backend/tests.rs`). A negative assertion elsewhere that holds because a
  `strip_prefix(config.root)` silently failed would pass under both `TMPDIR` modes. The suite cannot
  detect these; only reading can.
- `linked_config_subdir_and_root` now errors when the base repository has no working tree. No reachable
  case could be constructed — `config.root` is by construction a directory inside a working tree, so
  `workdir()` is `Some` — but if one exists it is a loud failure where it was previously an
  empty-subdir fallback. That is the intended direction; noted because it is a behaviour change with no
  test.

Fixes #1027
