### PR TITLE
feat(watch): report which linked checkout reindexed which paths

### DIFF
--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -93,7 +93,8 @@ pub use schema::RegisteredRepo;
 pub(crate) use util::*;
 pub(crate) use worktree_overlay::linked_source_root;
 pub use worktree_overlay::{
-    OverlayBasisUpdate, OverlayLogicalRebuild, OverlayRefreshTail, WorktreeOverlayReport,
+    ChangedPathsCoverage, OverlayBasisUpdate, OverlayLogicalRebuild, OverlayRefreshTail,
+    WorktreeOverlayReport,
 };
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
@@ -868,7 +868,7 @@ fn scoped_overlay_refresh_skips_an_unlisted_worktree_with_unchanged_basis() {
 
     let scope =
         crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([listed.clone()]));
-    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope);
+    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed;
     assert!(changed, "the listed worktree's dirty edit is refreshed");
 
     db.use_worktree_scope(&main, Some(&listed)).unwrap();
@@ -936,7 +936,7 @@ fn path_scoped_overlay_refresh_indexes_only_event_paths_and_clears_the_basis() {
         linked.clone(),
         std::collections::BTreeSet::from([linked.join("src/a.rs")]),
     )]));
-    assert!(crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope));
+    assert!(crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed);
 
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
     assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["event_edit".to_string()]);
@@ -987,7 +987,7 @@ fn widened_directory_removal_prunes_descendants_without_a_periodic_sweep() {
         linked.clone(),
         std::collections::BTreeSet::new(),
     )]));
-    assert!(crate::watch::refresh_worktree_overlays(&mut db, &config, None, &widened));
+    assert!(crate::watch::refresh_worktree_overlays(&mut db, &config, None, &widened).changed);
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
     assert!(
         names_in_scope(&db, "src/removed/stale.rs").is_empty(),
@@ -1026,7 +1026,7 @@ fn scoped_overlay_refresh_refreshes_an_unlisted_worktree_whose_head_moved() {
     // Control: with an unchanged basis, an empty-scoped pass is a no-op for this worktree.
     let empty = crate::watch::OverlayScope::Linked(std::collections::BTreeSet::new());
     assert!(
-        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty),
+        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty).changed,
         "unchanged basis + empty scope refreshes nothing"
     );
 
@@ -1035,7 +1035,7 @@ fn scoped_overlay_refresh_refreshes_an_unlisted_worktree_whose_head_moved() {
     run_git(&linked, &["add", "."]);
     run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
 
-    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty);
+    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty).changed;
     assert!(changed, "the moved linked HEAD invalidates the basis and forces the refresh");
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
     assert_eq!(
@@ -1078,7 +1078,7 @@ fn scoped_overlay_refresh_refreshes_after_a_base_commit_changes_the_diff_basis()
     // Control: empty scope + unchanged basis refreshes nothing.
     let empty = crate::watch::OverlayScope::Linked(std::collections::BTreeSet::new());
     assert!(
-        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty),
+        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty).changed,
         "unchanged basis + empty scope refreshes nothing"
     );
 
@@ -1087,7 +1087,7 @@ fn scoped_overlay_refresh_refreshes_after_a_base_commit_changes_the_diff_basis()
     run_git(&main, &["add", "."]);
     run_git(&main, &["commit", "-q", "-m", "v2"]);
 
-    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty);
+    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty).changed;
     assert!(changed, "the moved base HEAD invalidates every worktree's basis");
     set_base_scope(&mut db, &main);
     assert!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/quiet_window.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/quiet_window.rs
@@ -42,7 +42,7 @@ fn overlay_quiet_window_skips_a_dirty_only_listed_worktree_inside_the_window() {
     let scope =
         crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
     assert!(
-        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed,
         "inside the window a dirty-only listed worktree is skipped"
     );
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
@@ -64,7 +64,7 @@ fn overlay_quiet_window_skips_a_dirty_only_listed_worktree_inside_the_window() {
     )
     .unwrap();
     assert!(
-        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed,
         "an elapsed window refreshes the dirty-only worktree"
     );
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
@@ -99,7 +99,7 @@ fn overlay_quiet_window_never_defers_a_head_move() {
     let scope =
         crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
     assert!(
-        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed,
         "a linked HEAD move refreshes immediately inside the window"
     );
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
@@ -112,7 +112,7 @@ fn overlay_quiet_window_never_defers_a_head_move() {
     set_base_scope(&mut db, &main);
     let empty = crate::watch::OverlayScope::Linked(std::collections::BTreeSet::new());
     assert!(
-        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty),
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty).changed,
         "a base HEAD move refreshes immediately inside the window"
     );
 
@@ -137,7 +137,7 @@ fn overlay_quiet_window_zero_disables_and_sweeps_ignore_it() {
     let scope =
         crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
     assert!(
-        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed,
         "0 disables the window: a dirty-only listed worktree refreshes every pass"
     );
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
@@ -189,7 +189,7 @@ fn overlay_quiet_window_is_ignored_when_the_periodic_sweep_is_disabled() {
     let scope =
         crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
     assert!(
-        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed,
         "no sweep backstop → the window is ignored and the pass refreshes"
     );
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
@@ -219,7 +219,7 @@ fn a_cleared_basis_never_quiet_skips() {
     let scope =
         crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
     assert!(
-        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope).changed,
         "no recorded basis, no quiet skip — the pass refreshes"
     );
     db.use_worktree_scope(&main, Some(&linked)).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
@@ -793,12 +793,12 @@ fn an_overlay_refresh_reports_which_checkout_reindexed_which_paths() {
         refresh
             .reindexed
             .get(&edited_id)
-            .is_some_and(|paths| paths.iter().any(|path| path.ends_with("src/base.rs"))),
+            .is_some_and(|entry| entry.paths.iter().any(|path| path.ends_with("src/base.rs"))),
         "the edited checkout must name the path it reindexed: {:?}",
         refresh.reindexed,
     );
     assert!(
-        refresh.reindexed.get(&quiet_id).is_none_or(|paths| paths.is_empty()),
+        refresh.reindexed.get(&quiet_id).is_none_or(|entry| entry.paths.is_empty()),
         "an unedited sibling must not be credited with the other's work: {:?}",
         refresh.reindexed,
     );
@@ -806,4 +806,173 @@ fn an_overlay_refresh_reports_which_checkout_reindexed_which_paths() {
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&edited);
     let _ = fs::remove_dir_all(&quiet);
+}
+
+#[test]
+fn a_reported_path_resolves_against_the_reported_source_root_not_the_checkout_root() {
+    // The paths are config-root-relative (`src/lib.rs`), but the map is keyed by the CHECKOUT
+    // root. When `config.root` is a repo subdir the two differ, so a consumer that joined a path
+    // onto the key would open `<linked>/src/lib.rs` — which does not exist — instead of
+    // `<linked>/crate/src/lib.rs`. The report carries the directory its paths are relative to
+    // (#1010).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("crate/src")).unwrap();
+    // Canonical root, mirroring `Config::load` — see
+    // `worktree_overlay_serves_a_subdir_rooted_config`.
+    let main = main.canonicalize().unwrap();
+    fs::write(main.join("crate/src/lib.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    // Config rooted at the SUBDIR `crate`.
+    let config = source_config(main.join("crate"), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("crate/src/lib.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    let refresh = crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    let linked_id = crate::watch::enclosing_worktree_id(&linked);
+    let entry = refresh
+        .reindexed
+        .get(&linked_id)
+        .unwrap_or_else(|| panic!("the linked checkout must be reported: {:?}", refresh.reindexed));
+    assert_eq!(entry.paths, vec![PathBuf::from("src/lib.rs")], "paths stay config-root-relative");
+    // The property that matters: joining a reported path onto the reported root reaches the file
+    // the refresh actually read. Joining onto the checkout root does not.
+    let resolved = entry.source_root.join("src/lib.rs");
+    assert_eq!(
+        fs::read_to_string(&resolved).unwrap(),
+        "pub fn linked_fn() {}\n",
+        "source_root + path must reach the branch file: {resolved:?}"
+    );
+    assert!(
+        !linked.join("src/lib.rs").exists(),
+        "the checkout root is the WRONG base here — that is what this test pins"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn an_overlay_refresh_reports_paths_whose_rows_it_pruned() {
+    // Pruning an overlay row un-shadows the base version for that checkout, so the path's
+    // effective content changes exactly as much as a write does. Reporting only the files the
+    // refresh WROTE would leave a per-checkout consumer serving the branch version of a file that
+    // has gone back to the base one, until something unrelated edits it again (#1010).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/base.rs"), "pub fn base_fn() { let branch = 1; }\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch edit"]);
+    // First refresh: the divergence produces an overlay row.
+    let first = crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    let linked_id = crate::watch::enclosing_worktree_id(&linked);
+    assert!(first.reindexed.contains_key(&linked_id), "the divergence must be reported");
+
+    // The branch goes back to the base state: nothing to write, but the stale overlay row is
+    // pruned and the base file becomes visible to this checkout again.
+    run_git(&linked, &["reset", "-q", "--hard", "HEAD~1"]);
+    let second = crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    let entry = second
+        .reindexed
+        .get(&linked_id)
+        .unwrap_or_else(|| panic!("the checkout was visited: {:?}", second.reindexed));
+    assert!(
+        entry.paths.iter().any(|path| path.ends_with("src/base.rs")),
+        "the un-shadowed path must be reported even though the refresh wrote nothing: {entry:?}",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn a_path_scoped_refresh_reports_complete_coverage_despite_an_incomplete_status() {
+    // Two different questions share the word "complete". `status_complete` asks "may this
+    // refresh's outcome arm the #577 skip?" — always false on the path-scoped route, which never
+    // reconciles the whole overlay. `coverage` asks "is the reported path list the whole story?"
+    // — true there, because the caller named the exact paths. Deriving the second from the first
+    // would mark every event-driven pass lossy and push consumers into a whole-checkout fallback
+    // on the hot path (#1010).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // A whole-delta pass first, so the basis is recorded and the next pass can go path-scoped.
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    // A dirty edit delivered as an EVENT PATH — the route that takes
+    // `index_worktree_overlay_paths`.
+    fs::write(linked.join("src/base.rs"), "pub fn base_fn() { let branch = 1; }\n").unwrap();
+    let scope = crate::watch::OverlayScope::Paths(BTreeMap::from([(
+        linked.clone(),
+        BTreeSet::from([linked.join("src/base.rs")]),
+    )]));
+    let refresh = crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope);
+
+    let linked_id = crate::watch::enclosing_worktree_id(&linked);
+    let entry = refresh.reindexed.get(&linked_id).unwrap_or_else(|| {
+        panic!("the event-named checkout must be reported: {:?}", refresh.reindexed)
+    });
+    assert!(
+        entry.paths.iter().any(|path| path.ends_with("src/base.rs")),
+        "the event path must be reported: {entry:?}",
+    );
+    assert_eq!(
+        entry.coverage,
+        crate::index::ChangedPathsCoverage::Complete,
+        "the caller named the exact paths, so nothing is missing from the list: {entry:?}",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
@@ -188,13 +188,13 @@ fn refresh_worktree_overlays_reconciles_overlay_scope_embeddings() {
     let options = ai::ReconcileOptions { batch_size: Some(8), ..Default::default() };
     let budget = crate::watch::ReconcileBudget::new(options, std::time::Instant::now());
     // The pass refreshes the overlay AND reconciles its embeddings inline.
-    let changed = crate::watch::refresh_worktree_overlays(
+    let refresh = crate::watch::refresh_worktree_overlays(
         &mut db,
         &config,
         Some(&budget),
         &crate::watch::OverlayScope::All,
     );
-    assert!(changed, "the overlay changed (a new branch file was indexed)");
+    assert!(refresh.changed, "the overlay changed (a new branch file was indexed)");
 
     // In the overlay scope, the new branch file's chunk must carry a Current embedding — not be
     // left BM25-only. `refresh_worktree_overlays` restored the base scope, so re-enter the
@@ -748,4 +748,62 @@ fn lens_content_hash_follows_the_active_checkout_not_main() {
 
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn an_overlay_refresh_reports_which_checkout_reindexed_which_paths() {
+    // The refresh used to answer only "did anything change". That is enough for the pass's own
+    // control flow but not for a consumer that must act ON a particular checkout: a resident
+    // language server is rooted at one tree and can only answer for that tree (#1010).
+    //
+    // Two linked worktrees sharing one database, only ONE of them edited: the report must name the
+    // edited checkout and its path, and must not attribute that work to its sibling.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let edited = unique_temp_root();
+    let quiet = unique_temp_root();
+    let _ = fs::remove_dir_all(&edited);
+    let _ = fs::remove_dir_all(&quiet);
+    run_git(&main, &["worktree", "add", "-q", "-b", "edited", edited.to_str().unwrap()]);
+    run_git(&main, &["worktree", "add", "-q", "-b", "quiet", quiet.to_str().unwrap()]);
+    // Only the first worktree diverges.
+    fs::write(edited.join("src/base.rs"), "pub fn base_fn() { let branch = 1; }\n").unwrap();
+    run_git(&edited, &["add", "."]);
+    run_git(&edited, &["commit", "-q", "-m", "branch edit"]);
+
+    let refresh = crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    assert!(refresh.changed, "the edited worktree changed, so the pass changed something");
+    let edited_id = crate::watch::enclosing_worktree_id(&edited);
+    let quiet_id = crate::watch::enclosing_worktree_id(&quiet);
+    assert!(
+        refresh
+            .reindexed
+            .get(&edited_id)
+            .is_some_and(|paths| paths.iter().any(|path| path.ends_with("src/base.rs"))),
+        "the edited checkout must name the path it reindexed: {:?}",
+        refresh.reindexed,
+    );
+    assert!(
+        refresh.reindexed.get(&quiet_id).is_none_or(|paths| paths.is_empty()),
+        "an unedited sibling must not be credited with the other's work: {:?}",
+        refresh.reindexed,
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&edited);
+    let _ = fs::remove_dir_all(&quiet);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
@@ -922,6 +922,68 @@ fn an_overlay_refresh_reports_paths_whose_rows_it_pruned() {
 }
 
 #[test]
+fn an_idle_refresh_of_a_diverged_checkout_reports_a_visit_with_no_paths() {
+    // A diverged worktree's CANDIDATE set is its whole branch diff, and the refresh re-derives it
+    // every sweep — but an unchanged file is identity-skipped and no row moves. Reporting the
+    // candidates would name the same files on every pass forever while nothing changed, which is
+    // no better for a consumer than re-scanning the checkout and contradicts the empty-entry
+    // meaning ("visited, no work"). The list is built from what the transaction committed (#1010).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // A committed divergence, so the branch diff stays NON-EMPTY on every later pass.
+    fs::write(linked.join("src/base.rs"), "pub fn base_fn() { let branch = 1; }\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch edit"]);
+
+    let linked_id = crate::watch::enclosing_worktree_id(&linked);
+    let first = crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert!(
+        first.reindexed.get(&linked_id).is_some_and(|entry| !entry.paths.is_empty()),
+        "the first refresh really did write the diverged file: {:?}",
+        first.reindexed,
+    );
+
+    // Nothing touched since. The candidate set is unchanged (still the whole branch diff), but
+    // every candidate identity-skips.
+    let second = crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    assert!(!second.changed, "an idle overlay refresh writes nothing");
+    let entry = second
+        .reindexed
+        .get(&linked_id)
+        .unwrap_or_else(|| panic!("the checkout was still VISITED: {:?}", second.reindexed));
+    assert!(
+        entry.paths.is_empty(),
+        "an idle refresh must report the visit with NO paths, not re-report its branch diff: \
+         {entry:?}",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
 fn a_path_scoped_refresh_reports_complete_coverage_despite_an_incomplete_status() {
     // Two different questions share the word "complete". `status_complete` asks "may this
     // refresh's outcome arm the #577 skip?" — always false on the path-scoped route, which never

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -25,10 +25,10 @@ mod lifecycle;
 mod materialize;
 mod query_adaptation;
 
-pub use discovery::WorktreeOverlayReport;
 #[cfg(test)]
 use discovery::fold_status_candidates;
 use discovery::resolve_overlay_scope;
+pub use discovery::{ChangedPathsCoverage, WorktreeOverlayReport};
 pub(crate) use discovery::{
     CommittedDeltaSource, ResolvedOverlayScope, compute_linked_worktree_delta, linked_source_root,
 };

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -32,19 +32,54 @@ impl WorktreeOverlayDelta {
     }
 }
 
+/// Whether a refresh's [`WorktreeOverlayReport::changed_paths`] accounts for EVERY path whose
+/// effective content it may have changed.
+///
+/// Distinct from [`WorktreeOverlayReport::status_complete`], which answers a different question —
+/// "may this refresh's outcome be recorded as a skip-proof basis?" A path-scoped refresh is
+/// deliberately `status_complete = false` (it never reconciles the whole overlay, so it must not
+/// arm the #577 skip) while its path list is exactly what the caller asked for, hence `Complete`
+/// here. Deriving one from the other would make every event-driven pass — the hot path — look
+/// lossy and push consumers into a needless whole-checkout fallback.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ChangedPathsCoverage {
+    /// Every path this refresh may have changed is listed.
+    Complete,
+    /// The list may be MISSING paths: the linked working-tree status read failed, so dirty,
+    /// untracked, and working-tree-deleted files never became candidates. A consumer must treat
+    /// the whole checkout as potentially stale rather than trusting the list. The default, so a
+    /// skipped or defaulted report never reads as authoritative.
+    #[default]
+    Partial,
+}
+
 #[derive(Debug, Default)]
 pub struct WorktreeOverlayReport {
     /// The overlay scope's `worktree_id`; empty when `linked_path` was not a valid linked sibling
     /// (the pass was skipped).
     pub worktree_id: String,
+    /// The directory [`Self::changed_paths`] are relative to: this checkout's equivalent of
+    /// `config.root`. NOT the checkout root — when `config.root` is a repo SUBDIR the two differ
+    /// (`<linked>/crate` vs `<linked>`), and a consumer that joined at the checkout root would
+    /// resolve `src/lib.rs` instead of `crate/src/lib.rs`. Empty when the pass was skipped.
+    ///
+    /// Returned rather than rebasing the paths onto the checkout root so they keep the one
+    /// spelling the overlay rows and `target_for_path` already use — a consumer writing rows and
+    /// a consumer opening files both stay in the same coordinate system.
+    pub source_root: PathBuf,
     pub indexed: usize,
-    /// The repo-relative paths this refresh handed to the indexer.
+    /// The config-root-relative paths whose effective indexed content this refresh may have
+    /// changed: files it WROTE (readable), files it SHADOWED (tombstoned), and files it
+    /// UNSHADOWED (pruned — dropping an overlay row makes the base version visible to this
+    /// checkout again, which changes what a query serves just as much as a write does).
     ///
     /// A SUPERSET of what changed, deliberately and soundly: a consumer that only needs "which of
     /// this checkout's files may be stale" (the live oracle's per-checkout worklist, #1010)
     /// filters it further anyway, and over-reporting costs a skipped candidate rather than a
-    /// missed one. Empty when the refresh indexed nothing.
-    pub reindexed_paths: Vec<PathBuf>,
+    /// missed one. Read [`Self::coverage`] first — a `Partial` list is not a superset.
+    pub changed_paths: Vec<PathBuf>,
+    /// Whether [`Self::changed_paths`] is the complete set. See [`ChangedPathsCoverage`].
+    pub coverage: ChangedPathsCoverage,
     pub tombstoned: usize,
     pub pruned: usize,
     /// Whether the working-tree status portion of the delta was read in FULL (see

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -38,6 +38,13 @@ pub struct WorktreeOverlayReport {
     /// (the pass was skipped).
     pub worktree_id: String,
     pub indexed: usize,
+    /// The repo-relative paths this refresh handed to the indexer.
+    ///
+    /// A SUPERSET of what changed, deliberately and soundly: a consumer that only needs "which of
+    /// this checkout's files may be stale" (the live oracle's per-checkout worklist, #1010)
+    /// filters it further anyway, and over-reporting costs a skipped candidate rather than a
+    /// missed one. Empty when the refresh indexed nothing.
+    pub reindexed_paths: Vec<PathBuf>,
     pub tombstoned: usize,
     pub pruned: usize,
     /// Whether the working-tree status portion of the delta was read in FULL (see

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -68,15 +68,22 @@ pub struct WorktreeOverlayReport {
     /// a consumer opening files both stay in the same coordinate system.
     pub source_root: PathBuf,
     pub indexed: usize,
-    /// The config-root-relative paths whose effective indexed content this refresh may have
-    /// changed: files it WROTE (readable), files it SHADOWED (tombstoned), and files it
-    /// UNSHADOWED (pruned — dropping an overlay row makes the base version visible to this
-    /// checkout again, which changes what a query serves just as much as a write does).
+    /// The config-root-relative paths whose effective indexed content this refresh changed: files
+    /// it WROTE, files it SHADOWED (tombstoned), and files it UNSHADOWED (pruned — dropping an
+    /// overlay row makes the base version visible to this checkout again, which changes what a
+    /// query serves just as much as a write does).
     ///
-    /// A SUPERSET of what changed, deliberately and soundly: a consumer that only needs "which of
-    /// this checkout's files may be stale" (the live oracle's per-checkout worklist, #1010)
-    /// filters it further anyway, and over-reporting costs a skipped candidate rather than a
-    /// missed one. Read [`Self::coverage`] first — a `Partial` list is not a superset.
+    /// Built from what the transaction COMMITTED, not from the candidates it considered. That
+    /// distinction is the whole value of the field: the candidate set of a diverged worktree is
+    /// its entire branch diff, and reporting that on every pass would name the same files forever
+    /// while nothing changed — leaving a consumer no better off than re-scanning the checkout, and
+    /// contradicting the empty-entry meaning [`crate::watch::OverlayRefresh`] documents. An idle
+    /// refresh of a static worktree reports nothing, matching its write-free behaviour.
+    ///
+    /// Still a SUPERSET, by a small and bounded margin: a path that survived the identity skip but
+    /// then failed to parse is listed though no row moved. That direction is deliberate —
+    /// over-reporting costs a consumer one redundant look, omitting a path leaves it serving stale
+    /// content. Read [`Self::coverage`] first: a `Partial` list is not even a superset.
     pub changed_paths: Vec<PathBuf>,
     /// Whether [`Self::changed_paths`] is the complete set. See [`ChangedPathsCoverage`].
     pub coverage: ChangedPathsCoverage,

--- a/crates/rag-rat-core/src/index/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/lifecycle.rs
@@ -364,7 +364,7 @@ impl IndexDatabase {
         &self,
         worktree_id: &str,
         shadowing: &BTreeSet<PathBuf>,
-    ) -> anyhow::Result<usize> {
+    ) -> anyhow::Result<Vec<PathBuf>> {
         let existing: Vec<String> = {
             let conn = self.storage.connection();
             // Direct `main.files` probe → explicit `repo_id` predicate (A3), same class as the
@@ -378,11 +378,14 @@ impl IndexDatabase {
             })?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
-        let mut pruned = 0usize;
+        // The pruned PATHS, not just a count: dropping an overlay row un-shadows the base version
+        // for this checkout, so the path's effective content changed and a per-checkout consumer
+        // must be told about it (#1010).
+        let mut pruned = Vec::new();
         for path in existing {
             if !shadowing.contains(Path::new(&path)) {
                 self.remove_file_in_scope(Path::new(&path), "", worktree_id)?;
-                pruned += 1;
+                pruned.push(PathBuf::from(path));
             }
         }
         Ok(pruned)

--- a/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
@@ -161,6 +161,7 @@ impl IndexDatabase {
         Ok(WorktreeOverlayReport {
             worktree_id,
             indexed,
+            reindexed_paths: delta.readable.clone(),
             tombstoned,
             pruned,
             status_complete: delta.status_complete,
@@ -351,6 +352,7 @@ impl IndexDatabase {
         Ok(WorktreeOverlayReport {
             worktree_id,
             indexed,
+            reindexed_paths: readable.clone(),
             tombstoned,
             pruned,
             // A path-scoped pass never fully reconciles the overlay — signal incomplete so the

--- a/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
@@ -86,7 +86,7 @@ impl IndexDatabase {
         // instead of failing the deferred read→write upgrade with SQLITE_BUSY; ROLLBACK on
         // any error (#219 review).
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
-        let result = (|| -> anyhow::Result<(usize, usize, Vec<PathBuf>)> {
+        let result = (|| -> anyhow::Result<OverlayMutations> {
             // #826: arm scoped logical re-derive capture — the overlay's file removals / inserts
             // below stage the worktree's changed PATHS so `finalize_overlay_refresh`'s Inline case
             // can re-derive only those paths' logical groups instead of the whole repo. Armed (and
@@ -103,16 +103,19 @@ impl IndexDatabase {
                 &scope,
                 progress,
             )?;
-            let indexed = applied.written;
+            let indexed = applied.outcome.written;
             // Write a tombstone only when one isn't already present, so a re-run on a static
-            // worktree writes nothing (idle-safety, like the readable sha-skip).
-            let mut tombstoned = 0;
+            // worktree writes nothing (idle-safety, like the readable sha-skip). Collect the ones
+            // actually WRITTEN, for the same reason: an already-present tombstone shadowed the
+            // path on an earlier pass and changes nothing now.
+            let mut tombstoned_paths = Vec::new();
             for path in &delta.tombstones {
                 if !self.overlay_tombstone_exists(path, &worktree_id)? {
                     self.write_tombstone_in_scope(path, &worktree_id)?;
-                    tombstoned += 1;
+                    tombstoned_paths.push(path.clone());
                 }
             }
+            let tombstoned = tombstoned_paths.len();
             // Prune overlay rows that no longer differ from the base — but ONLY when the delta is
             // complete. A partial delta (the working-tree status read failed → `status_complete`
             // false) is missing untracked / working-tree-deleted paths, so pruning against its
@@ -130,23 +133,34 @@ impl IndexDatabase {
                 OverlayChangeCounts { indexed, tombstoned, pruned },
                 delta.manifest_changed,
                 tail.logical_rebuild,
-                applied.logical,
+                applied.outcome.logical,
             )?;
             // #824: the basis write rides the SAME transaction as the rows it proves current —
             // previously a separate autocommit per worktree per pass (an extra WAL-dirtying
             // commit each). Un-gated on the counts: a COMPLETE no-change refresh must still
             // record its basis (that skip proof is the whole point of #577).
             self.apply_overlay_basis_tail(&worktree_id, delta.status_complete, tail.basis)?;
-            Ok((indexed, tombstoned, pruned_paths))
+            // Written ∪ tombstoned ∪ pruned — all three change what a query serves for this
+            // checkout (un-shadowing by prune as much as a write), and all three are the sets the
+            // transaction COMMITTED, not the candidates it started from.
+            let changed_paths = applied
+                .planned
+                .into_iter()
+                .chain(tombstoned_paths)
+                .chain(pruned_paths)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            Ok(OverlayMutations { indexed, tombstoned, pruned, changed_paths })
         })();
         // #826: disarm scoped logical re-derive capture on BOTH Ok and Err paths — this pass's
         // `&mut self` outlives an error return, so the flag must not leak into the caller's next
         // use.
         self.finish_scoped_logical_rederive();
-        let (indexed, tombstoned, pruned_paths) = match result {
-            Ok(counts) => {
+        let mutations = match result {
+            Ok(mutations) => {
                 self.storage.execute_batch("COMMIT")?;
-                counts
+                mutations
             },
             Err(err) => {
                 let _ = self.storage.execute_batch("ROLLBACK");
@@ -159,19 +173,7 @@ impl IndexDatabase {
         // the obligation survives for the next pass, like the batch callers' error arms.
         self.settle_pending_logical_rebuild_inline(tail.logical_rebuild)?;
 
-        // Every path whose effective content moved: written, shadowed, and un-shadowed (see
-        // `changed_paths`). A partial delta already reports `Partial` coverage, so a consumer
-        // never mistakes this list for the whole story.
-        let pruned = pruned_paths.len();
-        let changed_paths = delta
-            .readable
-            .iter()
-            .chain(&delta.tombstones)
-            .cloned()
-            .chain(pruned_paths)
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
+        let OverlayMutations { indexed, tombstoned, pruned, changed_paths } = mutations;
         Ok(WorktreeOverlayReport {
             worktree_id,
             source_root,
@@ -292,7 +294,7 @@ impl IndexDatabase {
         // write tombstones, then the gated logical-symbol/edge/FTS refresh. BEGIN IMMEDIATE up
         // front; ROLLBACK on any error.
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
-        let result = (|| -> anyhow::Result<(usize, usize, usize)> {
+        let result = (|| -> anyhow::Result<OverlayMutations> {
             // #826: arm scoped logical re-derive capture — the overlay's file removals / inserts
             // below stage the worktree's changed PATHS so `finalize_overlay_refresh`'s Inline case
             // can re-derive only those paths' logical groups instead of the whole repo. Armed (and
@@ -309,8 +311,11 @@ impl IndexDatabase {
                 &scope,
                 progress,
             )?;
-            let indexed = applied.written;
-            let mut tombstoned = 0;
+            let indexed = applied.outcome.written;
+            // Collect the tombstones/removals actually APPLIED, not the candidates: a supplied
+            // path whose re-validation declined below changed nothing, and an unchanged supplied
+            // path was already identity-skipped inside the writer.
+            let mut tombstoned_paths = Vec::new();
             for (rel, full) in &tombstones {
                 // RE-VALIDATE under the write lock (like removals): if the file was recreated /
                 // became indexable after classification, do NOT write a tombstone that would hide
@@ -321,24 +326,26 @@ impl IndexDatabase {
                     && !self.overlay_tombstone_exists(rel, &worktree_id)?
                 {
                     self.write_tombstone_in_scope(rel, &worktree_id)?;
-                    tombstoned += 1;
+                    tombstoned_paths.push(rel.clone());
                 }
             }
+            let tombstoned = tombstoned_paths.len();
             // Targeted removal of stale branch-only overlay rows — the per-path equivalent of the
             // whole-delta prune this scoped pass skips. RE-VALIDATED here under the write lock
             // (BEGIN IMMEDIATE froze other writers): only remove a still-non-indexable path whose
             // overlay row still exists, so a concurrent heal that re-indexed the path (it
             // reappeared) between classification and now can't have its fresh row
             // deleted (#679 review).
-            let mut pruned = 0;
+            let mut pruned_paths = Vec::new();
             for (rel, full) in &removal_candidates {
                 if !is_present_indexable(rel, full)
                     && self.overlay_source_row_exists(rel, &worktree_id)?
                 {
                     self.remove_file_in_scope(rel, "", &worktree_id)?;
-                    pruned += 1;
+                    pruned_paths.push(rel.clone());
                 }
             }
+            let pruned = pruned_paths.len();
             // No global prune: a partial path set is not authoritative over the whole overlay. The
             // supplied-manifest package refresh is the caller's job, so `manifest_changed = false`.
             self.finalize_overlay_refresh(
@@ -347,18 +354,26 @@ impl IndexDatabase {
                 OverlayChangeCounts { indexed, tombstoned, pruned },
                 false,
                 logical_rebuild,
-                applied.logical,
+                applied.outcome.logical,
             )?;
-            Ok((indexed, tombstoned, pruned))
+            let changed_paths = applied
+                .planned
+                .into_iter()
+                .chain(tombstoned_paths)
+                .chain(pruned_paths)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            Ok(OverlayMutations { indexed, tombstoned, pruned, changed_paths })
         })();
         // #826: disarm scoped logical re-derive capture on BOTH Ok and Err paths — this pass's
         // `&mut self` outlives an error return, so the flag must not leak into the caller's next
         // use.
         self.finish_scoped_logical_rederive();
-        let (indexed, tombstoned, pruned) = match result {
-            Ok(counts) => {
+        let mutations = match result {
+            Ok(mutations) => {
                 self.storage.execute_batch("COMMIT")?;
-                counts
+                mutations
             },
             Err(err) => {
                 let _ = self.storage.execute_batch("ROLLBACK");
@@ -369,18 +384,7 @@ impl IndexDatabase {
         // supplied path identity-skips (the finalize above never ran), and a stale pending
         // obligation must not survive this exit.
         self.settle_pending_logical_rebuild_inline(logical_rebuild)?;
-        // Every supplied path landed in exactly one of the three buckets (or was dropped by the
-        // guards as un-indexable), so their union is this pass's changed set — written, shadowed,
-        // or un-shadowed. A superset: the in-transaction re-validation may have declined some
-        // tombstones and removals.
-        let changed_paths = readable
-            .iter()
-            .cloned()
-            .chain(tombstones.into_iter().map(|(rel, _)| rel))
-            .chain(removal_candidates.into_iter().map(|(rel, _)| rel))
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
+        let OverlayMutations { indexed, tombstoned, pruned, changed_paths } = mutations;
         Ok(WorktreeOverlayReport {
             worktree_id,
             source_root,
@@ -416,7 +420,7 @@ impl IndexDatabase {
         paths: &[PathBuf],
         scope: &FileScope,
         progress: &mut F,
-    ) -> anyhow::Result<incremental::IncrementalWriteOutcome>
+    ) -> anyhow::Result<ExplicitPathWrites>
     where
         F: FnMut(IndexProgress),
     {
@@ -455,6 +459,33 @@ impl IndexDatabase {
                 worktree_id: scope.worktree_id.clone(),
             });
         }
-        self.apply_incremental_file_plan(files, BTreeSet::new(), progress)
+        // The post-skip set — the paths this call will actually try to write. Captured HERE
+        // because the identity skip above is what separates "a candidate the delta offered" from
+        // "a row that moved": on a static worktree every candidate is skipped and this is empty,
+        // which is what keeps an idle refresh's report empty (#1010).
+        let planned = files.iter().map(|file| file.relative_path.clone()).collect();
+        let outcome = self.apply_incremental_file_plan(files, BTreeSet::new(), progress)?;
+        Ok(ExplicitPathWrites { outcome, planned })
     }
+}
+
+/// The outcome of [`IndexDatabase::index_explicit_paths_from_root`] plus the paths behind it.
+pub(super) struct ExplicitPathWrites {
+    pub(super) outcome: incremental::IncrementalWriteOutcome,
+    /// The paths that survived the identity skip. A tight SUPERSET of the rows actually written:
+    /// a file that fails to parse is dropped further down the write path. Over-reporting a path
+    /// costs a consumer one redundant look; omitting one leaves it serving stale content.
+    pub(super) planned: Vec<PathBuf>,
+}
+
+/// What one overlay transaction actually committed — counts for the caller's `changed` decision,
+/// and the paths behind them for a per-checkout consumer (#1010).
+pub(super) struct OverlayMutations {
+    pub(super) indexed: usize,
+    pub(super) tombstoned: usize,
+    pub(super) pruned: usize,
+    /// Deduped paths this transaction mutated: written, tombstoned, or pruned. Built from what
+    /// the transaction DID, not from the candidates it considered, so a refresh that changed
+    /// nothing reports nothing.
+    pub(super) changed_paths: Vec<PathBuf>,
 }

--- a/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
@@ -86,7 +86,7 @@ impl IndexDatabase {
         // instead of failing the deferred read→write upgrade with SQLITE_BUSY; ROLLBACK on
         // any error (#219 review).
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
-        let result = (|| -> anyhow::Result<(usize, usize, usize)> {
+        let result = (|| -> anyhow::Result<(usize, usize, Vec<PathBuf>)> {
             // #826: arm scoped logical re-derive capture — the overlay's file removals / inserts
             // below stage the worktree's changed PATHS so `finalize_overlay_refresh`'s Inline case
             // can re-derive only those paths' logical groups instead of the whole repo. Armed (and
@@ -118,11 +118,12 @@ impl IndexDatabase {
             // false) is missing untracked / working-tree-deleted paths, so pruning against its
             // `shadowing_paths` would delete valid overlay rows; skip the prune and let the
             // next complete pass reconcile (mirrors gc's empty-live-set guard) (#219 review).
-            let pruned = if delta.status_complete {
+            let pruned_paths = if delta.status_complete {
                 self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?
             } else {
-                0
+                Vec::new()
             };
+            let pruned = pruned_paths.len();
             self.finalize_overlay_refresh(
                 &source_root,
                 &worktree_id,
@@ -136,13 +137,13 @@ impl IndexDatabase {
             // commit each). Un-gated on the counts: a COMPLETE no-change refresh must still
             // record its basis (that skip proof is the whole point of #577).
             self.apply_overlay_basis_tail(&worktree_id, delta.status_complete, tail.basis)?;
-            Ok((indexed, tombstoned, pruned))
+            Ok((indexed, tombstoned, pruned_paths))
         })();
         // #826: disarm scoped logical re-derive capture on BOTH Ok and Err paths — this pass's
         // `&mut self` outlives an error return, so the flag must not leak into the caller's next
         // use.
         self.finish_scoped_logical_rederive();
-        let (indexed, tombstoned, pruned) = match result {
+        let (indexed, tombstoned, pruned_paths) = match result {
             Ok(counts) => {
                 self.storage.execute_batch("COMMIT")?;
                 counts
@@ -158,10 +159,29 @@ impl IndexDatabase {
         // the obligation survives for the next pass, like the batch callers' error arms.
         self.settle_pending_logical_rebuild_inline(tail.logical_rebuild)?;
 
+        // Every path whose effective content moved: written, shadowed, and un-shadowed (see
+        // `changed_paths`). A partial delta already reports `Partial` coverage, so a consumer
+        // never mistakes this list for the whole story.
+        let pruned = pruned_paths.len();
+        let changed_paths = delta
+            .readable
+            .iter()
+            .chain(&delta.tombstones)
+            .cloned()
+            .chain(pruned_paths)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
         Ok(WorktreeOverlayReport {
             worktree_id,
+            source_root,
             indexed,
-            reindexed_paths: delta.readable.clone(),
+            changed_paths,
+            coverage: if delta.status_complete {
+                ChangedPathsCoverage::Complete
+            } else {
+                ChangedPathsCoverage::Partial
+            },
             tombstoned,
             pruned,
             status_complete: delta.status_complete,
@@ -349,10 +369,30 @@ impl IndexDatabase {
         // supplied path identity-skips (the finalize above never ran), and a stale pending
         // obligation must not survive this exit.
         self.settle_pending_logical_rebuild_inline(logical_rebuild)?;
+        // Every supplied path landed in exactly one of the three buckets (or was dropped by the
+        // guards as un-indexable), so their union is this pass's changed set — written, shadowed,
+        // or un-shadowed. A superset: the in-transaction re-validation may have declined some
+        // tombstones and removals.
+        let changed_paths = readable
+            .iter()
+            .cloned()
+            .chain(tombstones.into_iter().map(|(rel, _)| rel))
+            .chain(removal_candidates.into_iter().map(|(rel, _)| rel))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
         Ok(WorktreeOverlayReport {
             worktree_id,
+            source_root,
             indexed,
-            reindexed_paths: readable.clone(),
+            changed_paths,
+            // COMPLETE despite `status_complete: false` below — the two answer different
+            // questions. The caller named the exact paths it wanted refreshed, so nothing is
+            // missing from the list; what is incomplete is the overlay's reconciliation against
+            // the whole checkout. Deriving this from `status_complete` would mark every
+            // event-driven pass lossy and force consumers into a whole-checkout fallback on the
+            // hot path.
+            coverage: ChangedPathsCoverage::Complete,
             tombstoned,
             pruned,
             // A path-scoped pass never fully reconciles the overlay — signal incomplete so the

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -31,10 +31,11 @@ pub use event_loop::Watcher;
 #[cfg(test)]
 pub(crate) use event_loop::{EventLoop, flush_watch_placement_failures, shutdown_discover};
 pub use overlay::{
-    OverlayScope, ReconcileBudget, is_manifest_path, refresh_worktree_overlays, reindex_paths,
+    OverlayRefresh, OverlayScope, ReconcileBudget, is_manifest_path, refresh_worktree_overlays,
+    reindex_paths,
 };
 #[cfg(test)]
-pub(crate) use overlay::{overlay_needs_embed, partition_paths_by_worktree};
+pub(crate) use overlay::{enclosing_worktree_id, overlay_needs_embed, partition_paths_by_worktree};
 #[cfg(test)]
 pub(crate) use papertrail::{PapertrailClock, PapertrailScheduler, papertrail_tick_interval};
 pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip};

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -142,6 +142,22 @@ impl OverlayScope {
 /// held back. With the sweep disabled the gate turns itself off (see the clamp below): deferring
 /// an edit that no later event or sweep would deliver would leave the overlay stale forever.
 ///
+/// What one pass's overlay refresh did.
+///
+/// This used to be a bare `bool` — whether anything, anywhere, changed. That is the only question
+/// the pass's own control flow asks, but it is not enough for a consumer that must act ON a
+/// particular checkout: the live oracle needs to know WHICH checkout reindexed WHICH paths, because
+/// a resident language server is rooted at one tree and can only answer for that tree (#1010).
+pub struct OverlayRefresh {
+    /// Whether any overlay changed. The answer this function used to return alone.
+    pub changed: bool,
+    /// Repo-relative paths each visited linked checkout reindexed, keyed by its worktree id —
+    /// which is that checkout's root. A checkout the pass skipped (unchanged basis, quiet
+    /// window, not implicated by events) has NO entry; one it visited with nothing to do has
+    /// an empty one.
+    pub reindexed: BTreeMap<String, Vec<PathBuf>>,
+}
+
 /// `pub` so the hook-driven CLI `maintenance` command shares this exact path: the git hooks invoke
 /// `rag-rat maintenance` (not the foreground watcher), so without calling this a commit/checkout/
 /// merge in a linked worktree would index the base `config.root` but leave that worktree's overlay
@@ -151,7 +167,7 @@ pub fn refresh_worktree_overlays(
     config: &Config,
     reconcile: Option<&ReconcileBudget>,
     scope: &OverlayScope,
-) -> bool {
+) -> OverlayRefresh {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
     // The base id is the ENCLOSING worktree root, not `config.root` itself — see
     // `enclosing_worktree_id` (a repo-SUBDIR `config.root` would otherwise mis-classify the main
@@ -173,6 +189,7 @@ pub fn refresh_worktree_overlays(
     let overlay_quiet_secs =
         if config.watch.periodic_sweep_secs == 0 { 0 } else { config.watch.overlay_quiet_secs };
     let mut changed = false;
+    let mut reindexed: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
     for worktree in worktrees {
         if worktree == base_id {
             continue; // the rooted checkout is the base scope, not an overlay
@@ -247,6 +264,12 @@ pub fn refresh_worktree_overlays(
                 }
                 let this_changed = report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
                 changed |= this_changed;
+                // Keyed by the WORKTREE ID, which is this checkout's root — the two things a
+                // consumer needs to act on the paths: a scope to write rows under, and a directory
+                // to root a tool at. Recorded even when the refresh reindexed nothing, so an empty
+                // entry reads as "this checkout was visited and had no work" rather than as
+                // "this checkout was never looked at".
+                reindexed.insert(worktree.clone(), report.reindexed_paths.clone());
                 // Embed the overlay's chunks NOW, while the connection is still scoped to this
                 // overlay (index_worktree_overlay left it there) — the trailing base reconcile
                 // won't see them (#219 review). Run when the overlay CHANGED, OR — on an `All`
@@ -295,7 +318,7 @@ pub fn refresh_worktree_overlays(
     // Restore the base scope for the rest of the pass (index_worktree_overlay leaves the connection
     // scoped to the last worktree it touched).
     let _ = db.use_worktree_scope(&config.root, None);
-    changed
+    OverlayRefresh { changed, reindexed }
 }
 
 /// Whether the #822 quiet window still holds for a heads-unchanged worktree: the last COMPLETE

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -7,7 +7,8 @@ use rag_rat_base::config::Config;
 
 use crate::index::ai::ReconcileOptions;
 use crate::index::{
-    IndexDatabase, IndexProgress, OverlayBasisUpdate, OverlayLogicalRebuild, OverlayRefreshTail,
+    ChangedPathsCoverage, IndexDatabase, IndexProgress, OverlayBasisUpdate, OverlayLogicalRebuild,
+    OverlayRefreshTail,
 };
 
 /// The canonical worktree id string [`crate::index::live_worktree_contexts`] reports. When `root`
@@ -151,11 +152,32 @@ impl OverlayScope {
 pub struct OverlayRefresh {
     /// Whether any overlay changed. The answer this function used to return alone.
     pub changed: bool,
-    /// Repo-relative paths each visited linked checkout reindexed, keyed by its worktree id —
-    /// which is that checkout's root. A checkout the pass skipped (unchanged basis, quiet
-    /// window, not implicated by events) has NO entry; one it visited with nothing to do has
-    /// an empty one.
-    pub reindexed: BTreeMap<String, Vec<PathBuf>>,
+    /// What each VISITED linked checkout's refresh changed, keyed by its worktree id. A checkout
+    /// the pass skipped (unchanged basis, quiet window, not implicated by events, or a refresh
+    /// that errored) has NO entry; one it visited with nothing to do has an entry with no paths.
+    pub reindexed: BTreeMap<String, CheckoutReindex>,
+}
+
+/// What one linked checkout's overlay refresh changed, for a consumer that must act on that
+/// checkout specifically (#1010).
+///
+/// The three fields travel together on purpose: paths alone are unusable. Without `source_root`
+/// they cannot be resolved to files (a subdir-rooted config makes the checkout root the wrong
+/// base), and without `coverage` an empty list is ambiguous between "nothing changed" and "the
+/// status read failed and the list is missing entries".
+#[derive(Debug, Clone)]
+pub struct CheckoutReindex {
+    /// The directory [`Self::paths`] are relative to — this checkout's equivalent of
+    /// `config.root`, which is NOT the checkout root when `config.root` is a repo subdir. See
+    /// [`crate::index::WorktreeOverlayReport::source_root`].
+    pub source_root: PathBuf,
+    /// Paths whose effective indexed content this refresh may have changed, relative to
+    /// [`Self::source_root`]. A superset when `coverage` is
+    /// [`ChangedPathsCoverage::Complete`]; otherwise not even that.
+    pub paths: Vec<PathBuf>,
+    /// Whether `paths` is the complete set. `Partial` means the consumer must treat the whole
+    /// checkout as suspect rather than trusting the list.
+    pub coverage: ChangedPathsCoverage,
 }
 
 /// `pub` so the hook-driven CLI `maintenance` command shares this exact path: the git hooks invoke
@@ -189,7 +211,7 @@ pub fn refresh_worktree_overlays(
     let overlay_quiet_secs =
         if config.watch.periodic_sweep_secs == 0 { 0 } else { config.watch.overlay_quiet_secs };
     let mut changed = false;
-    let mut reindexed: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+    let mut reindexed: BTreeMap<String, CheckoutReindex> = BTreeMap::new();
     for worktree in worktrees {
         if worktree == base_id {
             continue; // the rooted checkout is the base scope, not an overlay
@@ -264,12 +286,20 @@ pub fn refresh_worktree_overlays(
                 }
                 let this_changed = report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
                 changed |= this_changed;
-                // Keyed by the WORKTREE ID, which is this checkout's root — the two things a
-                // consumer needs to act on the paths: a scope to write rows under, and a directory
-                // to root a tool at. Recorded even when the refresh reindexed nothing, so an empty
-                // entry reads as "this checkout was visited and had no work" rather than as
-                // "this checkout was never looked at".
-                reindexed.insert(worktree.clone(), report.reindexed_paths.clone());
+                // Keyed by the report's RESOLVED worktree id, not the registered path this loop
+                // iterates: the id is what the overlay's rows are keyed by, so a consumer can use
+                // it directly as a DB scope. An empty id means the refresh never resolved a linked
+                // scope and returned the default report — record nothing rather than claim a visit
+                // to a checkout that was never read. Recorded even when the refresh changed
+                // nothing, so an entry with no paths reads as "visited, no work" rather than as
+                // "never looked at".
+                if !report.worktree_id.is_empty() {
+                    reindexed.insert(report.worktree_id.clone(), CheckoutReindex {
+                        source_root: report.source_root.clone(),
+                        paths: report.changed_paths.clone(),
+                        coverage: report.coverage,
+                    });
+                }
                 // Embed the overlay's chunks NOW, while the connection is still scoped to this
                 // overlay (index_worktree_overlay left it there) — the trailing base reconcile
                 // won't see them (#219 review). Run when the overlay CHANGED, OR — on an `All`

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -373,9 +373,10 @@ fn run_pass(
     // worktree change counts toward running the tail below even when config.root itself didn't
     // change. Reconcile a CHANGED overlay's embeddings INLINE (while scoped to it) so a worktree
     // query isn't BM25-only for branch content — the base reconcile below can't see overlay chunks.
-    let overlays_changed = timings.stage("overlays", || {
+    let overlays = timings.stage("overlays", || {
         refresh_worktree_overlays(&mut db, config, Some(&budget), overlay_scope)
     });
+    let overlays_changed = overlays.changed;
     let base_tail_forced =
         base_tail_forced_by_state(content_changed, run_gc, shutdown_reconcile_pending);
     let base_embedding_backlog = base_embedding_backlog_needs_tail(


### PR DESCRIPTION
Groundwork for #1010. **No behaviour change** — 4379 tests pass, both clippy configurations and `fmt --check` clean.

## Why

`refresh_worktree_overlays` returned a bare `bool`: whether anything, anywhere, changed. That is the only question the maintenance pass's own control flow asks — but it is not enough for a consumer that must act **on a particular checkout**.

The live oracle is that consumer. A resident language server is rooted at one tree and can only answer for that tree, so patching a linked worktree's freshness needs to know *which* checkout reindexed *which* paths. Today an edit that exists only in a linked worktree reaches no live backend at all (#1010).

## What

`OverlayRefresh { changed, reindexed }`. The map is keyed by each visited checkout's worktree id — which **is** its root, and those are exactly the two things a consumer needs: a scope to write rows under, and a directory to root a tool at.

Two distinctions the type makes deliberately:

- A checkout the pass **skipped** (unchanged basis, quiet window, not implicated by events) has **no entry**. One it **visited with nothing to do** has an **empty** entry. A consumer deciding whether it has seen a checkout's work needs to tell those apart.
- The paths are a **superset** of what changed — the set handed to the indexer, which both `WorktreeOverlayReport` construction sites already had in hand. A consumer needing "which of this checkout's files may be stale" filters further anyway, and over-reporting costs a skipped candidate rather than a missed one. That is the same soundness direction the base pass's changed-set hint already relies on.

## Test

Two linked worktrees sharing one database with only one of them edited: the report names the edited checkout and its path, and does not credit the quiet sibling with that work.

## Not in this PR

The consumer. #1010 proper — keying live sessions by `(backend, checkout)`, the LRU cap over concurrently-served checkouts, switching the DB scope per checkout, and making `run_live_oracle_pass`'s `source_root` guard worktree-aware — lands next, on top of this.

Sizing note recorded on #1010: this repository has **29 live worktrees**, so the naive "one session per (backend × checkout)" reading would be 87 resident language servers. The cap is what makes the feature shippable, and it defaults to one checkout's worth.