### PR TITLE
fix(index): treat a literal backslash in a Unix filename as part of the name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5184,7 +5184,6 @@ name = "rag-rat-oracle"
 version = "0.21.1"
 dependencies = [
  "anyhow",
- "path-slash",
  "protobuf",
  "rag-rat-base",
  "rag-rat-clones",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,7 +5026,6 @@ dependencies = [
  "minicbor",
  "model2vec-rs",
  "notify",
- "path-slash",
  "protobuf",
  "pulldown-cmark",
  "rag-rat-base",

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -3315,3 +3315,47 @@ fn a_loaded_config_root_is_a_spelling_git_and_gix_both_accept() {
     ]);
     assert!(linked.join("crate/src/a.rs").is_file(), "the linked checkout was created");
 }
+
+/// A `dir/**` glob claims what is INSIDE `dir/`, so the prefix has to end at a separator. A bare
+/// `starts_with` reads a prefix of a NAME as a directory boundary, which excluded a Unix file
+/// called `drafts\secret.md` (and `draftsman.md`) as though it sat in `drafts/` — undoing, at the
+/// matcher, exactly what preserving a literal backslash in `path_string` accomplishes.
+#[test]
+fn a_directory_glob_needs_a_separator_after_its_prefix() {
+    let target = ResolvedTarget {
+        name: "docs".to_string(),
+        language: Language::Markdown,
+        directories: vec![PathBuf::from(".")],
+        include: vec!["**/*.md".to_string()],
+        exclude: vec!["drafts/**".to_string()],
+        kind: TargetKind::Docs,
+    };
+
+    assert!(!target.globs_claim("drafts/secret.md"), "a real child of drafts/ is excluded");
+    assert!(
+        target.globs_claim("drafts\\secret.md"),
+        "a Unix file NAMED `drafts\\secret.md` is not in drafts/ and must not be excluded"
+    );
+    assert!(
+        target.globs_claim("draftsman.md"),
+        "a sibling whose name merely starts with the prefix is not in drafts/"
+    );
+    assert!(target.globs_claim("notes/keep.md"), "an unrelated path is claimed by the include");
+}
+
+/// The same boundary on the INCLUDE side: `foo/**` must not claim a file merely named `foo\bar.rs`.
+#[test]
+fn a_directory_include_glob_does_not_claim_a_backslash_named_sibling() {
+    let target = ResolvedTarget {
+        name: "rust".to_string(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from(".")],
+        include: vec!["foo/**".to_string()],
+        exclude: Vec::new(),
+        kind: TargetKind::Source,
+    };
+
+    assert!(target.globs_claim("foo/bar.rs"), "a real child of foo/ is claimed");
+    assert!(!target.globs_claim("foo\\bar.rs"), "a file NAMED `foo\\bar.rs` is not under foo/");
+    assert!(!target.globs_claim("foobar.rs"), "a prefix of the NAME is not a directory boundary");
+}

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -1090,6 +1090,41 @@ impl ResolvedTarget {
         let upgrade_rank = u8::from(!self.language.upgrades_ambiguous_extension());
         (kind_rank, upgrade_rank)
     }
+
+    /// Whether this target's `include` / `exclude` globs claim `relative_path` — exclude first, so
+    /// an excluded path is never claimed by a broader include.
+    ///
+    /// `relative_path` MUST be the `/`-separated rendering `files.path` is stored with
+    /// ([`crate::paths::path_string`]), never an OS-native spelling: the patterns are `/`-spelled,
+    /// and matching them against a different rendering is how a file ends up claimed for a
+    /// directory it is not in.
+    ///
+    /// The single definition of that matching, deliberately: the walk decides what to index and
+    /// the per-path resolver decides what an already-known path belongs to, and a second copy of
+    /// the rules lets those two answers drift.
+    pub fn globs_claim(&self, relative_path: &str) -> bool {
+        !self.exclude.iter().any(|pattern| glob_claims(relative_path, pattern))
+            && self.include.iter().any(|pattern| glob_claims(relative_path, pattern))
+    }
+}
+
+/// Whether one config glob claims `path` (a `/`-separated repo-relative rendering). Three shapes:
+/// a `**/*.ext` suffix, a `dir/**` subtree, and a literal (exact or substring).
+///
+/// A `dir/**` subtree requires the prefix to END AT A SEPARATOR. A bare `starts_with` reads a
+/// PREFIX OF A NAME as a directory boundary, so `drafts/**` also claimed the Unix file
+/// `drafts\secret.md` (and `draftsman.md`), excluding a file that is not in `drafts/` at all —
+/// which is exactly what preserving a literal backslash in the rendering exists to prevent.
+fn glob_claims(path: &str, pattern: &str) -> bool {
+    if let Some(extension) = pattern.strip_prefix("**/*.") {
+        return path.ends_with(&format!(".{extension}"));
+    }
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return path
+            .strip_prefix(prefix)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'));
+    }
+    path == pattern || path.contains(pattern.trim_matches('*'))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rag-rat-base/src/paths.rs
+++ b/crates/rag-rat-base/src/paths.rs
@@ -180,11 +180,26 @@ fn windows_utf16_len(s: &str) -> usize {
 const MAX_PLAIN_PATH_UNITS: usize = 260;
 const MAX_COMPONENT_UNITS: usize = 255;
 
+use path_slash::PathExt as _;
+
 /// The canonical `/`-separated rendering used everywhere a path is persisted or compared against
 /// the `files` table — Windows separators normalize so the same file hashes/joins identically on
 /// every platform.
+///
+/// Rewrites the platform SEPARATOR only, never a `\` that is part of a file NAME. On Windows `\`
+/// is the separator and cannot occur inside a name, so `src\lib.rs` renders `src/lib.rs`. On Unix
+/// `\` is an ordinary filename character, so `src/foo\bar.rs` and `src/foo/bar.rs` are two
+/// different files and must render as two different strings. Rewriting every backslash in the
+/// lossy string — a blanket `String::replace` of the escape character with `/` — collapsed them
+/// onto one `files.path`, and because this is the write path, both files shared a single row:
+/// chunks, clone postings, memory bindings, change coupling, and symbol `qualified_name`s all
+/// inherited the collision.
+///
+/// This function is the ONE place that normalization lives: an inlined copy at a call site
+/// reintroduces the collision for whatever it feeds, so `no_inlined_separator_normalization`
+/// below fails the build when a new one appears.
 pub fn path_string(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    path.to_slash_lossy().into_owned()
 }
 
 /// `path` with `.` dropped and `..` applied to the preceding component, TEXTUALLY — no filesystem
@@ -371,5 +386,103 @@ mod tests {
         // And the success arm is plain `canonicalize`.
         std::fs::create_dir_all(&absent).unwrap();
         assert_eq!(canonicalize_or_simplified(&absent), canonicalize(&absent).unwrap());
+    }
+
+    #[test]
+    fn path_string_renders_the_platform_separator_as_a_slash() {
+        let nested: PathBuf = ["src", "index", "walker.rs"].iter().collect();
+        assert_eq!(path_string(&nested), "src/index/walker.rs");
+    }
+
+    /// A backslash is a legal Unix filename character, so it must survive `path_string` — the
+    /// stored `files.path` is what distinguishes this file from the nested `src/foo/bar.rs`, and
+    /// `qualified_name` (`path::name`) inherits the same distinction. Unix-only: Windows forbids
+    /// `\` in a name, so the file this asserts about cannot exist there.
+    #[cfg(unix)]
+    #[test]
+    fn path_string_keeps_a_literal_backslash_in_a_unix_file_name() {
+        assert_eq!(path_string(Path::new("src/foo\\bar.rs")), "src/foo\\bar.rs");
+        assert_ne!(
+            path_string(Path::new("src/foo\\bar.rs")),
+            path_string(Path::new("src/foo/bar.rs")),
+            "a backslash-named file and a nested file must not share one files.path",
+        );
+    }
+
+    /// `path_string` is the single seam that decides what a path LOOKS like everywhere it is
+    /// persisted, compared against `files.path`, or folded into a symbol's `qualified_name`. An
+    /// inlined `to_string_lossy()` + blanket backslash rewrite at a call site silently opts that
+    /// call site out and reintroduces the Unix filename collision for whatever it feeds — which is
+    /// how the defect reached the walker, the chunker, the parser, the edge extractor and a
+    /// verbatim second copy of this function. Scan the workspace so a new copy fails here rather
+    /// than in a user's index.
+    #[test]
+    fn no_inlined_separator_normalization() {
+        // Written with doubled escapes so this test's own source does not match the needle.
+        let needle = "replace('\\\\', \"/\")";
+        // Files that rewrite backslashes in something that is NOT a path, where `path_string` does
+        // not apply. Each entry pins the exact number of occurrences, so an inlined path rewrite
+        // added to the same file still trips this — and a stale entry trips it too.
+        let allowed: &[(&str, usize, &str)] = &[(
+            "rag-rat-cli/tests/consolidate.rs",
+            1,
+            "normalizes a whole stderr MESSAGE with paths interpolated into it, not a path",
+        )];
+        let Some(crates_dir) = workspace_crates_dir() else {
+            // A packaged crate has no workspace around it; nothing to scan.
+            return;
+        };
+        let mut offenders = Vec::new();
+        for file in rust_sources(&crates_dir) {
+            let Ok(text) = std::fs::read_to_string(&file) else { continue };
+            let relative = path_string(file.strip_prefix(&crates_dir).unwrap_or(&file));
+            let hits: Vec<usize> = text
+                .lines()
+                .enumerate()
+                .filter(|(_, line)| line.contains(needle))
+                .map(|(index, _)| index + 1)
+                .collect();
+            let exempt = allowed
+                .iter()
+                .find(|(allowed_path, ..)| *allowed_path == relative)
+                .map_or(0, |(_, count, _)| *count);
+            if hits.len() != exempt {
+                offenders.push(format!("{relative} lines {hits:?} (allowed: {exempt})"));
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "inlined path-separator normalization found — call `rag_rat_base::paths::path_string` \
+             instead, which leaves a literal backslash in a Unix file name intact:\n{}",
+            offenders.join("\n"),
+        );
+    }
+
+    /// `<workspace>/crates`, derived from this crate's manifest dir. `None` when the crate is
+    /// built outside its workspace checkout (a packaged/vendored copy).
+    fn workspace_crates_dir() -> Option<PathBuf> {
+        let crates_dir = Path::new(env!("CARGO_MANIFEST_DIR")).parent()?.to_path_buf();
+        crates_dir.is_dir().then_some(crates_dir)
+    }
+
+    fn rust_sources(dir: &Path) -> Vec<PathBuf> {
+        let mut found = Vec::new();
+        let mut pending = vec![dir.to_path_buf()];
+        while let Some(current) = pending.pop() {
+            let Ok(entries) = std::fs::read_dir(&current) else { continue };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                // `target/` holds build output, including generated sources we do not own.
+                if path.is_dir() {
+                    if path.file_name().is_some_and(|name| name == "target") {
+                        continue;
+                    }
+                    pending.push(path);
+                } else if path.extension().is_some_and(|ext| ext == "rs") {
+                    found.push(path);
+                }
+            }
+        }
+        found
     }
 }

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -190,8 +190,13 @@ pub(crate) fn normal_component(component: &std::path::Component<'_>) -> bool {
 pub(crate) fn toml_string(value: &str) -> String {
     format!("{value:?}")
 }
+/// A repo-relative path as the config renders it — `/`-separated, with the empty (root) path
+/// spelled `.`. The value lands in `rag-rat.toml` as a target directory and is later matched
+/// against `files.path`, so it goes through the same `path_string` seam the index stores with
+/// rather than a blanket backslash rewrite, which would rename a Unix directory whose name
+/// contains a backslash.
 pub(crate) fn display_rel(path: &Path) -> String {
-    let text = path.to_string_lossy().replace('\\', "/");
+    let text = rag_rat_base::paths::path_string(path);
     if text.is_empty() { ".".to_string() } else { text }
 }
 pub(crate) fn supported_languages() -> Vec<Language> {

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -655,7 +655,7 @@ mod default_plan_tests {
         // A Windows path (C:\...) in a TOML BASIC (double-quoted) string parses its backslashes as
         // escape sequences (\U, \r, …) → a load error. Forward slashes are valid TOML and stay
         // absolute on Windows, so `database` resolves to the same path.
-        let db_literal = db_path.display().to_string().replace('\\', "/");
+        let db_literal = rag_rat_base::paths::path_string(&db_path);
         std::fs::write(
             &config_path,
             format!(

--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -1086,7 +1086,8 @@ mod tests {
         // Normalize separators: the display path uses `\` on Windows (correct for the user), but
         // the suffix check is separator-agnostic.
         assert!(
-            d.db_path.replace('\\', "/").ends_with("custom/index.sqlite"),
+            rag_rat_base::paths::path_string(std::path::Path::new(&d.db_path))
+                .ends_with("custom/index.sqlite"),
             "reconfigure displays the explicit database path, got {}",
             d.db_path
         );

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -93,9 +93,6 @@ iai-callgrind = "0.16"
 # Wall-clock benchmarking (full-index time on a larger corpus). default-features off to skip the
 # plotting deps — Bencher parses criterion's stdout estimates.
 criterion = { version = "0.8", default-features = false }
-# Test-only: forward-slashes a filesystem path so it can be embedded in a double-quoted TOML string
-# value without Windows `\U`/`\R` invalid-escape parse errors (config load tests).
-path-slash.workspace = true
 tempfile.workspace = true
 
 # iai-callgrind: deterministic instruction counts (index + cold/warm query).

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -517,6 +517,55 @@ mod low_signal_span_tests {
     }
 }
 
+/// On Unix a backslash is part of the file NAME, so `pkg/target\a.rs` is one file called
+/// `target\a.rs` under `pkg/` — NOT a file under a `target/` directory (#1032). Classifying it as
+/// generated would skip embedding a real source file, and would also disagree with the reconcile
+/// recompute, which reads the same name back out of `files.path`.
+///
+/// Deliberately NOT in the `policy_version_tests` corpus: that corpus's hash must be identical on
+/// Unix and Windows, and this input cannot exist on Windows at all. The whole module is gated so
+/// nothing inside it is dead code on the Windows leg.
+#[cfg(all(test, unix))]
+mod backslash_path_tests {
+    use std::path::Path;
+
+    /// Long enough to clear `MIN_EMBEDDING_CHARS`, so "no cheap skip applies" is reachable and the
+    /// assertion is not satisfied by an unrelated SkipTooSmall.
+    const SRC: &str =
+        "fn a() { let value = compute(input); let other = process(value); combine(value, other) }";
+
+    #[test]
+    fn a_literal_backslash_in_a_unix_file_name_is_not_a_generated_directory() {
+        let decision = super::cheap_skip_policy(
+            Path::new("pkg/target\\a.rs"),
+            "rust",
+            "source",
+            "code",
+            Some("s"),
+            SRC,
+            4000,
+        );
+        assert!(
+            decision.is_none(),
+            "a backslash in the file name must not read as a `target/` directory: {decision:?}"
+        );
+        // The same segment spelled as a real directory still classifies as generated.
+        assert_eq!(
+            super::cheap_skip_policy(
+                Path::new("pkg/target/a.rs"),
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                SRC,
+                4000,
+            )
+            .map(|decision| decision.policy),
+            Some("SkipGenerated".to_string()),
+        );
+    }
+}
+
 /// Behavior-hash tripwire for [`EMBEDDING_POLICY_VERSION`] (#530). The corpus routes through every
 /// embedding-policy gate — the parse-free cheap gates and the low-signal gate, the latter both
 /// `FromText` and `FromSpan` across every grammar — so any classifier change (a threshold, a gate,
@@ -550,6 +599,17 @@ mod policy_version_tests {
         // hash.
         let at_min = "a".repeat(80);
         let below_min = "a".repeat(79);
+        // The two `backslash_*` cases below: a path spelled with the PLATFORM separator, which on
+        // Windows IS `\`. They classify as SkipGenerated / SkipTestFixture only because the policy
+        // renders them through `paths::path_string` before matching the `/`-spelled `/target/` and
+        // `/fixtures/` heuristics, so they pin that normalization on the platform where it does
+        // work. Spelled from `MAIN_SEPARATOR` rather than a hardcoded `\`: on Unix a backslash is a
+        // legal file NAME character, `path_string` correctly leaves it alone, and a hardcoded
+        // spelling would make this corpus — and therefore EMBEDDING_POLICY_VERSION — classify
+        // differently on Unix than on Windows.
+        let separator = std::path::MAIN_SEPARATOR;
+        let native_generated_path = format!("pkg{separator}target{separator}a.rs");
+        let native_fixture_path = format!("pkg{separator}fixtures{separator}a.rs");
 
         // Parse-free cheap gates (FromText — no tree needed for these to decide).
         // (label, path, language, file_kind, chunk_kind, symbol_path, text, cap)
@@ -626,14 +686,10 @@ mod policy_version_tests {
                 "fn a() { let value = compute(); process(value); }",
                 4000,
             ),
-            // Backslash paths (Windows `relative_path`): these classify as SkipGenerated /
-            // SkipTestFixture ONLY because the policy `/`-normalizes via `paths::path_string` — so
-            // they pin that normalization AND bump the version, which forces existing Windows
-            // indexes (stamped before the normalization) to re-stamp their
-            // `chunks.embedding_policy`.
+            // Native-separator paths — `\` on Windows. See the `native_*_path` bindings above.
             (
                 "backslash_generated_path",
-                "pkg\\target\\a.rs",
+                native_generated_path.as_str(),
                 "rust",
                 "source",
                 "code",
@@ -643,7 +699,7 @@ mod policy_version_tests {
             ),
             (
                 "backslash_test_fixture_path",
-                "pkg\\fixtures\\a.rs",
+                native_fixture_path.as_str(),
                 "rust",
                 "source",
                 "code",

--- a/crates/rag-rat-core/src/index/chunker.rs
+++ b/crates/rag-rat-core/src/index/chunker.rs
@@ -201,7 +201,7 @@ fn push_uncovered_chunk(
             "code",
             Some(format!(
                 "{}::#context-{}{}",
-                path.to_string_lossy().replace('\\', "/"),
+                rag_rat_base::paths::path_string(path),
                 context_index + 1,
                 if part_idx == 0 { String::new() } else { format!("-{part_idx}") }
             )),

--- a/crates/rag-rat-core/src/index/discovery.rs
+++ b/crates/rag-rat-core/src/index/discovery.rs
@@ -251,10 +251,7 @@ pub(crate) fn target_claims_path(
         }) {
             return None;
         }
-        if target.exclude.iter().any(|pattern| matches_simple_pattern(&relative, pattern)) {
-            return None;
-        }
-        if !target.include.iter().any(|pattern| matches_simple_pattern(&relative, pattern)) {
+        if !target.globs_claim(&relative) {
             return None;
         }
         Some((target.language, target.kind))

--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -384,7 +384,7 @@ pub(crate) fn file_edge(
 ) -> EdgeCandidate {
     EdgeCandidate {
         from_symbol_id: None,
-        from_name: Some(path.to_string_lossy().replace('\\', "/")),
+        from_name: Some(rag_rat_base::paths::path_string(path)),
         to_name,
         target_qualified_name: None,
         evidence: Some(edge_evidence(node, text)),
@@ -414,7 +414,7 @@ pub(crate) fn file_edge_scoped(
 ) -> EdgeCandidate {
     EdgeCandidate {
         from_symbol_id: None,
-        from_name: Some(path.to_string_lossy().replace('\\', "/")),
+        from_name: Some(rag_rat_base::paths::path_string(path)),
         to_name,
         target_qualified_name: None,
         evidence,

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -108,11 +108,9 @@ pub(crate) fn scan_packages(root: &Path) -> (HashSet<String>, Vec<PackageRoots>)
         // Store `manifest_dir` RELATIVE to the indexed root (`/`-normalized) so it prefix-matches a
         // file's stored relative path when assigning `files.package_id`. The root manifest yields
         // an empty string, which is a prefix of every path (the root crate owns top-level files).
-        let relative = manifest_dir
-            .strip_prefix(root)
-            .unwrap_or(manifest_dir)
-            .to_string_lossy()
-            .replace('\\', "/");
+        let relative = rag_rat_base::paths::path_string(
+            manifest_dir.strip_prefix(root).unwrap_or(manifest_dir),
+        );
         packages.push(PackageRoots { manifest_dir: relative, local_roots });
     }
     (global_roots, packages)

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -44,8 +44,18 @@ pub(crate) fn git_changed_paths(root: &Path) -> anyhow::Result<GitChangedPaths> 
     Ok(paths)
 }
 
-/// The status pathspec for a SUBDIR config root (`<subdir>/**`), or `None` when the config root
-/// IS the worktree root.
+/// The status pathspec for a SUBDIR config root, or `None` when the config root IS the worktree
+/// root.
+///
+/// LITERAL MAGIC, NOT A GLOB. A repo-relative path rendered by `path_string` is DATA, and a bare
+/// pathspec is a PATTERN: gix parses one in shell-glob mode, where `\` escapes the following byte
+/// and `*`, `?`, `[` are wildcards, and a leading `:` opens a magic signature. So the subdir root
+/// `tools\api` (a legal Unix directory NAME, which the rendering now preserves instead of
+/// destroying) produced `tools\api/**`, which matches nothing under that directory — its
+/// modifications and deletions never reached `git_changed_paths`, and the default Changed pass
+/// left every file in it stale. `:(literal)<dir>` takes the rest of the spec as bytes, so no
+/// escaping is needed and no name can be misread as a pattern; git pathspec semantics already make
+/// a directory match everything under it, which is what the old `/**` suffix was for.
 ///
 /// #474: a pathspec disables gix's ignored-DIRECTORY pruning wherever the spec could still match —
 /// the former whole-root wildcard `"*"` could match anywhere, so the dirwalk descended into every
@@ -67,8 +77,18 @@ fn config_root_status_pathspec(worktree_root: &Path, config_root: &Path) -> Opti
     if relative.is_empty() || relative == "." {
         None
     } else {
-        Some(BString::from(format!("{relative}/**")))
+        Some(BString::from(literal_pathspec(&relative)))
     }
+}
+
+/// A path as a gix pathspec that matches it EXACTLY as bytes — `:(literal)` disables every
+/// wildcard, escape and magic-signature reading, so a name containing `\`, `*`, `?`, `[` or a
+/// leading `:` names the file it spells rather than a pattern that happens to look like it.
+///
+/// This is the only place a rendered path becomes a gix pathspec; the read-side conversions
+/// (`entry_by_path`, `blame_file`) take a literal path already and are not pattern-parsed.
+fn literal_pathspec(path: &str) -> String {
+    format!(":(literal){path}")
 }
 
 pub(crate) fn repo_relative_path_to_config_path(
@@ -120,7 +140,11 @@ pub(crate) fn path_is_dirty(repo: &gix::Repository, relative: &Path) -> bool {
     let Ok(platform) = repo.status(gix::progress::Discard) else {
         return false;
     };
-    let pathspec = gix::path::into_bstr(relative).into_owned();
+    // `:(literal)` over the `/`-separated rendering, for the reason
+    // `config_root_status_pathspec` documents: the OS-native bytes of a file NAME are not a
+    // pattern, and a name carrying `\`, `*`, `?`, `[` or a leading `:` would otherwise be parsed
+    // as one and report a file with uncommitted edits as clean.
+    let pathspec = BString::from(literal_pathspec(&path_string(relative)));
     let Ok(mut changes) = platform.untracked_files(UntrackedFiles::Files).into_iter([pathspec])
     else {
         return false;
@@ -368,6 +392,82 @@ mod worktree_scope_tests {
             intrusions.is_empty(),
             "a subdir pathspec must not open sibling ignored trees: {intrusions:?}"
         );
+    }
+
+    /// A rendered path is DATA; a bare gix pathspec is a PATTERN. Under a config root named
+    /// `tools\api` — a legal Unix directory name the rendering now preserves — the old
+    /// `<subdir>/**` spec spelled a backslash that gix's shell-glob parse reads as an escape, so it
+    /// matched nothing at all: every modification and deletion under that root was missing from
+    /// `git_changed_paths`, and the default Changed pass left those files stale forever.
+    ///
+    /// Unix-only: Windows forbids `\` in a name, so the fixture cannot exist there.
+    #[cfg(unix)]
+    #[test]
+    fn a_backslash_named_subdir_root_still_reports_its_changes() {
+        let dir = temp_dir("backslash-subdir");
+        git(&dir, &["init", "-q"]);
+        // A directory whose NAME contains a backslash, plus a slash-nested sibling that a collapsed
+        // reading of the same spec would match instead.
+        std::fs::create_dir_all(dir.join("tools\\api")).unwrap();
+        std::fs::create_dir_all(dir.join("tools/api")).unwrap();
+        std::fs::write(dir.join("tools\\api").join("edited.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(dir.join("tools\\api").join("removed.rs"), "pub fn b() {}\n").unwrap();
+        std::fs::write(dir.join("tools/api").join("nested.rs"), "pub fn c() {}\n").unwrap();
+        git(&dir, &["add", "-A", "."]);
+        git(&dir, &["commit", "-q", "-m", "seed"]);
+
+        std::fs::write(dir.join("tools\\api").join("edited.rs"), "pub fn a2() {}\n").unwrap();
+        std::fs::remove_file(dir.join("tools\\api").join("removed.rs")).unwrap();
+
+        let paths = git_changed_paths(&dir.join("tools\\api")).unwrap();
+        assert!(
+            paths.changed.contains(&PathBuf::from("edited.rs")),
+            "a modification under a backslash-named root must be reported: {paths:?}"
+        );
+        assert!(
+            paths.deleted.contains(&PathBuf::from("removed.rs")),
+            "and so must a deletion: {paths:?}"
+        );
+        // The spec names one directory, not a pattern a sibling can also satisfy.
+        let nested = git_changed_paths(&dir.join("tools/api")).unwrap();
+        assert!(
+            nested.changed.is_empty() && nested.deleted.is_empty(),
+            "the slash-nested sibling is untouched and must report nothing: {nested:?}"
+        );
+    }
+
+    /// The same class on the per-path status probe blame gates on. A whole-path spec survives a
+    /// backslash by accident — pathspec matching tries a literal byte compare before the glob, and
+    /// an exact path wins there — but a LEADING `:` is read as a magic signature before any
+    /// matching happens at all, so a top-level file named `:notes.rs` reported clean no matter how
+    /// dirty it was, and blame then attributed its uncommitted lines to the last commit.
+    ///
+    /// Unix-only, like the sibling above: neither name is legal on Windows.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_whose_name_looks_like_pathspec_syntax_reads_as_dirty_when_it_is() {
+        let dir = temp_dir("pathspec-syntax-dirty");
+        git(&dir, &["init", "-q"]);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        // `:notes.rs` opens a magic signature; `src/foo\bar.rs` spells an escape in glob mode.
+        let names = [":notes.rs", "src/foo\\bar.rs"];
+        for name in names {
+            std::fs::write(dir.join(name), "pub fn a() {}\n").unwrap();
+        }
+        git(&dir, &["add", "-A", "."]);
+        git(&dir, &["commit", "-q", "-m", "seed"]);
+
+        let repo = discover_repo(&dir).unwrap();
+        for name in names {
+            assert!(!path_is_dirty(&repo, Path::new(name)), "{name} is committed and unmodified");
+        }
+        for name in names {
+            std::fs::write(dir.join(name), "pub fn a2() {}\n").unwrap();
+            assert!(
+                path_is_dirty(&repo, Path::new(name)),
+                "{name} has uncommitted edits and must not be read as a pattern"
+            );
+        }
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -80,16 +80,6 @@ pub(crate) fn repo_relative_path_to_config_path(
     worktree_root.join(path).strip_prefix(config_root).ok().map(Path::to_path_buf)
 }
 
-pub(crate) fn matches_simple_pattern(path: &str, pattern: &str) -> bool {
-    if let Some(extension) = pattern.strip_prefix("**/*.") {
-        return path.ends_with(&format!(".{extension}"));
-    }
-    if let Some(prefix) = pattern.strip_suffix("/**") {
-        return path.starts_with(prefix);
-    }
-    path == pattern || path.contains(pattern.trim_matches('*'))
-}
-
 /// HEAD commit sha for `root` via gix, or empty if unborn / not a repo (matching the old
 /// `rev-parse HEAD` failure behavior).
 pub(crate) fn head_sha(root: &Path) -> String {

--- a/crates/rag-rat-core/src/index/git_history/query.rs
+++ b/crates/rag-rat-core/src/index/git_history/query.rs
@@ -281,7 +281,3 @@ fn fts_query(query: &str) -> String {
         .collect::<Vec<_>>();
     if terms.is_empty() { "\"\"".to_string() } else { terms.join(" OR ") }
 }
-
-pub(super) fn path_string(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}

--- a/crates/rag-rat-core/src/index/git_history/read.rs
+++ b/crates/rag-rat-core/src/index/git_history/read.rs
@@ -1,4 +1,5 @@
-use super::query::path_string;
+use rag_rat_base::paths::path_string;
+
 use super::*;
 
 /// Walk the commit history reachable from `head` with gix (gitoxide), producing the commit records

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -454,7 +454,9 @@ fn make_symbol(
     let is_test = rag_rat_base::path_class::is_test_path(path)
         || backend.is_test_symbol(text, node, &scope_path, &name);
     ParsedSymbol {
-        qualified_name: format!("{}::{name}", path.to_string_lossy().replace('\\', "/")),
+        // `path::name` is the symbol's human-readable identity every graph and MCP surface
+        // round-trips, so the path half must be spelled exactly as `files.path` spells it.
+        qualified_name: format!("{}::{name}", rag_rat_base::paths::path_string(path)),
         scope_path,
         name,
         kind: kind.to_string(),

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -516,7 +516,9 @@ fn check_against(
     }
 
     let lang = language.as_str();
-    let in_file = path.to_string_lossy().into_owned();
+    // Through the shared seam, because `self_prefix` is compared against the indexed `path::name`
+    // ref form, and that half is rendered by `paths::path_string`.
+    let in_file = rag_rat_base::paths::path_string(path);
     let self_prefix = format!("{in_file}::"); // refs starting with this are the file's own code
 
     let mut id_set: BTreeSet<i64> = BTreeSet::new();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/backslash_file_names.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/backslash_file_names.rs
@@ -103,6 +103,82 @@ fn a_backslash_named_file_gets_its_own_row_chunks_and_qualified_names() {
     );
 }
 
+/// A memory's stored binding path is the CALLER'S OWN string — `resolve_binding` copies
+/// `bind.path` verbatim, and no writer ever put a walked path through the rendering seam on its way
+/// into `repo_memory_bindings` — so the rendering change does not move it and there is nothing for
+/// the conversion to rekey. What the change does is make the binding RESOLVE: pre-fix the two files
+/// shared one `files.path`, so a memory bound to the backslash-named one answered for whichever row
+/// survived the collision.
+///
+/// Pinned because the alternative — quarantining every path-bearing binding on upgrade — would
+/// discard correct anchors wholesale, and because the old rendering was lossy: a stored
+/// `src/foo/bar.rs` cannot be told apart from a collapsed `src/foo\bar.rs`, so no rekey is
+/// derivable even in principle.
+#[test]
+fn a_path_bound_memory_resolves_to_the_file_it_names_not_its_slash_sibling() {
+    use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    write_colliding_pair(
+        &root,
+        "pub fn nested_fn() -> i32 { 1 }\n",
+        "pub fn backslash_fn() -> i32 { 2 }\n",
+    );
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let bind_to = |path: &str, title: &str| {
+        crate::memory_write::create_memory(db.storage.connection(), RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some(path.to_string()),
+                ..RepoMemoryBindTarget::default()
+            },
+        })
+        .unwrap()
+    };
+    let backslash = bind_to(BACKSLASH_PATH, "about the backslash-named file");
+    let nested = bind_to(NESTED_PATH, "about the nested file");
+    assert_eq!(
+        backslash.memory.bindings[0].anchor_status, "current",
+        "the binding resolves against a real row, not a collapsed sibling's"
+    );
+
+    let titles = |path: &str| {
+        let mut found: Vec<String> =
+            rag_rat_query::memory::memories_for_path(db.storage.connection(), path, 10)
+                .unwrap()
+                .into_iter()
+                .map(|memory| memory.title)
+                .collect();
+        found.sort();
+        found
+    };
+    assert_eq!(
+        titles(BACKSLASH_PATH),
+        vec![backslash.memory.title.clone()],
+        "the backslash-named file surfaces only its own memory"
+    );
+    assert_eq!(
+        titles(NESTED_PATH),
+        vec![nested.memory.title.clone()],
+        "and the nested sibling surfaces only its own — neither file inherits the other's"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
 #[test]
 fn a_worktree_overlay_shadows_only_the_backslash_named_sibling() {
     // The worktree-correctness leg: main checkout and linked worktree share ONE database, and the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/backslash_file_names.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/backslash_file_names.rs
@@ -1,0 +1,162 @@
+//! A literal `\` in a Unix file name is part of the NAME, not a separator (#1032).
+//!
+//! `src/foo\bar.rs` and `src/foo/bar.rs` are two different files on Unix. The index rendered both
+//! through a blanket backslash rewrite, so both landed on the `files.path` `src/foo/bar.rs` — one
+//! row, one set of chunks, one symbol `qualified_name` namespace — and the second file indexed
+//! silently overwrote the first. Everything keyed on `files.path` inherited that collision.
+//!
+//! The whole module is Unix-only rather than each test: Windows forbids `\` in a file name, so the
+//! fixture cannot be created there at all, and gating per-item would leave the helpers below as
+//! dead code on the Windows leg.
+
+use super::*;
+
+/// The nested file and the backslash-named file, as they must be spelled in `files.path`.
+const NESTED_PATH: &str = "src/foo/bar.rs";
+const BACKSLASH_PATH: &str = "src/foo\\bar.rs";
+
+/// Write the two files under `root`: a genuinely nested `src/foo/bar.rs` and a sibling whose NAME
+/// is `foo\bar.rs`. Their symbol names differ so a collision is visible as a missing symbol rather
+/// than as identical content.
+fn write_colliding_pair(root: &Path, nested_body: &str, backslash_body: &str) {
+    fs::create_dir_all(root.join("src/foo")).unwrap();
+    fs::write(root.join("src/foo/bar.rs"), nested_body).unwrap();
+    fs::write(root.join("src").join("foo\\bar.rs"), backslash_body).unwrap();
+}
+
+/// Every `files.path` in the active scope, sorted.
+fn scoped_paths(db: &IndexDatabase) -> Vec<String> {
+    let conn = db.storage.connection();
+    let mut stmt = conn.prepare("SELECT path FROM files ORDER BY path").unwrap();
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0)).unwrap();
+    rows.filter_map(Result::ok).collect()
+}
+
+/// Symbol `qualified_name`s in the active scope, sorted. Read through the `name_strings` intern
+/// table, which is where the column lives post-V028.
+fn scoped_qualified_names(db: &IndexDatabase) -> Vec<String> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT qn.value FROM symbols s
+             JOIN files f ON f.id = s.file_id
+             JOIN name_strings qn ON qn.id = s.qualified_name_id
+             ORDER BY qn.value",
+        )
+        .unwrap();
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0)).unwrap();
+    rows.filter_map(Result::ok).collect()
+}
+
+/// Chunk ids whose file row has `path` in the active scope.
+fn scoped_chunk_ids(db: &IndexDatabase, path: &str) -> Vec<i64> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.id FROM chunks c JOIN files f ON f.id = c.file_id
+             WHERE f.path = ?1 ORDER BY c.id",
+        )
+        .unwrap();
+    let rows = stmt.query_map([path], |row| row.get::<_, i64>(0)).unwrap();
+    rows.filter_map(Result::ok).collect()
+}
+
+#[test]
+fn a_backslash_named_file_gets_its_own_row_chunks_and_qualified_names() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    write_colliding_pair(
+        &root,
+        "pub fn nested_fn() -> i32 { 1 }\n",
+        "pub fn backslash_fn() -> i32 { 2 }\n",
+    );
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // One row EACH. Before the fix the backslash file rendered as `src/foo/bar.rs` too, so the
+    // second file to be walked replaced the first and only one row survived.
+    assert_eq!(
+        scoped_paths(&db),
+        vec![NESTED_PATH.to_string(), BACKSLASH_PATH.to_string()],
+        "the nested file and the backslash-named file are two rows"
+    );
+
+    // Chunks are keyed to the file row, so a collision would leave one of the two files with none.
+    let nested_chunks = scoped_chunk_ids(&db, NESTED_PATH);
+    let backslash_chunks = scoped_chunk_ids(&db, BACKSLASH_PATH);
+    assert!(!nested_chunks.is_empty(), "the nested file has chunks");
+    assert!(!backslash_chunks.is_empty(), "the backslash-named file has chunks");
+    assert!(
+        nested_chunks.iter().all(|id| !backslash_chunks.contains(id)),
+        "the two files must not share chunks: {nested_chunks:?} vs {backslash_chunks:?}"
+    );
+
+    // `qualified_name` is `path::name` — the human-readable symbol identity every graph and MCP
+    // surface round-trips — so the collision corrupted symbol identity, not just a row.
+    assert_eq!(
+        scoped_qualified_names(&db),
+        vec![format!("{NESTED_PATH}::nested_fn"), format!("{BACKSLASH_PATH}::backslash_fn")],
+        "each file names its own symbol"
+    );
+}
+
+#[test]
+fn a_worktree_overlay_shadows_only_the_backslash_named_sibling() {
+    // The worktree-correctness leg: main checkout and linked worktree share ONE database, and the
+    // branch edits ONLY the backslash-named file. Under the collision the two files were one row,
+    // so an overlay of either shadowed both — the sibling could not be preserved.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    write_colliding_pair(
+        &main,
+        "pub fn nested_base() -> i32 { 1 }\n",
+        "pub fn backslash_base() -> i32 { 2 }\n",
+    );
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(names_in_scope(&db, NESTED_PATH), vec!["nested_base".to_string()]);
+    assert_eq!(names_in_scope(&db, BACKSLASH_PATH), vec!["backslash_base".to_string()]);
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src").join("foo\\bar.rs"), "pub fn backslash_branch() -> i32 { 3 }\n")
+        .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch edits the backslash-named file"]);
+
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "the branch's edited file is indexed as an overlay row");
+
+    // ACTIVE-CHECKOUT SCOPE: the overlay shadows the backslash-named file...
+    assert_eq!(
+        names_in_scope(&db, BACKSLASH_PATH),
+        vec!["backslash_branch".to_string()],
+        "the overlay scope sees the branch's backslash-named file"
+    );
+    // ...and leaves its untouched nested SIBLING alone.
+    assert_eq!(
+        names_in_scope(&db, NESTED_PATH),
+        vec!["nested_base".to_string()],
+        "the nested sibling is not shadowed by an edit to the backslash-named file"
+    );
+
+    // SIBLING-CHECKOUT PRESERVATION: back in the main checkout's scope, both files still read as
+    // the base committed them.
+    set_base_scope(&mut db, &main);
+    assert_eq!(
+        names_in_scope(&db, BACKSLASH_PATH),
+        vec!["backslash_base".to_string()],
+        "the base scope keeps its own backslash-named file, unshadowed by the branch"
+    );
+    assert_eq!(names_in_scope(&db, NESTED_PATH), vec!["nested_base".to_string()]);
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -969,6 +969,11 @@ fn fingerprinted_symbol_id_for_ref(db: &IndexDatabase, qualified_name: &str) -> 
         .unwrap_or_else(|e| panic!("no fingerprinted symbol id for ref {qualified_name}: {e}"))
 }
 
+// Unix-only: the fixture needs a file whose NAME contains `\`, which Windows forbids. Gating the
+// module — rather than each item inside it — keeps its helpers from becoming `dead_code` on a
+// platform where none of its tests compile in.
+#[cfg(unix)]
+mod backslash_file_names;
 mod change_coupling;
 mod chunk_store_migrations;
 mod clones;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -449,8 +449,29 @@ fn full_ladder_replay_on_a_two_repo_db_is_idempotent() {
     schema::apply(&conn, &crate::index::migration_hooks())
         .expect("full-ladder replay on a consolidated 2-repo DB must not error");
 
-    // A no-op: no meta relocated, no rows resurrected in the source tables, no files moved.
-    assert_eq!(dump_repo_meta(&conn), repo_meta_before, "the replay moved no repo_meta rows");
+    // A no-op on the identity-bearing rows, with ONE deliberate exception: V098 clears the
+    // path-rendering freshness markers (`files_base_scope_discovered`, the
+    // `git_history_indexed_root` cursor) so the next pass re-walks. That is harmless on the
+    // replay path — `index --full`, the only production caller that re-runs the ladder,
+    // re-derives them in the same command — but it does move repo_meta, so the idempotence
+    // check expects exactly those keys gone and nothing else.
+    let expected_repo_meta: Vec<_> = repo_meta_before
+        .iter()
+        .filter(|(_, key, _)| {
+            key.as_str() != rag_rat_db::meta::BASE_SCOPE_DISCOVERED_META
+                && key.as_str() != rag_rat_db::meta::GIT_HISTORY_INDEXED_ROOT_META
+        })
+        .cloned()
+        .collect();
+    assert!(
+        expected_repo_meta.len() < repo_meta_before.len(),
+        "the fixture must carry the freshness markers V098 clears, or this proves nothing",
+    );
+    assert_eq!(
+        dump_repo_meta(&conn),
+        expected_repo_meta,
+        "the replay moved no repo_meta rows beyond V098's deliberate freshness-marker invalidation",
+    );
     assert_eq!(
         conn.query_row("SELECT COUNT(*) FROM index_meta", [], |r| r.get::<_, i64>(0)).unwrap(),
         index_meta_before,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1986,7 +1986,7 @@ fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
 /// binary that did not do the work.
 #[test]
 fn migration_097_records_the_same_ladder_entry_on_every_platform() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 97, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 98, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -70,7 +70,10 @@ fn is_target_file(root: &Path, path: &Path, target: &ResolvedTarget) -> bool {
         return false;
     }
     let relative = path.strip_prefix(root).unwrap_or(path);
-    let relative = relative.to_string_lossy().replace('\\', "/");
+    // The include/exclude patterns are `/`-spelled, so match against the SAME rendering
+    // `files.path` is stored with — never a blanket backslash rewrite, which would let a pattern
+    // claim (or exclude) a Unix file whose NAME contains a backslash by pretending it is nested.
+    let relative = rag_rat_base::paths::path_string(relative);
     if target.exclude.iter().any(|pattern| matches_simple_pattern(&relative, pattern)) {
         return false;
     }
@@ -141,7 +144,7 @@ mod tests {
         let rel: Vec<String> = walk_target(&root, &target, &ignore)
             .unwrap()
             .iter()
-            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .map(|p| rag_rat_base::paths::path_string(p.strip_prefix(&root).unwrap()))
             .collect();
 
         // The `.h` header is claimed by the cpp binding (the header-resolution fix)...
@@ -171,7 +174,7 @@ mod tests {
         found.sort();
         let rel: Vec<String> = found
             .iter()
-            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .map(|p| rag_rat_base::paths::path_string(p.strip_prefix(&root).unwrap()))
             .collect();
 
         assert!(rel.contains(&"crates/app/keep.rs".to_string()), "kept: {rel:?}");
@@ -201,7 +204,7 @@ mod tests {
         let found = walk_target(&root, &target, &ignore).expect("missing dir must not error");
         let rel: Vec<String> = found
             .iter()
-            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .map(|p| rag_rat_base::paths::path_string(p.strip_prefix(&root).unwrap()))
             .collect();
         assert_eq!(rel, vec!["present/lib.rs".to_string()], "present dir indexed, missing skipped");
     }

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -74,20 +74,7 @@ fn is_target_file(root: &Path, path: &Path, target: &ResolvedTarget) -> bool {
     // `files.path` is stored with — never a blanket backslash rewrite, which would let a pattern
     // claim (or exclude) a Unix file whose NAME contains a backslash by pretending it is nested.
     let relative = rag_rat_base::paths::path_string(relative);
-    if target.exclude.iter().any(|pattern| matches_simple_pattern(&relative, pattern)) {
-        return false;
-    }
-    target.include.iter().any(|pattern| matches_simple_pattern(&relative, pattern))
-}
-
-fn matches_simple_pattern(path: &str, pattern: &str) -> bool {
-    if let Some(extension) = pattern.strip_prefix("**/*.") {
-        return path.ends_with(&format!(".{extension}"));
-    }
-    if let Some(prefix) = pattern.strip_suffix("/**") {
-        return path.starts_with(prefix);
-    }
-    path == pattern || path.contains(pattern.trim_matches('*'))
+    target.globs_claim(&relative)
 }
 
 #[cfg(test)]
@@ -207,5 +194,37 @@ mod tests {
             .map(|p| rag_rat_base::paths::path_string(p.strip_prefix(&root).unwrap()))
             .collect();
         assert_eq!(rel, vec!["present/lib.rs".to_string()], "present dir indexed, missing skipped");
+    }
+
+    /// Unix-only: Windows forbids `\` in a file name, so the fixture cannot exist there.
+    ///
+    /// Preserving the backslash in the rendering accomplishes nothing if the exclude matcher then
+    /// claims the file for a directory it is not in. `drafts/**` used to `starts_with("drafts")`,
+    /// so a real source file NAMED `drafts\secret.rs` was dropped from the walk entirely.
+    #[cfg(unix)]
+    #[test]
+    fn a_directory_exclude_does_not_claim_a_backslash_named_file() {
+        let root = tempdir();
+        write(&root.join("drafts/secret.rs"), "fn inside_drafts() {}\n");
+        write(&root.join("drafts\\secret.rs"), "fn named_with_a_backslash() {}\n");
+        write(&root.join("draftsman.rs"), "fn a_longer_name() {}\n");
+
+        let target = ResolvedTarget { exclude: vec!["drafts/**".to_string()], ..rust_target() };
+        let ignore = IgnoreMatcher::compile(&root, &target.directories);
+        let rel: Vec<String> = walk_target(&root, &target, &ignore)
+            .unwrap()
+            .iter()
+            .map(|p| rag_rat_base::paths::path_string(p.strip_prefix(&root).unwrap()))
+            .collect();
+
+        assert!(
+            !rel.contains(&"drafts/secret.rs".to_string()),
+            "a real child is excluded: {rel:?}"
+        );
+        assert!(
+            rel.contains(&"drafts\\secret.rs".to_string()),
+            "a file NAMED `drafts\\secret.rs` is not under drafts/: {rel:?}"
+        );
+        assert!(rel.contains(&"draftsman.rs".to_string()), "a name prefix is not a dir: {rel:?}");
     }
 }

--- a/crates/rag-rat-core/src/memory_write/oracle_relocation_tests.rs
+++ b/crates/rag-rat-core/src/memory_write/oracle_relocation_tests.rs
@@ -182,6 +182,39 @@ fn dir_binding_to_unindexed_dir_present_on_disk_is_current() {
     );
 }
 
+/// A bound directory is DATA, not a pattern. `_` and `%` are SQLite `LIKE` wildcards, so the
+/// unescaped child pattern `src/foo_bar/%` also matched `src/fooXbar/lib.rs` and kept a binding to
+/// a directory that exists in neither the index nor the filesystem reading `current` on the
+/// strength of an unrelated sibling.
+#[test]
+fn dir_binding_is_not_kept_alive_by_a_like_wildcard_sibling() {
+    let h = Harness::new();
+    set_source_root(&h);
+    // Indexed, but under the SIBLING the wildcard reading would fold in. Neither directory exists
+    // on disk, so the off-index filesystem fallback cannot answer for either.
+    h.add_file_in_scope("src/fooXbar/lib.rs", "", "");
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "underscore dir note".to_string(),
+        body: "nothing here".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        payload_json: None,
+        bind: RepoMemoryBindTarget { dir: Some("src/foo_bar".to_string()), ..Default::default() },
+    })
+    .unwrap();
+    validate_memories(&h.conn, None).unwrap();
+    validate_memories(&h.conn, None).unwrap();
+    let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
+    let db = memory.bindings.iter().find(|b| b.binding_kind == "dir").expect("dir binding");
+    assert_eq!(
+        db.anchor_status, "gone",
+        "an unrelated sibling matched only through a LIKE wildcard must not vouch for this dir"
+    );
+}
+
 /// #98 (dir analogue): a `dir` binding to a directory absent from index and filesystem is `gone`.
 #[test]
 fn dir_binding_to_missing_dir_is_gone() {

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1383,6 +1383,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_095_ID => Some(95),
             MIGRATION_096_ID => Some(96),
             MIGRATION_097_ID => Some(97),
+            MIGRATION_098_ID => Some(98),
             _ => None,
         })
         .max()
@@ -1489,6 +1490,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_095_ID
             | MIGRATION_096_ID
             | MIGRATION_097_ID
+            | MIGRATION_098_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1592,6 +1594,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_095_ID => migration.checksum != MIGRATION_095_CHECKSUM,
         MIGRATION_096_ID => migration.checksum != MIGRATION_096_CHECKSUM,
         MIGRATION_097_ID => migration.checksum != MIGRATION_097_CHECKSUM,
+        MIGRATION_098_ID => migration.checksum != MIGRATION_098_CHECKSUM,
         _ => false,
     }
 }
@@ -6662,6 +6665,85 @@ const V097_WORKTREE_OVERLAY_BASIS_PREFIX: &str = crate::meta::WORKTREE_OVERLAY_B
 pub const V097_PATH_VALUED_META_KEYS: &[&str] =
     &["source_root", crate::meta::GIT_HISTORY_INDEXED_ROOT_META];
 
+/// The `repo_meta` freshness markers V098 deletes to force the next ordinary index pass to
+/// re-derive the path-keyed rows an older binary keyed under a collapsed backslash spelling.
+/// Deleting the marker is the lever, not deleting the table: each gates a re-derivation the indexer
+/// already owns. `BASE_SCOPE_DISCOVERED_META` gone promotes the next pass to a full tree re-walk,
+/// which replaces `files` and everything that CASCADES from it (chunks, symbols, edges, embeddings,
+/// blame). `GIT_HISTORY_INDEXED_ROOT_META` gone fails `is_history_current`, forcing a full revwalk
+/// that re-reads the commit and file-change rows and restamps the change couplings folded off its
+/// freshness key. The `worktree_overlay_basis` keys are cleared separately (their suffix is a
+/// worktree_id, so they need a prefix match, not an equality).
+const V098_CLEARED_FRESHNESS_KEYS: &[&str] =
+    &[crate::meta::BASE_SCOPE_DISCOVERED_META, crate::meta::GIT_HISTORY_INDEXED_ROOT_META];
+
+/// V098 (#1032): make the next ordinary `index` pass re-walk the tree and reload git history, so a
+/// store written before the Unix backslash-rendering fix re-derives its path-keyed rows off the
+/// corrected spelling.
+///
+/// The pre-fix binary rendered a path by replacing every backslash with a separator — right on
+/// Windows, where a backslash IS the separator, but wrong on Unix, where a literal backslash is an
+/// ordinary filename byte. So `foo\bar.rs` was persisted as `foo/bar.rs`: one `files.path`, one
+/// `path::name` symbol identity, shared with a genuinely nested `foo/bar.rs`. That rendering was
+/// LOSSY, so unlike the Windows verbatim rekey (V097) the stored spelling cannot be repaired in
+/// place — `foo/bar.rs` in the store cannot be told apart from a rewritten `foo\bar.rs`. Only a
+/// re-walk off the corrected renderer recovers the truth, and this forces one by deleting the
+/// freshness markers that would otherwise let the pass skip an unchanged file.
+///
+/// WHAT KEEPS A PRE-FIX BINARY OFF A STORE THIS HAS CONVERTED — and why that is the whole story.
+/// The fence is the SCHEMA VERSION, the ladder's, not this migration's: recording V098 puts an id
+/// in `schema_version` a pre-V098 binary does not know, so [`super::status`] answers `Newer` and
+/// every open refuses. It reaches a resident process wherever it re-opens — a watcher pass, a CLI
+/// or MCP read — because those re-open per operation. This is the SAME fence V097 relies on for the
+/// sibling bug; that reasoning applies here unchanged, including the one bounded residual it
+/// documents: a pass already past its status check when the upgrade commits can still write once
+/// under the old rendering, self-healing on the following pass. That residual is accepted rather
+/// than closed with cross-repo write-lock enumeration, which a consolidated store cannot order.
+///
+/// LEDGER-ATOMIC because the marker deletion and the `schema_version` stamp must never be
+/// separately visible: a store whose markers are gone but whose V098 row has not landed still
+/// answers `Compatible` to a pre-V098 binary, which would re-walk under the OLD renderer and
+/// re-collapse the very spellings this exists to correct — for a moment on a healthy upgrade,
+/// indefinitely after a crash between two commits. So the body takes the ladder's transaction and
+/// opens none of its own.
+///
+/// DELIBERATELY LEFT to a read-time filter or an ordinary later pass, not swept here:
+///  * the oracle verdict tables — `edge_oracle` is joined on `file_sha = files.sha256`, so a stale
+///    row only resurfaces against a real sibling of identical content and edge geometry, and it
+///    re-derives on the next `oracle run`;
+///  * the clone posting family — rotated out by the next clone generation;
+///  * durable path-anchored DECISION data — a persisted human/model choice keyed by a path, which a
+///    reindex must not destroy. Two tables hold it today: `repo_memory_bindings` (re-anchored by
+///    the relocation engine) and `papertrail_distill_anchors` rows with `selected = 1` (a model
+///    selection the distill extractor preserves across a rerun of unchanged input, by its own V078
+///    invariant — so quarantining or regenerating them here would lose the decision, which is why
+///    the reindex leaves them). Any future table of this shape belongs in this bucket, not in the
+///    sweep.
+///
+/// Reaching any of those needs a lossy collision with a real slash-spelled sibling AND a
+/// pre-existing backslash-named Unix file — the near-impossible case the correctness fix stops from
+/// ever recurring. Without a sibling the stale row simply points at a path no file has, and is
+/// inert.
+///
+/// Runs on every platform: which spellings a store carries is a property of the store, not of the
+/// host reading it, and the ladder is forward-only, so a skip would record V098 as applied without
+/// doing the work.
+pub fn apply_reindex_after_unix_backslash_rendering(conn: &Connection) -> rusqlite::Result<()> {
+    for key in V098_CLEARED_FRESHNESS_KEYS {
+        conn.execute("DELETE FROM repo_meta WHERE key = ?1", [key])?;
+    }
+    // The overlay basis lives under one key PER checkout, its worktree_id in the suffix — a prefix
+    // match clears them all. The constant holds no `%`/`_`/`\`, so a bare LIKE needs no ESCAPE.
+    conn.execute("DELETE FROM repo_meta WHERE key LIKE ?1 || '%'", [
+        crate::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX,
+    ])?;
+    // The one path-keyed DERIVED table a file re-walk does not cascade: no FK to `files`, keyed by
+    // a bare path, re-recorded per file on the next parse. Whole-table because every row
+    // re-derives.
+    conn.execute("DELETE FROM parser_failures", [])?;
+    Ok(())
+}
+
 /// V097 (#1048): rewrite every persisted path spelling that the pre-fix `canonicalize` wrote in
 /// the Windows `\\?\` VERBATIM form into the plain spelling this binary now produces.
 ///
@@ -7217,5 +7299,75 @@ mod sync_security_events_migration_tests {
             [],
         );
         assert!(inserted.is_err(), "STRICT rejects an INTEGER in the BLOB account_id column");
+    }
+}
+
+#[cfg(test)]
+mod reindex_after_unix_backslash_rendering_tests {
+    use super::*;
+
+    /// A `repo_meta` + `parser_failures` pair minimal enough to drive the V098 body, seeded with
+    /// every marker the migration clears plus one control row it must leave untouched.
+    fn seed(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE repo_meta(
+                 repo_id TEXT NOT NULL, key TEXT NOT NULL, value TEXT NOT NULL,
+                 PRIMARY KEY(repo_id, key));
+             CREATE TABLE parser_failures(
+                 repo_id TEXT NOT NULL, path TEXT NOT NULL, PRIMARY KEY(repo_id, path));",
+        )
+        .unwrap();
+        let put = |key: &str, value: &str| {
+            conn.execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('r', ?1, ?2)",
+                rusqlite::params![key, value],
+            )
+            .unwrap();
+        };
+        put(crate::meta::BASE_SCOPE_DISCOVERED_META, "1");
+        put(crate::meta::GIT_HISTORY_INDEXED_ROOT_META, "/some/root");
+        put(
+            &format!("{}abc123", crate::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX),
+            "base\nlinked\n42",
+        );
+        // A control the migration must NOT touch: source_root is a path-valued key too, but it is a
+        // config record the next index resets from config, not a walk gate — deleting it would
+        // break reads until that pass rather than merely forcing one.
+        put("source_root", "/some/root");
+        conn.execute("INSERT INTO parser_failures(repo_id, path) VALUES ('r', 'foo/bar.rs')", [])
+            .unwrap();
+    }
+
+    fn has_key(conn: &Connection, key: &str) -> bool {
+        conn.query_row("SELECT EXISTS(SELECT 1 FROM repo_meta WHERE key = ?1)", [key], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn clears_every_freshness_marker_and_leaves_the_control_row() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed(&conn);
+
+        apply_reindex_after_unix_backslash_rendering(&conn).unwrap();
+
+        assert!(
+            !has_key(&conn, crate::meta::BASE_SCOPE_DISCOVERED_META),
+            "base-scope marker gone → the next pass re-walks the tree",
+        );
+        assert!(
+            !has_key(&conn, crate::meta::GIT_HISTORY_INDEXED_ROOT_META),
+            "history root cursor gone → the next pass full-revwalks and re-reads file changes",
+        );
+        assert!(
+            !has_key(&conn, &format!("{}abc123", crate::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX)),
+            "overlay basis gone → each linked checkout re-derives its overlay",
+        );
+        let failures: i64 =
+            conn.query_row("SELECT COUNT(*) FROM parser_failures", [], |r| r.get(0)).unwrap();
+        assert_eq!(failures, 0, "the standalone parser-failure row is cleared for re-derivation");
+        assert!(
+            has_key(&conn, "source_root"),
+            "a path record the next index resets from config, not a walk gate, is left intact",
+        );
     }
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 97;
+pub const LATEST_SCHEMA_VERSION: u32 = 98;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -732,6 +732,23 @@ const MIGRATION_097_DESCRIPTION: &str =
      kept. Runs on every host: which spellings a store carries is a property of the store, not of \
      the binary that opens it";
 
+const MIGRATION_098_ID: &str = "098_reindex_after_unix_backslash_rendering";
+const MIGRATION_098_CHECKSUM: &str = "sha256:rag-rat-reindex-after-unix-backslash-rendering-v98";
+const MIGRATION_098_DESCRIPTION: &str =
+    "Force the next ordinary index pass to re-walk the tree and reload git history, so a store an \
+     older binary wrote before the Unix backslash-rendering fix (#1032) re-derives its path-keyed \
+     rows off the corrected spelling. That binary collapsed a literal backslash in a Unix \
+     filename to a separator, so files.path and the symbol identities keyed on it could not be \
+     told apart from a genuinely nested sibling; the old rendering was lossy, so the stored \
+     spelling cannot be repaired in place — only a re-walk recovers the truth. This deletes the \
+     freshness markers that gate that work: the base-scope discovery marker (files re-walk, which \
+     cascades chunks, symbols, and edges), the git-history root cursor (a full revwalk, which \
+     re-derives the commit and file-change rows and the change couplings folded off its freshness \
+     key), and the worktree_overlay_basis keys (per-checkout overlay re-derive); it also clears \
+     parser_failures, the one path-keyed derived table a file re-walk does not cascade. Runs on \
+     every host: which spellings a store carries is a property of the store, not of the binary \
+     that opens it";
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SchemaState {
@@ -937,7 +954,8 @@ impl MigrationFn {
 /// A listed migration's body must NOT open a transaction of its own — the ladder owns one here, and
 /// `BEGIN` inside a transaction fails. `blocking_the_ledger_stamp_rolls_the_body_back` drives every
 /// entry and pins the atomicity behaviorally.
-const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID];
+const LEDGER_ATOMIC_MIGRATIONS: &[&str] =
+    &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID, MIGRATION_098_ID];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
 /// older binary can still act on (see [`LEDGER_ATOMIC_MIGRATIONS`]).
@@ -1539,6 +1557,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_097_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_windows_verbatim_path_rekey),
     },
+    Migration {
+        id: MIGRATION_098_ID,
+        checksum: MIGRATION_098_CHECKSUM,
+        description: MIGRATION_098_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_reindex_after_unix_backslash_rendering),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1759,7 +1783,7 @@ mod ledger_atomicity {
     /// test with it, so the regression that reintroduces the two-commit window would pass. These
     /// tests range over the UNION, so removing an id from production fails here instead.
     const DATA_CONVERTING_MIGRATIONS: &[&str] =
-        &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID];
+        &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID, MIGRATION_098_ID];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.
     fn ledger_atomic_under_test() -> Vec<&'static str> {
@@ -1888,11 +1912,31 @@ mod ledger_atomicity {
         hooks: &MigrationHooks,
     ) {
         let target = step.id;
-        // Poisoned AFTER the earlier migrations, so nothing relocates it out from under V097.
-        conn.execute("INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)", [
-            POISONED_SOURCE_ROOT,
-        ])
-        .unwrap();
+        // Give this target's body a change that must NOT survive a blocked stamp. Seeded AFTER the
+        // earlier migrations, so nothing relocates it out from under the probe, and per-target so
+        // it lands where that body acts: V097 converts a verbatim `source_root`, V098
+        // deletes the path-rendering freshness markers. Restated per id rather than
+        // poisoning `source_root` for everything, so V098's probe cannot re-poison the root
+        // V097 already converted.
+        if target == MIGRATION_097_ID {
+            conn.execute(
+                "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
+                [POISONED_SOURCE_ROOT],
+            )
+            .unwrap();
+        }
+        if target == MIGRATION_098_ID {
+            // The placeholder repo the registry always carries, so the `repo_meta` FK to
+            // `repo_roots` holds; V098 deletes by key regardless of repo_id.
+            conn.execute(
+                "INSERT OR REPLACE INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, '/x')",
+                rusqlite::params![
+                    rag_rat_base::repo_identity::LEGACY_REPO_ID,
+                    crate::meta::GIT_HISTORY_INDEXED_ROOT_META
+                ],
+            )
+            .unwrap();
+        }
         conn.execute_batch(&format!(
             "CREATE TRIGGER block_ledger_stamp BEFORE INSERT ON schema_version
              WHEN new.id = '{target}'

--- a/crates/rag-rat-oracle/Cargo.toml
+++ b/crates/rag-rat-oracle/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-path-slash.workspace = true
 protobuf.workspace = true
 rag-rat-base.workspace = true
 rag-rat-clones.workspace = true

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -48,8 +48,8 @@ use std::collections::hash_map::Entry;
 use std::path::Path;
 use std::time::Instant;
 
-use path_slash::PathExt as _;
 use rag_rat_base::hash::hex_sha256;
+use rag_rat_base::paths;
 use rusqlite::Connection;
 use serde::Serialize;
 use url::Url;
@@ -972,7 +972,8 @@ fn path_from_uri(root_uri: &str, uri: &str) -> Option<String> {
     let root = Url::parse(root_uri).ok()?.to_file_path().ok()?;
     let target = Url::parse(uri).ok()?.to_file_path().ok()?;
     let relative = target.strip_prefix(root).ok()?;
-    Some(relative.to_slash_lossy().into_owned())
+    // Through the shared seam, so this reads back exactly as `files.path` stored it.
+    Some(paths::path_string(relative))
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-query/src/memory/resolve.rs
+++ b/crates/rag-rat-query/src/memory/resolve.rs
@@ -134,17 +134,28 @@ pub(crate) fn resolve_dir_binding(conn: &Connection, dir: &str) -> anyhow::Resul
 
 /// Read: are there indexed files at or under `dir`?
 /// Root (`""`) matches any indexed file.
+///
+/// The child pattern is `<dir>/%`, and a bound path is DATA, not a pattern: `_` and `%` in a
+/// directory NAME are SQLite `LIKE` wildcards, so an un-escaped `src/foo_bar` also matches
+/// `src/fooXbar/…` and reports a binding to a vanished directory as still current on the strength
+/// of an unrelated sibling. Same escaping the evidence resolver applies to the same shape.
 pub(crate) fn dir_has_files(conn: &Connection, dir: &str) -> anyhow::Result<bool> {
     let n: i64 = if dir.is_empty() {
         conn.query_row("SELECT EXISTS(SELECT 1 FROM files)", [], |r| r.get(0))?
     } else {
         conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM files WHERE path = ?1 OR path LIKE ?1 || '/%')",
-            [dir],
+            "SELECT EXISTS(SELECT 1 FROM files WHERE path = ?1 OR path LIKE ?2 ESCAPE '\\')",
+            rusqlite::params![dir, format!("{}/%", like_escape(dir))],
             |r| r.get(0),
         )?
     };
     Ok(n != 0)
+}
+
+/// Escape a string for use as a SQLite `LIKE` pattern under `ESCAPE '\'`: the three special
+/// characters `\`, `%`, `_` are backslash-escaped so a path containing one matches literally.
+fn like_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
 }
 
 pub(crate) fn resolve_logical_symbol_binding(


### PR DESCRIPTION
## The bug

`rag_rat_base::paths::path_string` rendered a path by replacing **every** backslash with `/`. On Windows that is the separator normalization the index needs. On Unix a backslash is an ordinary filename character, so `src/foo\bar.rs` was persisted as `src/foo/bar.rs` — the same `files.path` a genuinely nested `src/foo/bar.rs` gets.

It is on the **write** path, so this is not a display glitch: the two files share one row identity, and everything keyed on `files.path` inherits it — chunks, edges, clone postings, memory bindings, and symbol identity itself (a qualified name is `path::name`). A repository holding both files fails its rebuild outright with `UNIQUE constraint failed: files.repo_id, files.path, …`.

## The fix

**Render only the separator.** `path_string` now goes through `path-slash`'s `to_slash_lossy`. Windows normalization is unchanged (there `\` *is* the separator and cannot occur in a name). The sites that had each inlined the same rewrite now call `path_string`, and a source scan (`paths::tests::no_inlined_separator_normalization`) fails the build if a new copy appears.

**Require a slash boundary for a directory glob.** An exclude like `drafts/**` matched `drafts\secret.md`, because the matcher stripped `/**` and did `starts_with("drafts")`. A single `globs_claim` now requires a `dir/**` prefix to end at a `/` or match exactly, replacing the two duplicate matchers.

**Name a path as a literal pathspec, not a glob.** A configured root containing `\` was handed to gix as a glob pathspec, where `\` escapes the following byte; it is now passed literally.

## Existing stores

The old rendering was lossy — a stored `foo/bar.rs` cannot be told apart from a rewritten `foo\bar.rs` — so a store an older binary wrote cannot be repaired in place; only re-walking recovers the truth.

Migration **V098** forces that re-walk on the next ordinary `index` run by deleting the freshness markers that gate it: the base-scope discovery marker (files re-walk, which cascades chunks, symbols, and edges), the git-history root cursor (a full revwalk, which re-derives the commit and file-change rows and the change couplings folded off its freshness key), and the `worktree_overlay_basis` keys (per-checkout overlay re-derive). It also clears `parser_failures`, the one path-keyed derived table a file re-walk does not cascade.

No cross-binary coexistence machinery is needed. An older binary refuses the converted store — a `schema_version` id it does not know reads as `Newer` — and the migration is ledger-atomic, so the invalidation and the version stamp are never separately visible. This is the same fence, and the same bounded residual (a pass already past its status check when the upgrade commits can write once more under the old rendering, self-healing on the next pass), that the sibling Windows verbatim-path migration V097 already relies on.

Deliberately not swept, because it is a read-time filter away or durable decision data a reindex must not destroy: the oracle verdict tables (`edge_oracle` is joined on `file_sha = files.sha256` and re-derives on the next `oracle run`), the clone posting family (rotated out by the next clone generation), and path-anchored decision rows — `repo_memory_bindings` and `papertrail_distill_anchors` rows with `selected = 1` (a model selection the distill extractor preserves across reruns by its own invariant, so quarantining or regenerating them would lose the decision). Reaching any of these needs a lossy collision with a real slash-spelled sibling of a pre-existing backslash-named file; without a sibling the stale row points at a path no file has and is inert.

## Verification

New tests, each observed failing against the pre-fix code: a backslash-named file round-trips through indexing without colliding with its slash-nested sibling, the glob matcher refuses the backslash sibling, and the migration clears exactly the freshness markers and `parser_failures` while leaving a control row intact. The full-ladder replay idempotence test is extended to expect — and to require the fixture to carry — V098's deliberate marker invalidation.

Gates: `cargo nextest run --workspace` (4600 passed), both CI clippy invocations with `-D warnings`, and nightly `cargo +nightly fmt`.

Fixes #1032
