### PR TITLE
feat(oracle): give each checkout its own live oracle sessions and worklist

### DIFF
--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -372,6 +372,9 @@ fn validate_raw(raw: RawConfig) -> Result<RawConfig, ConfigError> {
     if raw.oracle.live.max_requests_per_pass == Some(0) {
         return Err(ConfigError::OracleLiveRequestBudgetZero);
     }
+    if raw.oracle.live.max_checkouts == Some(0) {
+        return Err(ConfigError::OracleLiveCheckoutCapZero);
+    }
     Ok(raw)
 }
 

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -185,6 +185,11 @@ pub enum ConfigError {
          permanently backlogged"
     )]
     OracleLiveRequestBudgetZero,
+    #[error(
+        "[oracle.live] `max_checkouts` must be positive — zero would leave every checkout's live \
+         work permanently backlogged"
+    )]
+    OracleLiveCheckoutCapZero,
 }
 
 pub use discovery::{

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -330,6 +330,7 @@ pub(crate) struct RawOracleLive {
     enabled: Option<bool>,
     idle_shutdown_secs: Option<u64>,
     pub(crate) max_requests_per_pass: Option<u64>,
+    pub(crate) max_checkouts: Option<usize>,
 }
 
 impl From<RawOracleLive> for OracleLiveConfig {
@@ -341,6 +342,7 @@ impl From<RawOracleLive> for OracleLiveConfig {
             max_requests_per_pass: raw
                 .max_requests_per_pass
                 .unwrap_or(default.max_requests_per_pass),
+            max_checkouts: raw.max_checkouts.unwrap_or(default.max_checkouts),
         }
     }
 }

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -2777,6 +2777,7 @@ fn oracle_defaults_off_and_parses_overrides() {
             enabled: true,
             idle_shutdown_secs: 120,
             max_requests_per_pass: 50,
+            max_checkouts: 1,
         },
     });
 
@@ -2802,6 +2803,30 @@ fn oracle_live_rejects_a_zero_request_budget() {
     let path = dir.path().join("rag-rat.toml");
     std::fs::write(&path, "[oracle.live]\nenabled = true\nmax_requests_per_pass = 0\n").unwrap();
     assert!(matches!(Config::load(path), Err(ConfigError::OracleLiveRequestBudgetZero)));
+}
+
+#[test]
+fn oracle_live_serves_one_checkout_by_default_and_takes_an_override() {
+    // A resident language server per (backend x checkout) multiplies by the worktree fleet, so the
+    // shipped default serves only the checkout being edited. The knob is how an operator pays for
+    // more (#1010).
+    let default = OracleLiveConfig::default();
+    assert_eq!(default.max_checkouts, 1, "the shipped default serves one checkout");
+
+    let raw: RawConfig =
+        toml::from_str("[oracle.live]\nenabled = true\nmax_checkouts = 4\n").unwrap();
+    let oracle: OracleConfig = raw.oracle.into();
+    assert_eq!(oracle.live.max_checkouts, 4, "the override is honoured");
+}
+
+#[test]
+fn oracle_live_rejects_a_zero_checkout_cap() {
+    // Zero would admit no checkout at all, so every checkout's live work would sit in a backlog
+    // that nothing ever drains — silently, since the stage never fails a pass.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rag-rat.toml");
+    std::fs::write(&path, "[oracle.live]\nenabled = true\nmax_checkouts = 0\n").unwrap();
+    assert!(matches!(Config::load(path), Err(ConfigError::OracleLiveCheckoutCapZero)));
 }
 
 #[test]

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -250,11 +250,35 @@ pub struct OracleLiveConfig {
     /// while it runs, so this is a lock-hold bound, and a mixed-language checkout must not spend
     /// one allowance per language. The backends draw from it in a rotating order so none starves.
     pub max_requests_per_pass: u64,
+    /// How many CHECKOUTS may hold resident language servers at once (default 1). Must be
+    /// positive; zero is rejected at config load.
+    ///
+    /// A linked worktree is a different source tree, so it needs its own server rooted there —
+    /// one per (backend x checkout) is the straightforward reading and it multiplies resident
+    /// servers by the number of active worktrees. That is the resource this bounds: a language
+    /// server is routinely gigabytes, and a repo with a worktree per in-flight branch can easily
+    /// have dozens.
+    ///
+    /// The default of 1 serves the checkout being edited and no more. Checkouts with work are
+    /// ranked by how recently they had any, and one that falls outside the cap has its sessions
+    /// shut down but KEEPS its backlog, so the work is served rather than lost once it becomes
+    /// current again.
+    ///
+    /// Editing two checkouts in alternation at the default will spawn and shut down repeatedly —
+    /// raise this to cover them concurrently. The alternative (refusing to switch until some
+    /// dwell time elapsed) would starve whichever checkout is being edited NOW, which is worse
+    /// than paying for a respawn.
+    pub max_checkouts: usize,
 }
 
 impl Default for OracleLiveConfig {
     fn default() -> Self {
-        Self { enabled: false, idle_shutdown_secs: 900, max_requests_per_pass: 200 }
+        Self {
+            enabled: false,
+            idle_shutdown_secs: 900,
+            max_requests_per_pass: 200,
+            max_checkouts: 1,
+        }
     }
 }
 

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -670,9 +670,11 @@ impl IndexDatabase {
         worktree_id: &str,
         generation: i64,
     ) -> anyhow::Result<()> {
-        self.active_commit_sha = commit_sha.to_string();
-        self.active_worktree_id = worktree_id.to_string();
-        self.active_generation = generation;
+        // Install the SQL scope view FIRST, and only commit the in-memory fields once it succeeded.
+        // The two are one scope: a failed view write that had already moved `active_worktree_id`
+        // would leave every subsequent direct-scoped write stamping a scope the view does not
+        // serve, and the caller's error handling cannot tell that the handle is now lying.
+        //
         // The repo dimension comes from `self.active_repo_id` (resolved at open), not re-derived
         // from the connection — a consolidated DB's sole-repo fallback would be ambiguous. This is
         // the one caller that scopes to a SPECIFIC repo without reading it back from the context.
@@ -682,6 +684,9 @@ impl IndexDatabase {
             worktree_id: worktree_id.to_string(),
             generation,
         })?;
+        self.active_commit_sha = commit_sha.to_string();
+        self.active_worktree_id = worktree_id.to_string();
+        self.active_generation = generation;
         Ok(())
     }
 
@@ -811,7 +816,28 @@ pub fn install_scope_view(
 /// and see only the active context. The `files` view filters on `repo_id` FIRST (A3) so a
 /// consolidated DB never leaks another repo's rows through the view — every read path that goes
 /// through `temp.files` is repo-scoped for free.
+/// Install the connection's scope, ALL-OR-NOTHING.
+///
+/// The view body reads `temp.connection_context` through sub-selects at query time, so writing
+/// those rows IS the scope switch — the view recreation below is idempotent boilerplate. Four
+/// separate statements therefore have four chances to leave a MIXED scope (a new `worktree_id`
+/// beside an old `commit_sha`), and the caller's `Err` handling cannot see that: it reasonably
+/// treats a failed switch as "still on the previous scope" and keeps using the handle, which would
+/// then read across checkouts. A savepoint makes the failure mean what the caller assumes it does.
+/// Nestable on purpose — callers switch scope inside an open transaction.
 fn write_scope_view(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite::Result<()> {
+    conn.execute_batch("SAVEPOINT rag_rat_scope_view")?;
+    match write_scope_view_inner(conn, ctx) {
+        Ok(()) => conn.execute_batch("RELEASE rag_rat_scope_view"),
+        Err(err) => {
+            let _ =
+                conn.execute_batch("ROLLBACK TO rag_rat_scope_view; RELEASE rag_rat_scope_view");
+            Err(err)
+        },
+    }
+}
+
+fn write_scope_view_inner(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite::Result<()> {
     conn.execute_batch(
         "
             CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -3,6 +3,7 @@
 
 use std::path::Path;
 
+use anyhow::Context as _;
 use rag_rat_base::time::now_ms;
 use rag_rat_oracle::{
     self, OracleEvalMetrics, OracleReport, OracleStatus, OracleTool, RecallCalls, ToolManifest,
@@ -114,24 +115,46 @@ impl IndexDatabase {
                 "index has no source_root metadata; rebuild required for the live oracle pass"
             );
         };
-        // The two disagreeing means the rows describe a different checkout than the session is
-        // serving (an index carried to a new path, a root reconfigured since the last build). A
+        // The rows a pass patches must belong to the checkout its server reads. Disagreement means
+        // an index carried to a new path or a root reconfigured since the last build, and a
         // per-pass freshness patch cannot reconcile that: it would write verdicts keyed to these
-        // rows from a server reading other files. Say so rather than patching the wrong checkout.
+        // rows from a server reading other files.
         //
-        // NOTE for per-checkout live sessions (#1010): `source_root` is the MAIN checkout's root in
-        // the shared-database model, so a pass scoped to a linked worktree trips this by
-        // construction. The predicate is right — the rows a pass patches must belong to the
-        // checkout its server reads — but the implementation encodes the single-checkout
-        // assumption. The rows are already keyed by `worktree_id`; this comparison has to
-        // become worktree-aware alongside that work.
+        // WHICH checkout that is depends on the active scope (#1010). `source_root` is the MAIN
+        // checkout's root, and in the shared-database model an overlay-scoped pass legitimately
+        // reads a DIFFERENT tree — the linked worktree its rows are keyed to. So the expected root
+        // is the active scope's own checkout, and the caller must have rooted the session there.
         let indexed_root =
             indexed_root.canonicalize().unwrap_or_else(|_| indexed_root.to_path_buf());
-        if indexed_root != scope.root() {
+        // The base checkout's scope id is `worktree_id_of(indexed_root)`, not the empty string —
+        // `resolve_worktree_scope` reports the root's own id for it. (Empty means no scope has
+        // been installed on this handle yet, which is also the base.) Test it explicitly rather
+        // than letting the linked derivation below round-trip back to the same answer.
+        let base_scope = self.active_worktree_id.is_empty()
+            || self.active_worktree_id == crate::index::worktree_id_of(&indexed_root);
+        let expected_root = if base_scope {
+            indexed_root.clone()
+        } else {
+            // The linked checkout's equivalent of the indexed root — NOT the checkout root itself,
+            // which differs whenever the indexed root is a repo subdir (`<linked>/crate` vs
+            // `<linked>`). Same derivation the overlay uses to read that checkout's bytes, so the
+            // guard and the rows agree by construction.
+            let worktree = std::path::Path::new(&self.active_worktree_id);
+            crate::index::linked_source_root(&indexed_root, worktree).with_context(|| {
+                format!(
+                    "the live oracle is scoped to worktree {} but its source root could not be \
+                     resolved against the indexed root {}",
+                    self.active_worktree_id,
+                    indexed_root.display(),
+                )
+            })?
+        };
+        let expected_root = expected_root.canonicalize().unwrap_or_else(|_| expected_root.clone());
+        if expected_root != scope.root() {
             anyhow::bail!(
-                "the index was built from {} but the live oracle is scoped to {}; reindex before \
-                 the live oracle can patch these rows",
-                indexed_root.display(),
+                "the active scope's checkout is rooted at {} but the live oracle is scoped to {}; \
+                 the server must be rooted at the tree whose rows the pass patches",
+                expected_root.display(),
                 scope.root().display(),
             );
         }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -8,6 +8,7 @@ mod config_root;
 mod delta_refresh;
 mod lens_handles;
 mod lifecycle;
+mod live_oracle;
 mod logical_rebuild;
 mod quiet_window;
 mod relink;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/live_oracle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/live_oracle.rs
@@ -1,0 +1,350 @@
+//! The live-oracle stage against REAL linked worktrees sharing one database (#1010).
+//!
+//! The unit tests next to the stage exercise its bookkeeping with hand-built state. These drive
+//! the production seam instead: real checkouts, real scope switching, and the real root derivation
+//! — the parts that can only be wrong against an actual repository.
+//!
+//! No language server is assumed present, so a spawn declines and the work stays in the backlog.
+//! That is exactly the state these assert on: which checkout the stage decided to act for, where
+//! it would have rooted the server, and what scope the connection is left in.
+
+use super::*;
+
+/// A config with the live stage enabled, rooted at `root`.
+fn live_source_config(root: PathBuf) -> Config {
+    let mut config = source_config(root, Language::Rust);
+    config.oracle.live.enabled = true;
+    config
+}
+
+/// A main checkout with one committed Rust file, plus `count` linked worktrees.
+///
+/// Returns the scratch GUARDS, not bare paths: a `ScratchRoot` removes its directory on drop, so
+/// handing back only the paths would delete every checkout the moment this returns.
+fn repo_with_worktrees(count: usize, subdir: Option<&str>) -> (ScratchRoot, Vec<ScratchRoot>) {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    let src = subdir.map_or_else(|| main.join("src"), |sub| main.join(sub).join("src"));
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+
+    let linked = (0..count)
+        .map(|index| {
+            let path = unique_temp_root();
+            let _ = fs::remove_dir_all(&path);
+            let branch = format!("feat{index}");
+            run_git(&main, &["worktree", "add", "-q", "-b", &branch, path.to_str().unwrap()]);
+            path
+        })
+        .collect();
+    (main, linked)
+}
+
+/// The changed-set shape a pass produces when only a linked checkout moved: the base hint is
+/// `Some(empty)` (a reliable superset that happens to be empty), and the overlay names the paths.
+fn linked_only_change(
+    worktree: &Path,
+    paths: &[&str],
+) -> std::collections::BTreeMap<String, crate::watch::CheckoutReindex> {
+    std::collections::BTreeMap::from([(
+        crate::index::worktree_id_of(worktree),
+        crate::watch::CheckoutReindex {
+            source_root: worktree.to_path_buf(),
+            paths: paths.iter().map(PathBuf::from).collect(),
+            coverage: crate::index::ChangedPathsCoverage::Complete,
+        },
+    )])
+}
+
+#[test]
+fn a_linked_only_pass_acts_for_the_linked_checkout_and_leaves_the_base_scope_restored() {
+    // The whole point of #1010: an edit that exists only in a linked worktree must reach the live
+    // stage keyed to THAT checkout. It must also not leave the connection scoped there — the base
+    // reconcile, gc, and memory validation that follow all assume base scope.
+    let (main_dir, linked_dirs) = repo_with_worktrees(2, None);
+    let main = main_dir.canonicalize().unwrap();
+    let edited = linked_dirs[0].canonicalize().unwrap();
+    let quiet = linked_dirs[1].canonicalize().unwrap();
+    let (edited, quiet) = (&edited, &quiet);
+    let config = live_source_config(main.clone());
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let _no_server = crate::watch::suppress_live_spawn();
+    let mut tail = crate::watch::LiveOracleTail::new();
+    let empty_base = std::collections::BTreeSet::new();
+    let overlays = linked_only_change(edited, &["src/base.rs"]);
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &overlays,
+    })
+    .expect("the live stage restored the base scope");
+
+    let edited_id = crate::index::worktree_id_of(edited);
+    let roots = tail.checkout_roots();
+    assert!(
+        roots.iter().any(|(id, _)| id == &edited_id),
+        "the edited linked checkout must be the one acted for: {roots:?}",
+    );
+    assert!(
+        !roots.iter().any(|(id, _)| id == &crate::index::worktree_id_of(quiet)),
+        "an unedited sibling must not be given live state: {roots:?}",
+    );
+    assert!(
+        !roots.iter().any(|(id, _)| id.is_empty()),
+        "an empty base change set must not claim a checkout slot: {roots:?}",
+    );
+    assert_eq!(
+        tail.backlog_for(&edited_id),
+        vec!["src/base.rs".to_string()],
+        "no language server is present, so the path stays retained for a later pass",
+    );
+    assert_eq!(
+        db.active_worktree_id,
+        crate::index::worktree_id_of(&config.root),
+        "the connection must be back on the BASE scope, not left on the linked checkout (the base \
+         scope's id is the root's own, not an empty string)",
+    );
+}
+
+#[test]
+fn a_linked_checkouts_server_is_rooted_at_its_own_equivalent_of_the_config_root() {
+    // With a subdir-rooted config the checkout root and the server root differ (`<linked>` vs
+    // `<linked>/crate`). A server rooted at the checkout would initialize a workspace that does
+    // not contain the indexed sources, and the pass's own guard would then reject its verdicts.
+    let (main_dir, linked_dirs) = repo_with_worktrees(1, Some("crate"));
+    let main = main_dir.canonicalize().unwrap();
+    let linked = linked_dirs[0].canonicalize().unwrap();
+    let config = live_source_config(main.join("crate"));
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let _no_server = crate::watch::suppress_live_spawn();
+    let mut tail = crate::watch::LiveOracleTail::new();
+    let empty_base = std::collections::BTreeSet::new();
+    let overlays = linked_only_change(&linked, &["src/base.rs"]);
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &overlays,
+    })
+    .unwrap();
+
+    let edited_id = crate::index::worktree_id_of(&linked);
+    let root = tail
+        .checkout_roots()
+        .into_iter()
+        .find(|(id, _)| id == &edited_id)
+        .map(|(_, root)| root)
+        .expect("the linked checkout is held");
+    assert_eq!(
+        root,
+        linked.join("crate"),
+        "the server root is the checkout's own equivalent of config.root, not the checkout root",
+    );
+}
+
+#[test]
+fn a_linked_checkout_is_judged_against_its_own_target_bindings() {
+    // A branch may ADD a target the main checkout does not have. The live stage must judge that
+    // checkout against ITS bindings, exactly as the overlay refresh indexed it: with the main
+    // config's targets the backend's language gate rejects the added language — and that arm has
+    // already taken the backlog — so the linked edit is dropped outright rather than deferred.
+    let (main_dir, linked_dirs) = repo_with_worktrees(1, None);
+    let main = main_dir.canonicalize().unwrap();
+    let linked = linked_dirs[0].canonicalize().unwrap();
+
+    // The branch adds a TypeScript target; the main config below stays Rust-only.
+    fs::write(
+        linked.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\ntypescript = [\"web\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(linked.join("web")).unwrap();
+    fs::write(linked.join("web/app.ts"), "export function appFn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds a typescript target"]);
+
+    let config = live_source_config(main.clone());
+    assert!(
+        config.targets.iter().all(|target| target.language != Language::TypeScript),
+        "the main config must NOT carry the branch's added target, or this proves nothing",
+    );
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let _no_server = crate::watch::suppress_live_spawn();
+    let mut tail = crate::watch::LiveOracleTail::new();
+    let empty_base = std::collections::BTreeSet::new();
+    let overlays = linked_only_change(&linked, &["web/app.ts"]);
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &overlays,
+    })
+    .unwrap();
+
+    // No language server is installed, so the spawn declines and the path rides the backlog. It
+    // only gets that far if the branch's bindings were used: judged against the main config the
+    // backend returns at its language gate, having already drained the backlog.
+    assert_eq!(
+        tail.backlog_for(&crate::index::worktree_id_of(&linked)),
+        vec!["web/app.ts".to_string()],
+        "the branch's own target bindings must decide what this checkout's backends serve",
+    );
+}
+
+#[test]
+fn a_checkout_whose_work_turns_out_not_to_be_real_releases_its_slot_to_a_sibling() {
+    // The structural rule behind the whole admission story: a slot is claimed by DOING work, not
+    // by being admitted. Predicting whether a checkout's paths are real means matching everything
+    // the run checks — target membership, ignore rules, existence, whether the paths even have
+    // oracle candidates — and every approximation leaves a gap where a checkout takes the sole
+    // slot and strands a sibling. Here the gap is a stale backlog: a branch retains `.rs` work
+    // from an earlier pass and then drops the target that owned it, so nothing predicts the
+    // emptiness — it only shows up when the backend drains the worklist at its language gate
+    // (#1010).
+    let _no_server = crate::watch::suppress_live_spawn();
+    let (main_dir, linked_dirs) = repo_with_worktrees(2, None);
+    let main = main_dir.canonicalize().unwrap();
+    let stale = linked_dirs[0].canonicalize().unwrap();
+    let sibling = linked_dirs[1].canonicalize().unwrap();
+    let config = live_source_config(main.clone());
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let stale_id = crate::index::worktree_id_of(&stale);
+    let sibling_id = crate::index::worktree_id_of(&sibling);
+
+    // Serve the stale checkout FIRST, then the sibling, so the stale one is provably the
+    // longest-unserved when both are running on backlog alone — that is what makes it take the
+    // single slot in the final pass, which is the situation under test.
+    let mut tail = crate::watch::LiveOracleTail::new();
+    let empty_base = std::collections::BTreeSet::new();
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &linked_only_change(&stale, &["src/base.rs"]),
+    })
+    .unwrap();
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &linked_only_change(&sibling, &["src/base.rs"]),
+    })
+    .unwrap();
+    assert_eq!(
+        tail.backlog_for(&stale_id),
+        vec!["src/base.rs".to_string()],
+        "the first checkout is holding real work",
+    );
+    assert_eq!(
+        tail.backlog_for(&sibling_id),
+        vec!["src/base.rs".to_string()],
+        "and so is the sibling",
+    );
+
+    // The first branch now drops Rust entirely. Its retained backlog is suddenly unservable, and
+    // nothing in the incoming change set says so — the next pass brings no new paths at all.
+    fs::write(
+        stale.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[target_bindings]\ntypescript = [\"web\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(stale.join("web")).unwrap();
+    run_git(&stale, &["add", "."]);
+    run_git(&stale, &["commit", "-q", "-m", "drop the rust target"]);
+
+    // Backlog-only pass at the default cap of one.
+    let no_overlays = std::collections::BTreeMap::new();
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &no_overlays,
+    })
+    .unwrap();
+
+    assert!(
+        tail.backlog_for(&stale_id).is_empty(),
+        "the stale checkout's work drained at its language gate: {:?}",
+        tail.backlog_for(&stale_id),
+    );
+    // The point: that turn did NOT consume the single slot, so the sibling ran in the SAME pass.
+    assert!(
+        tail.served_checkouts().contains(&sibling_id),
+        "the sibling was served once the stale checkout's turn proved empty: {:?}",
+        tail.served_checkouts(),
+    );
+    assert!(
+        !tail.served_checkouts().contains(&stale_id),
+        "and the checkout that did nothing did not claim the slot: {:?}",
+        tail.served_checkouts(),
+    );
+}
+
+#[test]
+fn a_checkout_that_stops_being_a_live_sibling_drops_its_state() {
+    // `use_worktree_scope` does not fail for a worktree that has gone away — it validates the path
+    // and falls back to the BASE scope. A removed checkout would otherwise stay resident with a
+    // backlog nothing can resolve, holding a cap slot the live checkouts need.
+    let (main_dir, linked_dirs) = repo_with_worktrees(2, None);
+    let main = main_dir.canonicalize().unwrap();
+    let linked = linked_dirs[0].canonicalize().unwrap();
+    let survivor = linked_dirs[1].canonicalize().unwrap();
+    let config = live_source_config(main.clone());
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let gone_id = crate::index::worktree_id_of(&linked);
+    let survivor_id = crate::index::worktree_id_of(&survivor);
+
+    let _no_server = crate::watch::suppress_live_spawn();
+    let mut tail = crate::watch::LiveOracleTail::new();
+    let empty_base = std::collections::BTreeSet::new();
+    let overlays = linked_only_change(&linked, &["src/base.rs"]);
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &overlays,
+    })
+    .unwrap();
+    assert_eq!(
+        tail.backlog_for(&gone_id),
+        vec!["src/base.rs".to_string()],
+        "the checkout is holding work before it disappears",
+    );
+
+    // A sibling picks up work of its own, so there is something to promote into the freed slot.
+    let survivor_change = linked_only_change(&survivor, &["src/base.rs"]);
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &survivor_change,
+    })
+    .unwrap();
+
+    // The first worktree goes away.
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "prune"]);
+
+    let no_overlays = std::collections::BTreeMap::new();
+    tail.on_pass(&mut db, &config, &crate::watch::LiveChangedSets {
+        base: Some(&empty_base),
+        overlays: &no_overlays,
+    })
+    .unwrap();
+
+    assert!(
+        !tail.checkout_roots().iter().any(|(id, _)| id == &gone_id),
+        "a checkout that is no longer a live sibling must be dropped: {:?}",
+        tail.checkout_roots(),
+    );
+    // The slot it was holding is freed IN THIS PASS, not left idle: dead checkouts are dropped
+    // before the cap ranks, so the surviving sibling is promoted rather than sitting unserved —
+    // and an unserved checkout schedules no wake, so with the periodic sweep disabled its work
+    // would otherwise be stranded until an unrelated filesystem event.
+    assert_eq!(
+        tail.backlog_for(&survivor_id),
+        vec!["src/base.rs".to_string()],
+        "the surviving sibling still holds its work",
+    );
+    assert!(
+        tail.served_checkouts().contains(&survivor_id),
+        "and it was promoted into the freed slot this pass: {:?}",
+        tail.served_checkouts(),
+    );
+    assert_eq!(
+        db.active_worktree_id,
+        crate::index::worktree_id_of(&config.root),
+        "and the base scope is still restored",
+    );
+}

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -23,6 +23,7 @@
 use std::collections::{BTreeSet, HashSet};
 use std::time::{Duration, Instant};
 
+use anyhow::Context as _;
 use rag_rat_base::config::Config;
 use rag_rat_base::time::now_ms;
 use rag_rat_oracle::{LiveBackend, LiveOracleSession, LivePassReport};
@@ -30,6 +31,48 @@ use rag_rat_oracle::{LiveBackend, LiveOracleSession, LivePassReport};
 use crate::index::IndexDatabase;
 
 const LIVE_ORACLE_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+// Test-only: force every spawn to behave as "no language server installed".
+//
+// The worktree regressions assert on what the stage DECIDED — which checkout it acted for, with
+// which bindings, what it retained — not on what a server answered. Without this they silently
+// depend on the developer's toolchain: with `rust-analyzer` on `PATH` a real session is launched
+// and may drain the very backlog the assertions read, so the same test passes or fails according
+// to what happens to be installed and how fast it warms.
+//
+// Thread-local because a test owns its thread under both runners this repo uses (nextest gives
+// each test a process; the coverage job's `cargo test` gives each a thread).
+#[cfg(test)]
+thread_local! {
+    static SUPPRESS_SPAWN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+fn spawn_suppressed() -> bool {
+    SUPPRESS_SPAWN.with(std::cell::Cell::get)
+}
+
+#[cfg(not(test))]
+fn spawn_suppressed() -> bool {
+    false
+}
+
+/// Suppress live-oracle spawns for as long as the returned guard is held (test-only).
+#[cfg(test)]
+pub(crate) fn suppress_live_spawn() -> SuppressSpawnGuard {
+    SUPPRESS_SPAWN.with(|flag| flag.set(true));
+    SuppressSpawnGuard
+}
+
+#[cfg(test)]
+pub(crate) struct SuppressSpawnGuard;
+
+#[cfg(test)]
+impl Drop for SuppressSpawnGuard {
+    fn drop(&mut self) {
+        SUPPRESS_SPAWN.with(|flag| flag.set(false));
+    }
+}
 const RESPAWN_BACKOFF_MAX: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Default)]
@@ -112,56 +155,624 @@ impl LiveOracleLifecycle {
     }
 }
 
-/// Resident live-oracle state for one watcher: one [`LiveBackendTail`] per live backend. Owned by
-/// the pass-worker closure (it must outlive individual passes); the hook/CLI `maintenance_pass*`
-/// entry points pass no state, so the live stage only ever runs from the resident watcher — a
-/// one-shot CLI pass must not spawn a minutes-warming language server.
+/// One pass's changed paths, split by the checkout they belong to (#1010).
+///
+/// A linked worktree is a different source tree, so its edits can only be answered by a server
+/// rooted there. Keeping the two halves separate all the way to the session is what stops a
+/// linked checkout's paths from being handed to the main checkout's server, which would resolve
+/// them against the wrong files.
+pub(crate) struct LiveChangedSets<'a> {
+    /// The base checkout's paths, or `None` when the pass has no reliable superset (a heal or
+    /// bootstrap): live's scope is exactly "files the pass reindexed", never a whole-tree sweep.
+    pub(crate) base: Option<&'a BTreeSet<String>>,
+    /// What each visited linked checkout's overlay refresh changed, keyed by worktree id.
+    pub(crate) overlays: &'a std::collections::BTreeMap<String, crate::watch::CheckoutReindex>,
+}
+
+/// Resident live-oracle state for one watcher: a [`CheckoutTail`] per checkout being served, each
+/// holding a [`LiveBackendTail`] per live backend. Owned by the pass-worker closure (it must
+/// outlive individual passes); the hook/CLI `maintenance_pass*` entry points pass no state, so the
+/// live stage only ever runs from the resident watcher — a one-shot CLI pass must not spawn a
+/// minutes-warming language server.
 pub(crate) struct LiveOracleTail {
+    /// Checkouts with live state. Created when one first has work, dropped when it has none left
+    /// to remember. Entries are cheap (strings and counters); the expensive thing is the session,
+    /// and that is what `max_checkouts` bounds.
+    checkouts: Vec<CheckoutTail>,
+}
+
+/// One checkout's resident live state: where its servers are rooted, its per-backend sessions, and
+/// when it last had work (which is what the `max_checkouts` cap ranks on).
+struct CheckoutTail {
+    /// `""` for the base checkout; otherwise the linked checkout's worktree id, which is both its
+    /// root and the scope its overlay rows are keyed by.
+    worktree_id: String,
+    /// The directory this checkout's servers are rooted at — its own equivalent of `config.root`,
+    /// NOT the checkout root, which differs whenever `config.root` is a repo subdir.
+    root: std::path::PathBuf,
     backends: Vec<LiveBackendTail>,
-    /// Which backend claims the shared request budget first on the next pass. Rotated every pass
-    /// so a language with a constantly-large change set cannot starve the others (see
-    /// [`Self::on_pass`]).
+    /// Which backend claims first within this checkout, rotated per served pass.
     first_claim: usize,
+    /// When this checkout last received NEW changed paths — not merely when it still held a
+    /// backlog. Stamping it for a backlog would give every waiting checkout the same instant on
+    /// every pass, collapsing the ranking below onto its tie-breaks and pinning the slot to
+    /// whichever checkout already held a session.
+    last_worked_at: Instant,
+    /// When this checkout last actually ran. `None` until it has. Breaks ties among checkouts
+    /// that are only waiting, so the one kept out longest goes first instead of the lowest index.
+    last_served_at: Option<Instant>,
+    /// Whether NEW paths arrived for this checkout on the pass in flight. Transient.
+    had_new_work: bool,
+    /// Whether this pass's ranking gave this checkout a turn that amounted to something.
+    /// Recomputed every pass.
+    served: bool,
+    /// Whether this pass gave this checkout a turn it could not take. Recomputed every pass; see
+    /// [`Self::defer_turn`].
+    deferred: bool,
+    /// This checkout's effective configuration, resolved once by `absorb` when it had new paths
+    /// and reused by [`Self::run`]. `None` for the base checkout, and on a pass where this
+    /// checkout only carries a backlog (then `run` resolves it).
+    pass_config: Option<Config>,
+}
+
+impl CheckoutTail {
+    fn new(worktree_id: String, root: std::path::PathBuf, now: Instant) -> Self {
+        Self {
+            worktree_id,
+            root,
+            backends: LiveBackend::all().map(LiveBackendTail::new).collect(),
+            first_claim: 0,
+            last_worked_at: now,
+            last_served_at: None,
+            had_new_work: false,
+            served: false,
+            deferred: false,
+            pass_config: None,
+        }
+    }
+
+    /// Retain this pass's changed paths in the per-backend backlogs, whatever the cap decides.
+    ///
+    /// Retention and service are separate questions. The cap bounds resident SERVERS, so it may
+    /// legitimately decline to run a checkout this pass — but declining to run it must never
+    /// discard its edits, or an edit made in a checkout that happens to be outside the cap is lost
+    /// with nothing to retry it. Each backend takes only the paths in its own languages, the same
+    /// filter [`assemble_worklist`] applies, so a `.ts` edit never lands in the Rust backlog.
+    fn retain_changed(&mut self, changed_paths: &BTreeSet<String>) {
+        for backend in &mut self.backends {
+            let known: HashSet<&String> = backend.backlog.iter().collect();
+            let fresh: Vec<String> = changed_paths
+                .iter()
+                .filter(|path| backend.backend.claims_path(path) && !known.contains(path))
+                .cloned()
+                .collect();
+            backend.backlog.extend(fresh);
+        }
+    }
+
+    /// This checkout's share of one pass: every backend in rotating order, against a scope rooted
+    /// at THIS checkout rather than at `config.root`.
+    fn run(&mut self, db: &IndexDatabase, config: &Config, budget: &mut u64) -> bool {
+        // The base checkout already IS `config`; a linked one needs the BRANCH's configuration
+        // rooted at its own tree.
+        //
+        // Both halves matter. `for_linked_worktree_overlay` swaps in that checkout's own target
+        // set — the same source the overlay refresh indexed it from — so a branch that ADDS a
+        // target is not judged against the main checkout's bindings. Cloning the main config
+        // instead would gate the added language out entirely: the backend's language check below
+        // would fail, and that arm has already taken the backlog, so the linked edit would be
+        // dropped outright. It also builds the corpus from the wrong bindings.
+        //
+        // Rooting it at this checkout is the other half: the branch config keeps the shared base
+        // `root`, and the server must read this checkout's tree.
+        // Resolved by `absorb` when this pass brought new paths (it needed the same answer to
+        // decide admission); recomputed here only when the checkout is running a pure backlog.
+        let linked_config = self
+            .pass_config
+            .take()
+            .or_else(|| effective_config(config, &self.worktree_id, &self.root));
+        let scope_config = linked_config.as_ref().unwrap_or(config);
+        let scope = LiveScope { config: scope_config, corpus: std::cell::OnceCell::new() };
+        let mut did_work = false;
+        for index in claim_order(self.backends.len(), self.first_claim) {
+            did_work |= self.backends[index].on_pass(db, scope_config, &scope, None, budget);
+        }
+        self.first_claim = self.first_claim.wrapping_add(1);
+        did_work
+    }
+
+    /// Whether this checkout is holding anything worth keeping an entry for.
+    fn is_idle(&self) -> bool {
+        self.backends.iter().all(|backend| {
+            backend.session.is_none()
+                && backend.backlog.is_empty()
+                && backend.unconfigured_paths.is_empty()
+        })
+    }
+
+    fn has_session(&self) -> bool {
+        self.backends.iter().any(|backend| backend.session.is_some())
+    }
+
+    /// Whether this checkout has anything a pass could actually act on.
+    ///
+    /// Parked (`unconfigured_paths`) entries do NOT count. They ride along with a real worklist and
+    /// can only be re-skipped on their own, so a checkout holding nothing else would win a cap
+    /// slot, run a pass that asks the server nothing, and schedule no wake — while the sibling it
+    /// displaced is filtered out of the wake computation too. With the periodic sweep disabled that
+    /// strands the sibling's work indefinitely. Such a checkout keeps its parked paths; it just
+    /// does not compete for a slot.
+    fn has_runnable_work(&self) -> bool {
+        self.backends.iter().any(|backend| !backend.backlog.is_empty()) || self.has_session()
+    }
+
+    /// A checkout that got a turn it could not take: give up the turn and back the retry off,
+    /// KEEPING its backlog. Distinct from cap eviction, which does not spend the turn.
+    ///
+    /// Marking it `deferred` is what keeps it in [`LiveOracleTail::next_wake_in`]. An unranked
+    /// checkout is deliberately excluded from that — waking sooner cannot help a checkout a
+    /// sibling is blocking — but this one HAD the slot, so its backoff is a real retry deadline
+    /// and nothing else will necessarily schedule the pass that honours it.
+    fn defer_turn(&mut self, now: Instant, reason: &'static str) {
+        self.evict_sessions(reason);
+        self.last_served_at = Some(now);
+        self.deferred = true;
+        for backend in &mut self.backends {
+            backend.lifecycle.on_failure(now);
+        }
+    }
+
+    /// Shut every resident server for this checkout down, keeping backlogs intact.
+    fn evict_sessions(&mut self, reason: &'static str) {
+        for backend in &mut self.backends {
+            if let Some(session) = backend.session.take() {
+                tracing::info!(
+                    target: "rag_rat_core::watch",
+                    tool = backend.tool_name(),
+                    checkout = %self.root.display(),
+                    reason,
+                    "live oracle: shutting a resident server down"
+                );
+                backend.lifecycle.on_session_ended();
+                session.shutdown();
+            }
+        }
+    }
 }
 
 impl LiveOracleTail {
     pub(crate) fn new() -> Self {
-        Self { backends: LiveBackend::all().map(LiveBackendTail::new).collect(), first_claim: 0 }
+        Self { checkouts: Vec::new() }
     }
 
     /// Delay until the watcher should run another pass without waiting for a filesystem event —
-    /// the EARLIEST any backend needs one, since a single pass services them all.
+    /// the EARLIEST any backend of any checkout needs one, since a single pass services them all.
     pub(crate) fn next_wake_in(&self, config: &Config, now: Instant) -> Option<Duration> {
         if !config.oracle.live.enabled {
             return None;
         }
         let idle = Duration::from_secs(config.oracle.live.idle_shutdown_secs);
-        self.backends.iter().filter_map(|backend| backend.next_wake_in(idle, now)).min()
+        self.checkouts
+            .iter()
+            // Checkouts that got a turn schedule a wake; ones that lost the ranking do not.
+            // An unranked checkout's backlog cannot be drained by waking sooner — it is held out
+            // precisely because a sibling owns the slot — so scheduling on its behalf would wake
+            // the watcher on a cadence no pass can satisfy. It is picked up by a pass that happens
+            // anyway: the served checkout's own idle-shutdown wake, or the periodic sweep.
+            //
+            // A DEFERRED checkout is the opposite case and must be included: it HAD its turn and
+            // could not take it because the checkout was unreachable, so its backoff is a real
+            // retry deadline. Excluding it meant that when every retained checkout was
+            // unreachable, nothing scheduled a pass at all and the work stayed stranded even
+            // after the checkouts came back.
+            .filter(|checkout| checkout.served || checkout.deferred)
+            .flat_map(|checkout| checkout.backends.iter())
+            .filter_map(|backend| backend.next_wake_in(idle, now))
+            .min()
     }
 
-    /// One pass's live stage, for every backend in turn.
+    /// One pass's live stage: every checkout with work, and every backend within it.
     ///
-    /// `max_requests_per_pass` bounds the whole MAINTENANCE PASS, not each backend: the pass holds
-    /// the repository write lock while it runs, so the cap is a lock-hold guarantee and giving
-    /// every backend its own copy would multiply the real bound by the number of live languages.
-    /// The backends therefore draw from ONE budget, and the order rotates each pass so a language
-    /// with a perpetually-large change set cannot starve the rest (whatever a backend does not
-    /// reach stays in its own backlog).
+    /// `max_requests_per_pass` bounds the whole MAINTENANCE PASS, not each backend and not each
+    /// checkout: the pass holds the repository write lock while it runs, so the cap is a lock-hold
+    /// guarantee, and giving every (checkout, backend) pair its own copy would multiply the real
+    /// bound by the size of the worktree fleet. Everything draws from ONE budget, and both
+    /// rotations advance each pass so no checkout or language starves.
+    ///
+    /// `max_checkouts` bounds resident SERVERS, which is the memory cost. Checkouts are ranked by
+    /// how recently they had work; those outside the cap have their sessions shut down but keep
+    /// their backlogs, so their work is deferred rather than lost.
     pub(crate) fn on_pass(
         &mut self,
-        db: &IndexDatabase,
+        db: &mut IndexDatabase,
         config: &Config,
-        changed_paths: Option<&BTreeSet<String>>,
-    ) {
+        changed: &LiveChangedSets<'_>,
+    ) -> anyhow::Result<()> {
         if !config.oracle.live.enabled {
+            return Ok(());
+        }
+        let now = Instant::now();
+        self.absorb(config, changed, now);
+        // BEFORE ranking, not while serving: a checkout whose worktree is gone must not be given a
+        // slot that then goes unused. Detecting it inside the serve loop meant the cap had already
+        // been spent on it, the sibling that should have had the slot stayed unserved — and an
+        // unserved checkout schedules no wake, so with the periodic sweep disabled its work was
+        // stranded until an unrelated filesystem event.
+        self.drop_dead_checkouts(config);
+
+        let cap = config.oracle.live.max_checkouts.max(1);
+        let mut budget = config.oracle.live.max_requests_per_pass;
+        let mut scope_switched = false;
+        let mut slots_used = 0usize;
+        for checkout in &mut self.checkouts {
+            checkout.served = false;
+            checkout.deferred = false;
+        }
+        // Rank order decides WHO gets a turn; the cap counts turns that amounted to something.
+        //
+        // A slot is claimed by doing work, not by being admitted. Predicting up front whether a
+        // checkout's paths are real work means matching, exactly, everything the run will check —
+        // target membership, ignore rules, file existence, whether the paths even have oracle
+        // candidates — and every approximation of that leaves a gap where a checkout takes the
+        // sole slot, resolves nothing, and strands a sibling's genuine backlog. Observing the
+        // outcome closes all of those at once, and lets admission stay a cheap filter.
+        for index in self.rank() {
+            if slots_used >= cap {
+                break;
+            }
+            // Point the connection at THIS checkout's rows before its servers answer for them:
+            // `run_live_oracle_pass` writes verdicts keyed to the active scope, and its guard
+            // checks that scope against the tree the session reads.
+            let worktree = (!self.checkouts[index].worktree_id.is_empty())
+                .then(|| std::path::PathBuf::from(&self.checkouts[index].worktree_id));
+            if let Err(err) = db.use_worktree_scope(&config.root, worktree.as_deref()) {
+                tracing::warn!(
+                    target: "rag_rat_core::watch",
+                    checkout = %self.checkouts[index].root.display(),
+                    error = %err,
+                    "live oracle: could not scope the connection to this checkout; deferring it"
+                );
+                // Not a bare `continue`: that left the checkout neither served nor deferred, so
+                // it scheduled no wake and its retained backlog was never retried once the
+                // periodic sweep is off. A failed switch is the same kind of event as an
+                // unreachable checkout — the turn is spent, the work is kept, the retry backs off.
+                self.checkouts[index].defer_turn(now, "scope switch failed");
+                continue;
+            }
+            scope_switched = true;
+            // `use_worktree_scope` does NOT fail for a worktree that has gone away: by contract it
+            // validates the path and silently falls back to the BASE scope. So a checkout removed
+            // while it still held a backlog would land here scoped to base, get its pass rejected
+            // by the root guard (the session reads a tree the rows no longer belong to), requeue
+            // the work, and stay resident forever — occupying a slot the live checkouts need. The
+            // scope we actually landed on is the authority on whether this checkout still exists.
+            //
+            // The base checkout's own scope id is NOT the empty string: `resolve_worktree_scope`
+            // reports `worktree_id_of(config.root)` for it. `""` is this module's sentinel for
+            // "the base checkout", so it has to be translated before the comparison — otherwise
+            // the base checkout looks stale on every pass and is dropped.
+            let expected_active = if self.checkouts[index].worktree_id.is_empty() {
+                crate::index::worktree_id_of(&config.root)
+            } else {
+                self.checkouts[index].worktree_id.clone()
+            };
+            if db.active_worktree_id != expected_active {
+                // Reaching here means the checkout is REGISTERED (the liveness pass above kept it)
+                // but its tree could not be validated right now — a worktree on an unmounted or
+                // briefly unreadable path. That is a deferral, NOT a removal: forgetting its
+                // backlog would lose work nothing can rebuild, because a checkout that returns
+                // with the same contents produces no changed paths for the overlay refresh to
+                // report. Removal is `drop_dead_checkouts`'s call, made from the live set.
+                //
+                // Its turn IS spent, though, and the backoff slows the retry — otherwise an
+                // unreachable checkout would win the slot every pass and never yield it.
+                tracing::info!(
+                    target: "rag_rat_core::watch",
+                    checkout = %self.checkouts[index].root.display(),
+                    "live oracle: this checkout is registered but not reachable right now; \
+                     deferring its work"
+                );
+                self.checkouts[index].defer_turn(now, "checkout not reachable");
+                continue;
+            }
+            // The work is already in the backlogs; the pass reads it from there.
+            let did_work = self.checkouts[index].run(db, config, &mut budget);
+            self.checkouts[index].last_served_at = Some(now);
+            // Did that turn amount to anything? If not — its work evaporated at a gate, or the
+            // changed files carried no oracle candidates — it must not hold a slot a sibling
+            // could use THIS pass. The verdict comes from what the backends DID (a request
+            // issued, or work still queued), not from the state left behind: a session spawned
+            // only to discover there was nothing to ask is exactly the case that must not count.
+            if did_work {
+                self.checkouts[index].served = true;
+                slots_used += 1;
+            } else if self.checkouts[index].has_session() {
+                // The turn spawned a server and then had nothing to ask it. Release it HERE, not
+                // in the cleanup after the loop: the loop is about to give the freed slot to the
+                // next checkout, which may spawn a server of its own, so deferring the eviction
+                // would let a single pass hold one resident server per no-op checkout at once —
+                // precisely the ceiling `max_checkouts` exists to impose.
+                self.checkouts[index].evict_sessions("turn resolved nothing");
+            }
+        }
+        // Sessions of checkouts that never got a turn: the cap is a bound on RESIDENT SERVERS, so
+        // one that is not being served must not keep one alive. Backlogs are untouched.
+        for checkout in &mut self.checkouts {
+            if !checkout.served && checkout.has_session() {
+                checkout.evict_sessions("checkout cap reached");
+            }
+            // The per-pass config cache must not outlive the pass that resolved it — a branch can
+            // change its bindings between passes.
+            checkout.pass_config = None;
+        }
+        // Forget checkouts holding nothing — no session, no backlog, no parked paths. A worktree
+        // edited once must not keep an entry forever.
+        self.checkouts.retain(|checkout| !checkout.is_idle());
+        // Restore the base scope for the rest of the pass. Unlike everything else in this stage
+        // this is NOT best-effort: the base reconcile, gc, and memory validation that follow all
+        // assume base scope, and running them against a linked checkout's view would write
+        // base-intended rows into an overlay. Failing the pass is recoverable — the next one
+        // retries; proceeding on the wrong scope is not.
+        if scope_switched {
+            db.use_worktree_scope(&config.root, None).context(
+                "live oracle: could not restore the base scope after the live stage; the rest of \
+                 the maintenance pass would have run against a linked checkout's view",
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Forget linked checkouts that are no longer live siblings of the repo.
+    ///
+    /// Their backlogs name paths in a tree that is gone, so no pass can ever resolve them; left in
+    /// place they keep competing for a cap slot. Only consulted when a LINKED checkout is actually
+    /// held — the base checkout is never in the live set's linked half, and the common case (no
+    /// linked live state) must not pay for a repo walk on every pass.
+    fn drop_dead_checkouts(&mut self, config: &Config) {
+        if !self.checkouts.iter().any(|checkout| !checkout.worktree_id.is_empty()) {
             return;
         }
-        let mut budget = config.oracle.live.max_requests_per_pass;
-        let scope = LiveScope { config, corpus: std::cell::OnceCell::new() };
-        for index in claim_order(self.backends.len(), self.first_claim) {
-            self.backends[index].on_pass(db, config, &scope, changed_paths, &mut budget);
+        let (_, live) = crate::index::live_worktree_contexts(&config.root);
+        self.checkouts.retain_mut(|checkout| {
+            if checkout.worktree_id.is_empty() || live.contains(&checkout.worktree_id) {
+                return true;
+            }
+            tracing::info!(
+                target: "rag_rat_core::watch",
+                checkout = %checkout.root.display(),
+                "live oracle: this checkout is no longer a live sibling; dropping its state"
+            );
+            checkout.evict_sessions("checkout no longer a live sibling");
+            false
+        });
+    }
+
+    /// Fold this pass's changed sets into per-checkout state: create entries for checkouts that
+    /// now have work, and retain their paths in the per-backend backlogs.
+    fn absorb(&mut self, config: &Config, changed: &LiveChangedSets<'_>, now: Instant) {
+        let mut pass_changed = std::collections::BTreeMap::new();
+        if let Some(base) = changed.base {
+            pass_changed.insert(String::new(), base.clone());
         }
-        self.first_claim = self.first_claim.wrapping_add(1);
+        for (worktree_id, entry) in changed.overlays {
+            // A PARTIAL report is used, not discarded. Its coverage flag says the list may be
+            // MISSING paths (the checkout's working-tree status read failed, so dirty, untracked,
+            // and deleted files never became candidates) — it does not say the listed paths are
+            // doubtful. The committed tree-diff half still ran, and every path here had its
+            // overlay row written, so the list is SOUND and merely incomplete.
+            //
+            // That distinction is what this stage needs. A best-effort freshness patch loses
+            // nothing by refreshing a subset: doing some of the work is the same soundness
+            // direction as the backlog, and the omitted half surfaces on the next refresh (a
+            // partial pass clears the overlay basis, so one is guaranteed). Dropping the entry
+            // instead threw away work that was known stale AND known which — and, since a
+            // non-empty backlog is what schedules the next wake, left nothing to schedule one.
+            //
+            // Do NOT widen a partial report to a whole-checkout sweep: unknown is not the same as
+            // everything, and that sweep is the batch pass's job, not something to run under the
+            // maintenance pass's write lock.
+            if entry.paths.is_empty() {
+                continue;
+            }
+            pass_changed.insert(
+                worktree_id.clone(),
+                entry.paths.iter().map(|path| path.to_string_lossy().into_owned()).collect(),
+            );
+        }
+        // Admit only checkouts a pass would actually DO something for — judged by that checkout's
+        // OWN configuration, which is also the configuration its backends will run under. See
+        // `would_serve`: "nonempty" and "the extension looks live" are both too weak, and each
+        // false admission is a cap slot spent on a checkout that resolves nothing while a sibling
+        // with real work stays unserved.
+        //
+        // The effective config is resolved ONCE here and handed to the run below, so the branch's
+        // `rag-rat.toml` is read at most once per checkout per pass.
+        let mut admitted = Vec::new();
+        for (worktree_id, paths) in std::mem::take(&mut pass_changed) {
+            // An already-held checkout keeps the root it was created with: re-deriving it every
+            // pass would repeat the repo discovery, and a transient failure would drop a checkout
+            // that is perfectly fine.
+            let existing_root = self
+                .checkouts
+                .iter()
+                .find(|checkout| checkout.worktree_id == worktree_id)
+                .map(|checkout| checkout.root.clone());
+            let Some(root) = existing_root.or_else(|| checkout_root(config, &worktree_id)) else {
+                continue;
+            };
+            let effective = effective_config(config, &worktree_id, &root);
+            if !would_serve(effective.as_ref().unwrap_or(config), &paths) {
+                continue;
+            }
+            admitted.push((worktree_id, paths, root, effective));
+        }
+        for (worktree_id, paths, root, effective) in admitted {
+            if !self.checkouts.iter().any(|checkout| checkout.worktree_id == worktree_id) {
+                self.checkouts.push(CheckoutTail::new(worktree_id.clone(), root, now));
+            }
+            if let Some(checkout) =
+                self.checkouts.iter_mut().find(|checkout| checkout.worktree_id == worktree_id)
+            {
+                checkout.pass_config = effective;
+            }
+            pass_changed.insert(worktree_id, paths);
+        }
+        // ...and RETAIN its paths before the cap gets a say. The cap decides which checkouts are
+        // SERVED, never which are remembered: an edit in a checkout that happens to fall outside
+        // it must wait, not vanish. Doing this after the cap check (or only inside the per-backend
+        // pass, which unserved checkouts never reach) silently dropped those edits, leaving
+        // nothing to retry them.
+        for checkout in &mut self.checkouts {
+            let Some(paths) = pass_changed.get(&checkout.worktree_id) else {
+                checkout.had_new_work = false;
+                continue;
+            };
+            checkout.retain_changed(paths);
+            checkout.had_new_work = true;
+            checkout.last_worked_at = now;
+        }
+    }
+
+    /// Mark which checkouts run this pass, and shut down the servers of those that do not.
+    ///
+    /// Ranking, in order:
+    ///
+    /// 1. checkouts that received NEW paths this pass, so the one being edited right now keeps its
+    ///    warm server;
+    /// 2. among those, the most recently worked;
+    /// 3. then the one kept waiting longest — never-served first.
+    ///
+    /// Rule 3 is what stops a waiting checkout from starving. Ranking on "still has a backlog"
+    /// instead would stamp every waiting checkout with the same instant on every pass, collapsing
+    /// the order onto its tie-breaks and handing the slot to whichever checkout already held a
+    /// session — permanently, since holding a session is exactly what such a tie-break rewards.
+    ///
+    /// A checkout outside the cap while another is edited continuously is still not served until
+    /// that editing pauses. It does not spin the watcher meanwhile: an unadmitted checkout
+    /// schedules no wake (see [`Self::next_wake_in`]), so its backlog waits for a pass that
+    /// happens anyway — the served checkout's own idle-shutdown wake, or the periodic sweep, the
+    /// same backstop the overlay quiet window relies on.
+    fn rank(&self) -> Vec<usize> {
+        // Only checkouts with something to run compete. A checkout holding nothing but parked
+        // paths would otherwise spend a turn on a pass that asks its server nothing.
+        let mut ranked: Vec<usize> = (0..self.checkouts.len())
+            .filter(|&index| self.checkouts[index].has_runnable_work())
+            .collect();
+        ranked.sort_by(|&left, &right| {
+            let (a, b) = (&self.checkouts[left], &self.checkouts[right]);
+            // New work first — the checkout being edited right now.
+            b.had_new_work
+                .cmp(&a.had_new_work)
+                .then_with(|| {
+                    if a.had_new_work {
+                        // Both are being edited: the more recent one leads.
+                        b.last_worked_at.cmp(&a.last_worked_at)
+                    } else {
+                        // Both are only WAITING, so service age decides and nothing else may
+                        // outrank it. Comparing historical work recency first would let a
+                        // checkout that was edited more recently — and already served for it —
+                        // keep beating one that has never run, which is the starvation this
+                        // ordering exists to prevent. `None` (never served) sorts first.
+                        a.last_served_at.cmp(&b.last_served_at)
+                    }
+                })
+                .then_with(|| a.last_served_at.cmp(&b.last_served_at))
+                .then_with(|| left.cmp(&right))
+        });
+        ranked
+    }
+}
+
+#[cfg(test)]
+impl LiveOracleTail {
+    /// `(worktree id, server root)` for every checkout this tail is holding. The shared-database
+    /// worktree regressions live where the git fixtures are, so they reach the state through here.
+    pub(crate) fn checkout_roots(&self) -> Vec<(String, std::path::PathBuf)> {
+        self.checkouts
+            .iter()
+            .map(|checkout| (checkout.worktree_id.clone(), checkout.root.clone()))
+            .collect()
+    }
+
+    /// The worktree ids the last pass's cap admitted.
+    pub(crate) fn served_checkouts(&self) -> Vec<String> {
+        self.checkouts
+            .iter()
+            .filter(|checkout| checkout.served)
+            .map(|checkout| checkout.worktree_id.clone())
+            .collect()
+    }
+
+    /// Every path a checkout is still holding, across its backends.
+    pub(crate) fn backlog_for(&self, worktree_id: &str) -> Vec<String> {
+        let mut paths: Vec<String> = self
+            .checkouts
+            .iter()
+            .filter(|checkout| checkout.worktree_id == worktree_id)
+            .flat_map(|checkout| checkout.backends.iter())
+            .flat_map(|backend| backend.backlog.iter().cloned())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+}
+
+/// A checkout's effective configuration: the BRANCH's target bindings, rooted at its own tree.
+/// `None` for the base checkout, which `config` already describes.
+fn effective_config(config: &Config, worktree_id: &str, root: &std::path::Path) -> Option<Config> {
+    (!worktree_id.is_empty()).then(|| Config {
+        root: root.to_path_buf(),
+        ..config.for_linked_worktree_overlay(std::path::Path::new(worktree_id))
+    })
+}
+
+/// Whether a pass would actually DO anything with `paths` in a checkout configured by `cfg`: does
+/// SOME PATH belong to a target this checkout indexes, in a language a live backend resolves?
+///
+/// Asked per path through `target_for_path` — the same membership predicate indexing itself uses,
+/// so directories, includes, and excludes all count. Weaker approximations keep producing the same
+/// bug in narrower forms, because each gap between this predicate and the real one is a cap slot
+/// spent on a checkout that resolves nothing while a sibling's real work waits:
+///
+/// - "the changed set is nonempty" admits a checkout that only changed markdown;
+/// - "some live backend claims the extension" admits one whose branch dropped that language
+///   entirely, since the pruned sources still end in `.rs`;
+/// - "some target is Rust AND some path ends in `.rs`" admits one that dropped the target those
+///   particular paths lived under, because the two halves are independent.
+///
+/// Matching each path against its own target closes the class rather than the instance.
+fn would_serve(cfg: &Config, paths: &BTreeSet<String>) -> bool {
+    paths.iter().any(|path| {
+        crate::index::target_for_path(cfg, std::path::Path::new(path)).is_some_and(
+            |(language, _kind)| {
+                LiveBackend::all().any(|backend| backend.resolves_language(language))
+            },
+        )
+    })
+}
+
+/// Where a checkout's servers are rooted: its own equivalent of `config.root`.
+///
+/// For a linked worktree that is NOT the checkout root — with a subdir-rooted config the two are
+/// `<linked>/crate` and `<linked>`, and a server rooted at the latter would initialize a workspace
+/// that does not contain the indexed sources. Same derivation the overlay uses to read that
+/// checkout's bytes, so the session and the rows it patches agree.
+fn checkout_root(config: &Config, worktree_id: &str) -> Option<std::path::PathBuf> {
+    if worktree_id.is_empty() {
+        return Some(config.root.clone());
+    }
+    match crate::index::linked_source_root(&config.root, std::path::Path::new(worktree_id)) {
+        Ok(root) => Some(root),
+        Err(err) => {
+            tracing::debug!(
+                target: "rag_rat_core::watch",
+                worktree = worktree_id,
+                error = %err,
+                "live oracle: could not resolve a linked checkout's source root; skipping it"
+            );
+            None
+        },
     }
 }
 
@@ -236,6 +847,10 @@ struct LiveBackendTail {
 const WARMING_PASSES_BEFORE_REPORT: u32 = 5;
 
 impl LiveBackendTail {
+    fn tool_name(&self) -> &'static str {
+        self.backend.tool.as_db_str()
+    }
+
     fn new(backend: LiveBackend) -> Self {
         Self {
             backend,
@@ -353,6 +968,11 @@ impl LiveBackendTail {
     /// This backend's share of one pass: resolve pending work, or shut an otherwise-workless
     /// session down once idle. Never returns an error — a failure is logged and the work rides
     /// the next pass.
+    ///
+    /// Returns whether the turn AMOUNTED to anything: it issued at least one request, or it still
+    /// holds work to retry. Holding a session is deliberately not enough — a changed file with no
+    /// call candidates spawns a server, asks it nothing, and finishes with an empty backlog, and
+    /// that must not consume a checkout slot a sibling could use (see `CheckoutTail::run`).
     fn on_pass(
         &mut self,
         db: &IndexDatabase,
@@ -360,7 +980,7 @@ impl LiveBackendTail {
         scope: &LiveScope<'_>,
         changed_paths: Option<&BTreeSet<String>>,
         budget: &mut u64,
-    ) {
+    ) -> bool {
         let live_cfg = &config.oracle.live;
         let now = Instant::now();
         let started_at_ms = now_ms();
@@ -387,18 +1007,18 @@ impl LiveBackendTail {
                 self.lifecycle.on_session_ended();
                 session.shutdown();
             }
-            return;
+            return false;
         }
         // An earlier backend spent the pass's whole request allowance. Keep this backend's work
         // (a spawn + a zero-budget pass would only defer it again, after paying a language-server
         // warm-up) and let the rotation give it first claim on a later pass.
         if *budget == 0 {
             self.backlog = worklist;
-            return;
+            return true;
         }
         // One of this backend's languages must be indexed in the checkout (clangd serves two).
         if !config.targets.iter().any(|target| self.backend.resolves_language(target.language)) {
-            return;
+            return false;
         }
         // Past every cheap gate, so this pass really is going to talk to a server: NOW the corpus
         // is worth compiling.
@@ -406,10 +1026,10 @@ impl LiveBackendTail {
 
         // Spawn the session lazily on the first eligible pass. A decline leaves the work in the
         // backlog for a later pass — the same degrade-quietly UX as a missing embedding model.
-        if self.session.is_none() {
+        if self.session.is_none() && !spawn_suppressed() {
             if !self.lifecycle.can_respawn(now) {
                 self.backlog = worklist;
-                return;
+                return true;
             }
             match LiveOracleSession::spawn(self.backend.tool, scope) {
                 Ok(session) => {
@@ -436,7 +1056,7 @@ impl LiveBackendTail {
         let Some(session) = &mut self.session else {
             self.backlog = worklist;
             self.lifecycle.on_failure(Instant::now());
-            return;
+            return true;
         };
         // A session exists, so whatever blocked earlier is resolved; report it again if it returns.
         self.prerequisite_reported = false;
@@ -495,6 +1115,11 @@ impl LiveBackendTail {
                         "live oracle pass"
                     );
                 }
+                // Did this turn amount to anything? A request issued, or work still queued (a
+                // warming server defers its whole worklist, so it counts). A session that was
+                // spawned only to find the changed file has no call candidates does NOT — it
+                // would otherwise hold the checkout slot until its idle shutdown.
+                report.requests_used > 0 || !self.backlog.is_empty()
             },
             Err(err) => {
                 // A DB-side failure (the only `Err`): drop the session so the next pass
@@ -509,6 +1134,7 @@ impl LiveBackendTail {
                     error = %err,
                     "live oracle pass failed; worklist deferred to the next pass"
                 );
+                true
             },
         }
     }
@@ -599,6 +1225,23 @@ mod tests {
         LiveBackend::for_tool(tool).expect("a live backend")
     }
 
+    /// A tail holding one checkout, for the tests that exercise BACKEND-level behaviour (backlog,
+    /// backoff, wake scheduling). Those properties are per backend within a checkout and are
+    /// unchanged by the per-checkout split.
+    fn single_checkout_tail(now: Instant) -> LiveOracleTail {
+        LiveOracleTail {
+            checkouts: vec![CheckoutTail::new(
+                String::new(),
+                std::path::PathBuf::from("/repo"),
+                now,
+            )],
+        }
+    }
+
+    fn backends_of(tail: &mut LiveOracleTail) -> &mut Vec<LiveBackendTail> {
+        &mut tail.checkouts[0].backends
+    }
+
     #[test]
     fn worklist_dedupes_backlog_against_changed_and_filters_other_languages() {
         let rust = backend(rag_rat_oracle::OracleTool::RaLsp);
@@ -657,15 +1300,17 @@ mod tests {
     fn the_tail_wakes_for_the_earliest_backend_that_needs_one() {
         // A single pass services every backend, so the tail's deadline is the minimum across
         // them — a backend with a backlog must not wait for another backend's longer idle timer.
-        let mut tail = LiveOracleTail::new();
-        assert!(tail.backends.len() >= 2, "the multi-backend case must actually be exercised");
         let now = Instant::now();
+        let mut tail = single_checkout_tail(now);
+        assert!(
+            backends_of(&mut tail).len() >= 2,
+            "the multi-backend case must actually be exercised"
+        );
         let idle = Duration::from_secs(600);
         // One backend holds a backlog (retry cadence); another holds an idle session.
-        tail.backends[0].backlog.push("src/a.rs".to_string());
-        tail.backends[1].lifecycle.on_spawned(now);
-        let earliest = tail
-            .backends
+        backends_of(&mut tail)[0].backlog.push("src/a.rs".to_string());
+        backends_of(&mut tail)[1].lifecycle.on_spawned(now);
+        let earliest = backends_of(&mut tail)
             .iter()
             .filter_map(|backend| backend.next_wake_in(idle, now))
             .min()
@@ -909,15 +1554,543 @@ mod tests {
         assert!(tail.unconfigured_paths.is_empty(), "it is in the backlog, not parked twice");
     }
 
+    /// A tail carrying two checkouts, both with a backlog so both count as having work.
+    fn two_checkout_tail(now: Instant) -> LiveOracleTail {
+        let mut tail = LiveOracleTail {
+            checkouts: vec![
+                CheckoutTail::new(String::new(), std::path::PathBuf::from("/repo"), now),
+                CheckoutTail::new(
+                    "/wt/feat".to_string(),
+                    std::path::PathBuf::from("/wt/feat"),
+                    now,
+                ),
+            ],
+        };
+        for checkout in &mut tail.checkouts {
+            checkout.backends[0].backlog.push("src/a.rs".to_string());
+        }
+        tail
+    }
+
+    /// A minimal enabled-live config. These tests exercise the checkout bookkeeping, which reads
+    /// only `oracle.live` and `root`.
+    fn live_config(max_checkouts: usize) -> Config {
+        let mut config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
+            sync: Default::default(),
+            repo_id_override: None,
+            database_key_pinned: true,
+            database: std::path::PathBuf::from("/repo/.rag-rat/index.sqlite"),
+            root: std::path::PathBuf::from("/repo"),
+            targets: vec![rag_rat_base::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: rag_rat_base::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: rag_rat_base::config::TargetKind::Source,
+            }],
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        };
+        config.oracle.live.enabled = true;
+        config.oracle.live.max_checkouts = max_checkouts;
+        config
+    }
+
+    #[test]
+    fn the_checkout_cap_serves_the_most_recently_worked_checkout_and_keeps_the_others_backlog() {
+        // A resident language server is the expensive thing here — routinely gigabytes — and one
+        // per (backend x checkout) multiplies that by the worktree fleet. The cap bounds SERVERS,
+        // so a checkout outside it stops holding sessions but must not lose its work (#1010).
+        let now = Instant::now();
+        let mut tail = two_checkout_tail(now);
+        // The linked checkout worked more recently than the base one.
+        tail.checkouts[0].last_worked_at = now - Duration::from_secs(60);
+        tail.checkouts[1].last_worked_at = now;
+
+        tail.checkouts[1].had_new_work = true;
+
+        let ranked = tail.rank();
+
+        assert_eq!(ranked.first(), Some(&1), "the checkout being edited now leads: {ranked:?}",);
+        assert_eq!(ranked.last(), Some(&0), "the older one follows it: {ranked:?}");
+        assert_eq!(
+            tail.checkouts[0].backends[0].backlog,
+            vec!["src/a.rs".to_string()],
+            "an unserved checkout defers its work — it must never be dropped",
+        );
+    }
+
+    #[test]
+    fn a_checkout_the_cap_excludes_still_retains_this_passs_new_paths() {
+        // The cap decides which checkouts are SERVED, never which are remembered. Retaining work
+        // only inside the per-backend pass — which an unserved checkout never reaches — silently
+        // discarded edits made in whichever checkout happened to fall outside the cap, with
+        // nothing left to retry them (#1010).
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![
+                CheckoutTail::new(String::new(), std::path::PathBuf::from("/repo"), now),
+                CheckoutTail::new(
+                    "/wt/feat".to_string(),
+                    std::path::PathBuf::from("/wt/feat"),
+                    now,
+                ),
+            ],
+        };
+        let config = live_config(1);
+        let base = BTreeSet::from(["src/base.rs".to_string()]);
+        let overlays = std::collections::BTreeMap::from([(
+            "/wt/feat".to_string(),
+            crate::watch::CheckoutReindex {
+                source_root: std::path::PathBuf::from("/wt/feat"),
+                paths: vec![std::path::PathBuf::from("src/linked.rs")],
+                coverage: crate::index::ChangedPathsCoverage::Complete,
+            },
+        )]);
+
+        tail.absorb(&config, &LiveChangedSets { base: Some(&base), overlays: &overlays }, now);
+        // Both are eligible for a turn — the cap counts turns in the serve loop, not here...
+        assert_eq!(tail.rank().len(), 2, "both checkouts have work to run");
+        // ...and whichever the cap leaves out, BOTH kept their paths.
+        assert_eq!(
+            backlog_union(&tail.checkouts[0]),
+            vec!["src/base.rs".to_string()],
+            "the base checkout retained its path",
+        );
+        assert_eq!(
+            backlog_union(&tail.checkouts[1]),
+            vec!["src/linked.rs".to_string()],
+            "the excluded checkout retained its path too — deferred, not dropped",
+        );
+    }
+
+    #[test]
+    fn a_waiting_checkout_is_admitted_ahead_of_one_that_has_already_been_served() {
+        // Neither checkout has new work, so both are merely waiting. Ranking on "still has a
+        // backlog" would stamp both with the same instant every pass and fall through to a
+        // tie-break that rewards holding a session — pinning the slot to the incumbent forever.
+        // The one kept out longest must go first (#1010).
+        let now = Instant::now();
+        let mut tail = two_checkout_tail(now);
+        for checkout in &mut tail.checkouts {
+            checkout.had_new_work = false;
+        }
+        // The incumbent was edited MORE recently and has already been served for it; the other has
+        // never run. Service age must still win — comparing work recency first would let the
+        // incumbent keep the slot for as long as it stays backlogged (warming, retrying), which is
+        // exactly the starvation this ordering exists to prevent.
+        tail.checkouts[0].last_worked_at = now;
+        tail.checkouts[0].last_served_at = Some(now);
+        tail.checkouts[1].last_worked_at = now - Duration::from_secs(600);
+        tail.checkouts[1].last_served_at = None;
+
+        let ranked = tail.rank();
+
+        assert_eq!(
+            ranked.first(),
+            Some(&1),
+            "the never-served checkout leads despite the incumbent's newer work: {ranked:?}",
+        );
+    }
+
+    #[test]
+    fn an_empty_base_change_set_does_not_claim_a_checkout_slot() {
+        // A pass that touched only a linked worktree still reports `Some(empty)` for the base —
+        // the hint means "this is a reliable superset", not "there is something in it". Admitting
+        // that as work gave the base checkout a phantom claim: it tied every linked checkout on
+        // recency, sorted ahead of them, spent the only slot doing nothing, and was pruned as
+        // idle — every pass, so the linked checkout the edit belongs to never ran (#1010).
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![
+                CheckoutTail::new(String::new(), std::path::PathBuf::from("/repo"), now),
+                CheckoutTail::new(
+                    "/wt/feat".to_string(),
+                    std::path::PathBuf::from("/wt/feat"),
+                    now,
+                ),
+            ],
+        };
+        let config = live_config(1);
+        let empty_base = BTreeSet::new();
+        let overlays = std::collections::BTreeMap::from([(
+            "/wt/feat".to_string(),
+            crate::watch::CheckoutReindex {
+                source_root: std::path::PathBuf::from("/wt/feat"),
+                paths: vec![std::path::PathBuf::from("src/linked.rs")],
+                coverage: crate::index::ChangedPathsCoverage::Complete,
+            },
+        )]);
+
+        tail.absorb(
+            &config,
+            &LiveChangedSets { base: Some(&empty_base), overlays: &overlays },
+            now,
+        );
+        let ranked = tail.rank();
+
+        assert!(!tail.checkouts[0].had_new_work, "an empty base set is not work");
+        assert!(
+            !ranked.contains(&0),
+            "the idle base checkout is not eligible for a turn: {ranked:?}",
+        );
+        assert!(ranked.contains(&1), "the linked checkout that actually changed is: {ranked:?}",);
+    }
+
+    #[test]
+    fn a_checkout_whose_config_no_longer_indexes_the_language_is_not_admitted() {
+        // A branch that DROPS its last target for a live language still reports the pruned source
+        // paths as changed, so their extensions still look live. Admitting on the extension alone
+        // hands the checkout a slot it cannot use: the backend takes the backlog, returns at its
+        // language gate, and the checkout is pruned as idle — while a sibling with real work stays
+        // unserved. Admission asks the same question the backend will (#1010).
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![CheckoutTail::new(
+                String::new(),
+                std::path::PathBuf::from("/repo"),
+                now,
+            )],
+        };
+        // A `.rs` path — claimed by the Rust backend on extension — but nothing indexed here.
+        let mut config = live_config(1);
+        config.targets.clear();
+        let base = BTreeSet::from(["src/a.rs".to_string()]);
+        let no_overlays = std::collections::BTreeMap::new();
+
+        tail.absorb(&config, &LiveChangedSets { base: Some(&base), overlays: &no_overlays }, now);
+
+        assert!(
+            !tail.checkouts[0].had_new_work,
+            "a path whose language this checkout no longer indexes is not work for it",
+        );
+        assert!(
+            backlog_union(&tail.checkouts[0]).is_empty(),
+            "and it is not retained: {:?}",
+            backlog_union(&tail.checkouts[0]),
+        );
+    }
+
+    #[test]
+    fn a_path_outside_this_checkouts_targets_is_not_admitted_even_in_a_live_language() {
+        // The narrow form of the same bug: a branch drops ONE Rust target and keeps another. The
+        // pruned paths still end in `.rs` and a Rust target still exists, so any predicate that
+        // tests those two things independently admits the checkout — and it then holds the cap
+        // slot, possibly with a resident server, for paths that are not in its corpus at all.
+        // Matching each path against its own target is what closes this (#1010).
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![CheckoutTail::new(
+                String::new(),
+                std::path::PathBuf::from("/repo"),
+                now,
+            )],
+        };
+        // The fixture indexes `src` only; this path is Rust, but under a directory that is not a
+        // target of THIS checkout.
+        let config = live_config(1);
+        assert!(
+            config
+                .targets
+                .iter()
+                .any(|target| target.language == rag_rat_base::language::Language::Rust),
+            "a Rust target must still exist, or this tests the wrong thing",
+        );
+        let base = BTreeSet::from(["extra/dropped.rs".to_string()]);
+        let no_overlays = std::collections::BTreeMap::new();
+
+        tail.absorb(&config, &LiveChangedSets { base: Some(&base), overlays: &no_overlays }, now);
+
+        assert!(
+            !tail.checkouts[0].had_new_work,
+            "a Rust path outside this checkout's targets is not work for it",
+        );
+        assert!(
+            backlog_union(&tail.checkouts[0]).is_empty(),
+            "and it is not retained: {:?}",
+            backlog_union(&tail.checkouts[0]),
+        );
+
+        // The control: the same language, under the target this checkout DOES index.
+        let indexed = BTreeSet::from(["src/live.rs".to_string()]);
+        tail.absorb(
+            &config,
+            &LiveChangedSets { base: Some(&indexed), overlays: &no_overlays },
+            now,
+        );
+        assert!(
+            tail.checkouts[0].had_new_work,
+            "a path inside the target is still admitted — the gate must not reject everything",
+        );
+    }
+
+    #[test]
+    fn an_unreachable_checkout_keeps_its_backlog_and_yields_its_turn() {
+        // A registered worktree that cannot be validated right now (unmounted, briefly unreadable)
+        // is a DEFERRAL, not a removal: forgetting its backlog would lose work nothing can
+        // rebuild, since a checkout returning with unchanged contents produces no changed paths
+        // for the overlay refresh to report. Its turn is still spent, so it cannot hold the slot
+        // every pass (#1010).
+        let now = Instant::now();
+        let mut tail = two_checkout_tail(now);
+
+        tail.checkouts[1].defer_turn(now, "test");
+
+        assert_eq!(
+            tail.checkouts[1].backends[0].backlog,
+            vec!["src/a.rs".to_string()],
+            "the deferred checkout keeps its work",
+        );
+        assert_eq!(
+            tail.checkouts[1].last_served_at,
+            Some(now),
+            "but it has spent its turn, so a sibling ranks ahead of it next pass",
+        );
+        assert!(
+            !tail.checkouts[1].backends[0].lifecycle.can_respawn(now),
+            "and the retry is backed off rather than re-attempted every pass",
+        );
+        assert!(
+            tail.checkouts[1].deferred,
+            "it is marked deferred, which is what keeps it in the wake computation",
+        );
+    }
+
+    #[test]
+    fn a_deferred_checkout_still_schedules_the_pass_that_will_retry_it() {
+        // A deferred checkout had its turn and could not take it, so its backoff is a real retry
+        // deadline. Excluding it from the wake computation — as an unranked checkout correctly is
+        // — meant that when every retained checkout was unreachable, nothing scheduled a pass at
+        // all and the work stayed stranded even after the checkouts came back (#1010).
+        let now = Instant::now();
+        let mut tail = two_checkout_tail(now);
+        let config = live_config(1);
+        // Nothing was served this pass; the sole checkout with work was unreachable.
+        tail.checkouts.truncate(1);
+        tail.checkouts[0].defer_turn(now, "test");
+
+        let wake = tail.next_wake_in(&config, now);
+
+        assert!(
+            wake.is_some(),
+            "a deferred checkout must schedule the pass that retries it, or its backlog is \
+             stranded whenever the periodic sweep is off",
+        );
+    }
+
+    #[test]
+    fn a_checkout_holding_only_parked_paths_does_not_claim_a_slot() {
+        // Parked paths ride along with a real worklist and can only be re-skipped on their own, so
+        // a checkout holding nothing else has nothing to run. Letting it rank would spend the slot
+        // on a pass that asks its server nothing — and since an unadmitted checkout schedules no
+        // wake, the sibling it displaced would have its work stranded with the periodic sweep off.
+        let now = Instant::now();
+        let mut tail = two_checkout_tail(now);
+        // The base checkout keeps only parked paths; the linked one holds real work.
+        backends_of(&mut tail)[0].backlog.clear();
+        backends_of(&mut tail)[0].unconfigured_paths.insert("src/parked.c".to_string());
+        for checkout in &mut tail.checkouts {
+            checkout.had_new_work = false;
+        }
+
+        let ranked = tail.rank();
+
+        assert!(
+            !ranked.contains(&0),
+            "a parked-only checkout has nothing to run, so it is not ranked: {ranked:?}",
+        );
+        assert!(ranked.contains(&1), "the sibling with a real backlog is: {ranked:?}");
+        assert_eq!(
+            tail.checkouts[0].backends[0].unconfigured_paths.len(),
+            1,
+            "and its parked paths are kept, not discarded",
+        );
+    }
+
+    #[test]
+    fn a_change_set_no_live_backend_claims_does_not_claim_a_checkout_slot() {
+        // The general form: "nonempty" is not the test. Most repos change files no live backend
+        // can answer — Python, markdown, config. Admitting those gave the checkout a phantom claim
+        // on the cap: it ranked as freshly worked, won the slot, resolved nothing, and was pruned
+        // as idle, repeating every pass while a sibling's real backlog stayed out (#1010).
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![
+                CheckoutTail::new(String::new(), std::path::PathBuf::from("/repo"), now),
+                CheckoutTail::new(
+                    "/wt/feat".to_string(),
+                    std::path::PathBuf::from("/wt/feat"),
+                    now,
+                ),
+            ],
+        };
+        let config = live_config(1);
+        // A busy base checkout, but every path is in a language no live backend serves.
+        let base = BTreeSet::from([
+            "scripts/build.py".to_string(),
+            "README.md".to_string(),
+            "rag-rat.toml".to_string(),
+        ]);
+        let overlays = std::collections::BTreeMap::from([(
+            "/wt/feat".to_string(),
+            crate::watch::CheckoutReindex {
+                source_root: std::path::PathBuf::from("/wt/feat"),
+                paths: vec![std::path::PathBuf::from("src/linked.rs")],
+                coverage: crate::index::ChangedPathsCoverage::Complete,
+            },
+        )]);
+
+        tail.absorb(&config, &LiveChangedSets { base: Some(&base), overlays: &overlays }, now);
+        let ranked = tail.rank();
+
+        assert!(
+            !tail.checkouts[0].had_new_work,
+            "a change set no live backend claims is not work for this stage",
+        );
+        assert!(!ranked.contains(&0), "so the base checkout is not ranked: {ranked:?}");
+        assert!(
+            backlog_union(&tail.checkouts[0]).is_empty(),
+            "and nothing of it is retained: {:?}",
+            backlog_union(&tail.checkouts[0]),
+        );
+        assert!(
+            ranked.contains(&1),
+            "while the linked checkout that actually changed is ranked: {ranked:?}",
+        );
+    }
+
+    #[test]
+    fn both_checkouts_with_work_are_eligible_for_a_turn() {
+        // The cap is the whole knob: the same state that serves one checkout at the default must
+        // serve both when an operator pays for it.
+        let now = Instant::now();
+        let mut tail = two_checkout_tail(now);
+        tail.checkouts[0].last_worked_at = now - Duration::from_secs(60);
+
+        assert_eq!(
+            tail.rank().len(),
+            2,
+            "both checkouts have work, so both are eligible; how many actually run is the cap's \
+             business in the serve loop",
+        );
+    }
+
+    /// Every path a checkout is holding, across its backends.
+    fn backlog_union(checkout: &CheckoutTail) -> Vec<String> {
+        let mut paths: Vec<String> =
+            checkout.backends.iter().flat_map(|backend| backend.backlog.iter().cloned()).collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    #[test]
+    fn a_partial_overlay_report_still_contributes_the_paths_it_does_list() {
+        // `Partial` means the list may be MISSING paths — the checkout's working-tree status read
+        // failed, so dirty/untracked/deleted files never became candidates. It does NOT mean the
+        // listed paths are doubtful: the committed tree-diff half still ran and every path here
+        // had its overlay row written. Sound, merely incomplete.
+        //
+        // A best-effort freshness patch loses nothing by refreshing a subset, and the omitted half
+        // surfaces on the next refresh (a partial pass clears the overlay basis). Discarding the
+        // entry threw away work that was known stale and known which — and since a non-empty
+        // backlog is what schedules the next wake, left nothing to schedule one (#1010).
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![CheckoutTail::new(
+                "/wt/feat".to_string(),
+                std::path::PathBuf::from("/wt/feat"),
+                now,
+            )],
+        };
+        let config = live_config(1);
+        let overlays = std::collections::BTreeMap::from([(
+            "/wt/feat".to_string(),
+            crate::watch::CheckoutReindex {
+                source_root: std::path::PathBuf::from("/wt/feat"),
+                paths: vec![std::path::PathBuf::from("src/a.rs")],
+                coverage: crate::index::ChangedPathsCoverage::Partial,
+            },
+        )]);
+
+        tail.absorb(&config, &LiveChangedSets { base: None, overlays: &overlays }, now);
+
+        assert_eq!(
+            backlog_union(&tail.checkouts[0]),
+            vec!["src/a.rs".to_string()],
+            "the paths a partial report DOES list are real committed changes, and are retained",
+        );
+        assert!(
+            tail.checkouts[0].had_new_work,
+            "and they count as work, so the checkout can be ranked and its backlog schedules a \
+             wake",
+        );
+    }
+
+    #[test]
+    fn a_complete_overlay_report_becomes_that_checkouts_worklist() {
+        // The counterpart: a complete list IS the checkout's changed set, and it is keyed to that
+        // checkout rather than folded into the base one — a linked worktree's paths handed to the
+        // main checkout's server would resolve against the wrong files.
+        let now = Instant::now();
+        let mut tail = LiveOracleTail {
+            checkouts: vec![
+                CheckoutTail::new(String::new(), std::path::PathBuf::from("/repo"), now),
+                CheckoutTail::new(
+                    "/wt/feat".to_string(),
+                    std::path::PathBuf::from("/wt/feat"),
+                    now,
+                ),
+            ],
+        };
+        let config = live_config(1);
+        let base = BTreeSet::from(["src/base.rs".to_string()]);
+        let overlays = std::collections::BTreeMap::from([(
+            "/wt/feat".to_string(),
+            crate::watch::CheckoutReindex {
+                source_root: std::path::PathBuf::from("/wt/feat"),
+                paths: vec![std::path::PathBuf::from("src/linked.rs")],
+                coverage: crate::index::ChangedPathsCoverage::Complete,
+            },
+        )]);
+
+        tail.absorb(&config, &LiveChangedSets { base: Some(&base), overlays: &overlays }, now);
+
+        assert_eq!(
+            backlog_union(&tail.checkouts[0]),
+            vec!["src/base.rs".to_string()],
+            "the base checkout holds only its own path",
+        );
+        assert_eq!(
+            backlog_union(&tail.checkouts[1]),
+            vec!["src/linked.rs".to_string()],
+            "the linked checkout's path stays with it — never folded into the base checkout, \
+             whose server reads different files",
+        );
+    }
+
     #[test]
     fn one_backends_failure_does_not_disturb_another() {
         // Backends are independent: a crash streak on one must not gate the other's respawn, or
         // a wedged rust-analyzer would silently stop TypeScript resolution.
-        let mut tail = LiveOracleTail::new();
         let now = Instant::now();
-        tail.backends[0].lifecycle.on_failure(now);
-        assert!(!tail.backends[0].lifecycle.can_respawn(now));
-        assert!(tail.backends[1].lifecycle.can_respawn(now), "sibling backoff must be separate");
+        let mut tail = single_checkout_tail(now);
+        backends_of(&mut tail)[0].lifecycle.on_failure(now);
+        assert!(!backends_of(&mut tail)[0].lifecycle.can_respawn(now));
+        assert!(
+            backends_of(&mut tail)[1].lifecycle.can_respawn(now),
+            "sibling backoff must be separate"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -30,9 +30,11 @@ mod placement;
 pub use event_loop::Watcher;
 #[cfg(test)]
 pub(crate) use event_loop::{EventLoop, flush_watch_placement_failures, shutdown_discover};
+#[cfg(test)]
+pub(crate) use live_oracle::{LiveChangedSets, LiveOracleTail, suppress_live_spawn};
 pub use overlay::{
-    OverlayRefresh, OverlayScope, ReconcileBudget, is_manifest_path, refresh_worktree_overlays,
-    reindex_paths,
+    CheckoutReindex, OverlayRefresh, OverlayScope, ReconcileBudget, is_manifest_path,
+    refresh_worktree_overlays, reindex_paths,
 };
 #[cfg(test)]
 pub(crate) use overlay::{enclosing_worktree_id, overlay_needs_embed, partition_paths_by_worktree};

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -171,12 +171,18 @@ pub struct CheckoutReindex {
     /// `config.root`, which is NOT the checkout root when `config.root` is a repo subdir. See
     /// [`crate::index::WorktreeOverlayReport::source_root`].
     pub source_root: PathBuf,
-    /// Paths whose effective indexed content this refresh may have changed, relative to
-    /// [`Self::source_root`]. A superset when `coverage` is
-    /// [`ChangedPathsCoverage::Complete`]; otherwise not even that.
+    /// Paths whose effective indexed content this refresh changed, relative to
+    /// [`Self::source_root`]. Always SOUND — every path listed really did change — and a superset
+    /// of the change set only when `coverage` is [`ChangedPathsCoverage::Complete`].
     pub paths: Vec<PathBuf>,
-    /// Whether `paths` is the complete set. `Partial` means the consumer must treat the whole
-    /// checkout as suspect rather than trusting the list.
+    /// Whether `paths` accounts for everything that changed. `Partial` means paths may be MISSING
+    /// (the checkout's working-tree status read failed); it does NOT devalue the ones listed.
+    ///
+    /// So what a consumer should do with `Partial` depends on the question it is asking. One that
+    /// needs completeness — "may I skip re-examining this checkout?" — must answer no. One
+    /// building a best-effort worklist should still take the paths: refreshing a sound subset is
+    /// strictly better than refreshing nothing, and the omitted half surfaces on the next refresh,
+    /// which a partial pass guarantees by clearing the overlay basis.
     pub coverage: ChangedPathsCoverage,
 }
 

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -416,7 +416,17 @@ fn run_pass(
     // must still fire so a gone-quiet server releases the resident language server. Only the
     // resident watcher passes the state in — hook/CLI passes skip the stage entirely.
     if let Some(live) = live_oracle {
-        timings.stage("live_oracle", || live.on_pass(&db, config, clone_delta_hint.as_ref()));
+        // Both halves of the pass's changed set (#1010): the base scope's paths, and what each
+        // linked checkout's overlay refresh above changed. A linked worktree is a different source
+        // tree, so its edits can only be answered by a server rooted there — handing them to the
+        // main checkout's session would resolve them against the wrong files.
+        let changed = super::live_oracle::LiveChangedSets {
+            base: clone_delta_hint.as_ref(),
+            overlays: &overlays.reindexed,
+        };
+        // The only failure this stage propagates is a base scope it could not restore — see
+        // `on_pass`. Everything else about the live oracle is best-effort and logged.
+        timings.stage("live_oracle", || live.on_pass(&mut db, config, &changed))?;
     }
     // Idle backstop (issue #63, facet 2): when the sweep changed nothing, skip everything past
     // discovery — an idle server should do no work. `run_gc` (every GC_EVERY_PASSES) still forces

--- a/docs/config/oracle.md
+++ b/docs/config/oracle.md
@@ -43,6 +43,7 @@ patch for files being edited, and where both tools cover the same edge the batch
 enabled = false               # off by default — opt in explicitly
 idle_shutdown_secs = 900      # shut each language server down after 15 min idle
 max_requests_per_pass = 200   # positive cap per maintenance pass; zero is rejected
+max_checkouts = 1             # how many checkouts hold resident servers; zero is rejected
 ```
 
 One setting configures every live backend. A checkout indexed in several of these languages runs
@@ -50,6 +51,20 @@ one resident server per language, each with its own backlog and respawn backoff,
 server for one language never stalls another. `max_requests_per_pass` is **shared** across them —
 it bounds the pass, which holds the repository write lock — and the backends take turns claiming
 it so none is starved.
+
+**Linked worktrees and `max_checkouts`.** A linked worktree is a different source tree, so its
+edits can only be answered by a server rooted there — the main checkout's server would resolve
+them against the wrong files. Live state is therefore per checkout, and the straightforward
+reading (one server per backend per checkout) multiplies resident servers by the size of your
+worktree fleet. A language server is routinely gigabytes, so `max_checkouts` bounds how many
+checkouts hold servers at once.
+
+The default of `1` serves whichever checkout you are editing. Checkouts are ranked by how recently
+they had work; one that falls outside the cap has its servers shut down but **keeps its backlog**,
+so its work is deferred rather than lost, and it is served again once it is current. Editing two
+checkouts in alternation at the default will spawn and shut down repeatedly — raise `max_checkouts`
+to cover them concurrently. (The batch pass covers every checkout regardless; this only affects the
+per-pass live freshness patch.)
 
 **TypeScript needs a `tsconfig.json`.** `typescript-language-server` reports that it has finished
 loading a project only for a real tsconfig project, and the oracle waits for that signal before it


### PR DESCRIPTION
The live-oracle stage spawned one session per backend rooted at `config.root` and was handed only the base scope's changed set. An edit that exists only in a linked worktree therefore never reached a live backend: no worklist was built for that checkout, and no server was rooted at its tree. The batch pass covered those files; the per-pass freshness patch did not.

Builds on #1051, which made the overlay refresh report which checkout reindexed which paths.

## What changed

**Live state is keyed by checkout, then by backend within it.** A checkout's servers are rooted at its own equivalent of `config.root` — not the checkout root, which differs whenever `config.root` is a repo subdir — using the same derivation the overlay uses to read that checkout's bytes. The connection is scoped to the checkout before its servers answer for it.

**Both halves of the pass's changed set reach the stage**: the base paths, and each linked checkout's reindexed paths. A checkout whose overlay report is `Partial` contributes nothing, exactly as a base pass with no reliable hint does — a list that may be missing entries is not a worklist, and widening to a whole-checkout sweep is the batch pass's job.

**`run_live_oracle_pass`'s root guard keeps its predicate** — the rows a pass patches must belong to the checkout its server reads — but resolves the expected root from the active scope instead of assuming the main checkout, so an overlay-scoped pass no longer trips it by construction.

## Resource ceiling

New `[oracle.live] max_checkouts`, default 1, zero rejected at config load.

One resident server per (backend × checkout) multiplies by the worktree fleet, and a language server is routinely gigabytes — this repo has 29 live worktrees, so the uncapped reading is 87 servers. The cap bounds checkouts holding servers.

Checkouts are ranked by recency of new work, so the one being edited keeps its warm server. A checkout outside the cap has its servers shut down but **keeps its backlog** — retention and service are separate questions, and the cap decides only the latter. Checkouts that are merely waiting are ordered by how long they have been kept out, never-served first, so an incumbent cannot hold the slot indefinitely. An excluded checkout schedules no watcher wake, since waking sooner cannot drain a backlog held out by a sibling; it is picked up by the served checkout's idle-shutdown wake or the periodic sweep.

Editing two checkouts in alternation at the default will spawn and shut down repeatedly. Raising the cap is the fix; refusing to switch until some dwell time elapsed would starve whichever checkout is being edited now, which is worse.

## Scope safety

Restoring the base scope after the live stage is not best-effort: the base reconcile, gc, and memory validation that follow all assume base scope, so a failed restore fails the pass rather than running them against a linked checkout's view. `set_context_at_generation` also committed its in-memory scope fields before the SQL scope view write that could fail; the view is now installed first, so a failure cannot leave the handle describing a scope the view does not serve.

## Verification

4404 tests pass; `cargo +nightly fmt --check` and both clippy configurations exit 0. New coverage: the cap admitting one checkout while both retain their paths, a waiting checkout admitted ahead of a previously-served one, `Partial` contributing no worklist, a complete overlay report staying keyed to its own checkout, and the config knob's default plus zero rejection. Each was mutation-checked — reverting its own fix fails that test and only that test.

Fixes #1010.