### PR TITLE
test(lens): wait for the content gate to retract a stale diagnostic

### DIFF
--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -3974,10 +3974,9 @@ test('a hidden document reloaded underneath loses the diagnostics nothing will r
     // `refreshEditor` is what re-runs the content gate, and it runs per VISIBLE editor — there is
     // none, so nothing will ask whether the warning still describes line 2. It has to come down
     // here rather than sit in the panel, pointing at unrelated code, until the tab is selected.
-    assert.deepEqual(
-      harness.problems(key),
-      [],
-      'a hidden document\'s diagnostics must not survive its bytes',
+    await harness.until(
+      () => harness.problems(key).length === 0,
+      'a hidden document\'s diagnostics to stop surviving its bytes',
     );
   } finally {
     harness.dispose();
@@ -4006,7 +4005,10 @@ test('a visible document reloaded underneath keeps being asked, and the gate ans
     harness.reload(document, 'fn renamed() {}\n');
     await harness.change(document);
 
-    assert.deepEqual(harness.problems(key), [], 'the gate must take a stale warning down');
+    await harness.until(
+      () => harness.problems(key).length === 0,
+      'the gate to take a stale warning down',
+    );
   } finally {
     harness.dispose();
   }


### PR DESCRIPTION
## Problem

Two tests in `editors/vscode/test/client.test.cjs` assert an empty Problems panel immediately after
`harness.change()`. That helper delivers the content-change event to the listeners and then waits a
fixed two ticks:

```js
await settle();
await settle();
```

The redraw that re-runs the content gate sometimes needs a third. When it does, the stale
`rag-rat memory diverged: Bound invariant (the code moved ahead of this note)` diagnostic is still
in the panel and the assertion fires.

This is independent of whatever change is under test, so it lands on whichever CI run loses the coin
flip — including branches that do not contain the test.

Measured on `origin/main` with no local changes, `npm ci && npm test`:

| | failures |
|---|---|
| before | **5 / 20 runs** (`a visible document reloaded underneath keeps being asked, and the gate answers`) |
| after | **0 / 40 runs** |

## Fix

Both directions of these tests are eventually-consistent, and the "warning appears" direction
already polls with the file's own `until` helper. The "warning goes away" direction now does too.

`until` is not a weaker assertion: it retries for 500 ticks and then `assert.fail`s with the
captured log, so a diagnostic that never comes down still fails the test — it just reports a timeout
with context instead of a one-shot mismatch. "Eventually retracted" is the actual contract, and the
preceding `until(… length === 1)` already establishes that the warning appeared in the first place.

## Scope

Both sites are fixed, not only the one observed failing:

- `a hidden document reloaded underneath loses the diagnostics nothing will re-ask about`
- `a visible document reloaded underneath keeps being asked, and the gate answers`

They share the construct. Only the second was seen failing, most likely because `hide()` removes the
editor synchronously and so wins the race more often — which makes the first a latent flake rather
than a sound test.

## Verification

`npm ci && npm run package && npm run lint` clean; the suite run 40 times with zero failures, against
a 5-in-20 baseline reproduced on unmodified `main` immediately beforehand.