### PR TITLE
fix(paths): resolve filesystem paths off the Windows verbatim spelling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,6 +4970,7 @@ name = "rag-rat-base"
 version = "0.21.1"
 dependencies = [
  "anyhow",
+ "dunce",
  "filetime",
  "gix",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,13 @@ chacha20poly1305 = { version = "0.11", default-features = false, features = ["al
 # line that rag-rat-core's own SHA-256 (`sha2` 0.11, used by oplog::cbor + oplog::device) already
 # links, so it adds NO second sha2/digest stack — `Hkdf::<sha2::Sha256>` reuses the existing hash.
 hkdf = "0.13"
+# Windows path normalization: strips the `\\?\` verbatim prefix `std::fs::canonicalize` returns
+# whenever the plain `C:\…` spelling names the same file, and keeps verbatim form where it is
+# load-bearing (UNC, >260 chars, reserved DOS names, trailing dot/space). `gix-discover` already
+# depends on it and runs `dunce::simplified` over the directory it discovers from, so routing our own
+# canonicalization through the same crate is what keeps our roots comparable to gix's `workdir()`.
+# No-op on non-Windows. Already in the tree via gix; this only makes it a direct dependency.
+dunce = "1.0"
 fastembed = { version = "5.17.3", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 # Cross-platform mtime setter, used only by `test_scratch`'s sweep test to age a fixture dir past
 # the sweep threshold (already in the tree transitively; a dev-dependency, not shipped).

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,17 @@
+# Clippy configuration for the rag-rat workspace.
+#
+# `disallowed-methods` is the enforcement seam for invariants that a reviewer would otherwise have
+# to catch by eye. Every entry names the replacement in its `reason`, which clippy prints at the
+# offending call site.
+
+disallowed-methods = [
+  # Windows' `canonicalize` returns a `\\?\` VERBATIM path, which neither the `git` CLI nor gix's
+  # `workdir()` matches — a verbatim `config.root` cannot even `git worktree add`, and strips to
+  # nothing against the repository workdir, so the worktree overlay scopes its refresh at the wrong
+  # directory (#1048). `rag_rat_base::paths::canonicalize` drops that prefix wherever the plain
+  # spelling names the same file and keeps it where it is load-bearing (UNC, >MAX_PATH, reserved DOS
+  # names). It is `std::fs::canonicalize` verbatim on Unix, so there is never a reason to prefer the
+  # std call. The one exception is the helper itself, which carries a local `expect`.
+  { path = "std::path::Path::canonicalize", reason = "use rag_rat_base::paths::canonicalize — std's returns a Windows \\\\?\\ verbatim path git and gix do not match (#1048)" },
+  { path = "std::fs::canonicalize", reason = "use rag_rat_base::paths::canonicalize — std's returns a Windows \\\\?\\ verbatim path git and gix do not match (#1048)" },
+]

--- a/crates/rag-rat-base/Cargo.toml
+++ b/crates/rag-rat-base/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 minicbor.workspace = true
 unicode-normalization.workspace = true
 anyhow.workspace = true
+dunce.workspace = true
 gix.workspace = true
 libc.workspace = true
 path-slash.workspace = true

--- a/crates/rag-rat-base/src/config/discovery.rs
+++ b/crates/rag-rat-base/src/config/discovery.rs
@@ -57,7 +57,7 @@ pub fn nearest_config_at_or_above(dir: &Path) -> Option<PathBuf> {
     // filesystem tree (the callers pass `Path::new(".")` for cwd). `canonicalize` also collapses
     // `..`/symlinks so the climb follows the true directory chain. If it fails (a non-existent
     // `dir`), fall back to walking `dir` as given rather than aborting discovery.
-    let absolute = dir.canonicalize().ok();
+    let absolute = crate::paths::canonicalize(dir).ok();
     let start = absolute.as_deref().unwrap_or(dir);
     // The enclosing git repo's workdir root — the ceiling the climb must not cross (canonicalized
     // so it compares equal to the canonicalized `cur`). `None` for a non-git `dir` ⇒ no
@@ -65,7 +65,7 @@ pub fn nearest_config_at_or_above(dir: &Path) -> Option<PathBuf> {
     let boundary = crate::repo_discover::discover_repo(start)
         .ok()
         .and_then(|repo| repo.workdir().map(Path::to_path_buf))
-        .and_then(|workdir| workdir.canonicalize().ok());
+        .and_then(|workdir| crate::paths::canonicalize(workdir).ok());
     let mut current = Some(start);
     while let Some(cur) = current {
         let candidate = cur.join("rag-rat.toml");
@@ -94,7 +94,7 @@ pub fn linked_worktree_main_root(root: &Path) -> Option<PathBuf> {
     let repo = crate::repo_discover::discover_repo(root).ok()?;
     let main = main_worktree_root(root)?;
     let workdir = repo.workdir()?;
-    let workdir = workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf());
+    let workdir = crate::paths::canonicalize_or_simplified(workdir);
     (main != workdir).then_some(main)
 }
 
@@ -105,12 +105,12 @@ pub fn linked_worktree_main_root(root: &Path) -> Option<PathBuf> {
 pub fn worktree_root(path: &Path) -> Option<PathBuf> {
     let repo = crate::repo_discover::discover_repo(path).ok()?;
     let workdir = repo.workdir()?;
-    Some(workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf()))
+    Some(crate::paths::canonicalize_or_simplified(workdir))
 }
 
 pub(crate) fn main_worktree_root(root: &Path) -> Option<PathBuf> {
     let repo = crate::repo_discover::discover_repo(root).ok()?;
-    let common_dir = repo.common_dir().canonicalize().ok()?;
+    let common_dir = crate::paths::canonicalize(repo.common_dir()).ok()?;
     // Only the standard `<main>/.git` layout maps cleanly to a main worktree root.
     if common_dir.file_name()?.to_str()? != ".git" {
         return None;
@@ -235,10 +235,17 @@ pub fn default_legacy_database_path(root: &Path) -> PathBuf {
     main_worktree_root(root).unwrap_or_else(|| root.to_path_buf()).join(".rag-rat/index.sqlite")
 }
 
+/// `path` as an absolute, canonical directory — the ONE production of `config.root`.
+///
+/// Everything downstream treats this spelling as authoritative: the worktree overlay strips it
+/// against the repository workdir gix reports, and callers hand paths derived from it to the `git`
+/// CLI. Both reject the Windows `\\?\` verbatim form, so the canonicalization goes through
+/// [`crate::paths::canonicalize`] rather than `std::fs::canonicalize` (#1048).
+/// `test_scratch::canonical_config_root` mirrors this for hand-built fixture `Config`s.
 pub(crate) fn normalize_existing_dir(path: &Path) -> Result<PathBuf, ConfigError> {
     let absolute =
         if path.is_absolute() { path.to_path_buf() } else { std::env::current_dir()?.join(path) };
-    let canonical = absolute.canonicalize()?;
+    let canonical = crate::paths::canonicalize(absolute)?;
     if !canonical.is_dir() {
         return Err(ConfigError::MissingDirectory(canonical));
     }

--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -141,8 +141,7 @@ impl Config {
                             Err(_) => true,
                         };
                         if divergent {
-                            let ignored =
-                                path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+                            let ignored = crate::paths::canonicalize_or_simplified(path);
                             let invalid_note =
                                 if local_parse.is_err() { " (also invalid)" } else { "" };
                             eprintln!(
@@ -494,7 +493,8 @@ fn root_relative_within(root: &Path, path: &Path) -> Option<PathBuf> {
     // When both resolve, the filesystem has the final say on containment. When either does not — a
     // root the caller has not created, a directory racing a delete — the textual answer is all
     // there is, and it is the one this function gave before.
-    if let (Ok(canonical_root), Ok(canonical_path)) = (root.canonicalize(), path.canonicalize())
+    if let (Ok(canonical_root), Ok(canonical_path)) =
+        (crate::paths::canonicalize(root), crate::paths::canonicalize(path))
         && !canonical_path.starts_with(&canonical_root)
     {
         return None;
@@ -516,7 +516,7 @@ pub(crate) fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
     else {
         return root.to_path_buf();
     };
-    let workdir = workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf());
+    let workdir = crate::paths::canonicalize_or_simplified(workdir);
     if main_root == workdir {
         return root.to_path_buf(); // already the main worktree — keep the configured (sub)root
     }

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -685,7 +685,7 @@ pub(crate) fn resolve_relative_cookbook_path(cookbook: &str, config_dir: &Path) 
     // <path>` (spawned directly, not through a shell), and both accept the platform-native
     // separator — `\` on Windows, `/` on Unix — so the join output is already correct as-is.
     // Rewriting `\`→`/` would be wrong two ways: on Windows it corrupts a verbatim
-    // extended-length prefix (canonicalize can yield `\\?\C:\repo`, where the suffix MUST stay
+    // extended-length prefix (a long or UNC path stays `\\?\C:\repo`, where the suffix MUST stay
     // backslash-delimited), and on Unix it would mangle a literal backslash in a filename.
     // `to_string_lossy` touches neither.
     let mut out = resolved.to_string_lossy().into_owned();

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -80,7 +80,10 @@ fn config_load_resolves_main_and_linked_worktrees_to_one_database() {
         from_main.database, from_linked.database,
         "main and linked worktrees must share one index database",
     );
-    assert_eq!(from_main.database, main.canonicalize().unwrap().join(".rag-rat/index.sqlite"));
+    assert_eq!(
+        from_main.database,
+        crate::paths::canonicalize(&main).unwrap().join(".rag-rat/index.sqlite")
+    );
     // AND the `root` anchors to the main worktree from either launch point — so every process
     // uses the same base commit for the shared index, instead of a worktree-launched one
     // rooting at the worktree (a different base → conflicting overlay writes /
@@ -88,7 +91,7 @@ fn config_load_resolves_main_and_linked_worktrees_to_one_database() {
     assert_eq!(from_main.root, from_linked.root, "main and linked configs resolve to one root");
     assert_eq!(
         from_linked.root,
-        main.canonicalize().unwrap(),
+        crate::paths::canonicalize(&main).unwrap(),
         "a linked worktree's config root anchors to the main worktree",
     );
 }
@@ -441,7 +444,7 @@ fn config_load_falls_back_to_the_local_config_when_main_has_none() {
     )
     .unwrap();
     let cfg = Config::load(linked.join("rag-rat.toml")).unwrap();
-    let canonical_main = main.canonicalize().unwrap();
+    let canonical_main = crate::paths::canonicalize(&main).unwrap();
     assert_eq!(cfg.root, canonical_main, "root anchors to main even on the fallback");
     assert_eq!(
         cfg.database,
@@ -471,7 +474,7 @@ fn discover_config_path_resolves_the_governing_checkout() {
     git(&main, &["commit", "-qm", "seed"]);
     let linked = tmp.join("wt");
     git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
-    let main_c = main.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
 
     // Linked, no local file, main config not yet written: MAIN's path (where it belongs).
     assert_eq!(config::discover_config_path(&linked), main_c.join("rag-rat.toml"));
@@ -504,14 +507,14 @@ fn discover_config_path_walks_up_to_a_parent_repo_config() {
 
     // The walk returns a canonical absolute path (a found file), so compare canonically — temp
     // roots can be symlinked (macOS `/tmp` → `/private/tmp`).
-    let want = repo.join("rag-rat.toml").canonicalize().unwrap();
+    let want = crate::paths::canonicalize(repo.join("rag-rat.toml")).unwrap();
     assert_eq!(
-        config::discover_config_path(&nested).canonicalize().unwrap(),
+        crate::paths::canonicalize(config::discover_config_path(&nested)).unwrap(),
         want,
         "subdir → repo cfg"
     );
     assert_eq!(
-        config::discover_config_path(&repo).canonicalize().unwrap(),
+        crate::paths::canonicalize(config::discover_config_path(&repo)).unwrap(),
         want,
         "repo root → local"
     );
@@ -547,8 +550,8 @@ fn discover_config_path_does_not_cross_a_nested_repo_boundary() {
     let got = config::discover_config_path(&nested);
     assert_eq!(got, nested.join("rag-rat.toml"), "must not adopt the parent repo's config");
     assert_ne!(
-        got.canonicalize().ok(),
-        parent.join("rag-rat.toml").canonicalize().ok(),
+        crate::paths::canonicalize(&got).ok(),
+        crate::paths::canonicalize(parent.join("rag-rat.toml")).ok(),
         "the parent repo's rag-rat.toml must not leak across the nested boundary",
     );
 }
@@ -573,7 +576,7 @@ fn discover_config_path_finds_a_branch_local_config_from_a_linked_worktree_subdi
     git(&main, &["commit", "-qm", "seed"]);
     let linked = tmp.join("wt");
     git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
-    let main_c = main.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
     let sub = linked.join("src");
     std::fs::create_dir_all(&sub).unwrap();
 
@@ -588,8 +591,8 @@ fn discover_config_path_finds_a_branch_local_config_from_a_linked_worktree_subdi
     // climbing past the worktree root into main).
     std::fs::write(linked.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
     assert_eq!(
-        config::discover_config_path(&sub).canonicalize().unwrap(),
-        linked.join("rag-rat.toml").canonicalize().unwrap(),
+        crate::paths::canonicalize(config::discover_config_path(&sub)).unwrap(),
+        crate::paths::canonicalize(linked.join("rag-rat.toml")).unwrap(),
         "a subdir launch must find the branch-local config, not jump to main",
     );
 }
@@ -614,7 +617,7 @@ fn linked_worktree_main_root_derives_linkedness_from_topology() {
     git(&main, &["commit", "-qm", "seed"]);
     let linked = tmp.join("wt");
     git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
-    let main_c = main.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
 
     assert_eq!(config::linked_worktree_main_root(&main), None, "the main worktree is not linked");
     assert_eq!(
@@ -664,7 +667,7 @@ fn config_load_ignores_an_invalid_branch_config_when_main_governs() {
     std::fs::write(linked.join("rag-rat.toml"), "this is [not toml").unwrap();
     let cfg = Config::load(linked.join("rag-rat.toml"))
         .expect("a broken branch config is ignored when main governs");
-    let main_c = main.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
     assert_eq!(cfg.database, main_c.join("main.sqlite"));
 
     // The deprecated `[local_ai]` table on the branch: same posture (it is a VALIDATION
@@ -725,7 +728,7 @@ fn config_load_governs_from_main_even_when_a_branch_only_root_defeats_anchoring(
     )
     .unwrap();
     let cfg = Config::load(linked.join("rag-rat.toml")).unwrap();
-    let main_c = main.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
     assert_eq!(
         cfg.database,
         main_c.join("main.sqlite"),
@@ -871,7 +874,7 @@ fn config_load_without_a_database_key_prefers_an_existing_legacy_index() {
     let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
     assert_eq!(
         config.database,
-        tmp.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+        crate::paths::canonicalize(&tmp).unwrap().join(".rag-rat/index.sqlite"),
         "a pre-existing legacy index wins over the global default until consolidated",
     );
 
@@ -925,12 +928,12 @@ fn config_load_without_a_database_key_stays_per_root_for_identity_less_roots() {
     let config_b = Config::load(b.join("rag-rat.toml")).unwrap();
     assert_eq!(
         config_a.database,
-        a.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+        crate::paths::canonicalize(&a).unwrap().join(".rag-rat/index.sqlite"),
         "an identity-less root stays on its per-root legacy path",
     );
     assert_eq!(
         config_b.database,
-        b.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+        crate::paths::canonicalize(&b).unwrap().join(".rag-rat/index.sqlite"),
         "each identity-less root gets its own database",
     );
     assert_ne!(config_a.database, config_b.database, "identity-less roots never share scope");
@@ -946,7 +949,7 @@ fn config_load_without_a_database_key_stays_per_root_for_identity_less_roots() {
     let config = Config::load(unborn.join("rag-rat.toml")).unwrap();
     assert_eq!(
         config.database,
-        unborn.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+        crate::paths::canonicalize(&unborn).unwrap().join(".rag-rat/index.sqlite"),
         "an unborn repo stays per-root until its first commit mints an identity",
     );
     // A `[index] repo_id` pin IS an identity: the same root then resolves globally.
@@ -1032,7 +1035,7 @@ fn config_load_in_a_linked_worktree_uses_main_base_targets_not_the_branch() {
     // root still anchors to main (one shared base index).
     assert_eq!(
         from_linked.root,
-        main.canonicalize().unwrap(),
+        crate::paths::canonicalize(&main).unwrap(),
         "root anchors to the main worktree for the shared base index",
     );
     // The stored BASE targets come from MAIN's config (`src` only), NOT the branch's
@@ -1221,8 +1224,8 @@ fn load_records_the_pre_anchor_root_for_a_linked_worktree() {
     git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
     std::fs::write(linked.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
 
-    let main_c = main.canonicalize().unwrap();
-    let linked_c = linked.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
+    let linked_c = crate::paths::canonicalize(&linked).unwrap();
     let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
     assert_eq!(from_linked.root, main_c, "root anchors to main (existing behavior)");
     assert_eq!(
@@ -1293,8 +1296,8 @@ fn anchor_root_preserves_subdir_and_redirects_linked_to_main() {
     git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
     std::fs::create_dir_all(linked.join("src")).unwrap();
 
-    let main_c = main.canonicalize().unwrap();
-    let linked_c = linked.canonicalize().unwrap();
+    let main_c = crate::paths::canonicalize(&main).unwrap();
+    let linked_c = crate::paths::canonicalize(&linked).unwrap();
 
     // Main worktree (any root) resolves to itself.
     assert_eq!(config::anchor_root_to_main_worktree(&main_c), main_c);
@@ -1309,7 +1312,7 @@ fn anchor_root_preserves_subdir_and_redirects_linked_to_main() {
     // A non-git directory falls back to itself.
     let plain = tmp.join("plain");
     std::fs::create_dir_all(&plain).unwrap();
-    let plain_c = plain.canonicalize().unwrap();
+    let plain_c = crate::paths::canonicalize(&plain).unwrap();
     assert_eq!(config::anchor_root_to_main_worktree(&plain_c), plain_c);
 
     // A linked-worktree subdir root that does NOT exist in main must NOT anchor to a missing
@@ -1318,7 +1321,7 @@ fn anchor_root_preserves_subdir_and_redirects_linked_to_main() {
     // (existing) root — otherwise `Config.root` would point outside any discoverable repo path.
     let branch_only = linked.join("branch_only");
     std::fs::create_dir_all(&branch_only).unwrap();
-    let branch_only_c = branch_only.canonicalize().unwrap();
+    let branch_only_c = crate::paths::canonicalize(&branch_only).unwrap();
     assert!(!main_c.join("branch_only").exists(), "main never had this dir");
     assert_eq!(
         config::anchor_root_to_main_worktree(&branch_only_c),
@@ -3204,4 +3207,62 @@ fn a_symlinked_target_directory_keeps_its_configured_spelling() {
         vec![PathBuf::from("src")],
         "stored as configured, because that is the spelling the walk produces",
     );
+}
+
+/// Whether `path` carries the Windows extended-length (`\\?\`) prefix — asked TEXTUALLY, because
+/// that is how `git` and gix see it.
+fn is_verbatim(path: &Path) -> bool {
+    path.as_os_str().to_string_lossy().starts_with(r"\\?\")
+}
+
+/// `Config::load` normalizes its root, and the rest of the system consumes that root as a `git`
+/// argument and compares it against gix's `workdir()`. Both consumers reject the `\\?\C:\…`
+/// verbatim spelling `std::fs::canonicalize` returns on Windows, so the normalized root must not
+/// carry it (#1048).
+///
+/// Not `cfg`-gated: on Unix the assertions hold trivially, and the Windows leg is the one that has
+/// to run them — a Unix-only probe would have caught none of this.
+#[test]
+fn a_loaded_config_root_is_a_spelling_git_and_gix_both_accept() {
+    let tmp = scratch("root-spelling");
+    let main = tmp.join("main");
+    std::fs::create_dir_all(main.join("crate/src")).unwrap();
+    crate::test_git::run(&main, &["init", "-q"]);
+    std::fs::write(main.join("crate/src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    crate::test_git::run(&main, &["add", "."]);
+    crate::test_git::run(&main, &["commit", "-qm", "seed"]);
+    std::fs::write(main.join("rag-rat.toml"), "[index]\nroot = \"crate\"\n").unwrap();
+
+    let cfg = Config::load(main.join("rag-rat.toml")).unwrap();
+    assert!(
+        !is_verbatim(&cfg.root),
+        "Config::load must not hand out a verbatim root: {:?}",
+        cfg.root,
+    );
+
+    // gix: the root strips against the workdir of the repository discovered from it, which is what
+    // the worktree overlay derives its config subdir from.
+    let repo = crate::repo_discover::discover_repo(&cfg.root).unwrap();
+    let workdir = crate::paths::canonicalize_or_simplified(repo.workdir().unwrap());
+    assert_eq!(
+        cfg.root.strip_prefix(&workdir).ok(),
+        Some(Path::new("crate")),
+        "the loaded root {:?} must strip against the repository workdir {:?}",
+        cfg.root,
+        workdir,
+    );
+
+    // git: a destination derived from the loaded root is usable as a `worktree add` argument. On
+    // the unfixed Windows path this fails with `could not create leading directories of
+    // '//?/C:/…'`.
+    let linked = cfg.root.parent().expect("the root has a repository above it").join("linked-wt");
+    assert!(!is_verbatim(&linked), "the derived destination is not verbatim: {linked:?}");
+    crate::test_git::run(&main, &[
+        "worktree",
+        "add",
+        "--detach",
+        "-q",
+        linked.to_str().expect("a scratch path is UTF-8"),
+    ]);
+    assert!(linked.join("crate/src/a.rs").is_file(), "the linked checkout was created");
 }

--- a/crates/rag-rat-base/src/locks.rs
+++ b/crates/rag-rat-base/src/locks.rs
@@ -214,7 +214,7 @@ fn lock_dir(database: &Path) -> PathBuf {
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
     let mut cur = parent;
     loop {
-        if let Ok(canonical) = cur.canonicalize() {
+        if let Ok(canonical) = crate::paths::canonicalize(cur) {
             let mut out = canonical;
             out.extend(tail.iter().rev());
             return out;
@@ -560,7 +560,7 @@ pub const MAX_SOCKET_PATH_LEN: usize = 100;
 /// Stable per-worktree key: sha256 of the canonicalized root (see `election_lock_path` doc
 /// comment for why canonicalize-but-not-case-fold).
 fn worktree_hash(worktree_root: &Path) -> String {
-    let canonical = worktree_root.canonicalize().unwrap_or_else(|_| worktree_root.to_path_buf());
+    let canonical = crate::paths::canonicalize_or_simplified(worktree_root);
     let digest = Sha256::digest(canonical.to_string_lossy().as_bytes());
     let mut hash = String::with_capacity(32);
     for byte in &digest[..16] {

--- a/crates/rag-rat-base/src/paths.rs
+++ b/crates/rag-rat-base/src/paths.rs
@@ -69,6 +69,24 @@ pub fn canonicalize_or_simplified(path: &Path) -> PathBuf {
 /// Only the verbatim DISK shape (`\\?\C:\…`) is ever rewritten. No rag-rat writes a value in that
 /// shape today on any platform — post-fix Windows records `C:\…`, Unix records `/…` — so a Unix
 /// directory deliberately named to look like one is out of scope rather than defended against.
+///
+/// TWO LIMITS, DISCLOSED RATHER THAN DEFENDED AGAINST — see the corpus in
+/// `rekeyed_from_verbatim_rewrites_only_the_droppable_prefix`, which pins both.
+///  * A stored spelling reaches this rule ALREADY LOSSY. `worktree_id_of` persists
+///    `canonicalize_or_simplified(path).to_string_lossy()`, so a checkout path carrying an unpaired
+///    UTF-16 surrogate arrives here with U+FFFD in that component's place. Production keeps the
+///    prefix for such a path (`dunce` judges a component through `to_str()` and declines when that
+///    fails), but the stored string is well-formed UTF-8 by the time it gets here and U+FFFD is an
+///    ordinary character, so the rule strips — rewriting a value production still spells verbatim,
+///    and moving the row out of the active scope and the GC live set. Declining every U+FFFD breaks
+///    the opposite case (a component genuinely NAMED with U+FFFD, which production does simplify)
+///    and the stored string cannot tell the two apart, so the rewrite stands.
+///  * `names_a_reserved_dos_device` matches `dunce` 1.0.5, which lists only the ASCII device names
+///    and misses `COM¹`/`COM²`/`COM³` and the `LPT` equivalents. Here the rule and production
+///    AGREE, so no row is rekeyed to a spelling production does not produce; the cost is inherited
+///    from [`canonicalize`], which strips a prefix that is load-bearing for such a path. Widening
+///    the list here rather than upstream would BREAK that agreement — the rule would decline a
+///    rewrite production performs — which is the worse trade.
 pub fn rekeyed_from_verbatim(stored: &str) -> Option<String> {
     let plain = stored.strip_prefix(VERBATIM_PREFIX)?;
     verbatim_disk_prefix_is_droppable(stored, plain).then(|| plain.to_string())
@@ -271,6 +289,16 @@ mod tests {
         (r"\\?\C:\repo\..\sibling", None),
         // A character the plain spelling cannot carry.
         (r"\\?\C:\repo\pipe|name", None),
+        // The two disclosed limits (see `rekeyed_from_verbatim`). U+FFFD is an ordinary character
+        // to this rule, so a stored id that reached it through `to_string_lossy` over an unpaired
+        // surrogate is rewritten even though production keeps the prefix for that path; and the
+        // superscript DOS device names are absent from `dunce`'s list, so both sides strip. Pinned
+        // as expectations because "fixing" either one would make the rule DISAGREE with production
+        // — which is the failure mode the rekey exists to avoid, not a hardening. U+FFFD is
+        // spelled as an escape rather than literally so it cannot be read as this file
+        // being mis-decoded.
+        ("\\\\?\\C:\\repo\\lossy\u{FFFD}name", Some("C:\\repo\\lossy\u{FFFD}name")),
+        (r"\\?\C:\repo\COM¹", Some(r"C:\repo\COM¹")),
     ];
 
     /// The rekey rule, on every platform. It decides a property of a STORED STRING, so it cannot be

--- a/crates/rag-rat-base/src/paths.rs
+++ b/crates/rag-rat-base/src/paths.rs
@@ -43,6 +43,24 @@ pub fn canonicalize_or_simplified(path: &Path) -> PathBuf {
     canonicalize(path).unwrap_or_else(|_| simplified(path).to_path_buf())
 }
 
+/// The [`simplified`] rule applied to a path that was PERSISTED as a string — `None` when the
+/// stored spelling is already the one this binary produces, `Some(plain)` when it is a verbatim
+/// path that must be rekeyed to keep matching.
+///
+/// The rekey seam for stored identity. Values like a `worktree_id` scope key or a recorded
+/// `repo_roots.root` are compared TEXTUALLY against a freshly-canonicalized path, so an index
+/// written when [`canonicalize`] still answered `\\?\C:\…` stops matching the moment this binary
+/// answers `C:\…` — the rows go out of scope and GC prunes them as a dead checkout. Rewriting the
+/// stored string through the SAME rule production uses is what keeps the two comparable; a blind
+/// `\\?\` strip would not, because [`simplified`] deliberately KEEPS the prefix where it is
+/// load-bearing (UNC, >`MAX_PATH`, reserved DOS names) and this binary still produces it there.
+///
+/// `None` on Unix for every input, so a rekey pass over a Unix index is a strict no-op.
+pub fn rekeyed_from_verbatim(stored: &str) -> Option<String> {
+    let plain = simplified(Path::new(stored)).to_string_lossy();
+    (plain != stored).then(|| plain.into_owned())
+}
+
 /// The canonical `/`-separated rendering used everywhere a path is persisted or compared against
 /// the `files` table — Windows separators normalize so the same file hashes/joins identically on
 /// every platform.
@@ -116,6 +134,42 @@ mod tests {
         let canonical = canonicalize(dir.path()).unwrap();
         assert_eq!(simplified(&canonical), canonical.as_path());
         assert!(!is_verbatim(simplified(&canonical)));
+    }
+
+    /// A spelling this binary already produces is left ALONE — the rekey must be a no-op for every
+    /// value that is not stale, or a migration would rewrite rows it has no business touching.
+    /// Holds on both platforms: `C:\plain` is what Windows produces, and on Unix `simplified` is
+    /// the identity for everything.
+    #[test]
+    fn rekeyed_from_verbatim_leaves_a_current_spelling_alone() {
+        assert_eq!(rekeyed_from_verbatim(r"C:\plain\root"), None);
+        assert_eq!(rekeyed_from_verbatim("/home/user/repo"), None);
+        assert_eq!(rekeyed_from_verbatim(""), None);
+    }
+
+    /// On Unix NOTHING is rekeyed, including a string that merely LOOKS verbatim: a Unix index
+    /// never held one, and rewriting a path that happens to start with those bytes would corrupt
+    /// it. This is what makes the migration a strict no-op off Windows.
+    #[cfg(unix)]
+    #[test]
+    fn rekeyed_from_verbatim_is_inert_on_unix() {
+        assert_eq!(rekeyed_from_verbatim(r"\\?\C:\Users\dev\repo"), None);
+    }
+
+    /// The rekey itself: a stored verbatim path maps to the plain spelling `canonicalize` now
+    /// answers, and the prefix is KEPT where it is load-bearing (a UNC share), because this binary
+    /// still produces it there and rewriting would break the match it exists to preserve.
+    #[cfg(windows)]
+    #[test]
+    fn rekeyed_from_verbatim_rewrites_only_the_droppable_prefix() {
+        assert_eq!(
+            rekeyed_from_verbatim(r"\\?\C:\Users\dev\repo").as_deref(),
+            Some(r"C:\Users\dev\repo"),
+        );
+        // Load-bearing verbatim: `simplified` keeps it, so the stored value is already current.
+        assert_eq!(rekeyed_from_verbatim(r"\\?\UNC\server\share\repo"), None);
+        // Idempotent — re-running a rekey pass changes nothing the first one produced.
+        assert_eq!(rekeyed_from_verbatim(r"C:\Users\dev\repo"), None);
     }
 
     /// The fallback arm must hold the invariant too: a path that cannot be resolved comes back

--- a/crates/rag-rat-base/src/paths.rs
+++ b/crates/rag-rat-base/src/paths.rs
@@ -1,6 +1,47 @@
-//! Path rendering shared across subsystems.
+//! Path rendering and resolution shared across subsystems.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// `std::fs::canonicalize`, minus the Windows `\\?\` verbatim prefix wherever the plain spelling
+/// names the same file — THE canonicalization every subsystem resolves a filesystem path through.
+/// Identical to `std::fs::canonicalize` on Unix.
+///
+/// Windows' `canonicalize` always returns a VERBATIM path (`\\?\C:\Users\…`), and that spelling is
+/// not interchangeable with the ordinary one:
+///  * `git worktree add \\?\C:\…\linked` fails outright — `fatal: could not create leading
+///    directories of '//?/C:/…': Invalid argument` — so a `config.root` in verbatim form cannot
+///    build a linked worktree at all;
+///  * gix reports `workdir()` in the ORDINARY form (`gix-discover` runs `dunce::simplified` over
+///    the directory it discovers from), so a verbatim root strips to nothing against it and the
+///    worktree overlay scopes its refresh at the repo root instead of the config root.
+///
+/// Verbatim form is kept exactly where it is load-bearing (UNC shares, paths past `MAX_PATH`,
+/// reserved DOS names such as `CON`, components with a trailing dot or space): those are the cases
+/// where the plain spelling would resolve somewhere else, or nowhere. `dunce` owns that rule, and
+/// using the SAME crate gix does is what makes the two sides comparable rather than merely similar.
+///
+/// Every filesystem canonicalization in the workspace goes through here; `clippy.toml` disallows
+/// `Path::canonicalize` / `std::fs::canonicalize` so a new call site cannot reintroduce a verbatim
+/// path (#1048). It takes `impl AsRef<Path>` so it is a drop-in for both halves of the
+/// `std::fs::canonicalize` / `Path::canonicalize` pair it replaces.
+pub fn canonicalize(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+    dunce::canonicalize(path.as_ref())
+}
+
+/// The verbatim-prefix rule of [`canonicalize`] applied to a path we did NOT resolve ourselves — a
+/// user-supplied argument, a repository path handed back by another library. Borrowing, no I/O, and
+/// the identity on Unix.
+pub fn simplified(path: &Path) -> &Path {
+    dunce::simplified(path)
+}
+
+/// [`canonicalize`], falling back to the [`simplified`] original when the path cannot be resolved
+/// (it does not exist, or is unreadable). The fallback is simplified rather than returned verbatim
+/// so BOTH arms hold the no-verbatim invariant — a caller that compares the result against a
+/// canonical path must not start matching only on the success arm.
+pub fn canonicalize_or_simplified(path: &Path) -> PathBuf {
+    canonicalize(path).unwrap_or_else(|_| simplified(path).to_path_buf())
+}
 
 /// The canonical `/`-separated rendering used everywhere a path is persisted or compared against
 /// the `files` table — Windows separators normalize so the same file hashes/joins identically on
@@ -37,4 +78,59 @@ pub fn lexically_normalized(path: &Path) -> Option<std::path::PathBuf> {
         }
     }
     Some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Whether `path` carries the Windows extended-length (`\\?\`) prefix — asked TEXTUALLY,
+    /// because that is how `git` and gix see it.
+    fn is_verbatim(path: &Path) -> bool {
+        path.as_os_str().to_string_lossy().starts_with(r"\\?\")
+    }
+
+    /// The invariant the whole module exists for: an ordinary existing directory resolves to a
+    /// NON-verbatim path, and that path still names the same directory. `std::fs::canonicalize`
+    /// fails the first half on Windows for every path it is given (#1048).
+    #[test]
+    fn canonicalize_resolves_an_ordinary_directory_without_the_verbatim_prefix() {
+        let dir = crate::test_scratch::ScratchDir::new("verbatim-probe");
+        let canonical = canonicalize(dir.path()).unwrap();
+        assert!(
+            !is_verbatim(&canonical),
+            "a canonicalized ordinary directory must not carry the verbatim prefix: {canonical:?}",
+        );
+        // Same directory under both spellings — the prefix strip resolved, it did not redirect.
+        std::fs::write(canonical.join("probe"), "payload").unwrap();
+        assert_eq!(std::fs::read_to_string(dir.path().join("probe")).unwrap(), "payload");
+        // Idempotent: re-resolving the result is a fixed point.
+        assert_eq!(canonicalize(&canonical).unwrap(), canonical);
+    }
+
+    /// [`simplified`] applies the same rule without touching the filesystem, and is the identity
+    /// on a path that is already in the plain spelling.
+    #[test]
+    fn simplified_leaves_an_already_plain_path_alone() {
+        let dir = crate::test_scratch::ScratchDir::new("simplified-probe");
+        let canonical = canonicalize(dir.path()).unwrap();
+        assert_eq!(simplified(&canonical), canonical.as_path());
+        assert!(!is_verbatim(simplified(&canonical)));
+    }
+
+    /// The fallback arm must hold the invariant too: a path that cannot be resolved comes back
+    /// SIMPLIFIED, not verbatim, so a caller comparing it against a canonical path does not start
+    /// matching only when the directory happens to exist.
+    #[test]
+    fn canonicalize_or_simplified_falls_back_without_reintroducing_the_prefix() {
+        let dir = crate::test_scratch::ScratchDir::new("fallback-probe");
+        let absent = dir.path().join("not-created-yet");
+        let resolved = canonicalize_or_simplified(&absent);
+        assert!(!is_verbatim(&resolved), "the fallback must not be verbatim: {resolved:?}");
+        assert_eq!(resolved, simplified(&absent));
+
+        // And the success arm is plain `canonicalize`.
+        std::fs::create_dir_all(&absent).unwrap();
+        assert_eq!(canonicalize_or_simplified(&absent), canonicalize(&absent).unwrap());
+    }
 }

--- a/crates/rag-rat-base/src/paths.rs
+++ b/crates/rag-rat-base/src/paths.rs
@@ -51,15 +51,116 @@ pub fn canonicalize_or_simplified(path: &Path) -> PathBuf {
 /// `repo_roots.root` are compared TEXTUALLY against a freshly-canonicalized path, so an index
 /// written when [`canonicalize`] still answered `\\?\C:\…` stops matching the moment this binary
 /// answers `C:\…` — the rows go out of scope and GC prunes them as a dead checkout. Rewriting the
-/// stored string through the SAME rule production uses is what keeps the two comparable; a blind
-/// `\\?\` strip would not, because [`simplified`] deliberately KEEPS the prefix where it is
-/// load-bearing (UNC, >`MAX_PATH`, reserved DOS names) and this binary still produces it there.
+/// stored string through the same rule keeps the two comparable; a blind `\\?\` strip would not,
+/// because the prefix is load-bearing where the plain spelling names something else (UNC shares,
+/// paths past `MAX_PATH`, reserved DOS names), and a Windows binary still produces it there.
 ///
-/// `None` on Unix for every input, so a rekey pass over a Unix index is a strict no-op.
+/// DECIDED TEXTUALLY, ON EVERY PLATFORM — this is the one place the verbatim rule is NOT delegated
+/// to `dunce`. A stored string is data, not a path on this host: the store that carries Windows
+/// spellings is not necessarily opened by a Windows binary (one repo directory reachable from both
+/// a Windows and a WSL/container mount is one SQLite file), and `dunce::simplified` compiles to the
+/// identity off Windows. Deferring to it would let whichever binary opened first record the rekey
+/// migration as applied without performing it, after which the ladder — forward-only — never
+/// revisits it and the Windows binary keeps the spellings that get its rows collected as a dead
+/// checkout. Nothing here touches the filesystem: droppability is a property of the string.
+/// `windows_verbatim_droppability_matches_dunce` pins the rule against `dunce::simplified` on the
+/// Windows leg of CI, so the two cannot drift.
+///
+/// Only the verbatim DISK shape (`\\?\C:\…`) is ever rewritten. No rag-rat writes a value in that
+/// shape today on any platform — post-fix Windows records `C:\…`, Unix records `/…` — so a Unix
+/// directory deliberately named to look like one is out of scope rather than defended against.
 pub fn rekeyed_from_verbatim(stored: &str) -> Option<String> {
-    let plain = simplified(Path::new(stored)).to_string_lossy();
-    (plain != stored).then(|| plain.into_owned())
+    let plain = stored.strip_prefix(VERBATIM_PREFIX)?;
+    verbatim_disk_prefix_is_droppable(stored, plain).then(|| plain.to_string())
 }
+
+/// The Windows extended-length prefix a pre-fix `canonicalize` put on every path it resolved.
+const VERBATIM_PREFIX: &str = r"\\?\";
+
+/// Whether `plain` — `stored` minus its [`VERBATIM_PREFIX`] — names the same file as `stored`.
+///
+/// `stored` is passed alongside because the length limit applies to the WHOLE verbatim path, which
+/// is what the plain spelling would have to fit under.
+fn verbatim_disk_prefix_is_droppable(stored: &str, plain: &str) -> bool {
+    // A verbatim DISK path is the only form whose prefix is droppable: `\\?\UNC\server\share` and
+    // the raw device forms name things the drive-letter spelling cannot reach at all.
+    let mut prefix = plain.chars();
+    match (prefix.next(), prefix.next()) {
+        (Some(drive), Some(':')) if drive.is_ascii_alphabetic() => {},
+        _ => return false,
+    }
+    // Everything after `C:` is the root separator plus the components under it. A bare `C:` (no
+    // root) and `C:\` (root, no components) are both already whole paths.
+    if let Some(under_root) = plain.get(2..).filter(|rest| !rest.is_empty()) {
+        let Some(components) = under_root.strip_prefix('\\') else { return false };
+        if !components.is_empty()
+            && !components.split('\\').all(component_is_reachable_without_the_prefix)
+        {
+            return false;
+        }
+    }
+    // Past the legacy limit the plain spelling is not addressable through the ANSI APIs, so the
+    // prefix is what makes the path usable. Byte length is checked first because it is the cheap
+    // over-estimate: only a path that fails it is worth counting UTF-16 units for.
+    stored.len() <= MAX_PLAIN_PATH_UNITS || windows_utf16_len(stored) <= MAX_PLAIN_PATH_UNITS
+}
+
+/// Whether one path component resolves to itself under the plain spelling.
+///
+/// The DOS layer the plain spelling goes through trims trailing dots and spaces, reserves a handful
+/// of device names, and rejects a set of characters outright — a component that trips any of those
+/// resolves somewhere else, or nowhere, once the prefix is gone.
+fn component_is_reachable_without_the_prefix(component: &str) -> bool {
+    if component.is_empty() {
+        return false;
+    }
+    if component.len() > MAX_COMPONENT_UNITS && windows_utf16_len(component) > MAX_COMPONENT_UNITS {
+        return false;
+    }
+    if component.bytes().any(|b| {
+        matches!(b, 0..=31 | b'<' | b'>' | b':' | b'"' | b'/' | b'\\' | b'|' | b'?' | b'*')
+    }) {
+        return false;
+    }
+    // Trailing dots and spaces are trimmed by the DOS layer, so the plain spelling names a
+    // different file. This also rejects `.` and `..`, which a verbatim path takes literally.
+    if component.ends_with('.') || component.ends_with(' ') {
+        return false;
+    }
+    !names_a_reserved_dos_device(component)
+}
+
+/// Whether `component` is one of the reserved DOS device names — `CON`, `NUL`, `COM1`, … — under
+/// which the plain spelling opens the DEVICE rather than the file.
+///
+/// The reservation applies to the STEM (`con.txt` is `CON`) after trailing dots and spaces are
+/// trimmed (`con. . ` is `CON`).
+fn names_a_reserved_dos_device(component: &str) -> bool {
+    const RESERVED: [&str; 22] = [
+        "AUX", "NUL", "PRN", "CON", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+    // `Path::file_stem`'s rule: everything before the LAST dot, unless the only dot is a leading
+    // one (a dotfile is all stem).
+    let stem = match component.rfind('.') {
+        Some(0) | None => component,
+        Some(dot) => &component[..dot],
+    };
+    let trimmed = stem.trim_end_matches([' ', '.']);
+    // Every reserved name is ASCII and at most 4 bytes, so the length test rejects the long
+    // majority before any comparison — and keeps a multi-byte suffix (`CON。`) from matching.
+    trimmed.len() <= 4 && RESERVED.iter().any(|name| trimmed.eq_ignore_ascii_case(name))
+}
+
+/// The length of `s` in UTF-16 code units — the unit Windows measures its path limits in, counted
+/// from the UTF-8 without encoding.
+fn windows_utf16_len(s: &str) -> usize {
+    s.chars().map(|c| if (c as u32) <= 0xFFFF { 1 } else { 2 }).sum()
+}
+
+/// The longest plain-spelled path the ANSI APIs accept, and the longest single component.
+const MAX_PLAIN_PATH_UNITS: usize = 260;
+const MAX_COMPONENT_UNITS: usize = 255;
 
 /// The canonical `/`-separated rendering used everywhere a path is persisted or compared against
 /// the `files` table — Windows separators normalize so the same file hashes/joins identically on
@@ -136,40 +237,96 @@ mod tests {
         assert!(!is_verbatim(simplified(&canonical)));
     }
 
-    /// A spelling this binary already produces is left ALONE — the rekey must be a no-op for every
-    /// value that is not stale, or a migration would rewrite rows it has no business touching.
-    /// Holds on both platforms: `C:\plain` is what Windows produces, and on Unix `simplified` is
-    /// the identity for everything.
-    #[test]
-    fn rekeyed_from_verbatim_leaves_a_current_spelling_alone() {
-        assert_eq!(rekeyed_from_verbatim(r"C:\plain\root"), None);
-        assert_eq!(rekeyed_from_verbatim("/home/user/repo"), None);
-        assert_eq!(rekeyed_from_verbatim(""), None);
-    }
+    /// The corpus the rekey rule is pinned on, as `(stored, rekeyed)` pairs. `None` means the
+    /// stored spelling is one a current binary still produces, so the value is already correct and
+    /// must be left alone.
+    ///
+    /// Shared by the platform-independent test below and by the Windows-only agreement test, so the
+    /// rule and `dunce` are compared on exactly the cases the rule is specified against rather than
+    /// on two separately-remembered lists.
+    const REKEY_CORPUS: &[(&str, Option<&str>)] = &[
+        // The ordinary case, and the whole point: a checkout root a pre-fix binary resolved.
+        (r"\\?\C:\Users\dev\repo", Some(r"C:\Users\dev\repo")),
+        (r"\\?\c:\lower\drive", Some(r"c:\lower\drive")),
+        (r"\\?\C:\", Some(r"C:\")),
+        (r"\\?\C:", Some("C:")),
+        // Already current — a rekey pass must be idempotent and must not touch a Unix path.
+        (r"C:\Users\dev\repo", None),
+        ("/home/user/repo", None),
+        ("", None),
+        // Load-bearing verbatim: the plain spelling names something else, or nothing.
+        (r"\\?\UNC\server\share\repo", None),
+        (r"\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}\repo", None),
+        // Reserved DOS device names, including through a stem and through trimmed dots/spaces.
+        (r"\\?\C:\CON\repo", None),
+        (r"\\?\C:\repo\com4.txt", None),
+        (r"\\?\C:\repo\con . .txt", None),
+        // Not reserved, though it looks close.
+        (r"\\?\C:\repo\COM77", Some(r"C:\repo\COM77")),
+        (r"\\?\C:\repo\not.CON", Some(r"C:\repo\not.CON")),
+        // Trailing dot / space: the DOS layer trims both, so the plain spelling is a different
+        // file. `..` is taken literally in a verbatim path and is caught by the same rule.
+        (r"\\?\C:\repo\trailing.", None),
+        (r"\\?\C:\repo\trailing ", None),
+        (r"\\?\C:\repo\..\sibling", None),
+        // A character the plain spelling cannot carry.
+        (r"\\?\C:\repo\pipe|name", None),
+    ];
 
-    /// On Unix NOTHING is rekeyed, including a string that merely LOOKS verbatim: a Unix index
-    /// never held one, and rewriting a path that happens to start with those bytes would corrupt
-    /// it. This is what makes the migration a strict no-op off Windows.
-    #[cfg(unix)]
-    #[test]
-    fn rekeyed_from_verbatim_is_inert_on_unix() {
-        assert_eq!(rekeyed_from_verbatim(r"\\?\C:\Users\dev\repo"), None);
-    }
-
-    /// The rekey itself: a stored verbatim path maps to the plain spelling `canonicalize` now
-    /// answers, and the prefix is KEPT where it is load-bearing (a UNC share), because this binary
-    /// still produces it there and rewriting would break the match it exists to preserve.
-    #[cfg(windows)]
+    /// The rekey rule, on every platform. It decides a property of a STORED STRING, so it cannot be
+    /// allowed to depend on the host that happens to be reading it: a store carrying Windows
+    /// spellings is reachable from a non-Windows binary, and a rekey that no-ops there would let
+    /// the migration record itself as applied without converting anything.
     #[test]
     fn rekeyed_from_verbatim_rewrites_only_the_droppable_prefix() {
+        for (stored, expected) in REKEY_CORPUS {
+            assert_eq!(
+                rekeyed_from_verbatim(stored).as_deref(),
+                *expected,
+                "the rekey rule must not depend on the host reading the store: {stored:?}",
+            );
+        }
+    }
+
+    /// A path past the legacy limit keeps its prefix — that is the case the prefix exists for — and
+    /// one just under it does not. Built rather than spelled out because the boundary is 260 units.
+    ///
+    /// Both paths are made of 100-unit components, so the WHOLE-PATH limit is what separates them:
+    /// a single 300-unit component would be rejected by the 255-unit per-component rule instead,
+    /// and the test would pass without the length check existing at all.
+    #[test]
+    fn rekeyed_from_verbatim_keeps_the_prefix_past_the_legacy_length_limit() {
+        let component = "a".repeat(100);
+        let long = format!(r"\\?\C:\{component}\{component}\{component}");
+        assert!(long.len() > 260, "the fixture must actually exceed the limit: {}", long.len());
+        assert_eq!(rekeyed_from_verbatim(&long), None, "a >MAX_PATH path needs its prefix");
+
+        let short = format!(r"\\?\C:\{component}\{component}");
+        assert!(short.len() <= 260, "the fixture must stay inside the limit: {}", short.len());
         assert_eq!(
-            rekeyed_from_verbatim(r"\\?\C:\Users\dev\repo").as_deref(),
-            Some(r"C:\Users\dev\repo"),
+            rekeyed_from_verbatim(&short).as_deref(),
+            Some(&short[4..]),
+            "a path inside the limit is reachable without the prefix",
         );
-        // Load-bearing verbatim: `simplified` keeps it, so the stored value is already current.
-        assert_eq!(rekeyed_from_verbatim(r"\\?\UNC\server\share\repo"), None);
-        // Idempotent — re-running a rekey pass changes nothing the first one produced.
-        assert_eq!(rekeyed_from_verbatim(r"C:\Users\dev\repo"), None);
+    }
+
+    /// The rule is a reimplementation of `dunce`'s — the crate `simplified` delegates to, and the
+    /// one gix resolves its `workdir()` through — so on Windows the two must agree exactly. This is
+    /// what makes the platform-independent copy safe: if the rule ever drifts from the authority,
+    /// the Windows leg of CI says so instead of the drift surfacing as rows rekeyed to a spelling
+    /// production does not produce.
+    #[cfg(windows)]
+    #[test]
+    fn windows_verbatim_droppability_matches_dunce() {
+        for (stored, _) in REKEY_CORPUS {
+            let authority = simplified(Path::new(stored)).to_string_lossy();
+            let ours = rekeyed_from_verbatim(stored);
+            assert_eq!(
+                ours.as_deref(),
+                (authority != *stored).then_some(authority.as_ref()),
+                "the rekey rule disagrees with dunce about {stored:?}",
+            );
+        }
     }
 
     /// The fallback arm must hold the invariant too: a path that cannot be resolved comes back

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -376,9 +376,10 @@ const NON_CANONICAL_ALIAS: &str = "via-symlink";
 /// [`ScratchDir`] for that reason (the roots not on it today are synthetic paths, explicitly
 /// canonicalized ones, and the bench corpus, none of which carry a scratch spelling at all).
 ///
-/// It is also only an approximation of Windows: `std::fs::canonicalize` there returns a `\\?\`
-/// verbatim path and expands 8.3 names, neither of which a Unix symlink produces. A root-spelling
-/// bug specific to those two shapes still surfaces first on the cross-platform legs.
+/// It is also only an approximation of Windows: canonicalization there expands 8.3 names
+/// (`RUNNER~1`) and, for a long or UNC path, keeps the `\\?\` extended-length prefix — neither of
+/// which a Unix symlink produces. A root-spelling bug specific to those shapes still surfaces first
+/// on the cross-platform legs.
 fn aliased_root(root: &Path) -> PathBuf {
     #[cfg(unix)]
     {
@@ -396,25 +397,27 @@ fn aliased_root(root: &Path) -> PathBuf {
 
 /// `root` in the canonical form a `Config` loaded from disk would carry.
 ///
-/// `Config::load` normalizes its root through `canonicalize()`, and index/overlay code depends on
-/// that: the worktree overlay derives `config.root`'s subdir by stripping it against a
-/// canonicalized repo workdir, so a hand-built `Config` holding a non-canonical root strips to
-/// nothing and scopes the refresh at the repo root instead of the config root. A fixture that
-/// builds its `Config` by hand must therefore canonicalize the same way — otherwise it exercises a
-/// configuration production can never produce, and the mis-scoping stays invisible (#1027).
+/// `Config::load` normalizes its root through [`crate::paths::canonicalize`], and index/overlay
+/// code depends on that: the worktree overlay derives `config.root`'s subdir by stripping it
+/// against a canonicalized repo workdir, so a hand-built `Config` holding a non-canonical root
+/// strips to nothing and scopes the refresh at the repo root instead of the config root. A fixture
+/// that builds its `Config` by hand must therefore canonicalize the same way — otherwise it
+/// exercises a configuration production can never produce, and the mis-scoping stays invisible
+/// (#1027). Mirroring THAT helper rather than `std::fs::canonicalize` is what keeps fixture roots
+/// out of the Windows `\\?\` verbatim spelling `git` and gix reject (#1048).
 ///
 /// Fixtures hand roots over before creating them (a `git worktree add` destination must not
-/// exist), which plain `canonicalize()` rejects, so this canonicalizes the longest EXISTING
-/// ancestor and re-joins the remainder. For a root that exists it is exactly `canonicalize()`.
+/// exist), which plain canonicalization rejects, so this resolves the longest EXISTING ancestor and
+/// re-joins the remainder. For a root that exists it is exactly `paths::canonicalize`.
 ///
 /// A root with NO existing ancestor below the filesystem root comes back UNCHANGED, and that is
 /// load-bearing rather than a degenerate case. Placement and event-classification tests reason over
 /// SYNTHETIC paths (`/repo`, `/main/.git/worktrees`, `/checkout/packages`) that are never on disk;
 /// `Config::load` rejects such a root outright (`normalize_existing_dir` requires the directory to
 /// exist), so there is no production spelling to match and inventing one would only introduce a
-/// divergence. Windows is where that bites: `canonicalize()` on the bare root yields the current
-/// drive's `\\?\C:\` verbatim prefix, so a canonicalized `/repo` would stop matching the sibling
-/// literals the same test compares it against — a mismatch the Linux legs can never see (#1027).
+/// divergence. Windows is where that bites: canonicalizing the bare root yields the current drive
+/// (`C:\`), so a canonicalized `/repo` would stop matching the sibling literals the same test
+/// compares it against — a mismatch the Linux legs can never see (#1027).
 pub fn canonical_config_root(root: impl Into<PathBuf>) -> PathBuf {
     let root = root.into();
     resolve_through_existing_ancestor(&root).unwrap_or(root)
@@ -426,14 +429,14 @@ pub fn canonical_config_root(root: impl Into<PathBuf>) -> PathBuf {
 ///
 /// The ascent deliberately stops ABOVE the filesystem root instead of resolving it. A path with no
 /// existing ancestor at all names nothing on this machine, so there is no spelling to normalize
-/// toward — and on Windows `canonicalize()` of the bare root returns the current drive's `\\?\C:\`
-/// verbatim form, which would rewrite the path into one none of its siblings match.
+/// toward — and on Windows canonicalizing the bare root returns the current drive (`C:\`), which
+/// would rewrite the path into one none of its siblings match.
 fn resolve_through_existing_ancestor(path: &Path) -> Option<PathBuf> {
     let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
     let mut probe = path;
     loop {
         let (parent, name) = (probe.parent()?, probe.file_name()?);
-        if let Ok(canonical) = probe.canonicalize() {
+        if let Ok(canonical) = crate::paths::canonicalize(probe) {
             return Some(tail.iter().rev().fold(canonical, |acc, part| acc.join(part)));
         }
         tail.push(name);
@@ -722,13 +725,13 @@ mod tests {
     fn canonical_config_root_resolves_an_absent_leaf_through_its_symlinked_ancestors() {
         let dir = ScratchDir::new("absent-leaf-probe");
         let existing = canonical_config_root(dir.path());
-        assert_eq!(existing, dir.path().canonicalize().unwrap());
+        assert_eq!(existing, crate::paths::canonicalize(dir.path()).unwrap());
 
         let absent = dir.path().join("not-created-yet/nested");
         assert_eq!(canonical_config_root(&absent), existing.join("not-created-yet/nested"));
         // Once it exists, plain canonicalization agrees.
         std::fs::create_dir_all(&absent).unwrap();
-        assert_eq!(canonical_config_root(&absent), absent.canonicalize().unwrap());
+        assert_eq!(canonical_config_root(&absent), crate::paths::canonicalize(absent).unwrap());
     }
 
     /// The ancestor search stops ABOVE the filesystem root, so a SYNTHETIC path — one with no
@@ -756,7 +759,7 @@ mod tests {
         let dir = ScratchDir::new("ancestor-search");
         assert_eq!(
             resolve_through_existing_ancestor(&dir.join("absent/leaf")),
-            Some(dir.path().canonicalize().unwrap().join("absent/leaf")),
+            Some(crate::paths::canonicalize(dir.path()).unwrap().join("absent/leaf")),
         );
     }
 

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -786,8 +786,8 @@ fn worktree_rel_path(file_path: &str, worktree_root: &Path) -> Option<String> {
     // so canonicalize BOTH (when they exist) to survive a symlinked/`..`-laden checkout path;
     // fall back to a raw strip when either can't be resolved (keeps this unit-testable with
     // synthetic paths).
-    let file_c = file.canonicalize();
-    let root_c = worktree_root.canonicalize();
+    let file_c = rag_rat_base::paths::canonicalize(file);
+    let root_c = rag_rat_base::paths::canonicalize(worktree_root);
     let (f, r): (&Path, &Path) = match (file_c.as_deref(), root_c.as_deref()) {
         (Ok(f), Ok(r)) => (f, r),
         _ => (file, worktree_root),

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -419,11 +419,10 @@ mod tests {
         let worktrees = worktree_dirs_for(&linked_a).unwrap();
         assert!(worktrees.warnings.is_empty());
         // gix returns canonical worktree paths; the raw temp paths do not match on macOS (TempDir
-        // under /var → /private/var symlink) or Windows (canonicalize adds a \\?\-verbatim
-        // long-name form, and the temp dir uses an 8.3 short name). Canonicalize BOTH sides
-        // — the worktrees exist — so the compare is separator/prefix/symlink agnostic (and
-        // the set dedups too).
-        let canon = |p: &std::path::Path| std::fs::canonicalize(p).unwrap();
+        // under /var → /private/var symlink) or Windows (the temp dir uses an 8.3 short name that
+        // canonicalization expands). Canonicalize BOTH sides — the worktrees exist — so the
+        // compare is separator/prefix/symlink agnostic (and the set dedups too).
+        let canon = |p: &std::path::Path| rag_rat_base::paths::canonicalize(p).unwrap();
         let dirs: std::collections::BTreeSet<std::path::PathBuf> =
             worktrees.dirs.iter().map(|p| canon(p)).collect();
         assert!(dirs.contains(&canon(&main)));

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -167,8 +167,8 @@ pub(crate) fn absolute_config_root_value(root: &Path, parent: &Path) -> String {
     // stripping so they share one form (no-op when there's no symlink, i.e. everywhere on Linux
     // CI). Fall back to the raw path if canonicalize fails (e.g. the dir doesn't exist yet) —
     // same behavior as before for that edge. (#446)
-    let root_canon = root.canonicalize();
-    let parent_canon = parent.canonicalize();
+    let root_canon = rag_rat_base::paths::canonicalize(root);
+    let parent_canon = rag_rat_base::paths::canonicalize(parent);
     let root_ref = root_canon.as_deref().unwrap_or(root);
     let parent_ref = parent_canon.as_deref().unwrap_or(parent);
     if let Ok(relative_parent) = parent_ref.strip_prefix(root_ref) {
@@ -219,7 +219,7 @@ mod tests {
 
         // `root` = canonicalized real dir (what Config::load stores); `parent` reaches the same dir
         // through the symlink (what a config path under `link/` yields).
-        let root = real.canonicalize().unwrap();
+        let root = rag_rat_base::paths::canonicalize(real).unwrap();
         assert_ne!(link, root, "the symlinked path must differ from the canonical one");
         assert_eq!(config_root_value(&root, &link.join("rag-rat.toml")), ".");
 

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -5,7 +5,7 @@ use crate::{hook_script, install_hook, is_rag_rat_hook, make_executable, write_a
 pub(crate) fn run(args: &crate::cli::InitArgs, config_path: &str) -> anyhow::Result<()> {
     let options = InitOptions::from_args(args, config_path);
     let _terminal_reset = TerminalResetGuard::install_if_interactive(!options.yes)?;
-    let root = env::current_dir()?.canonicalize()?;
+    let root = rag_rat_base::paths::canonicalize(env::current_dir()?)?;
 
     // A config authored in a LINKED worktree is a trap: `Config::load`'s governing seam resolves
     // every worktree of a repo through the MAIN worktree's `rag-rat.toml`, so a branch-local file
@@ -157,7 +157,7 @@ fn interactive_scan_root(existing: Option<&ExistingWizardConfig>) -> anyhow::Res
     if let Some((_, config)) = existing.and_then(|existing| existing.config.as_ref()) {
         return Ok(config.root.clone());
     }
-    Ok(env::current_dir()?.canonicalize()?)
+    Ok(rag_rat_base::paths::canonicalize(env::current_dir()?)?)
 }
 
 fn local_config_root_from_raw(raw: &str, config_path: &Path) -> anyhow::Result<Option<PathBuf>> {
@@ -178,7 +178,7 @@ fn local_config_root_from_raw(raw: &str, config_path: &Path) -> anyhow::Result<O
     } else {
         config_dir(config_path)?.join(root_path)
     };
-    match candidate.canonicalize() {
+    match rag_rat_base::paths::canonicalize(candidate) {
         Ok(path) => Ok(Some(path)),
         Err(_) => Ok(None),
     }
@@ -192,7 +192,7 @@ fn config_dir(config_path: &Path) -> anyhow::Result<PathBuf> {
         (false, Some(parent)) => env::current_dir()?.join(parent),
         (false, None) => env::current_dir()?,
     };
-    Ok(dir.canonicalize().unwrap_or(dir))
+    Ok(rag_rat_base::paths::canonicalize_or_simplified(&dir))
 }
 
 /// Apply the git maintenance hooks the wizard selected, honoring each foreign-hook conflict
@@ -515,7 +515,7 @@ mod default_plan_tests {
 
         assert_eq!(
             interactive_scan_root(Some(&existing)).unwrap(),
-            root.path().canonicalize().unwrap()
+            rag_rat_base::paths::canonicalize(root.path()).unwrap()
         );
         assert!(existing.config.is_some());
     }
@@ -530,7 +530,7 @@ mod default_plan_tests {
 
         assert_eq!(
             local_config_root_from_raw(raw, &config_path).unwrap(),
-            Some(config_dir.canonicalize().unwrap())
+            Some(rag_rat_base::paths::canonicalize(config_dir).unwrap())
         );
     }
 
@@ -557,7 +557,10 @@ mod default_plan_tests {
         let existing = load_existing_for_wizard(&options).unwrap();
 
         assert!(existing.config.is_none());
-        assert_eq!(existing.local_root, Some(root.path().canonicalize().unwrap()));
+        assert_eq!(
+            existing.local_root,
+            Some(rag_rat_base::paths::canonicalize(root.path()).unwrap())
+        );
     }
 
     /// #181: a repo whose only `.py` files live under a dependency tree must NOT get

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -756,10 +756,10 @@ mod tests {
             .unwrap()
             .expect("the existing target checkout's governing config should load");
         // Config::load resolves the relative `database` against the CANONICALIZED config dir
-        // (normalize_existing_dir → fs::canonicalize): /var→/private/var on macOS, \\?\ + long name
+        // (normalize_existing_dir → paths::canonicalize): /var→/private/var on macOS, 8.3 expansion
         // on Windows. Canonicalize the base and join components so the expectation matches
         // natively.
-        let root = root.canonicalize().unwrap();
+        let root = rag_rat_base::paths::canonicalize(root).unwrap();
         assert_eq!(config.database, root.join("custom").join("index.sqlite"));
     }
 }

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -282,7 +282,7 @@ fn init_refuses_to_run_in_a_linked_worktree() {
     assert!(!output.status.success(), "init in a linked worktree is refused");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("main worktree"), "the refusal points at the main worktree: {stderr}");
-    let root_canonical = root.canonicalize().unwrap();
+    let root_canonical = rag_rat_base::paths::canonicalize(&root).unwrap();
     assert!(
         stderr.contains(&root_canonical.display().to_string()),
         "the refusal names the main worktree path: {stderr}"

--- a/crates/rag-rat-cli/tests/worktree_git_env.rs
+++ b/crates/rag-rat-cli/tests/worktree_git_env.rs
@@ -120,7 +120,7 @@ fn default_config_discovery_reaches_the_main_worktree_from_a_linked_checkout() {
     let out = run(&linked, &["gc"]);
     assert!(!out.status.success());
     let stderr = String::from_utf8_lossy(&out.stderr);
-    let main_toml = main.canonicalize().unwrap().join("rag-rat.toml");
+    let main_toml = rag_rat_base::paths::canonicalize(&main).unwrap().join("rag-rat.toml");
     assert!(
         stderr.contains(&main_toml.display().to_string()),
         "the config-less hint names MAIN's config path from a linked checkout: {stderr}"

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -602,7 +602,7 @@ mod tests {
         );
         assert_eq!(
             config.root,
-            root.path().canonicalize().unwrap(),
+            rag_rat_base::paths::canonicalize(root.path()).unwrap(),
             "both spellings name the same directory",
         );
     }

--- a/crates/rag-rat-core/src/index/corpus.rs
+++ b/crates/rag-rat-core/src/index/corpus.rs
@@ -167,7 +167,7 @@ mod tests {
         );
         assert_eq!(
             config.root,
-            scratch.path().canonicalize().unwrap(),
+            rag_rat_base::paths::canonicalize(scratch.path()).unwrap(),
             "both spellings name the same directory",
         );
     }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -240,8 +240,10 @@ fn dependency_tables(manifest: &toml::Value) -> Vec<&toml::value::Table> {
 /// unresolvable target (not present on disk) can't hold indexed symbols, so it's treated as
 /// outside.
 fn path_dependency_is_in_corpus(manifest_dir: &Path, path: &str, root: &Path) -> bool {
-    let Ok(target) = manifest_dir.join(path).canonicalize() else { return false };
-    match root.canonicalize() {
+    let Ok(target) = rag_rat_base::paths::canonicalize(manifest_dir.join(path)) else {
+        return false;
+    };
+    match rag_rat_base::paths::canonicalize(root) {
         Ok(canonical_root) => target.starts_with(&canonical_root),
         Err(_) => target.starts_with(root),
     }

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -158,7 +158,7 @@ pub fn resolve_git_context(root: &Path) -> (String, String) {
 /// (#219 review). Falls back to the literal path when it can't be resolved (a removed
 /// worktree mid-GC), trailing slash trimmed either way.
 pub(crate) fn worktree_id_of(path: &Path) -> String {
-    let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let resolved = rag_rat_base::paths::canonicalize_or_simplified(path);
     resolved.to_string_lossy().trim_end_matches('/').to_string()
 }
 
@@ -186,15 +186,16 @@ pub(crate) fn resolve_worktree_scope(root: &Path, worktree: Option<&Path>) -> (S
 /// `live_worktree_contexts`.
 fn validated_sibling_worktree(root: &Path, candidate: &Path) -> Option<PathBuf> {
     let repo = discover_repo(candidate).ok()?;
-    let git_dir = repo.git_dir().canonicalize().ok()?;
-    let common_dir = repo.common_dir().canonicalize().ok()?;
+    let git_dir = rag_rat_base::paths::canonicalize(repo.git_dir()).ok()?;
+    let common_dir = rag_rat_base::paths::canonicalize(repo.common_dir()).ok()?;
     // The main worktree's per-worktree git dir IS the common dir; a linked worktree's differs. Main
     // → None → base scope (which already serves the main checkout).
     if git_dir == common_dir {
         return None;
     }
     // Same repository as `root` iff they share a common dir — rejects an unrelated repo's worktree.
-    let root_common = discover_repo(root).ok()?.common_dir().canonicalize().ok()?;
+    let root_common =
+        rag_rat_base::paths::canonicalize(discover_repo(root).ok()?.common_dir()).ok()?;
     if common_dir != root_common {
         return None;
     }
@@ -277,7 +278,7 @@ mod worktree_scope_tests {
         std::fs::write(dir.join("a.txt"), "hello").unwrap();
         git(&dir, &["add", "."]);
         git(&dir, &["commit", "-q", "-m", "init"]);
-        let canonical = dir.canonicalize().unwrap();
+        let canonical = rag_rat_base::paths::canonicalize(&dir).unwrap();
         (dir, canonical)
     }
 
@@ -395,7 +396,10 @@ mod worktree_scope_tests {
         // changes, selecting the linked worktree's overlay.
         assert_eq!(sha, base_sha, "base commit must remain the rooted checkout's HEAD");
         assert_ne!(wt, base_id, "worktree_id must select the linked worktree");
-        assert_eq!(PathBuf::from(&wt).canonicalize().unwrap(), linked.canonicalize().unwrap());
+        assert_eq!(
+            rag_rat_base::paths::canonicalize(PathBuf::from(&wt)).unwrap(),
+            rag_rat_base::paths::canonicalize(linked).unwrap()
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -34,7 +34,11 @@ pub use query::{
 };
 
 const GIT_HISTORY_INDEXED_HEAD_META: &str = "git_history_indexed_head";
-const GIT_HISTORY_INDEXED_ROOT_META: &str = "git_history_indexed_root";
+/// The one cursor of the four whose value is a PATH (`root_key` = `config.root`'s spelling), so the
+/// V096 path-spelling rekey has to rewrite it. Declared in `rag-rat-db` and referenced here rather
+/// than spelled twice — the migration lives below this crate and a drifted literal there is a
+/// silent miss, not a compile error.
+const GIT_HISTORY_INDEXED_ROOT_META: &str = rag_rat_db::meta::GIT_HISTORY_INDEXED_ROOT_META;
 const GIT_HISTORY_INDEXED_SHALLOW_META: &str = "git_history_indexed_shallow";
 const GIT_HISTORY_INDEXED_COMPLETE_META: &str = "git_history_indexed_complete";
 

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -35,7 +35,7 @@ pub use query::{
 
 const GIT_HISTORY_INDEXED_HEAD_META: &str = "git_history_indexed_head";
 /// The one cursor of the four whose value is a PATH (`root_key` = `config.root`'s spelling), so the
-/// V096 path-spelling rekey has to rewrite it. Declared in `rag-rat-db` and referenced here rather
+/// V097 path-spelling rekey has to rewrite it. Declared in `rag-rat-db` and referenced here rather
 /// than spelled twice — the migration lives below this crate and a drifted literal there is a
 /// silent miss, not a compile error.
 const GIT_HISTORY_INDEXED_ROOT_META: &str = rag_rat_db::meta::GIT_HISTORY_INDEXED_ROOT_META;

--- a/crates/rag-rat-core/src/index/git_history/read.rs
+++ b/crates/rag-rat-core/src/index/git_history/read.rs
@@ -242,8 +242,8 @@ fn blob_line_counts(
 /// the old `git log -- .` (run from `root`) covered. Canonicalizes both sides so a symlink / path-
 /// representation mismatch doesn't spuriously scope (or fail to scope).
 fn scope_prefix(root: &Path, worktree_root: &Path) -> Option<String> {
-    let root = root.canonicalize().ok()?;
-    let worktree_root = worktree_root.canonicalize().ok()?;
+    let root = rag_rat_base::paths::canonicalize(root).ok()?;
+    let worktree_root = rag_rat_base::paths::canonicalize(worktree_root).ok()?;
     let relative = root.strip_prefix(&worktree_root).ok()?;
     let prefix = path_string(relative);
     (!prefix.is_empty()).then_some(prefix)

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -465,7 +465,7 @@ fn rel_contains_floor_dir(rel: &Path) -> bool {
 ///
 /// Shared with `watch.rs` (gitignore watch-dir + subdir-prefix derivation hit the same mismatch).
 pub(crate) fn base_under_worktree(root: &Path, wt: &Path) -> Option<PathBuf> {
-    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let canon = |p: &Path| rag_rat_base::paths::canonicalize_or_simplified(p);
     let canon_wt = canon(wt);
     root.ancestors().find(|ancestor| canon(ancestor) == canon_wt).map(Path::to_path_buf)
 }
@@ -844,7 +844,7 @@ mod tests {
         // Canonicalize so the absolute paths we build match what worktree-root resolution returns
         // (macOS /tmp is a symlink to /private/tmp; git reports the canonical form). The guard
         // still removes the directory: the canonical form is the same inode.
-        let root = guard.path().canonicalize().unwrap_or_else(|_| guard.path().to_path_buf());
+        let root = rag_rat_base::paths::canonicalize_or_simplified(guard.path());
         (guard, root)
     }
 

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -607,7 +607,20 @@ impl IndexDatabase {
         .ok_or_else(|| {
             anyhow::anyhow!("timed out waiting for the schema-migration lock to apply the schema")
         })?;
-        let state = schema::status(conn)?.state;
+        let current = schema::status(conn)?;
+        let state = current.state;
+        // A store whose roster carries an id THIS binary does not recognize was written by a newer
+        // rag-rat, and `schema::apply` would replay this binary's ladder over it and hand the
+        // caller a connection to write through — which is how an `index --full` from a stale
+        // binary rewrites a store that a newer one has already converted (its `files.path`
+        // spellings, its rekeyed worktree ids) back into the shape this binary knows. Every OTHER
+        // schema path already refuses `Newer`; refusing it HERE — the one function that calls
+        // `apply` — is what makes the refusal hold on every route into the store rather than on
+        // the routes someone remembered. `Dirty` still proceeds: `index --full` is the recovery
+        // its own message names.
+        if state == schema::SchemaState::Newer {
+            anyhow::bail!("{}", current.message);
+        }
         if state != schema::SchemaState::Compatible {
             // #585: a dev/test build must not silently forward-migrate the shared global store —
             // it would strand every process still on an older binary. Refused here (Older only;

--- a/crates/rag-rat-core/src/index/migration_gate.rs
+++ b/crates/rag-rat-core/src/index/migration_gate.rs
@@ -115,7 +115,7 @@ fn env_flag(key: &str) -> bool {
 /// equality. Both sides are canonicalized (per the `strip_prefix` two-sided-canonicalize rule);
 /// falls back to literal comparison when either path can't be canonicalized.
 fn same_file(a: &Path, b: &Path) -> bool {
-    match (a.canonicalize(), b.canonicalize()) {
+    match (rag_rat_base::paths::canonicalize(a), rag_rat_base::paths::canonicalize(b)) {
         (Ok(a), Ok(b)) => a == b,
         _ => a == b,
     }

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -195,7 +195,7 @@ pub(crate) fn explicit_index_files_and_changes(
     } else {
         crate::index::git_changed_paths(&config.root).unwrap_or_default()
     };
-    let canonical_root = config.root.canonicalize().unwrap_or_else(|_| config.root.clone());
+    let canonical_root = rag_rat_base::paths::canonicalize_or_simplified(&config.root);
     let mut files = Vec::new();
     let mut changes = GitChangedPaths::default();
     // Whether a supplied path is a `Cargo.toml` (present, or a real deletion) — the package-map
@@ -380,7 +380,7 @@ pub(crate) fn root_relative_path(
 pub(crate) fn canonicalize_nearest_ancestor(path: &Path) -> Option<PathBuf> {
     let mut ancestor = path;
     loop {
-        if let Ok(canonical) = ancestor.canonicalize() {
+        if let Ok(canonical) = rag_rat_base::paths::canonicalize(ancestor) {
             let suffix = path.strip_prefix(ancestor).unwrap_or_else(|_| Path::new(""));
             return Some(canonical.join(suffix));
         }

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -1920,7 +1920,7 @@ fn the_lens_fixture_config_root_diverges_from_its_scratch_spelling() {
     );
     assert_eq!(
         config.root,
-        temp.path().canonicalize().unwrap(),
+        rag_rat_base::paths::canonicalize(temp.path()).unwrap(),
         "both spellings must name the same directory",
     );
 }

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -124,8 +124,7 @@ impl IndexDatabase {
         // checkout's root, and in the shared-database model an overlay-scoped pass legitimately
         // reads a DIFFERENT tree — the linked worktree its rows are keyed to. So the expected root
         // is the active scope's own checkout, and the caller must have rooted the session there.
-        let indexed_root =
-            indexed_root.canonicalize().unwrap_or_else(|_| indexed_root.to_path_buf());
+        let indexed_root = rag_rat_base::paths::canonicalize_or_simplified(indexed_root);
         // The base checkout's scope id is `worktree_id_of(indexed_root)`, not the empty string —
         // `resolve_worktree_scope` reports the root's own id for it. (Empty means no scope has
         // been installed on this handle yet, which is also the base.) Test it explicitly rather
@@ -149,7 +148,7 @@ impl IndexDatabase {
                 )
             })?
         };
-        let expected_root = expected_root.canonicalize().unwrap_or_else(|_| expected_root.clone());
+        let expected_root = rag_rat_base::paths::canonicalize_or_simplified(&expected_root);
         if expected_root != scope.root() {
             anyhow::bail!(
                 "the active scope's checkout is rooted at {} but the live oracle is scoped to {}; \

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -91,10 +91,15 @@ pub fn resolve_removable_repo(
     conn: &Connection,
     path: &Path,
 ) -> anyhow::Result<Option<ResolvedRepo>> {
-    let canonical = path
-        .canonicalize()
-        .or_else(|_| std::path::absolute(path).map(|path| lexically_normalize(&path)))
-        .unwrap_or_else(|_| path.to_path_buf());
+    // Every arm ends on a simplified spelling: the recorded roots this is matched against were
+    // written from a canonicalized `config.root`, so a fallback that kept a Windows `\\?\` verbatim
+    // prefix the argument happened to carry would never compare equal to them.
+    let canonical = rag_rat_base::paths::canonicalize(path)
+        .or_else(|_| {
+            std::path::absolute(path)
+                .map(|path| lexically_normalize(rag_rat_base::paths::simplified(&path)))
+        })
+        .unwrap_or_else(|_| rag_rat_base::paths::simplified(path).to_path_buf());
 
     // Route 1: a derivable git identity that is a REGISTERED repo, but ONLY when the argument is
     // the discovered worktree top. `discover_repo` walks upward, so running `rm --yes repo/src`
@@ -145,7 +150,7 @@ fn path_is_worktree_top(path: &Path) -> bool {
     rag_rat_base::repo_discover::discover_repo(path)
         .ok()
         .and_then(|repo| repo.workdir().map(Path::to_path_buf))
-        .and_then(|work_dir| work_dir.canonicalize().ok())
+        .and_then(|work_dir| rag_rat_base::paths::canonicalize(work_dir).ok())
         .is_some_and(|work_dir| work_dir == path)
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -138,7 +138,7 @@ fn reindex_paths_routes_a_linked_worktree_path_to_its_overlay_not_the_base() {
     assert_eq!(partition.linked.len(), 1, "the linked path routes to exactly its checkout overlay",);
     let (root, root_paths) = partition.linked.iter().next().unwrap();
     assert!(
-        linked.canonicalize().is_ok_and(|canonical| *root == canonical),
+        rag_rat_base::paths::canonicalize(&linked).is_ok_and(|canonical| *root == canonical),
         "the routed root is the canonical linked checkout: {root:?}",
     );
     assert_eq!(
@@ -987,7 +987,7 @@ fn index_paths_indexes_an_absolute_path_through_a_symlinked_root_spelling() {
     fs::create_dir_all(realroot.join("src")).unwrap();
     fs::write(realroot.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
     // config.root is the CANONICAL root (as `Config::load` would normalize it).
-    let canonical_root = realroot.canonicalize().unwrap();
+    let canonical_root = rag_rat_base::paths::canonicalize(&realroot).unwrap();
     let config = source_config(canonical_root.clone(), Language::Rust);
     let _ = IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/lens_clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/lens_clones.rs
@@ -226,7 +226,7 @@ fn lens_clone_graph_uses_scope_correct_live_fallback_for_a_linked_overlay() {
     // wherever the temp directory is already canonical and breaks where it is not — macOS
     // resolving `/var` to `/private/var`, Windows expanding 8.3 names. Doing it fixture-wide is
     // the real fix and is #1027; here it is done locally so this test states what it means to.
-    let main = main.canonicalize().unwrap_or_else(|_| main.to_path_buf());
+    let main = rag_rat_base::paths::canonicalize_or_simplified(&main);
     fs::write(main.join("crate/src/base.rs"), "pub fn tiny() -> i32 { 0 }\n").unwrap();
     init_git_repo(&main);
     run_git(&main, &["add", "."]);
@@ -257,7 +257,7 @@ fn lens_clone_graph_uses_scope_correct_live_fallback_for_a_linked_overlay() {
     // only on the revision below cannot tell "resolved and found no change" from "never resolved".
     assert_eq!(
         db.active_worktree_id,
-        linked.canonicalize().unwrap_or_else(|_| linked.clone()).display().to_string(),
+        rag_rat_base::paths::canonicalize_or_simplified(&linked).display().to_string(),
         "the overlay refresh must scope itself to the linked checkout"
     );
     let after_overlay = db.lens_version().unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1430,7 +1430,7 @@ fn reconcile_heals_an_op_log_ghost_in_an_idle_repo() {
         "-m",
         "initial",
     ]);
-    let root = root.canonicalize().unwrap();
+    let root = rag_rat_base::paths::canonicalize(&root).unwrap();
 
     let mut config = source_config(root.clone(), Language::Rust);
     config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1480,8 +1480,6 @@ fn migration_092_normalizes_invite_receipts() {
 /// it, so the assertion keeps meaning something when a later migration also touches it.
 #[test]
 fn migration_096_holds_entries_awaiting_a_chain_predecessor() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 96, "move this pin with the next schema migration");
-
     let bare = rusqlite::Connection::open_in_memory().unwrap();
     assert!(
         !schema::table_exists(&bare, "table_sync_gapped_entries").unwrap(),
@@ -1976,13 +1974,31 @@ fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
 
 /// V097 (#1048) rekeys the persisted Windows path spellings an older binary wrote in the `\\?\`
 /// verbatim form, so an upgrade does not orphan every scoped row it indexed.
+///
+/// Both halves have to be host-independent, and this pins the LEDGER half. A store migrated on
+/// Linux must read as current to a Windows binary — otherwise it is `Older` there and the whole
+/// tail re-runs — and a store migrated on Windows must not read as `Newer` on Linux and refuse to
+/// open at all. Asserted on whichever platform runs it, so the legs of CI check it between them.
+///
+/// The ROW half is host-independent too, and is pinned separately by
+/// `the_production_pass_rekeys_a_windows_store_on_any_host`: the rekey rule decides a property of
+/// the stored string rather than of the host, precisely so this ledger row cannot be stamped by a
+/// binary that did not do the work.
 #[test]
-fn migration_096_rekeys_the_persisted_windows_path_spellings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 96, "move this pin with the next schema migration");
+fn migration_097_records_the_same_ladder_entry_on_every_platform() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 97, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(status.current_version, schema::LATEST_SCHEMA_VERSION);
+    // `Compatible` is the load-bearing half: a ledger row that recorded a DIFFERENT checksum on
+    // this platform would surface as `Dirty` here, and a skipped stamp as `Older`.
+    assert_eq!(
+        status.state,
+        schema::SchemaState::Compatible,
+        "V097's ledger row must be stamped identically wherever the migration runs",
+    );
     let recorded: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM schema_version WHERE id = '097_windows_verbatim_path_rekey'",
@@ -2004,7 +2020,7 @@ fn migration_096_rekeys_the_persisted_windows_path_spellings() {
 /// `worktree_id` silently misses the rekey and its rows are pruned as a dead checkout on the next
 /// Windows upgrade — exactly the failure V097 exists to prevent, one table at a time.
 #[test]
-fn migration_096_covers_every_worktree_id_column_in_the_schema() {
+fn migration_097_covers_every_worktree_id_column_in_the_schema() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1973,3 +1973,64 @@ fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
     conn.execute("DELETE FROM repos WHERE repo_id = 'retired'", [])
         .expect("retiring a repo with Lens metadata must not reinsert rows during FK cascade");
 }
+
+/// V097 (#1048) rekeys the persisted Windows path spellings an older binary wrote in the `\\?\`
+/// verbatim form, so an upgrade does not orphan every scoped row it indexed.
+#[test]
+fn migration_096_rekeys_the_persisted_windows_path_spellings() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 96, "move this pin with the next schema migration");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '097_windows_verbatim_path_rekey'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V097");
+    // `schema::apply` is the `index --full` recovery and replays the WHOLE ladder over an existing
+    // store, so the pass has to be replay-safe on the real schema, not just on a fixture.
+    schema::migrations::apply_windows_verbatim_path_rekey(&conn).expect("replay is a no-op");
+}
+
+/// The rekey's table list is the WHOLE class, checked against the live schema rather than against
+/// the author's memory: any table carrying a `worktree_id` is keyed by a canonicalized checkout
+/// path and goes stale on the same upgrade, so a new one must join the sweep.
+///
+/// This is the guard that makes the fix a class fix. Without it, the next table to grow a
+/// `worktree_id` silently misses the rekey and its rows are pruned as a dead checkout on the next
+/// Windows upgrade — exactly the failure V097 exists to prevent, one table at a time.
+#[test]
+fn migration_096_covers_every_worktree_id_column_in_the_schema() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT m.name FROM sqlite_master m
+             WHERE m.type = 'table'
+               AND EXISTS (SELECT 1 FROM pragma_table_info(m.name) p WHERE p.name = 'worktree_id')
+             ORDER BY m.name",
+        )
+        .unwrap();
+    let in_schema: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    let mut covered: Vec<String> = schema::migrations::V097_WORKTREE_ID_SCOPED_TABLES
+        .iter()
+        .map(|t| (*t).to_string())
+        .collect();
+    covered.sort();
+    assert_eq!(
+        in_schema, covered,
+        "every table with a `worktree_id` must be in V097_WORKTREE_ID_SCOPED_TABLES — an \
+         uncovered one keeps the old Windows spelling on upgrade, falls out of the active scope, \
+         and is deleted by the next GC as a checkout that no longer exists",
+    );
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -12,6 +12,7 @@ mod live_oracle;
 mod logical_rebuild;
 mod quiet_window;
 mod relink;
+mod root_spelling;
 mod visibility;
 
 use logical_rebuild::{logical_rebuild_pending, logical_symbol_named};

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/config_root.rs
@@ -178,7 +178,7 @@ fn the_fixture_config_canonicalizes_its_root_like_config_load() {
     let config = source_config(alias.join("crate"), Language::Rust);
     assert_eq!(
         config.root,
-        alias.join("crate").canonicalize().unwrap(),
+        rag_rat_base::paths::canonicalize(alias.join("crate")).unwrap(),
         "a fixture Config must normalize its root the way `Config::load` does",
     );
     assert!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
@@ -737,7 +737,7 @@ fn worktree_overlay_serves_a_subdir_rooted_config() {
     // canonicalized base workdir. On macOS `std::env::temp_dir()` is `/var/folders/...` (a symlink
     // to `/private/var/folders/...`), so an un-canonicalized root fails the `strip_prefix` and the
     // subdir derivation collapses → zero overlay rows.
-    let main = main.canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main).unwrap();
     fs::write(main.join("crate/src/lib.rs"), "pub fn base_fn() {}\n").unwrap();
     init_git_repo(&main);
     run_git(&main, &["add", "."]);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/live_oracle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/live_oracle.rs
@@ -65,9 +65,9 @@ fn a_linked_only_pass_acts_for_the_linked_checkout_and_leaves_the_base_scope_res
     // stage keyed to THAT checkout. It must also not leave the connection scoped there — the base
     // reconcile, gc, and memory validation that follow all assume base scope.
     let (main_dir, linked_dirs) = repo_with_worktrees(2, None);
-    let main = main_dir.canonicalize().unwrap();
-    let edited = linked_dirs[0].canonicalize().unwrap();
-    let quiet = linked_dirs[1].canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main_dir).unwrap();
+    let edited = rag_rat_base::paths::canonicalize(&linked_dirs[0]).unwrap();
+    let quiet = rag_rat_base::paths::canonicalize(&linked_dirs[1]).unwrap();
     let (edited, quiet) = (&edited, &quiet);
     let config = live_source_config(main.clone());
     let mut db = IndexDatabase::rebuild(&config).unwrap();
@@ -115,8 +115,8 @@ fn a_linked_checkouts_server_is_rooted_at_its_own_equivalent_of_the_config_root(
     // `<linked>/crate`). A server rooted at the checkout would initialize a workspace that does
     // not contain the indexed sources, and the pass's own guard would then reject its verdicts.
     let (main_dir, linked_dirs) = repo_with_worktrees(1, Some("crate"));
-    let main = main_dir.canonicalize().unwrap();
-    let linked = linked_dirs[0].canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main_dir).unwrap();
+    let linked = rag_rat_base::paths::canonicalize(&linked_dirs[0]).unwrap();
     let config = live_source_config(main.join("crate"));
     let mut db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -151,8 +151,8 @@ fn a_linked_checkout_is_judged_against_its_own_target_bindings() {
     // config's targets the backend's language gate rejects the added language — and that arm has
     // already taken the backlog — so the linked edit is dropped outright rather than deferred.
     let (main_dir, linked_dirs) = repo_with_worktrees(1, None);
-    let main = main_dir.canonicalize().unwrap();
-    let linked = linked_dirs[0].canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main_dir).unwrap();
+    let linked = rag_rat_base::paths::canonicalize(&linked_dirs[0]).unwrap();
 
     // The branch adds a TypeScript target; the main config below stays Rust-only.
     fs::write(
@@ -204,9 +204,9 @@ fn a_checkout_whose_work_turns_out_not_to_be_real_releases_its_slot_to_a_sibling
     // (#1010).
     let _no_server = crate::watch::suppress_live_spawn();
     let (main_dir, linked_dirs) = repo_with_worktrees(2, None);
-    let main = main_dir.canonicalize().unwrap();
-    let stale = linked_dirs[0].canonicalize().unwrap();
-    let sibling = linked_dirs[1].canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main_dir).unwrap();
+    let stale = rag_rat_base::paths::canonicalize(&linked_dirs[0]).unwrap();
+    let sibling = rag_rat_base::paths::canonicalize(&linked_dirs[1]).unwrap();
     let config = live_source_config(main.clone());
     let mut db = IndexDatabase::rebuild(&config).unwrap();
     let stale_id = crate::index::worktree_id_of(&stale);
@@ -281,9 +281,9 @@ fn a_checkout_that_stops_being_a_live_sibling_drops_its_state() {
     // and falls back to the BASE scope. A removed checkout would otherwise stay resident with a
     // backlog nothing can resolve, holding a cap slot the live checkouts need.
     let (main_dir, linked_dirs) = repo_with_worktrees(2, None);
-    let main = main_dir.canonicalize().unwrap();
-    let linked = linked_dirs[0].canonicalize().unwrap();
-    let survivor = linked_dirs[1].canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main_dir).unwrap();
+    let linked = rag_rat_base::paths::canonicalize(&linked_dirs[0]).unwrap();
+    let survivor = rag_rat_base::paths::canonicalize(&linked_dirs[1]).unwrap();
     let config = live_source_config(main.clone());
     let mut db = IndexDatabase::rebuild(&config).unwrap();
     let gone_id = crate::index::worktree_id_of(&linked);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/root_spelling.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/root_spelling.rs
@@ -1,0 +1,137 @@
+//! The overlay's scoping contract for the SPELLING a canonical `config.root` carries (#1048).
+//!
+//! `config_root` (beside this file) covers the case where the root is spelled through a symlink,
+//! which is a Unix-only fixture. This module covers the other half: the root is exactly what
+//! `Config::load` produces, and the question is whether that spelling is one the rest of the system
+//! consumes. On Windows `std::fs::canonicalize` answers `\\?\C:\…`, and:
+//!   * `git worktree add \\?\C:\…\linked` fails outright — `fatal: could not create leading
+//!     directories of '//?/C:/…': Invalid argument`;
+//!   * gix reports `workdir()` in the ordinary `C:\…` form, so the overlay's subdir derivation
+//!     (`config.root` stripped against the workdir) matches nothing.
+//!
+//! Nothing here is `cfg`-gated: on Unix the assertions are cheap and hold trivially, and it is the
+//! Windows leg that has to run them. That is deliberate — a Unix-only probe would have caught none
+//! of this.
+
+use super::*;
+
+/// Whether `path` carries the Windows extended-length (`\\?\`) prefix. Textual on purpose: this is
+/// asking about the SPELLING, and the answer must be the same one `git` and gix compute from the
+/// bytes they are handed.
+fn is_verbatim(path: &Path) -> bool {
+    path.as_os_str().to_string_lossy().starts_with(r"\\?\")
+}
+
+/// A committed `crate/`-in-repo main checkout, plus the `Config` a load from disk would produce for
+/// its `crate/` subroot.
+fn canonical_root_repo() -> (ScratchRoot, Config) {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("crate/src")).unwrap();
+    fs::write(main.join("crate/src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+
+    let config = source_config(main.join("crate"), Language::Rust);
+    (main, config)
+}
+
+/// A linked-worktree destination in the same canonical spelling `config.root` carries — what a
+/// caller building a sibling checkout from a loaded config actually hands `git`.
+fn canonical_worktree_destination() -> (ScratchRoot, PathBuf) {
+    let scratch = unique_temp_root();
+    let _ = fs::remove_dir_all(&scratch);
+    let destination = test_scratch::canonical_config_root(scratch.to_path_buf());
+    (scratch, destination)
+}
+
+/// The two consumers of `config.root` must both accept the spelling it is normalized to: `git`
+/// as a `worktree add` destination, and gix as a path its `workdir()` is a prefix of.
+///
+/// Before the fix this failed on Windows at the `git worktree add` — the canonical root is a
+/// `\\?\` verbatim path there, and git cannot create leading directories for one.
+#[test]
+fn a_canonical_config_root_is_a_spelling_git_and_gix_both_accept() {
+    let (main, config) = canonical_root_repo();
+    assert!(
+        !is_verbatim(&config.root),
+        "a canonical config root must not carry the Windows verbatim prefix: {:?}",
+        config.root,
+    );
+
+    // gix: the repository discovered FROM the canonical root reports a workdir the root is under,
+    // so the overlay's `strip_prefix` derives the `crate/` subdir instead of collapsing to nothing.
+    let repo = rag_rat_base::repo_discover::discover_repo(&config.root).unwrap();
+    let workdir = rag_rat_base::paths::canonicalize_or_simplified(repo.workdir().unwrap());
+    assert_eq!(
+        config.root.strip_prefix(&workdir).ok(),
+        Some(Path::new("crate")),
+        "config.root {:?} must strip against the repository workdir {:?}",
+        config.root,
+        workdir,
+    );
+
+    // git: a destination spelled the way the canonical root is must be usable verbatim as a
+    // `worktree add` argument.
+    let (_scratch, destination) = canonical_worktree_destination();
+    assert!(
+        !is_verbatim(&destination),
+        "the worktree destination is not verbatim: {destination:?}"
+    );
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", destination.to_str().unwrap()]);
+    assert!(destination.join("crate/src/a.rs").is_file(), "the linked checkout was created");
+}
+
+/// The end-to-end scoping this protects: with a root in the canonical spelling, a linked
+/// worktree's refresh indexes the branch-only file under a `config.root`-relative path, and a
+/// SECOND linked worktree sharing the same database neither sees nor disturbs the first one's rows.
+///
+/// Main checkout, two linked siblings, one database — the overlay's whole contract, driven through
+/// the root spelling production produces rather than a hand-built one.
+#[test]
+fn a_canonical_config_root_scopes_the_overlay_and_isolates_siblings() {
+    let (main, config) = canonical_root_repo();
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(
+        path_in_scope(&db, "src/a.rs"),
+        "the base index is scoped to `crate/`, so its paths are config-root-relative",
+    );
+
+    let (_first_scratch, first) = canonical_worktree_destination();
+    run_git(&main, &["worktree", "add", "-q", "-b", "first", first.to_str().unwrap()]);
+    fs::write(first.join("crate/src/first.rs"), "pub fn first_fn() {}\n").unwrap();
+    run_git(&first, &["add", "."]);
+    run_git(&first, &["commit", "-q", "-m", "first"]);
+    let first_report = db.index_worktree_overlay(&config, &first, &mut |_| {}).unwrap();
+    assert_eq!(first_report.indexed, 1, "the branch-only file is indexed into the overlay");
+    assert!(
+        path_in_scope(&db, "src/first.rs"),
+        "the overlay row is keyed relative to `config.root`, so the subdir derivation matched",
+    );
+    assert_eq!(names_in_scope(&db, "src/first.rs"), vec!["first_fn".to_string()]);
+
+    let (_second_scratch, second) = canonical_worktree_destination();
+    run_git(&main, &["worktree", "add", "-q", "-b", "second", second.to_str().unwrap()]);
+    fs::write(second.join("crate/src/second.rs"), "pub fn second_fn() {}\n").unwrap();
+    run_git(&second, &["add", "."]);
+    run_git(&second, &["commit", "-q", "-m", "second"]);
+    let second_report = db.index_worktree_overlay(&config, &second, &mut |_| {}).unwrap();
+    assert_eq!(second_report.indexed, 1, "the sibling's branch-only file gets its own overlay");
+
+    // Active scope = the SECOND worktree: it sees its own file, never the sibling's.
+    assert!(path_in_scope(&db, "src/second.rs"));
+    assert!(!path_in_scope(&db, "src/first.rs"), "a sibling worktree's overlay is not visible");
+
+    // The FIRST worktree's rows survived, read by their own `(worktree_id, commit_sha)` key rather
+    // than through the connection's installed scope (still the second worktree's).
+    let scoped = db.storage.connection();
+    let rows: Vec<String> = scoped
+        .prepare("SELECT path FROM main.files WHERE worktree_id = ?1 AND commit_sha = ''")
+        .unwrap()
+        .query_map([&first_report.worktree_id], |row| row.get::<_, String>(0))
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(rows, vec!["src/first.rs".to_string()], "the first overlay is intact and isolated");
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/root_spelling.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/root_spelling.rs
@@ -135,3 +135,200 @@ fn a_canonical_config_root_scopes_the_overlay_and_isolates_siblings() {
         .collect();
     assert_eq!(rows, vec!["src/first.rs".to_string()], "the first overlay is intact and isolated");
 }
+
+/// The marker a poisoned fixture prefixes onto every persisted spelling, standing in for the
+/// `\\?\` a pre-fix Windows index wrote. A stand-in because the real prefix is only ever produced
+/// (and only ever rewritten) on Windows, so a fixture built with it would leave the Linux gate
+/// asserting that nothing happened — which a rekey covering no tables at all would satisfy too.
+const STALE_SPELLING_MARKER: &str = "<<stale>>";
+
+/// Rewrite every persisted checkout spelling into the stale form, the way an index written before
+/// the canonicalization change carries it.
+///
+/// Every target is named LITERALLY here — no list, constant, or helper is shared with the
+/// migration. A fixture poisoned through the code under test can only ever be as complete as that
+/// code, so a table or key the rekey forgets would be one the fixture never poisoned either, and
+/// the miss would be invisible. Enumerated independently, dropping a target from the migration's
+/// own lists turns into a failing assertion below.
+fn poison_persisted_spellings(db: &IndexDatabase) {
+    let conn = db.storage.connection();
+    for table in ["files", "packages", "oracle_runs", "external_symbols"] {
+        conn.execute(
+            &format!(
+                "UPDATE main.{table} SET worktree_id = ?1 || worktree_id WHERE worktree_id != ''"
+            ),
+            [STALE_SPELLING_MARKER],
+        )
+        .unwrap();
+    }
+    conn.execute("UPDATE main.repo_roots SET root = ?1 || root", [STALE_SPELLING_MARKER]).unwrap();
+    for key in ["source_root", "git_history_indexed_root"] {
+        conn.execute(
+            "UPDATE main.repo_meta SET value = ?1 || value WHERE key = ?2",
+            rusqlite::params![STALE_SPELLING_MARKER, key],
+        )
+        .unwrap();
+    }
+    // Only the SUFFIX goes stale: the prefix is a constant, the worktree path after it is what an
+    // older binary spelled differently.
+    let prefix = rag_rat_db::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX;
+    conn.execute(
+        "UPDATE main.repo_meta SET key = ?1 || substr(key, ?2) WHERE substr(key, 1, ?3) = ?4",
+        rusqlite::params![
+            format!("{prefix}{STALE_SPELLING_MARKER}"),
+            prefix.len() as i64 + 1,
+            prefix.len() as i64,
+            prefix,
+        ],
+    )
+    .unwrap();
+}
+
+/// Raw count of rows keyed to `worktree_id`, bypassing the scope view — what GC prunes when a
+/// checkout falls out of the live set.
+fn rows_keyed_to(db: &IndexDatabase, worktree_id: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE worktree_id = ?1", [worktree_id], |row| {
+            row.get(0)
+        })
+        .unwrap()
+}
+
+/// The working-tree root recorded in `repo_roots` — the "this checkout was indexed here" signal
+/// `repo_indexed_at_this_root` compares TEXTUALLY against `config.root` behind the empty-index
+/// guard.
+fn recorded_repo_root(db: &IndexDatabase) -> Option<String> {
+    use rusqlite::OptionalExtension as _;
+    db.storage
+        .connection()
+        .query_row("SELECT root FROM main.repo_roots", [], |row| row.get::<_, String>(0))
+        .optional()
+        .unwrap()
+}
+
+/// Whether the git-history reload gate still accepts the indexed commit / file-change rows for
+/// `root`. It compares the recorded `git_history_indexed_root` cursor TEXTUALLY against a freshly
+/// canonicalized root, so a stale spelling answers false — and false means the next pass deletes
+/// and re-reads the entire history off a fresh revwalk and wipes the repo's blame cache with it.
+fn history_is_current(db: &IndexDatabase, root: &Path) -> bool {
+    crate::index::git_history::is_history_current(db.storage.connection(), root)
+}
+
+/// Upgrading an index whose persisted spellings predate the canonicalization change must REKEY
+/// them, not orphan them.
+///
+/// This is the data-loss case (#1048). A non-empty `worktree_id` is a canonicalized checkout path
+/// — it keys every linked worktree's overlay and every dirty row (committed base rows are shared
+/// across checkouts under `worktree_id = ''` and are not implicated). Once production answers a
+/// different spelling than the one on disk, those rows fall out of the active scope AND out of
+/// `garbage_collect`'s live set, which is built from the new spelling: GC sees each stored id as a
+/// checkout that no longer exists and deletes its rows. Registered, live worktrees, pruned as
+/// dead, on the first maintenance pass after the upgrade. The recorded roots go with them: the
+/// empty-index guard's "indexed here" signal, and the git-history reload cursor whose staleness
+/// costs a full revwalk and the repo's blame cache on the first pass after the upgrade.
+///
+/// Driven through a real main checkout plus TWO linked worktrees on ONE database, so the assertion
+/// covers the active-checkout scope and sibling preservation, not just a single-checkout shape.
+#[test]
+fn an_upgrade_rekeys_stale_checkout_spellings_instead_of_collecting_them() {
+    let (main, config) = canonical_root_repo();
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (_first_scratch, first) = canonical_worktree_destination();
+    run_git(&main, &["worktree", "add", "-q", "-b", "first", first.to_str().unwrap()]);
+    fs::write(first.join("crate/src/first.rs"), "pub fn first_fn() {}\n").unwrap();
+    run_git(&first, &["add", "."]);
+    run_git(&first, &["commit", "-q", "-m", "first"]);
+    let first_report = db.index_worktree_overlay(&config, &first, &mut |_| {}).unwrap();
+
+    let (_second_scratch, second) = canonical_worktree_destination();
+    run_git(&main, &["worktree", "add", "-q", "-b", "second", second.to_str().unwrap()]);
+    fs::write(second.join("crate/src/second.rs"), "pub fn second_fn() {}\n").unwrap();
+    run_git(&second, &["add", "."]);
+    run_git(&second, &["commit", "-q", "-m", "second"]);
+    let second_report = db.index_worktree_overlay(&config, &second, &mut |_| {}).unwrap();
+
+    let first_rows = rows_keyed_to(&db, &first_report.worktree_id);
+    let second_rows = rows_keyed_to(&db, &second_report.worktree_id);
+    assert!(first_rows > 0 && second_rows > 0, "both overlays are keyed by their checkout path");
+    let recorded_root = recorded_repo_root(&db);
+    assert_eq!(
+        recorded_root.as_deref(),
+        Some(config.root.to_string_lossy().as_ref()),
+        "the indexed-here signal records the canonical root spelling",
+    );
+    assert!(
+        history_is_current(&db, &config.root),
+        "the rebuild leaves the git-history reload gate satisfied, so there is a skipped reload \
+         for a stale spelling to un-skip",
+    );
+
+    // The per-worktree refresh basis, recorded the way a completed overlay refresh leaves it. Its
+    // worktree identity lives in the KEY, so it is the one value a column-only rekey would miss.
+    db.record_worktree_overlay_basis(&first_report.worktree_id, "base-sha", "linked-sha", 42)
+        .unwrap();
+
+    // The store as an older binary left it.
+    poison_persisted_spellings(&db);
+    assert_eq!(
+        rows_keyed_to(&db, &first_report.worktree_id),
+        0,
+        "the harm this guards: with a stale spelling on disk the overlay rows are unreachable \
+         under the id production now derives",
+    );
+    assert!(
+        !history_is_current(&db, &config.root),
+        "the second harm: the git-history reload gate no longer recognizes its own cursor, so the \
+         next pass re-reads the whole history and wipes the blame cache",
+    );
+
+    // The upgrade.
+    rag_rat_db::schema::migrations::rekey_persisted_path_spellings(
+        db.storage.connection(),
+        |stored| stored.strip_prefix(STALE_SPELLING_MARKER).map(str::to_string),
+    )
+    .unwrap();
+
+    assert_eq!(
+        rows_keyed_to(&db, &first_report.worktree_id),
+        first_rows,
+        "every row of the first overlay is rekeyed, not a subset",
+    );
+    assert_eq!(rows_keyed_to(&db, &second_report.worktree_id), second_rows);
+    assert_eq!(
+        recorded_repo_root(&db),
+        recorded_root,
+        "the indexed-here signal behind the empty-index guard is rekeyed too — left stale, an \
+         established checkout reads as a first-time empty repo",
+    );
+    assert!(
+        history_is_current(&db, &config.root),
+        "the git-history reload cursor is rekeyed alongside them, so the upgrade does not force a \
+         full revwalk and a cold blame cache",
+    );
+
+    // The load-bearing half: GC's live set is built from the CURRENT spelling, so a row the rekey
+    // missed is a row GC deletes as a dead checkout. Running it here is what turns "the rekey
+    // covered these tables" into "no live worktree loses data on upgrade".
+    set_base_scope(&mut db, &config.root);
+    db.garbage_collect().unwrap();
+    assert_eq!(
+        rows_keyed_to(&db, &first_report.worktree_id),
+        first_rows,
+        "a registered linked worktree's overlay is not collected as a dead checkout",
+    );
+    assert_eq!(
+        rows_keyed_to(&db, &second_report.worktree_id),
+        second_rows,
+        "the sibling worktree's overlay is preserved alongside it, not just the last one indexed",
+    );
+
+    // The refresh basis is keyed BY worktree id, so it has to move with the rows it describes —
+    // otherwise the overlay re-derives from scratch and the GC that prunes basis rows outside the
+    // live set drops the quiet-window anchor.
+    assert!(
+        db.worktree_overlay_basis(&first_report.worktree_id).unwrap().is_some(),
+        "the overlay refresh basis is rekeyed alongside its overlay rows",
+    );
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/root_spelling.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/root_spelling.rs
@@ -332,3 +332,218 @@ fn an_upgrade_rekeys_stale_checkout_spellings_instead_of_collecting_them() {
         "the overlay refresh basis is rekeyed alongside its overlay rows",
     );
 }
+
+/// Record a migration id this binary does not know — the exact `schema_version` state a store
+/// carries once a NEWER binary has migrated it, and therefore the state a pre-upgrade binary sees
+/// after V097 lands.
+///
+/// Written as an unknown id rather than by tampering with V097's own row because the fence is the
+/// LADDER's, not this migration's: `known_migration` is a closed set, so any id outside it makes
+/// `status` answer `Newer`. V097 arms that fence purely by being on the ladder, which
+/// `schema::migration_arming` already pins mechanically.
+fn stamp_a_migration_from_a_newer_binary(db: &IndexDatabase) {
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO schema_version(id, applied_at_ms, checksum, description)
+             VALUES ('097_applied_by_a_newer_binary', 0, 'sha256:future', 'future migration')",
+            [],
+        )
+        .unwrap();
+}
+
+/// What a pre-upgrade binary is looking at once a newer one has converted the store: a main
+/// checkout plus a linked worktree whose overlay rows are keyed by a spelling this binary no
+/// longer derives, and a `schema_version` roster carrying an id it does not know.
+///
+/// Returned so each route into the store can be driven against the SAME state. The scratch roots
+/// come back with it because dropping them deletes the checkouts.
+struct AStoreANewerBinaryMigrated {
+    config: Config,
+    db: IndexDatabase,
+    stale_id: String,
+    stale_rows: i64,
+    _main: ScratchRoot,
+    _linked: ScratchRoot,
+}
+
+fn a_store_a_newer_binary_migrated() -> AStoreANewerBinaryMigrated {
+    let (main, config) = canonical_root_repo();
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (linked_scratch, first) = canonical_worktree_destination();
+    run_git(&main, &["worktree", "add", "-q", "-b", "first", first.to_str().unwrap()]);
+    fs::write(first.join("crate/src/first.rs"), "pub fn first_fn() {}\n").unwrap();
+    run_git(&first, &["add", "."]);
+    run_git(&first, &["commit", "-q", "-m", "first"]);
+    let first_report = db.index_worktree_overlay(&config, &first, &mut |_| {}).unwrap();
+
+    // Only the CHECKOUT keys go stale — not `repo_roots.root` / `source_root`, which the
+    // empty-index guard reads: a stale root there would abort the pass for an unrelated reason and
+    // the mutation this test exists to catch would hide behind it.
+    let conn = db.storage.connection();
+    for table in ["files", "packages", "oracle_runs", "external_symbols"] {
+        conn.execute(
+            &format!(
+                "UPDATE main.{table} SET worktree_id = ?1 || worktree_id WHERE worktree_id != ''"
+            ),
+            [STALE_SPELLING_MARKER],
+        )
+        .unwrap();
+    }
+    let stale_id = format!("{STALE_SPELLING_MARKER}{}", first_report.worktree_id);
+    let stale_rows = rows_keyed_to(&db, &stale_id);
+    assert!(stale_rows > 0, "the linked worktree's overlay is keyed to the stale spelling");
+
+    // A newer binary migrated the store while this one stayed resident, holding its connection.
+    stamp_a_migration_from_a_newer_binary(&db);
+    let status = rag_rat_db::schema::status(db.storage.connection()).unwrap();
+    assert_eq!(status.state, rag_rat_db::schema::SchemaState::Newer);
+
+    AStoreANewerBinaryMigrated {
+        config,
+        db,
+        stale_id,
+        stale_rows,
+        _main: main,
+        _linked: linked_scratch,
+    }
+}
+
+/// The coexistence question a store-converting migration has to answer: what stops a binary that
+/// predates the conversion from garbage-collecting the rows it just rekeyed?
+///
+/// The answer is the schema version, and this pins that it reaches a RESIDENT process and not only
+/// a fresh command. A maintenance pass re-opens the database through `open_and_migrate` at its
+/// start — inside the per-repo write flock, and long before its gc stage — so the pass after an
+/// upgrade fails at the version gate with nothing read, written, or collected. Without that, an
+/// older build would derive its live worktree set from the OLD spelling, find every rekeyed id
+/// outside it, and prune registered linked worktrees as dead checkouts.
+///
+/// Driven with the checkout spellings left STALE on disk, so the assertion is not merely "the pass
+/// returned an error": if the gate ever stopped refusing, gc would run with a live set that cannot
+/// match those rows and would delete them, and the surviving-rows assertion fails too.
+#[test]
+fn a_pre_upgrade_binary_cannot_collect_a_store_a_newer_one_migrated() {
+    let store = a_store_a_newer_binary_migrated();
+
+    // The resident process's NEXT pass — the gc-cadence one, the only kind that prunes.
+    let err = crate::watch::maintenance_pass(&store.config, true)
+        .expect_err("a pass must refuse a store migrated by a newer binary");
+    assert!(
+        err.to_string().contains("newer rag-rat"),
+        "the pass must fail at the schema version gate, not incidentally: {err}",
+    );
+
+    assert_eq!(
+        rows_keyed_to(&store.db, &store.stale_id),
+        store.stale_rows,
+        "the refused pass collected nothing — an older binary cannot prune rows keyed by a \
+         spelling it no longer derives",
+    );
+}
+
+/// The same fence over the OTHER route into the store: `rag-rat index --full`.
+///
+/// A full rebuild does not open through `open_and_migrate` — it reaches `schema::apply` through
+/// `create_or_migrate`, which asks only whether the state is `Compatible` and migrates whenever it
+/// is not. `Newer` fell into that "not" and the rebuild proceeded: this binary's ladder replayed
+/// over a store a newer one had already converted, and the rebuild then re-registered
+/// `repo_roots.root` / `source_root` and re-staged the base scope in the spelling THIS binary
+/// derives, stranding the converted overlay rows for the next collector to prune. Refused inside
+/// `apply_schema_under_lock`, the single function that calls `schema::apply`, so the refusal holds
+/// on every route rather than on the ones an enumeration remembered.
+///
+/// Asserted on the error MESSAGE and on the surviving rows, for the same reason as the pass test —
+/// "it returned an error" would also be satisfied by a rebuild that failed after writing.
+#[test]
+fn a_pre_upgrade_full_index_cannot_replay_its_ladder_over_a_store_a_newer_one_migrated() {
+    let store = a_store_a_newer_binary_migrated();
+
+    // `expect_err` would need `IndexDatabase: Debug`, which it deliberately is not.
+    let Err(err) = IndexDatabase::rebuild(&store.config) else {
+        panic!("a full rebuild must refuse a store migrated by a newer binary")
+    };
+    assert!(
+        err.to_string().contains("newer rag-rat"),
+        "the rebuild must fail at the schema version gate, not incidentally: {err}",
+    );
+
+    assert_eq!(
+        rows_keyed_to(&store.db, &store.stale_id),
+        store.stale_rows,
+        "the refused rebuild rewrote nothing — the converted overlay rows are still keyed as the \
+         newer binary left them",
+    );
+}
+
+/// `repo_meta` / `index_meta` are the open-ended half of the persisted surface: a table growing a
+/// `worktree_id` is caught by
+/// `migration_097_covers_every_worktree_id_column_in_the_schema`, but a new meta key is just a
+/// string, and a path-valued one goes stale on the same upgrade with nothing to notice it.
+///
+/// So classify by VALUE rather than by memory: every meta value in a real, exercised index that is
+/// an absolute path must be one the rekey rewrites, or an explicitly reviewed exception. A new key
+/// that starts holding a checkout path fails here, by name, instead of quietly missing the sweep.
+#[test]
+fn every_absolute_path_in_the_meta_bag_is_rekeyed_or_reviewed() {
+    /// Reviewed and deliberately NOT rekeyed. Each is an absolute path, and each is left alone for
+    /// a reason that is about what the value MEANS, not about it being awkward to rewrite.
+    const REVIEWED_NOT_REKEYED: &[&str] = &[
+        // Provenance of the binary that last migrated this store (#585), read by humans
+        // diagnosing a fleet stranding. Never compared against a canonicalized path — and
+        // rewriting it would falsify the record of what actually ran.
+        "last_migration_binary_exe",
+        // A composite freshness key that FOLDS the history cursor, root spelling included.
+        // Rekeying the cursor makes it stale, which is the change-coupling table's ordinary
+        // invalidation path (a bounded window recompute the next history apply would trigger
+        // anyway); rewriting a stamp from a migration would couple the ladder to its format.
+        "git_coupling_stamp",
+    ];
+
+    let (main, config) = canonical_root_repo();
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let (_first_scratch, first) = canonical_worktree_destination();
+    run_git(&main, &["worktree", "add", "-q", "-b", "first", first.to_str().unwrap()]);
+    fs::write(first.join("crate/src/first.rs"), "pub fn first_fn() {}\n").unwrap();
+    run_git(&first, &["add", "."]);
+    run_git(&first, &["commit", "-q", "-m", "first"]);
+    let first_report = db.index_worktree_overlay(&config, &first, &mut |_| {}).unwrap();
+    db.record_worktree_overlay_basis(&first_report.worktree_id, "base-sha", "linked-sha", 42)
+        .unwrap();
+
+    let basis_prefix = rag_rat_db::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX;
+    let conn = db.storage.connection();
+    for table in ["repo_meta", "index_meta"] {
+        let mut stmt = conn.prepare(&format!("SELECT key, value FROM main.{table}")).unwrap();
+        let rows: Vec<(String, String)> = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        for (key, value) in rows {
+            // The overlay basis carries its checkout in the KEY; the value is a sha triple.
+            if let Some(worktree_id) = key.strip_prefix(basis_prefix) {
+                assert!(
+                    Path::new(worktree_id).is_absolute(),
+                    "the overlay-basis key suffix is a checkout path, so V097 rekeys the KEY: \
+                     {key}",
+                );
+                continue;
+            }
+            if !Path::new(&value).is_absolute() {
+                continue;
+            }
+            let covered =
+                rag_rat_db::schema::migrations::V097_PATH_VALUED_META_KEYS.contains(&key.as_str());
+            assert!(
+                covered || REVIEWED_NOT_REKEYED.contains(&key.as_str()),
+                "`{table}[{key}]` holds an absolute path ({value:?}) that V097 neither rekeys nor \
+                 records as reviewed. A persisted path is compared TEXTUALLY against a \
+                 freshly-canonicalized one, so on the next Windows upgrade this value stops \
+                 matching. Add it to V097_PATH_VALUED_META_KEYS, or to REVIEWED_NOT_REKEYED with \
+                 the reason it must keep the spelling it was written with.",
+            );
+        }
+    }
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/visibility.rs
@@ -820,7 +820,7 @@ fn a_reported_path_resolves_against_the_reported_source_root_not_the_checkout_ro
     fs::create_dir_all(main.join("crate/src")).unwrap();
     // Canonical root, mirroring `Config::load` — see
     // `worktree_overlay_serves_a_subdir_rooted_config`.
-    let main = main.canonicalize().unwrap();
+    let main = rag_rat_base::paths::canonicalize(&main).unwrap();
     fs::write(main.join("crate/src/lib.rs"), "pub fn base_fn() {}\n").unwrap();
     init_git_repo(&main);
     run_git(&main, &["add", "."]);

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -44,7 +44,7 @@ pub(crate) use discovery::{
 /// dedicated table: it is a marker, not queried relationally, and the
 /// `watch_shutdown_reconcile_pending` marker set the pattern.
 ///
-/// The literal itself is owned by `rag-rat-db`: the V096 rekey (#1048) has to find these keys to
+/// The literal itself is owned by `rag-rat-db`: the V097 rekey (#1048) has to find these keys to
 /// rewrite a stale Windows path spelling in their `worktree_id` suffix, and migrations sit below
 /// this crate. Aliasing it here rather than repeating it is what keeps the rekey and these reads
 /// from drifting into a silent miss.

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -43,7 +43,13 @@ pub(crate) use discovery::{
 /// (never the safe-direction refresh). Kept per worktree in the per-repo kv rather than a
 /// dedicated table: it is a marker, not queried relationally, and the
 /// `watch_shutdown_reconcile_pending` marker set the pattern.
-const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str = "worktree_overlay_basis:";
+///
+/// The literal itself is owned by `rag-rat-db`: the V096 rekey (#1048) has to find these keys to
+/// rewrite a stale Windows path spelling in their `worktree_id` suffix, and migrations sit below
+/// this crate. Aliasing it here rather than repeating it is what keeps the rekey and these reads
+/// from drifting into a silent miss.
+const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str =
+    rag_rat_db::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX;
 
 /// A parsed refresh-basis value: the #577 skip-proof pair plus, when recorded by a #822-aware
 /// build, the recording refresh's timestamp. Internal to the two projection readers so the meta

--- a/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/discovery.rs
@@ -137,8 +137,11 @@ fn linked_config_subdir_and_root(
             config_root.display(),
         )
     })?;
-    let base_workdir = canonical_or_raw(base_workdir);
-    let config_subdir = canonical_or_raw(config_root)
+    // Both sides of the strip resolve the same way — canonical when the directory exists, the
+    // simplified original when it does not, so the strip fails on a genuine mismatch rather than on
+    // one side having been normalized and the other not.
+    let base_workdir = rag_rat_base::paths::canonicalize_or_simplified(base_workdir);
+    let config_subdir = rag_rat_base::paths::canonicalize_or_simplified(config_root)
         .strip_prefix(&base_workdir)
         .map_err(|_| {
             anyhow::anyhow!(
@@ -151,12 +154,6 @@ fn linked_config_subdir_and_root(
         .to_path_buf();
     let linked_config_root = linked_workdir.join(&config_subdir);
     Ok((config_subdir, linked_config_root))
-}
-
-/// `path` canonicalized, or `path` itself when it cannot be resolved (a vanished directory) — the
-/// caller then fails on the strip rather than on the canonicalization.
-fn canonical_or_raw(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub(crate) fn linked_source_root(

--- a/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay/materialize.rs
@@ -243,7 +243,7 @@ impl IndexDatabase {
         // drift from the base one. `ignore` is the LINKED checkout's matcher (a branch
         // `.gitignore` governs the overlay's indexable set), recompiled per call so a
         // branch ignore edit takes effect immediately.
-        let canonical_source = source_root.canonicalize().unwrap_or_else(|_| source_root.clone());
+        let canonical_source = rag_rat_base::paths::canonicalize_or_simplified(&source_root);
         let ignore =
             ignore_rules::IgnoreMatcher::compile(&source_root, &config.target_directories());
         // Present + indexable = a regular, in-root, non-symlink-crossed, NON-ignored file the

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -37,7 +37,7 @@ impl ScratchRoot {
     }
 
     fn canonicalize(mut self) -> std::io::Result<Self> {
-        self.path = self.path.canonicalize()?;
+        self.path = rag_rat_base::paths::canonicalize(self.path)?;
         Ok(self)
     }
 }
@@ -154,7 +154,7 @@ fn the_watch_fixture_config_root_diverges_from_its_scratch_spelling() {
     );
     assert_eq!(
         config.root,
-        scratch.as_path().canonicalize().unwrap(),
+        rag_rat_base::paths::canonicalize(scratch.as_path()).unwrap(),
         "both spellings name the same directory",
     );
     assert_eq!(root, config.root, "the returned root is the one the Config carries");
@@ -1983,7 +1983,7 @@ fn linked_subdir_root_watch_placement_keeps_checkout_root_when_config_root_missi
     }
     std::fs::create_dir_all(checkout.join("packages")).unwrap();
     let checkout = checkout.canonicalize().unwrap();
-    let config_root = repo.join("packages/crate").canonicalize().unwrap();
+    let config_root = rag_rat_base::paths::canonicalize(repo.join("packages/crate")).unwrap();
     let target_dirs = vec![PathBuf::from("src")];
     let (config, _) = whole_root_config(&config_root, &target_dirs);
 
@@ -2289,7 +2289,7 @@ fn event_touches_worktree_rebases_subdir_rooted_config() {
         rag_rat_base::test_git::run(&repo, &args);
     }
     // `config.root` is the `crate` SUBDIR of the repo.
-    let config_root = repo.join("crate").canonicalize().unwrap();
+    let config_root = rag_rat_base::paths::canonicalize(repo.join("crate")).unwrap();
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
@@ -3089,7 +3089,7 @@ fn worktree_watch_targets_excludes_the_main_checkout_for_a_subdir_config_root() 
     git(&main, &["add", "-A"]);
     git(&main, &["commit", "-qm", "seed"]);
 
-    let sub = main.join("crate").canonicalize().unwrap(); // config.root is the subdir.
+    let sub = rag_rat_base::paths::canonicalize(main.join("crate")).unwrap(); // config.root is the subdir.
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
@@ -3118,7 +3118,7 @@ fn worktree_watch_targets_excludes_the_main_checkout_for_a_subdir_config_root() 
     };
 
     let (roots, _registry) = worktree_watch_targets(&config);
-    let main_id = crate::index::worktree_id_of(&std::fs::canonicalize(&main).unwrap());
+    let main_id = crate::index::worktree_id_of(&rag_rat_base::paths::canonicalize(&main).unwrap());
     assert!(
         !roots.iter().any(|r| crate::index::worktree_id_of(r) == main_id),
         "the main checkout must NOT be watched as a linked worktree: {roots:?}",

--- a/crates/rag-rat-db/src/meta.rs
+++ b/crates/rag-rat-db/src/meta.rs
@@ -26,7 +26,7 @@ pub const LENS_ENRICHMENT_REVISION_META: &str = "lens_enrichment_revision";
 /// Prefix of the per-worktree overlay refresh-basis key; the SUFFIX is a `worktree_id`, so the key
 /// carries a checkout path.
 ///
-/// Declared here rather than beside its runtime reads because the V096 rekey (#1048) must find
+/// Declared here rather than beside its runtime reads because the V097 rekey (#1048) must find
 /// these keys to rewrite a stale Windows path spelling, and lives below the crate that reads them.
 /// One literal, shared, so the migration and the reader cannot drift into a silent miss.
 pub const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str = "worktree_overlay_basis:";
@@ -35,7 +35,7 @@ pub const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str = "worktree_overlay_basis:";
 /// siblings (`_head`, `_shallow`, `_complete`) are a commit hash and two flags, so this is the only
 /// one of the four that carries a path.
 ///
-/// Declared here for the same reason as [`WORKTREE_OVERLAY_BASIS_META_PREFIX`]: the V096 rekey
+/// Declared here for the same reason as [`WORKTREE_OVERLAY_BASIS_META_PREFIX`]: the V097 rekey
 /// (#1048) must rewrite this value and lives below the crate that reads it. One literal, shared, so
 /// the migration and the reader cannot drift into a silent miss.
 pub const GIT_HISTORY_INDEXED_ROOT_META: &str = "git_history_indexed_root";

--- a/crates/rag-rat-db/src/meta.rs
+++ b/crates/rag-rat-db/src/meta.rs
@@ -23,6 +23,22 @@ pub const BASE_SCOPE_DISCOVERED_META: &str = "files_base_scope_discovered";
 /// Monotonic per-repo clock maintained by schema triggers and transactional bulk writers for
 /// Lens-visible enrichment rows.
 pub const LENS_ENRICHMENT_REVISION_META: &str = "lens_enrichment_revision";
+/// Prefix of the per-worktree overlay refresh-basis key; the SUFFIX is a `worktree_id`, so the key
+/// carries a checkout path.
+///
+/// Declared here rather than beside its runtime reads because the V096 rekey (#1048) must find
+/// these keys to rewrite a stale Windows path spelling, and lives below the crate that reads them.
+/// One literal, shared, so the migration and the reader cannot drift into a silent miss.
+pub const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str = "worktree_overlay_basis:";
+/// Per-repo git-history reload cursor whose VALUE is the indexed root — the `config.root` spelling
+/// the history rows were read at, compared TEXTUALLY against a freshly canonicalized root. Its
+/// siblings (`_head`, `_shallow`, `_complete`) are a commit hash and two flags, so this is the only
+/// one of the four that carries a path.
+///
+/// Declared here for the same reason as [`WORKTREE_OVERLAY_BASIS_META_PREFIX`]: the V096 rekey
+/// (#1048) must rewrite this value and lives below the crate that reads it. One literal, shared, so
+/// the migration and the reader cannot drift into a silent miss.
+pub const GIT_HISTORY_INDEXED_ROOT_META: &str = "git_history_indexed_root";
 
 /// Advance the per-repo Lens enrichment write clock once for one logical transaction.
 pub fn bump_lens_enrichment_revision(

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6703,11 +6703,24 @@ pub const V097_PATH_VALUED_META_KEYS: &[&str] =
 /// a checkout that no longer exists. The fence is the SCHEMA VERSION, and it is the ladder's, not
 /// this migration's: recording V097 puts a migration id in `schema_version` that a pre-V097 binary
 /// does not know, so [`super::status`] answers `Newer` and every open refuses. It covers a RESIDENT
-/// process, not just a fresh command, because no long-lived component holds a connection across
-/// that check — a watcher pass re-opens through `open_and_migrate` at its start, inside the
-/// per-repo write flock and long before its gc stage, so the pass after the upgrade fails at the
-/// gate with nothing written. The same is true of the lighter watch-counter flush, which tests
-/// `status() == Compatible` on its own connection before writing.
+/// process, not just a fresh command, WHEREVER THAT PROCESS RE-OPENS, which every path that
+/// indexes, queries, or garbage-collects does per operation: a watcher pass re-opens through
+/// `open_and_migrate` at its start, inside the per-repo write flock and long before its gc stage,
+/// so the pass after the upgrade fails at the gate with nothing written; the lighter watch-counter
+/// flush tests `status() == Compatible` on its own connection before writing; CLI and MCP reads go
+/// through `open_and_migrate` or `try_open_config_read_only`.
+///
+/// ONE resident writer does hold a connection across that check, and it is the reason this
+/// paragraph is not a general rule: `sync serve` / `sync init` open the index once and then run the
+/// accept loop on that same connection for the process's whole life, ingesting peer op-log entries
+/// without re-checking the schema. A server started before the upgrade keeps writing to a store a
+/// newer binary has converted. That is outside THIS migration's hazard for reasons specific to what
+/// the loop writes, not because the fence reaches it: no table is registered for table-sync
+/// (`SYNCABLE_TABLES` is empty), `repo_roots` is written only by the indexing path's
+/// `register_repo`, and the loop runs no gc and derives no live-worktree set — so it can neither
+/// prune a rekeyed row nor write a path-spelled column back in the old spelling. A FUTURE
+/// data-converting migration over a table the op-log projection or table-sync touches must re-check
+/// that for itself rather than inherit this conclusion.
 ///
 /// That fence only holds if the conversion and the stamp are never separately visible, so this
 /// migration is in `LEDGER_ATOMIC_MIGRATIONS`: the ladder runs the sweep inside the same IMMEDIATE

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6635,7 +6635,7 @@ pub fn apply_table_sync_gapped_entries(conn: &Connection) -> rusqlite::Result<()
 /// `(commit_sha, worktree_id)` pair is the active-scope view every read goes through); the other
 /// three are keyed the same way, and GC prunes all four off the same live worktree set.
 ///
-/// `migration_096_covers_every_worktree_id_column_in_the_schema` pins this list against the live
+/// `migration_097_covers_every_worktree_id_column_in_the_schema` pins this list against the live
 /// schema, so a table that grows a `worktree_id` cannot silently miss the rekey.
 pub const V097_WORKTREE_ID_SCOPED_TABLES: &[&str] =
     &["files", "packages", "oracle_runs", "external_symbols"];
@@ -6654,7 +6654,12 @@ const V097_WORKTREE_OVERLAY_BASIS_PREFIX: &str = crate::meta::WORKTREE_OVERLAY_B
 /// `local_crate_roots` (Cargo crate NAMES), and everything model/embedding/FTS-related (ids,
 /// versions, counters). `files.path` and `packages.manifest_dir` are stored RELATIVE to the root,
 /// so a root respelling never reaches them.
-const V097_PATH_VALUED_META_KEYS: &[&str] =
+///
+/// `pub` for the same reason as [`V097_WORKTREE_ID_SCOPED_TABLES`]: a meta key is just a string, so
+/// nothing about adding a path-valued one fails to compile.
+/// `every_absolute_path_in_the_meta_bag_is_rekeyed_or_reviewed` walks a real index and requires
+/// every absolute-path value to be either in this list or in an explicitly reviewed exception set.
+pub const V097_PATH_VALUED_META_KEYS: &[&str] =
     &["source_root", crate::meta::GIT_HISTORY_INDEXED_ROOT_META];
 
 /// V097 (#1048): rewrite every persisted path spelling that the pre-fix `canonicalize` wrote in
@@ -6690,8 +6695,41 @@ const V097_PATH_VALUED_META_KEYS: &[&str] =
 /// Rewriting goes through `paths::rekeyed_from_verbatim`, the SAME rule production canonicalizes
 /// with, not a blind prefix strip: verbatim form is still produced (and still correct) for UNC
 /// shares, paths past `MAX_PATH`, and reserved DOS names, and rewriting those would BREAK the match
-/// this exists to preserve. On Unix that rule is the identity for every input, so this migration is
-/// a strict no-op there.
+/// this exists to preserve.
+///
+/// WHAT KEEPS A PRE-UPGRADE BINARY OFF A STORE THIS HAS CONVERTED. Rekeying is only safe if no
+/// binary that predates it can still write to, or garbage-collect, the rekeyed rows — an older
+/// build derives the live worktree set from the OLD spelling, so it would read every rekeyed id as
+/// a checkout that no longer exists. The fence is the SCHEMA VERSION, and it is the ladder's, not
+/// this migration's: recording V097 puts a migration id in `schema_version` that a pre-V097 binary
+/// does not know, so [`super::status`] answers `Newer` and every open refuses. It covers a RESIDENT
+/// process, not just a fresh command, because no long-lived component holds a connection across
+/// that check — a watcher pass re-opens through `open_and_migrate` at its start, inside the
+/// per-repo write flock and long before its gc stage, so the pass after the upgrade fails at the
+/// gate with nothing written. The same is true of the lighter watch-counter flush, which tests
+/// `status() == Compatible` on its own connection before writing.
+///
+/// The one case the version cannot fence is a pass ALREADY past that check when the upgrade
+/// commits. A new binary's INDEXING opens cannot cause it (they take the per-repo write flock
+/// before migrating, so they wait behind the in-flight pass); only a non-indexing open — a query,
+/// an MCP read — migrates under the global schema lock alone, which by design does not serialize
+/// against per-repo writers. Deliberately left: the migration must not take per-repo flocks it
+/// would have to enumerate and order across every repo in a consolidated store, and the exposure
+/// is bounded — the rows at risk are derived overlay/dirty rows, which the next overlay refresh
+/// re-derives, and committed base rows (`worktree_id = ''`, a live `commit_sha`) are outside it.
+///
+/// IT RUNS ON EVERY PLATFORM, not only on Windows. Which spellings a store carries is a property of
+/// the STORE, not of the host reading it: one repository directory reachable from both a Windows
+/// path and a WSL/container mount is one SQLite file, and whichever binary opens first is the one
+/// that runs the ladder. Skipping the sweep off Windows would let that first opener record V097 as
+/// applied without converting anything — and the ladder is forward-only, so the Windows binary
+/// would never revisit it and would keep the spellings that get its rows collected as a dead
+/// checkout, which is the failure this migration exists to prevent. `rekeyed_from_verbatim` decides
+/// droppability textually for that reason. The cost of dropping the host skip is small and was
+/// measured rather than assumed: the sweep's reads are `SELECT DISTINCT` over four `worktree_id`
+/// columns, and `files` — the only large one — answers from `idx_files_worktree_path` as a covering
+/// scan; on a ~2 GB twenty-repo store the whole sweep is tens of milliseconds, once, on the open
+/// that upgrades it.
 pub fn apply_windows_verbatim_path_rekey(conn: &Connection) -> rusqlite::Result<()> {
     rekey_persisted_path_spellings(conn, rag_rat_base::paths::rekeyed_from_verbatim)
 }
@@ -6699,12 +6737,11 @@ pub fn apply_windows_verbatim_path_rekey(conn: &Connection) -> rusqlite::Result<
 /// [`apply_windows_verbatim_path_rekey`] with the spelling rule injected.
 ///
 /// The rule is a parameter so the ROW-WALKING half — which columns and which meta keys the pass
-/// covers — is testable on every platform. The real rule is inert off Windows, so a Unix-only test
-/// of the production entry point can only ever observe "nothing happened" and would pass just as
-/// well against a pass that covers no tables at all. `pub` for that reason alone: the engine's
-/// upgrade regression test drives a real multi-worktree index through this with a rule that is
-/// active everywhere, so the Linux gate sees the scope-restore and the GC-survival that the
-/// Windows leg then confirms under the production rule.
+/// covers — can be driven over a REAL index built on the host running the test. The production rule
+/// only ever rewrites the Windows verbatim shape, which no checkout on a Unix CI runner is spelled
+/// in; injecting a rule that maps the spellings such an index actually holds is what lets the Linux
+/// leg observe the scope-restore and the GC-survival, rather than observing "nothing happened" and
+/// passing just as well against a pass that covers no tables at all. `pub` for that reason alone.
 pub fn rekey_persisted_path_spellings(
     conn: &Connection,
     rekey: fn(&str) -> Option<String>,
@@ -6835,10 +6872,11 @@ fn rekey_worktree_overlay_basis_keys(
 mod windows_verbatim_rekey_tests {
     use super::*;
 
-    /// The stand-in spelling rule. The production rule (`paths::rekeyed_from_verbatim`) is the
-    /// identity on Unix by design, so driving this pass with it here would assert nothing: this
-    /// one is active on every platform, which is what lets the Linux gate observe that each
-    /// covered column and meta key is actually rewritten.
+    /// The stand-in spelling rule: a blind prefix strip. Used for the ROW-WALKING assertions —
+    /// which columns and which meta keys the sweep reaches — so those stay legible against a rule
+    /// with one obvious answer per input, and so the two halves fail separately. Which spellings
+    /// the PRODUCTION rule declines is `paths`' concern and is asserted there;
+    /// `the_production_pass_rekeys_a_windows_store_on_any_host` covers the two composed.
     fn strip_verbatim(stored: &str) -> Option<String> {
         stored.strip_prefix(r"\\?\").map(str::to_string)
     }
@@ -7012,23 +7050,20 @@ mod windows_verbatim_rekey_tests {
         assert_eq!(live, 1, "the row production just wrote is intact, not replaced or cascaded");
     }
 
-    /// The real entry point is a no-op on Unix: nothing in a Unix store was ever spelled verbatim,
-    /// and a pass that rewrote a path merely because it starts with those bytes would corrupt it.
-    #[cfg(unix)]
+    /// The real entry point, end-to-end, on WHICHEVER platform runs it — deliberately not
+    /// `cfg`-gated.
+    ///
+    /// Which spellings a store holds is a property of the store, not of the host that opens it: one
+    /// repository directory reachable from both a Windows path and a WSL/container mount is one
+    /// SQLite file, and whichever binary opens first is the one that runs the ladder. A pass that
+    /// converted only on Windows would let a non-Windows opener stamp V097 as applied without
+    /// converting anything, and the forward-only ladder would never revisit it — leaving the
+    /// Windows binary with exactly the spellings whose rows its next GC prunes as a dead checkout.
+    ///
+    /// So this asserts the conversion on Unix too, where the host-gated version returned before
+    /// opening the transaction and left every value below verbatim.
     #[test]
-    fn the_production_pass_is_inert_on_unix() {
-        let conn = poisoned_store();
-        apply_windows_verbatim_path_rekey(&conn).unwrap();
-        assert_eq!(
-            scalar(&conn, "SELECT worktree_id FROM files WHERE path = 'src/a.rs'"),
-            r"\\?\C:\repo",
-        );
-    }
-
-    /// The real entry point end-to-end on the platform that has the hazard.
-    #[cfg(windows)]
-    #[test]
-    fn the_production_pass_rekeys_on_windows() {
+    fn the_production_pass_rekeys_a_windows_store_on_any_host() {
         let conn = poisoned_store();
         apply_windows_verbatim_path_rekey(&conn).unwrap();
         assert_eq!(
@@ -7036,6 +7071,10 @@ mod windows_verbatim_rekey_tests {
             r"C:\repo",
         );
         assert_eq!(scalar(&conn, "SELECT root FROM repo_roots"), r"C:\repo");
+        assert_eq!(
+            scalar(&conn, "SELECT value FROM repo_meta WHERE key = 'git_history_indexed_root'"),
+            r"C:\repo",
+        );
         assert_eq!(
             scalar(&conn, "SELECT key FROM repo_meta WHERE key LIKE 'worktree_overlay_basis:%'"),
             r"worktree_overlay_basis:C:\linked",

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1382,6 +1382,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_094_ID => Some(94),
             MIGRATION_095_ID => Some(95),
             MIGRATION_096_ID => Some(96),
+            MIGRATION_097_ID => Some(97),
             _ => None,
         })
         .max()
@@ -1487,6 +1488,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_094_ID
             | MIGRATION_095_ID
             | MIGRATION_096_ID
+            | MIGRATION_097_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1589,6 +1591,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_094_ID => migration.checksum != MIGRATION_094_CHECKSUM,
         MIGRATION_095_ID => migration.checksum != MIGRATION_095_CHECKSUM,
         MIGRATION_096_ID => migration.checksum != MIGRATION_096_CHECKSUM,
+        MIGRATION_097_ID => migration.checksum != MIGRATION_097_CHECKSUM,
         _ => false,
     }
 }
@@ -6625,6 +6628,434 @@ pub fn apply_table_sync_gapped_entries(conn: &Connection) -> rusqlite::Result<()
                  stream_id, prev_hash, device_fingerprint, entry_hash);",
     )?;
     tx.commit()
+}
+
+/// Every table whose `worktree_id` column holds a CHECKOUT PATH — the scope key `worktree_id_of`
+/// derives by canonicalizing a checkout directory. `files` is the load-bearing one (its
+/// `(commit_sha, worktree_id)` pair is the active-scope view every read goes through); the other
+/// three are keyed the same way, and GC prunes all four off the same live worktree set.
+///
+/// `migration_096_covers_every_worktree_id_column_in_the_schema` pins this list against the live
+/// schema, so a table that grows a `worktree_id` cannot silently miss the rekey.
+pub const V097_WORKTREE_ID_SCOPED_TABLES: &[&str] =
+    &["files", "packages", "oracle_runs", "external_symbols"];
+
+/// The `repo_meta` key prefix whose SUFFIX is a `worktree_id` — the overlay refresh basis, THE
+/// same constant `rag-rat-core`'s overlay reads and writes. Rekeying the row's VALUE is not enough
+/// here: the worktree identity is in the KEY, so a stale key is a basis record the rekeyed scope
+/// can never find.
+const V097_WORKTREE_OVERLAY_BASIS_PREFIX: &str = crate::meta::WORKTREE_OVERLAY_BASIS_META_PREFIX;
+
+/// Every meta key whose VALUE is a checkout path — the `repo_meta` / `index_meta` rows a freshly
+/// canonicalized root is compared against TEXTUALLY.
+///
+/// Deliberately NOT here, having been checked one by one: `git_history_indexed_head` and
+/// `git_commit` (commit hashes), `git_history_indexed_shallow` / `_complete` (flags),
+/// `local_crate_roots` (Cargo crate NAMES), and everything model/embedding/FTS-related (ids,
+/// versions, counters). `files.path` and `packages.manifest_dir` are stored RELATIVE to the root,
+/// so a root respelling never reaches them.
+const V097_PATH_VALUED_META_KEYS: &[&str] =
+    &["source_root", crate::meta::GIT_HISTORY_INDEXED_ROOT_META];
+
+/// V097 (#1048): rewrite every persisted path spelling that the pre-fix `canonicalize` wrote in
+/// the Windows `\\?\` VERBATIM form into the plain spelling this binary now produces.
+///
+/// The upgrade hazard this closes is silent on Windows. These stored strings are compared
+/// TEXTUALLY against a freshly-canonicalized path:
+///  * `worktree_id` — a canonicalized checkout path, carried by every linked worktree's overlay
+///    rows and every dirty row (committed base rows are shared across checkouts under `worktree_id
+///    = ''` and are not implicated). Once production answers `C:\…` and the rows still say
+///    `\\?\C:\…`, those rows fall out of the active scope AND out of the GC live set, which is
+///    built from the same fresh canonicalization: `garbage_collect` reads every stored id as a
+///    checkout that no longer exists and DELETES its rows. Registered, live worktrees, pruned as
+///    dead on the first maintenance pass after the upgrade.
+///  * `repo_roots.root` / `repo_meta[source_root]` — `repo_indexed_at_this_root` is the "this
+///    checkout was indexed here" signal behind the empty-index guard. A stale spelling makes an
+///    established checkout look first-time, so an index run whose files have just been deleted is
+///    refused as an accidental empty repo instead of pruning, and the deleted files' rows stay live
+///    until the user finds `--allow-empty`.
+///  * `repo_meta[git_history_indexed_root]` — the git-history reload gate's root cursor. A stale
+///    spelling fails the `is_history_current` / `prepare_plan` comparison, so the first pass after
+///    the upgrade takes the FULL path: the whole commit + file-change set is deleted and re-read
+///    off a fresh revwalk, and the repo's blame cache is wiped with it. Self-healing after one
+///    pass, but a minutes-long stall and a cold blame cache on a large repo.
+///
+/// One derived value is knowingly left to re-derive: `repo_meta[git_coupling_stamp]` folds the
+/// history cursor snapshot (root spelling included) into its own freshness key, so rekeying the
+/// cursor makes it stale. That is the change-coupling table's ordinary invalidation path — a
+/// bounded window recompute, with an in-memory fallback that keeps reads correct meanwhile — and
+/// the same recompute happens anyway on the next history apply. Rewriting a composite freshness
+/// stamp from a migration would buy nothing and couple the ladder to that stamp's format.
+///
+/// Rewriting goes through `paths::rekeyed_from_verbatim`, the SAME rule production canonicalizes
+/// with, not a blind prefix strip: verbatim form is still produced (and still correct) for UNC
+/// shares, paths past `MAX_PATH`, and reserved DOS names, and rewriting those would BREAK the match
+/// this exists to preserve. On Unix that rule is the identity for every input, so this migration is
+/// a strict no-op there.
+pub fn apply_windows_verbatim_path_rekey(conn: &Connection) -> rusqlite::Result<()> {
+    rekey_persisted_path_spellings(conn, rag_rat_base::paths::rekeyed_from_verbatim)
+}
+
+/// [`apply_windows_verbatim_path_rekey`] with the spelling rule injected.
+///
+/// The rule is a parameter so the ROW-WALKING half — which columns and which meta keys the pass
+/// covers — is testable on every platform. The real rule is inert off Windows, so a Unix-only test
+/// of the production entry point can only ever observe "nothing happened" and would pass just as
+/// well against a pass that covers no tables at all. `pub` for that reason alone: the engine's
+/// upgrade regression test drives a real multi-worktree index through this with a rule that is
+/// active everywhere, so the Linux gate sees the scope-restore and the GC-survival that the
+/// Windows leg then confirms under the production rule.
+pub fn rekey_persisted_path_spellings(
+    conn: &Connection,
+    rekey: fn(&str) -> Option<String>,
+) -> rusqlite::Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    for table in V097_WORKTREE_ID_SCOPED_TABLES {
+        if column_exists(&tx, table, "worktree_id")? {
+            rekey_column(&tx, table, "worktree_id", rekey)?;
+        }
+    }
+    if column_exists(&tx, "repo_roots", "root")? {
+        rekey_column(&tx, "repo_roots", "root", rekey)?;
+    }
+    // These keys land in `repo_meta` at V039; a pre-V039 store still carries them in the global
+    // `index_meta`, and the ladder replays in order, so by here they have moved. Both are swept
+    // anyway — the pass is idempotent and a stale copy either table kept is equally stale. The
+    // sweep is KEY-SCOPED: most meta values are not paths, and rewriting one that merely starts
+    // with those bytes would corrupt it.
+    for (table, column) in [("repo_meta", "value"), ("index_meta", "value")] {
+        if column_exists(&tx, table, column)? {
+            for key in V097_PATH_VALUED_META_KEYS {
+                rekey_meta_value_at_key(&tx, table, key, rekey)?;
+            }
+        }
+    }
+    if column_exists(&tx, "repo_meta", "key")? {
+        rekey_worktree_overlay_basis_keys(&tx, rekey)?;
+    }
+    tx.commit()
+}
+
+/// Rewrite the stale spellings in `table.column` in place.
+///
+/// Reads the DISTINCT values first: a `worktree_id` column has one value per checkout however many
+/// million rows carry it, so the rule runs a handful of times and each rewrite is one indexed
+/// UPDATE.
+///
+/// `UPDATE OR IGNORE` because the target spelling can already be present. On the real upgrade it
+/// cannot be — the old binary only ever wrote the verbatim form — but a store written by a MIX of
+/// binaries can hold both, and there the plain-spelled row is the one production just wrote and
+/// must win. Skipping leaves the verbatim row for GC, which is the correct disposition for a
+/// superseded duplicate; the alternatives are worse in both directions (`OR REPLACE` would cascade
+/// the live row's children away, a bare UPDATE would abort the upgrade on a constraint failure).
+fn rekey_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    rekey: fn(&str) -> Option<String>,
+) -> rusqlite::Result<()> {
+    let stored: Vec<String> = {
+        let mut stmt = conn
+            .prepare(&format!("SELECT DISTINCT {column} FROM main.{table} WHERE {column} != ''"))?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        rows.collect::<rusqlite::Result<_>>()?
+    };
+    for old in stored {
+        let Some(new) = rekey(&old) else { continue };
+        conn.execute(
+            &format!("UPDATE OR IGNORE main.{table} SET {column} = ?1 WHERE {column} = ?2"),
+            params![new, old],
+        )?;
+    }
+    Ok(())
+}
+
+/// Rewrite the VALUE of a single meta row whose key is `key` — the `source_root` case, where the
+/// path is the value rather than part of the key.
+fn rekey_meta_value_at_key(
+    conn: &Connection,
+    table: &str,
+    key: &str,
+    rekey: fn(&str) -> Option<String>,
+) -> rusqlite::Result<()> {
+    let stored: Vec<String> = {
+        let mut stmt =
+            conn.prepare(&format!("SELECT DISTINCT value FROM main.{table} WHERE key = ?1"))?;
+        let rows = stmt.query_map([key], |row| row.get::<_, String>(0))?;
+        rows.collect::<rusqlite::Result<_>>()?
+    };
+    for old in stored {
+        let Some(new) = rekey(&old) else { continue };
+        conn.execute(
+            &format!("UPDATE OR IGNORE main.{table} SET value = ?1 WHERE key = ?2 AND value = ?3"),
+            params![new, key, old],
+        )?;
+    }
+    Ok(())
+}
+
+/// Rewrite the overlay-basis rows whose KEY embeds a stale `worktree_id`
+/// (`worktree_overlay_basis:<worktree_id>`).
+///
+/// Left behind, the basis record is unreachable under the rekeyed scope, and the overlay refresh
+/// reads a missing basis as "never refreshed" — correct but wasteful (a full re-derive per linked
+/// checkout). The GC that prunes basis rows outside the live worktree set would then delete it,
+/// which is harmless once the row is orphaned but leaves the quiet-window anchor gone. Moving the
+/// key keeps the basis attached to the checkout it describes.
+fn rekey_worktree_overlay_basis_keys(
+    conn: &Connection,
+    rekey: fn(&str) -> Option<String>,
+) -> rusqlite::Result<()> {
+    let stored: Vec<String> = {
+        // `\` is not a LIKE metacharacter in SQLite, but `_` in the prefix is — match on the
+        // literal prefix with `substr` instead of relying on an ESCAPE clause.
+        let mut stmt =
+            conn.prepare("SELECT DISTINCT key FROM main.repo_meta WHERE substr(key, 1, ?1) = ?2")?;
+        let prefix_len = V097_WORKTREE_OVERLAY_BASIS_PREFIX.len() as i64;
+        let rows = stmt
+            .query_map(params![prefix_len, V097_WORKTREE_OVERLAY_BASIS_PREFIX], |row| {
+                row.get::<_, String>(0)
+            })?;
+        rows.collect::<rusqlite::Result<_>>()?
+    };
+    for old_key in stored {
+        let Some(worktree_id) = old_key.strip_prefix(V097_WORKTREE_OVERLAY_BASIS_PREFIX) else {
+            continue;
+        };
+        let Some(rekeyed) = rekey(worktree_id) else { continue };
+        conn.execute("UPDATE OR IGNORE main.repo_meta SET key = ?1 WHERE key = ?2", params![
+            format!("{V097_WORKTREE_OVERLAY_BASIS_PREFIX}{rekeyed}"),
+            old_key
+        ])?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod windows_verbatim_rekey_tests {
+    use super::*;
+
+    /// The stand-in spelling rule. The production rule (`paths::rekeyed_from_verbatim`) is the
+    /// identity on Unix by design, so driving this pass with it here would assert nothing: this
+    /// one is active on every platform, which is what lets the Linux gate observe that each
+    /// covered column and meta key is actually rewritten.
+    fn strip_verbatim(stored: &str) -> Option<String> {
+        stored.strip_prefix(r"\\?\").map(str::to_string)
+    }
+
+    /// A store shaped like a pre-V097 Windows index: every scope key and recorded root spelled the
+    /// way `std::fs::canonicalize` used to answer.
+    fn poisoned_store() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r"
+            CREATE TABLE files(id INTEGER PRIMARY KEY, path TEXT NOT NULL, commit_sha TEXT NOT NULL
+                DEFAULT '', worktree_id TEXT NOT NULL DEFAULT '',
+                UNIQUE(path, commit_sha, worktree_id));
+            CREATE TABLE packages(manifest_dir TEXT NOT NULL, commit_sha TEXT NOT NULL DEFAULT '',
+                worktree_id TEXT NOT NULL DEFAULT '');
+            CREATE TABLE oracle_runs(id INTEGER PRIMARY KEY, worktree_id TEXT NOT NULL DEFAULT '');
+            CREATE TABLE external_symbols(name TEXT NOT NULL, worktree_id TEXT NOT NULL);
+            CREATE TABLE repo_roots(repo_id TEXT NOT NULL, root TEXT NOT NULL,
+                PRIMARY KEY(repo_id, root));
+            CREATE TABLE repo_meta(repo_id TEXT NOT NULL, key TEXT NOT NULL, value TEXT NOT NULL,
+                PRIMARY KEY(repo_id, key));
+            CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+
+            INSERT INTO files(path, commit_sha, worktree_id)
+                VALUES ('src/a.rs', 'headsha', '\\?\C:\repo'),
+                       ('src/b.rs', '', '\\?\C:\linked');
+            INSERT INTO packages VALUES ('crate', 'headsha', '\\?\C:\repo');
+            INSERT INTO oracle_runs(worktree_id) VALUES ('\\?\C:\repo');
+            INSERT INTO external_symbols VALUES ('Ext', '\\?\C:\repo');
+            INSERT INTO repo_roots VALUES ('repo-1', '\\?\C:\repo');
+            INSERT INTO repo_meta VALUES ('repo-1', 'source_root', '\\?\C:\repo');
+            INSERT INTO repo_meta VALUES ('repo-1', 'git_history_indexed_root', '\\?\C:\repo');
+            -- The reload cursor's SIBLING key, given a value the rule would happily rewrite so a
+            -- blanket value-sweep would visibly corrupt it. In a real store this holds a commit
+            -- hash; the sweep must be scoped to the keys that carry a path.
+            INSERT INTO repo_meta VALUES ('repo-1', 'git_history_indexed_head', '\\?\C:\repo');
+            INSERT INTO repo_meta VALUES
+                ('repo-1', 'worktree_overlay_basis:\\?\C:\linked',
+                 'base' || char(10) || 'linked' || char(10) || '42');
+            INSERT INTO index_meta VALUES ('source_root', '\\?\C:\repo');
+            ",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn scalar(conn: &Connection, sql: &str) -> String {
+        conn.query_row(sql, [], |row| row.get::<_, String>(0)).unwrap()
+    }
+
+    /// The whole class in one pass: every table whose `worktree_id` names a checkout, the recorded
+    /// root behind the empty-index guard, the `source_root` fallback beside it, the git-history
+    /// reload cursor's root, and the overlay basis whose worktree identity lives in the KEY — plus
+    /// the negative half, a meta key that is NOT a path staying put.
+    ///
+    /// Against the unfixed state (no migration at all) every one of these still reads the verbatim
+    /// spelling, which is precisely the state where the active scope selects nothing and GC prunes
+    /// the rows as dead.
+    #[test]
+    fn the_rekey_covers_every_persisted_path_spelling() {
+        let conn = poisoned_store();
+        rekey_persisted_path_spellings(&conn, strip_verbatim).unwrap();
+
+        for (table, column) in [
+            ("files", "worktree_id"),
+            ("packages", "worktree_id"),
+            ("oracle_runs", "worktree_id"),
+            ("external_symbols", "worktree_id"),
+        ] {
+            let remaining: i64 = conn
+                .query_row(
+                    &format!(r"SELECT COUNT(*) FROM {table} WHERE substr({column}, 1, 4) = '\\?\'"),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(remaining, 0, "{table}.{column} still holds a verbatim spelling");
+        }
+        assert_eq!(
+            scalar(&conn, "SELECT worktree_id FROM files WHERE path = 'src/a.rs'"),
+            r"C:\repo",
+            "the base index's scope key is rekeyed, not just the overlay's",
+        );
+        assert_eq!(
+            scalar(&conn, "SELECT worktree_id FROM files WHERE path = 'src/b.rs'"),
+            r"C:\linked",
+        );
+        assert_eq!(scalar(&conn, "SELECT root FROM repo_roots"), r"C:\repo");
+        assert_eq!(
+            scalar(&conn, "SELECT value FROM repo_meta WHERE key = 'source_root'"),
+            r"C:\repo",
+        );
+        assert_eq!(
+            scalar(&conn, "SELECT value FROM index_meta WHERE key = 'source_root'"),
+            r"C:\repo",
+        );
+        assert_eq!(
+            scalar(&conn, "SELECT value FROM repo_meta WHERE key = 'git_history_indexed_root'"),
+            r"C:\repo",
+            "the git-history reload cursor is a ROOT PATH, not a commit hash — left stale it \
+             fails the freshness comparison and forces a full revwalk plus a blame-cache wipe",
+        );
+        assert_eq!(
+            scalar(&conn, "SELECT value FROM repo_meta WHERE key = 'git_history_indexed_head'"),
+            r"\\?\C:\repo",
+            "a meta key that does not carry a path is left alone — the sweep is key-scoped, not a \
+             blanket rewrite of every value that happens to start with those bytes",
+        );
+        assert_eq!(
+            scalar(&conn, "SELECT key FROM repo_meta WHERE key LIKE 'worktree_overlay_basis:%'",),
+            r"worktree_overlay_basis:C:\linked",
+            "the basis key carries the worktree identity, so the KEY must move with it",
+        );
+        assert_eq!(
+            scalar(&conn, "SELECT value FROM repo_meta WHERE key LIKE 'worktree_overlay_basis:%'",),
+            "base\nlinked\n42",
+            "the basis payload rides the key move intact",
+        );
+    }
+
+    /// Re-running the pass changes nothing — the ladder can replay it, and a store already written
+    /// by a fixed binary must come through untouched.
+    #[test]
+    fn the_rekey_is_idempotent() {
+        let conn = poisoned_store();
+        rekey_persisted_path_spellings(&conn, strip_verbatim).unwrap();
+        let snapshot =
+            scalar(&conn, "SELECT group_concat(worktree_id, '|') FROM files ORDER BY id");
+        rekey_persisted_path_spellings(&conn, strip_verbatim).unwrap();
+        assert_eq!(
+            scalar(&conn, "SELECT group_concat(worktree_id, '|') FROM files ORDER BY id"),
+            snapshot,
+        );
+    }
+
+    /// A spelling the rule declines to rewrite is LEFT ALONE. This is the half a blind `\\?\`
+    /// strip would get wrong: verbatim form is still produced for UNC shares and reserved names,
+    /// and rewriting one would break the very match the migration exists to preserve.
+    #[test]
+    fn a_spelling_the_rule_declines_is_untouched() {
+        let conn = poisoned_store();
+        rekey_persisted_path_spellings(&conn, |_| None).unwrap();
+        assert_eq!(
+            scalar(&conn, "SELECT worktree_id FROM files WHERE path = 'src/a.rs'"),
+            r"\\?\C:\repo",
+            "a declined rewrite must not be applied anyway",
+        );
+        assert_eq!(scalar(&conn, "SELECT root FROM repo_roots"), r"\\?\C:\repo");
+    }
+
+    /// A mixed-binary store already holds the plain spelling for one of the rows being rekeyed.
+    /// The pass must not abort the upgrade on the unique constraint, and must not cascade the live
+    /// plain-spelled row away: it keeps that row and leaves the superseded verbatim duplicate for
+    /// GC.
+    #[test]
+    fn a_colliding_plain_row_survives_the_rekey() {
+        let conn = poisoned_store();
+        conn.execute(
+            r"INSERT INTO files(path, commit_sha, worktree_id) VALUES ('src/a.rs', 'headsha', 'C:\repo')",
+            [],
+        )
+        .unwrap();
+        rekey_persisted_path_spellings(&conn, strip_verbatim).unwrap();
+        let live: i64 = conn
+            .query_row(
+                r"SELECT COUNT(*) FROM files WHERE path = 'src/a.rs' AND worktree_id = 'C:\repo'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(live, 1, "the row production just wrote is intact, not replaced or cascaded");
+    }
+
+    /// The real entry point is a no-op on Unix: nothing in a Unix store was ever spelled verbatim,
+    /// and a pass that rewrote a path merely because it starts with those bytes would corrupt it.
+    #[cfg(unix)]
+    #[test]
+    fn the_production_pass_is_inert_on_unix() {
+        let conn = poisoned_store();
+        apply_windows_verbatim_path_rekey(&conn).unwrap();
+        assert_eq!(
+            scalar(&conn, "SELECT worktree_id FROM files WHERE path = 'src/a.rs'"),
+            r"\\?\C:\repo",
+        );
+    }
+
+    /// The real entry point end-to-end on the platform that has the hazard.
+    #[cfg(windows)]
+    #[test]
+    fn the_production_pass_rekeys_on_windows() {
+        let conn = poisoned_store();
+        apply_windows_verbatim_path_rekey(&conn).unwrap();
+        assert_eq!(
+            scalar(&conn, "SELECT worktree_id FROM files WHERE path = 'src/a.rs'"),
+            r"C:\repo",
+        );
+        assert_eq!(scalar(&conn, "SELECT root FROM repo_roots"), r"C:\repo");
+        assert_eq!(
+            scalar(&conn, "SELECT key FROM repo_meta WHERE key LIKE 'worktree_overlay_basis:%'"),
+            r"worktree_overlay_basis:C:\linked",
+        );
+    }
+
+    /// A store that predates a covered table (a partial-schema bootstrap fixture) must not abort
+    /// the ladder — every sweep is guarded on the column actually being there.
+    #[test]
+    fn a_missing_table_is_skipped_rather_than_failing() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r"CREATE TABLE files(id INTEGER PRIMARY KEY, path TEXT NOT NULL,
+                  worktree_id TEXT NOT NULL DEFAULT '');
+              INSERT INTO files(path, worktree_id) VALUES ('a.rs', '\\?\C:\repo');",
+        )
+        .unwrap();
+        rekey_persisted_path_spellings(&conn, strip_verbatim).unwrap();
+        assert_eq!(scalar(&conn, "SELECT worktree_id FROM files"), r"C:\repo");
+    }
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6709,6 +6709,13 @@ pub const V097_PATH_VALUED_META_KEYS: &[&str] =
 /// gate with nothing written. The same is true of the lighter watch-counter flush, which tests
 /// `status() == Compatible` on its own connection before writing.
 ///
+/// That fence only holds if the conversion and the stamp are never separately visible, so this
+/// migration is in `LEDGER_ATOMIC_MIGRATIONS`: the ladder runs the sweep inside the same IMMEDIATE
+/// transaction that writes the `schema_version` row. Committed separately, the rekeyed store would
+/// answer `Compatible` to a pre-V097 binary until the stamp landed — for a moment on a healthy
+/// upgrade, indefinitely after a crash between the two commits — and every refusal above would wave
+/// that binary through onto rows it reads as dead checkouts.
+///
 /// The one case the version cannot fence is a pass ALREADY past that check when the upgrade
 /// commits. A new binary's INDEXING opens cannot cause it (they take the per-repo write flock
 /// before migrating, so they wait behind the in-flight pass); only a non-indexing open — a query,
@@ -6742,18 +6749,22 @@ pub fn apply_windows_verbatim_path_rekey(conn: &Connection) -> rusqlite::Result<
 /// in; injecting a rule that maps the spellings such an index actually holds is what lets the Linux
 /// leg observe the scope-restore and the GC-survival, rather than observing "nothing happened" and
 /// passing just as well against a pass that covers no tables at all. `pub` for that reason alone.
+///
+/// No transaction of its own: the ladder runs this migration inside one and commits it WITH the
+/// `schema_version` row, because a converted store that is not yet stamped still answers
+/// `Compatible` to the pre-V097 binary the conversion locks out. Opening a nested transaction here
+/// would fail outright, and committing one would reintroduce that window.
 pub fn rekey_persisted_path_spellings(
     conn: &Connection,
     rekey: fn(&str) -> Option<String>,
 ) -> rusqlite::Result<()> {
-    let tx = conn.unchecked_transaction()?;
     for table in V097_WORKTREE_ID_SCOPED_TABLES {
-        if column_exists(&tx, table, "worktree_id")? {
-            rekey_column(&tx, table, "worktree_id", rekey)?;
+        if column_exists(conn, table, "worktree_id")? {
+            rekey_column(conn, table, "worktree_id", rekey)?;
         }
     }
-    if column_exists(&tx, "repo_roots", "root")? {
-        rekey_column(&tx, "repo_roots", "root", rekey)?;
+    if column_exists(conn, "repo_roots", "root")? {
+        rekey_column(conn, "repo_roots", "root", rekey)?;
     }
     // These keys land in `repo_meta` at V039; a pre-V039 store still carries them in the global
     // `index_meta`, and the ladder replays in order, so by here they have moved. Both are swept
@@ -6761,16 +6772,16 @@ pub fn rekey_persisted_path_spellings(
     // sweep is KEY-SCOPED: most meta values are not paths, and rewriting one that merely starts
     // with those bytes would corrupt it.
     for (table, column) in [("repo_meta", "value"), ("index_meta", "value")] {
-        if column_exists(&tx, table, column)? {
+        if column_exists(conn, table, column)? {
             for key in V097_PATH_VALUED_META_KEYS {
-                rekey_meta_value_at_key(&tx, table, key, rekey)?;
+                rekey_meta_value_at_key(conn, table, key, rekey)?;
             }
         }
     }
-    if column_exists(&tx, "repo_meta", "key")? {
-        rekey_worktree_overlay_basis_keys(&tx, rekey)?;
+    if column_exists(conn, "repo_meta", "key")? {
+        rekey_worktree_overlay_basis_keys(conn, rekey)?;
     }
-    tx.commit()
+    Ok(())
 }
 
 /// Rewrite the stale spellings in `table.column` in place.

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -911,23 +911,52 @@ impl MigrationFn {
     }
 }
 
-/// Apply one migration and stamp its ledger row. V064 is special because it projects existing
-/// grow-only account history: DDL, source snapshot, all-account refold, and the ledger stamp must
-/// share one IMMEDIATE transaction so older writers cannot land an unprojected candidate in a
-/// migration race.
+/// Every migration whose ledger row MUST commit in the SAME transaction as its body.
+///
+/// The default is body-then-stamp, in two commits. That is safe for a migration that only ADDS
+/// structure: in the window between the two, an older binary reads a store carrying tables it does
+/// not know but DATA it still interprets correctly. It is NOT safe for a migration that CONVERTS
+/// data an older binary reads and acts on, because `schema_version` is the entire coexistence
+/// fence — an unrecognized migration id is what makes [`status`] answer `Newer`, and every refusal
+/// (`ensure_compatible_or_migrate`, `migrate_schema_only`, the read-only config open) is downstream
+/// of that answer. A converted-but-unstamped store answers `Compatible` to exactly the binary the
+/// conversion locks out, and nothing else serializes the two: the migrating process holds only the
+/// global schema lock, which an old binary opening a `Compatible` store never takes. The window is
+/// normally sub-millisecond but it is not bounded — the stamp can block on another writer up to the
+/// busy timeout, and a crash between the two commits leaves the store durably converted with an old
+/// roster until some newer binary happens to re-open it.
+///
+/// * V064/V065 project existing grow-only account history: DDL, source snapshot, and the
+///   all-account refold must land with the stamp so an older writer cannot slip an unprojected
+///   candidate into a migration race.
+/// * V097 rewrites the persisted checkout-path spellings. An older binary derives its live worktree
+///   set from the OLD spelling, so inside the window its GC reads every rekeyed row as a dead
+///   checkout and prunes a registered, live worktree's overlay.
+///
+/// A listed migration's body must NOT open a transaction of its own — the ladder owns one here, and
+/// `BEGIN` inside a transaction fails. `blocking_the_ledger_stamp_rolls_the_body_back` drives every
+/// entry and pins the atomicity behaviorally.
+const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID];
+
+/// Apply one migration and stamp its ledger row, atomically when the migration converts data an
+/// older binary can still act on (see [`LEDGER_ATOMIC_MIGRATIONS`]).
 fn apply_and_record_migration(
     conn: &Connection,
     step: &Migration,
     hooks: &MigrationHooks,
 ) -> rusqlite::Result<()> {
-    if !matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID) {
+    if !LEDGER_ATOMIC_MIGRATIONS.contains(&step.id) {
         step.apply.run(conn, hooks)?;
         return migrations::record_migration(conn, step.id, step.checksum, step.description);
     }
 
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     step.apply.run(&tx, hooks)?;
-    (hooks.backfill_authority_projection)(&tx)?;
+    // The authority refold is the account-projection pair's own requirement, not the ledger's: it
+    // rebuilds what V064 creates and V065 bounds, off a domain builder this crate cannot link.
+    if matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID) {
+        (hooks.backfill_authority_projection)(&tx)?;
+    }
     migrations::record_migration(&tx, step.id, step.checksum, step.description)?;
     tx.commit()
 }
@@ -1702,6 +1731,227 @@ pub fn ensure_compatible_or_migrate(
             "no index at this path yet; build one with `rag-rat index` or `rag-rat index --full`"
         ),
         SchemaState::Newer | SchemaState::Dirty => anyhow::bail!("{}", current.message),
+    }
+}
+
+/// The coexistence fence for a data-CONVERTING migration: its rewrite and its `schema_version` row
+/// are one commit, never two (see [`LEDGER_ATOMIC_MIGRATIONS`]).
+///
+/// A converted-but-unstamped store is the failure these tests exist for, and it is invisible by
+/// construction: on a healthy run the two commits are microseconds apart, and every gate downstream
+/// of [`status`] reads the ledger, not the data. So the tests reach the state the only way it can
+/// be held still — by making the ledger stamp FAIL, then asking a second connection what the store
+/// committed. Under a two-commit ladder the body's rewrite is durably there with no ledger row: a
+/// pre-upgrade binary reads that store as `Compatible` and walks straight into it.
+#[cfg(test)]
+mod ledger_atomicity {
+    use super::*;
+
+    /// A pre-V097 Windows spelling parked where the V097 sweep will find it. The sweep decides
+    /// droppability TEXTUALLY, so this converts on any host — without it the V097 leg would run a
+    /// body that rewrites nothing and would pass just as well against a separate commit.
+    const POISONED_SOURCE_ROOT: &str = r"\\?\C:\repo";
+
+    /// The migrations known to CONVERT data an older binary reads and acts on — restated here
+    /// rather than read from [`LEDGER_ATOMIC_MIGRATIONS`] on purpose. Driving the behavioral test
+    /// off the production list alone would let a migration dropped from that list drop out of the
+    /// test with it, so the regression that reintroduces the two-commit window would pass. These
+    /// tests range over the UNION, so removing an id from production fails here instead.
+    const DATA_CONVERTING_MIGRATIONS: &[&str] =
+        &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID];
+
+    /// Every migration whose ledger stamp must be atomic, from both statements of the set.
+    fn ledger_atomic_under_test() -> Vec<&'static str> {
+        let mut ids: Vec<&'static str> =
+            LEDGER_ATOMIC_MIGRATIONS.iter().chain(DATA_CONVERTING_MIGRATIONS).copied().collect();
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
+    /// Everything a SECOND connection can see: the schema, plus every row of every ordinary table,
+    /// order-normalized. Opened fresh, so it reads COMMITTED state only — the same state a
+    /// pre-upgrade binary opening the store mid-ladder would read.
+    fn committed_state(path: &std::path::Path) -> Vec<String> {
+        let conn = Connection::open(path).unwrap();
+        let tables: Vec<String> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE \
+                     'sqlite_%' ORDER BY name",
+                )
+                .unwrap();
+            let names = stmt.query_map([], |row| row.get::<_, String>(0)).unwrap();
+            names.collect::<rusqlite::Result<_>>().unwrap()
+        };
+        // The DDL first (a migration's structure is as observable as its data), then the contents.
+        let mut state: Vec<String> = {
+            let mut stmt = conn
+                .prepare("SELECT type, name, sql FROM sqlite_master ORDER BY type, name")
+                .unwrap();
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(format!(
+                        "{} {} {}",
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?.unwrap_or_default()
+                    ))
+                })
+                .unwrap();
+            rows.collect::<rusqlite::Result<_>>().unwrap()
+        };
+        for table in tables {
+            let mut stmt = conn.prepare(&format!("SELECT * FROM main.\"{table}\"")).unwrap();
+            let width = stmt.column_count();
+            let mut rows: Vec<String> = stmt
+                .query_map([], |row| {
+                    let mut cells = Vec::with_capacity(width);
+                    for column in 0..width {
+                        // Text rendered as text, so a leaked path spelling is readable in the
+                        // failure rather than a byte array.
+                        cells.push(match row.get_ref(column)? {
+                            rusqlite::types::ValueRef::Text(text) =>
+                                String::from_utf8_lossy(text).into_owned(),
+                            other => format!("{other:?}"),
+                        });
+                    }
+                    Ok(format!("{table}: {}", cells.join("|")))
+                })
+                .unwrap()
+                .collect::<rusqlite::Result<_>>()
+                .unwrap();
+            // Row order is not part of what a reader observes; content is.
+            rows.sort();
+            state.extend(rows);
+        }
+        state.sort();
+        state
+    }
+
+    /// What the store gained and lost between two snapshots, capped so a failure prints the leak
+    /// rather than a dump of every row in the schema.
+    fn committed_delta(before: &[String], after: &[String]) -> Vec<String> {
+        let before_set: std::collections::BTreeSet<&str> =
+            before.iter().map(String::as_str).collect();
+        let after_set: std::collections::BTreeSet<&str> =
+            after.iter().map(String::as_str).collect();
+        after_set
+            .difference(&before_set)
+            .map(|line| format!("+ {line}"))
+            .chain(before_set.difference(&after_set).map(|line| format!("- {line}")))
+            .take(20)
+            .collect()
+    }
+
+    /// The value `index_meta[source_root]` currently commits to, as a second connection sees it.
+    fn committed_source_root(path: &std::path::Path) -> Option<String> {
+        let conn = Connection::open(path).unwrap();
+        conn.query_row("SELECT value FROM index_meta WHERE key = 'source_root'", [], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()
+        .unwrap()
+    }
+
+    #[test]
+    fn every_ledger_atomic_migration_is_in_the_ladder() {
+        for id in ledger_atomic_under_test() {
+            assert!(
+                ADDITIVE_MIGRATIONS.iter().any(|step| step.id == id),
+                "{id} is listed as ledger-atomic but is not a shipped migration, so the arm that \
+                 stamps it atomically never runs",
+            );
+        }
+    }
+
+    #[test]
+    fn every_data_converting_migration_is_ledger_atomic() {
+        for id in DATA_CONVERTING_MIGRATIONS {
+            assert!(
+                LEDGER_ATOMIC_MIGRATIONS.contains(id),
+                "{id} converts data an older binary acts on but is not in \
+                 `LEDGER_ATOMIC_MIGRATIONS`, so its rewrite commits before its `schema_version` \
+                 row and the store reads as `Compatible` while already converted",
+            );
+        }
+    }
+
+    #[test]
+    fn blocking_the_ledger_stamp_rolls_the_body_back() {
+        for target in &ledger_atomic_under_test() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("index.db");
+            let conn = Connection::open(&path).unwrap();
+            let hooks = MigrationHooks::noop();
+            crate::content_digest::register_content_digest_fold(&conn).unwrap();
+            provision_baseline(&conn).unwrap();
+
+            // Replay the ladder up to — not including — the migration under test, so its body runs
+            // against the store shape it actually ships against.
+            let mut under_test = None;
+            for step in ADDITIVE_MIGRATIONS {
+                if step.id == *target {
+                    under_test = Some(step);
+                    break;
+                }
+                apply_and_record_migration(&conn, step, &hooks).unwrap();
+            }
+            let step = under_test.unwrap_or_else(|| panic!("{target} is not in the ladder"));
+
+            // Poisoned AFTER the earlier migrations, so nothing relocates it out from under V097.
+            conn.execute(
+                "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
+                [POISONED_SOURCE_ROOT],
+            )
+            .unwrap();
+            conn.execute_batch(&format!(
+                "CREATE TRIGGER block_ledger_stamp BEFORE INSERT ON schema_version
+                 WHEN new.id = '{target}'
+                 BEGIN SELECT RAISE(ABORT, 'ledger stamp blocked'); END;"
+            ))
+            .unwrap();
+
+            let before = committed_state(&path);
+            let err = apply_and_record_migration(&conn, step, &hooks).unwrap_err();
+            assert!(
+                err.to_string().contains("ledger stamp blocked"),
+                "{target}: expected the blocked stamp to surface, got {err}",
+            );
+
+            let leaked = committed_delta(&before, &committed_state(&path));
+            assert!(
+                leaked.is_empty(),
+                "{target} committed changes without its `schema_version` row: until the stamp \
+                 lands, `status` answers `Compatible` to a binary that predates the migration, so \
+                 every `Newer` refusal lets it onto converted data\n{}",
+                leaked.join("\n"),
+            );
+            if *target == MIGRATION_097_ID {
+                assert_eq!(
+                    committed_source_root(&path).as_deref(),
+                    Some(POISONED_SOURCE_ROOT),
+                    "V097 rekeyed the stored root and left the ledger at V096",
+                );
+            }
+
+            // The store is not wedged: the aborted step is simply owed, and the next open runs it.
+            conn.execute_batch("DROP TRIGGER block_ledger_stamp").unwrap();
+            migrate_forward(&conn, &hooks).unwrap();
+            let applied: Vec<String> = migrations::applied_migrations(&conn)
+                .unwrap()
+                .into_iter()
+                .map(|migration| migration.id)
+                .collect();
+            assert!(applied.iter().any(|id| id == target), "{target} never landed on retry");
+            if *target == MIGRATION_097_ID {
+                assert_eq!(
+                    committed_source_root(&path).as_deref(),
+                    Some(r"C:\repo"),
+                    "the retried V097 did not convert the stored root",
+                );
+            }
+        }
     }
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 96;
+pub const LATEST_SCHEMA_VERSION: u32 = 97;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -717,6 +717,19 @@ const MIGRATION_096_DESCRIPTION: &str =
      authoring Lamport clock, the lamport-advance bound, the chain tail, entry existence, the LWW \
      winner lookup, and the refold's pending set — and every one of them must keep excluding an \
      entry that is not on a chain";
+
+const MIGRATION_097_ID: &str = "097_windows_verbatim_path_rekey";
+const MIGRATION_097_CHECKSUM: &str = "sha256:rag-rat-windows-verbatim-path-rekey-v97";
+const MIGRATION_097_DESCRIPTION: &str =
+    "Rekey the persisted Windows path spellings an older binary wrote in the \\\\?\\ verbatim \
+     form (#1048): every worktree_id scope key, repo_roots.root, the path-valued meta keys \
+     (source_root and the git_history_indexed_root reload cursor), and the worktree_overlay_basis \
+     keys whose suffix is a worktree_id. Production now canonicalizes to the plain spelling, and \
+     these values are compared textually against it — left stale, the overlay and dirty rows fall \
+     out of the active scope and GC prunes them as a dead checkout, and the git-history gate \
+     forces a full revwalk plus a blame-cache wipe. Rewriting uses the same rule canonicalization \
+     does, so a verbatim path that is still load-bearing (UNC, >MAX_PATH, reserved DOS names) is \
+     kept. A no-op on Unix";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1489,6 +1502,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_096_CHECKSUM,
         description: MIGRATION_096_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_table_sync_gapped_entries),
+    },
+    Migration {
+        id: MIGRATION_097_ID,
+        checksum: MIGRATION_097_CHECKSUM,
+        description: MIGRATION_097_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_windows_verbatim_path_rekey),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -729,7 +729,8 @@ const MIGRATION_097_DESCRIPTION: &str =
      out of the active scope and GC prunes them as a dead checkout, and the git-history gate \
      forces a full revwalk plus a blame-cache wipe. Rewriting uses the same rule canonicalization \
      does, so a verbatim path that is still load-bearing (UNC, >MAX_PATH, reserved DOS names) is \
-     kept. A no-op on Unix";
+     kept. Runs on every host: which spellings a store carries is a property of the store, not of \
+     the binary that opens it";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -2069,5 +2070,48 @@ mod migration_arming {
             (1..=LATEST_SCHEMA_VERSION).collect::<Vec<u32>>(),
             "the shipped ladder must be 1..=LATEST_SCHEMA_VERSION in order, with no gaps or reuse",
         );
+    }
+
+    /// A migration description is not a comment: [`apply_and_record_migration`] writes it into
+    /// `schema_version.description`, so it ships into every store's ledger and is what a maintainer
+    /// reads back out of it. The ladder applies every body UNCONDITIONALLY on whichever host opens
+    /// the store, so a description claiming a per-platform no-op documents behaviour the ladder
+    /// cannot perform — and worse, it is the belief that produces the bug: a body that skips off
+    /// its "own" platform still gets its ledger row stamped, the forward-only ladder never revisits
+    /// it, and the store carries an unconverted value the migration was written to convert.
+    ///
+    /// Ranged over the shipped ladder so a future description inherits the check rather than
+    /// relying on a reviewer noticing the phrasing.
+    #[test]
+    fn no_migration_description_claims_a_host_skip() {
+        // Phrasings that assert the ladder does different work on different hosts. Wording, not
+        // meaning, so it is a lint rather than a proof — but it catches the shape the mistake takes
+        // and costs nothing.
+        const HOST_SKIP_PHRASES: &[&str] = &[
+            "no-op on unix",
+            "no-op on linux",
+            "no-op on macos",
+            "no-op on windows",
+            "no-op off windows",
+            "only on windows",
+            "only on unix",
+            "windows only",
+            "unix only",
+            "windows-only",
+            "unix-only",
+        ];
+        let described = std::iter::once((MIGRATION_001_ID, MIGRATION_001_DESCRIPTION))
+            .chain(ADDITIVE_MIGRATIONS.iter().map(|step| (step.id, step.description)));
+        for (id, description) in described {
+            let lowered = description.to_lowercase();
+            for phrase in HOST_SKIP_PHRASES {
+                assert!(
+                    !lowered.contains(phrase),
+                    "{id}'s ledger description claims {phrase:?}, but the ladder runs every \
+                     migration body on every host; describe what the migration converts, not a \
+                     host it supposedly skips",
+                );
+            }
+        }
     }
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -1877,81 +1877,90 @@ mod ledger_atomicity {
         }
     }
 
+    /// Run `step` with its ledger stamp rigged to fail, and assert a second connection sees the
+    /// store exactly as it was. The step is left UNAPPLIED — the caller applies it for real
+    /// afterwards, which is also the assertion that an aborted step is merely owed, not wedging.
+    fn probe_ledger_atomicity(
+        conn: &Connection,
+        path: &std::path::Path,
+        step: &Migration,
+        hooks: &MigrationHooks,
+    ) {
+        let target = step.id;
+        // Poisoned AFTER the earlier migrations, so nothing relocates it out from under V097.
+        conn.execute("INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)", [
+            POISONED_SOURCE_ROOT,
+        ])
+        .unwrap();
+        conn.execute_batch(&format!(
+            "CREATE TRIGGER block_ledger_stamp BEFORE INSERT ON schema_version
+             WHEN new.id = '{target}'
+             BEGIN SELECT RAISE(ABORT, 'ledger stamp blocked'); END;"
+        ))
+        .unwrap();
+
+        let before = committed_state(path);
+        let err = apply_and_record_migration(conn, step, hooks).unwrap_err();
+        assert!(
+            err.to_string().contains("ledger stamp blocked"),
+            "{target}: expected the blocked stamp to surface, got {err}",
+        );
+
+        let leaked = committed_delta(&before, &committed_state(path));
+        assert!(
+            leaked.is_empty(),
+            "{target} committed changes without its `schema_version` row: until the stamp lands, \
+             `status` answers `Compatible` to a binary that predates the migration, so every \
+             `Newer` refusal lets it onto converted data\n{}",
+            leaked.join("\n"),
+        );
+        conn.execute_batch("DROP TRIGGER block_ledger_stamp").unwrap();
+    }
+
     #[test]
     fn blocking_the_ledger_stamp_rolls_the_body_back() {
-        for target in &ledger_atomic_under_test() {
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join("index.db");
-            let conn = Connection::open(&path).unwrap();
-            let hooks = MigrationHooks::noop();
-            crate::content_digest::register_content_digest_fold(&conn).unwrap();
-            provision_baseline(&conn).unwrap();
+        let targets = ledger_atomic_under_test();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.db");
+        let conn = Connection::open(&path).unwrap();
+        // The ladder is fsync-bound, not logic-bound, and this test walks all of it. Durability
+        // across a crash is not what it observes — cross-connection VISIBILITY is, and that is a
+        // property of the commit, not of the journal reaching the platter.
+        conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = OFF;").unwrap();
+        let hooks = MigrationHooks::noop();
+        crate::content_digest::register_content_digest_fold(&conn).unwrap();
+        provision_baseline(&conn).unwrap();
 
-            // Replay the ladder up to — not including — the migration under test, so its body runs
-            // against the store shape it actually ships against.
-            let mut under_test = None;
-            for step in ADDITIVE_MIGRATIONS {
-                if step.id == *target {
-                    under_test = Some(step);
-                    break;
-                }
-                apply_and_record_migration(&conn, step, &hooks).unwrap();
+        // ONE pass over the ladder, probing each target as it comes up: every target's body runs
+        // against the store shape it actually ships against, without replaying the ladder per
+        // target (which on a file-backed store costs minutes, not seconds).
+        let mut probed: Vec<&str> = Vec::new();
+        for step in ADDITIVE_MIGRATIONS {
+            if targets.contains(&step.id) {
+                probe_ledger_atomicity(&conn, &path, step, &hooks);
+                probed.push(step.id);
             }
-            let step = under_test.unwrap_or_else(|| panic!("{target} is not in the ladder"));
-
-            // Poisoned AFTER the earlier migrations, so nothing relocates it out from under V097.
-            conn.execute(
-                "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
-                [POISONED_SOURCE_ROOT],
-            )
-            .unwrap();
-            conn.execute_batch(&format!(
-                "CREATE TRIGGER block_ledger_stamp BEFORE INSERT ON schema_version
-                 WHEN new.id = '{target}'
-                 BEGIN SELECT RAISE(ABORT, 'ledger stamp blocked'); END;"
-            ))
-            .unwrap();
-
-            let before = committed_state(&path);
-            let err = apply_and_record_migration(&conn, step, &hooks).unwrap_err();
-            assert!(
-                err.to_string().contains("ledger stamp blocked"),
-                "{target}: expected the blocked stamp to surface, got {err}",
-            );
-
-            let leaked = committed_delta(&before, &committed_state(&path));
-            assert!(
-                leaked.is_empty(),
-                "{target} committed changes without its `schema_version` row: until the stamp \
-                 lands, `status` answers `Compatible` to a binary that predates the migration, so \
-                 every `Newer` refusal lets it onto converted data\n{}",
-                leaked.join("\n"),
-            );
-            if *target == MIGRATION_097_ID {
-                assert_eq!(
-                    committed_source_root(&path).as_deref(),
-                    Some(POISONED_SOURCE_ROOT),
-                    "V097 rekeyed the stored root and left the ledger at V096",
-                );
-            }
-
-            // The store is not wedged: the aborted step is simply owed, and the next open runs it.
-            conn.execute_batch("DROP TRIGGER block_ledger_stamp").unwrap();
-            migrate_forward(&conn, &hooks).unwrap();
-            let applied: Vec<String> = migrations::applied_migrations(&conn)
-                .unwrap()
-                .into_iter()
-                .map(|migration| migration.id)
-                .collect();
-            assert!(applied.iter().any(|id| id == target), "{target} never landed on retry");
-            if *target == MIGRATION_097_ID {
-                assert_eq!(
-                    committed_source_root(&path).as_deref(),
-                    Some(r"C:\repo"),
-                    "the retried V097 did not convert the stored root",
-                );
-            }
+            apply_and_record_migration(&conn, step, &hooks).unwrap();
         }
+        probed.sort_unstable();
+        assert_eq!(probed, targets, "a ledger-atomic migration was never reached by the ladder");
+
+        // The aborted steps were owed, not lost: the ladder is complete and V097 converted the
+        // spelling its probe had to see left alone.
+        migrate_forward(&conn, &hooks).unwrap();
+        let applied: std::collections::BTreeSet<String> = migrations::applied_migrations(&conn)
+            .unwrap()
+            .into_iter()
+            .map(|migration| migration.id)
+            .collect();
+        for target in &targets {
+            assert!(applied.contains(*target), "{target} never landed after its aborted stamp");
+        }
+        assert_eq!(
+            committed_source_root(&path).as_deref(),
+            Some(r"C:\repo"),
+            "the applied V097 did not convert the stored root",
+        );
     }
 }
 

--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -552,7 +552,7 @@ async fn clones_uses_the_native_lens_composition() {
     // name like `RUNNER~1` — would otherwise fail this on a value that is perfectly correct.
     assert_eq!(
         status["worktree_id"],
-        root.canonicalize().unwrap_or_else(|_| root.clone()).display().to_string(),
+        rag_rat_base::paths::canonicalize_or_simplified(&root).display().to_string(),
     );
     assert_eq!(status["case_insensitive_paths"], true);
     assert_eq!(status["live_file_count"], 2);
@@ -1022,5 +1022,9 @@ fn the_http_fixture_config_root_diverges_from_its_scratch_spelling() {
          invisible on the per-PR matrix",
     );
     assert_eq!(config.root, root, "the Config carries the canonical spelling");
-    assert_eq!(root, scratch.path().canonicalize().unwrap(), "both spellings name one directory");
+    assert_eq!(
+        root,
+        rag_rat_base::paths::canonicalize(scratch.path()).unwrap(),
+        "both spellings name one directory"
+    );
 }

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -452,7 +452,7 @@ fn indexed_root_relative(config: &Config, workspace_root: &Path) -> anyhow::Resu
 }
 
 fn path_case_insensitive(path: &Path) -> bool {
-    let Ok(canonical) = path.canonicalize() else { return false };
+    let Ok(canonical) = rag_rat_base::paths::canonicalize(path) else { return false };
     if path_has_case_alias(&canonical) {
         return true;
     }
@@ -470,9 +470,9 @@ fn path_has_case_alias(path: &Path) -> bool {
         toggled[index].to_ascii_lowercase()
     };
     let Ok(toggled) = String::from_utf8(toggled) else { return false };
-    let Ok(canonical) = path.canonicalize() else { return false };
+    let Ok(canonical) = rag_rat_base::paths::canonicalize(path) else { return false };
     path.parent()
-        .and_then(|parent| parent.join(toggled).canonicalize().ok())
+        .and_then(|parent| rag_rat_base::paths::canonicalize(parent.join(toggled)).ok())
         .is_some_and(|alias| alias == canonical)
 }
 
@@ -535,13 +535,15 @@ pub fn workspace_root(config: &Config) -> PathBuf {
 /// rather than serving the wrong repo.
 fn validated_linked_worktree(root: &Path, candidate: &Path) -> Option<PathBuf> {
     let repo = rag_rat_base::repo_discover::discover_repo(candidate).ok()?;
-    let git_dir = repo.git_dir().canonicalize().ok()?;
-    let common_dir = repo.common_dir().canonicalize().ok()?;
+    let git_dir = rag_rat_base::paths::canonicalize(repo.git_dir()).ok()?;
+    let common_dir = rag_rat_base::paths::canonicalize(repo.common_dir()).ok()?;
     if git_dir == common_dir {
         return None;
     }
-    let root_common =
-        rag_rat_base::repo_discover::discover_repo(root).ok()?.common_dir().canonicalize().ok()?;
+    let root_common = rag_rat_base::paths::canonicalize(
+        rag_rat_base::repo_discover::discover_repo(root).ok()?.common_dir(),
+    )
+    .ok()?;
     if common_dir != root_common {
         return None;
     }
@@ -1227,10 +1229,9 @@ mod tests {
         let probe = numeric_root.join("CaseProbe");
         fs::create_dir(&probe).unwrap();
         let alias = numeric_root.join("caseProbe");
-        let expected = alias
-            .canonicalize()
+        let expected = rag_rat_base::paths::canonicalize(alias)
             .ok()
-            .zip(probe.canonicalize().ok())
+            .zip(rag_rat_base::paths::canonicalize(&probe).ok())
             .is_some_and(|(alias, probe)| alias == probe);
 
         assert_eq!(path_case_insensitive(&probe), expected);

--- a/crates/rag-rat-oracle/src/backend/layout.rs
+++ b/crates/rag-rat-oracle/src/backend/layout.rs
@@ -485,7 +485,7 @@ impl MarkerSearch<'_> {
         // A marker file that will not canonicalize is recorded under its own path rather than
         // dropped: it exists, and losing the checkout's only database is worse than the alias this
         // set exists to collapse.
-        let identity = candidate.canonicalize().unwrap_or_else(|_| candidate.clone());
+        let identity = rag_rat_base::paths::canonicalize_or_simplified(&candidate);
         if !self.recorded_markers.insert(identity) {
             return;
         }
@@ -536,7 +536,7 @@ impl MarkerSearch<'_> {
             if !path.is_dir() {
                 return Step::Excluded;
             }
-            let Ok(target) = path.canonicalize() else {
+            let Ok(target) = rag_rat_base::paths::canonicalize(&path) else {
                 return Step::Indeterminate;
             };
             // Outside the checkout is EXCLUDED rather than indeterminate: indexing skips symlinks
@@ -829,7 +829,7 @@ impl EntryPaths {
         let resolved = self
             .canonical_parents
             .entry(parent.to_path_buf())
-            .or_insert_with(|| parent.canonicalize().ok());
+            .or_insert_with(|| rag_rat_base::paths::canonicalize(parent).ok());
         resolved.as_ref().is_some_and(|dir| corpus.indexes_file(&dir.join(name)))
     }
 }

--- a/crates/rag-rat-oracle/src/backend/scope.rs
+++ b/crates/rag-rat-oracle/src/backend/scope.rs
@@ -47,7 +47,7 @@ impl<'a> CheckoutScope<'a> {
     /// config loads — so it costs nothing and removes a class of mismatch from every test fixture
     /// and every checkout reached through a symlink.
     pub fn resolve(root: &Path, corpus: &'a dyn IndexedCorpus) -> Self {
-        let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        let root = rag_rat_base::paths::canonicalize_or_simplified(root);
         // The CONTAINING checkout, never the main one: each linked worktree is a different source
         // tree, so a ceiling pointing at main would admit another checkout's databases and
         // ancestors. `config::main_worktree_root` is the adjacent function that must NOT be used

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -36,7 +36,11 @@ fn checkout(tag: &str) -> (ScratchDir, PathBuf) {
 fn a_scratch_checkouts_canonical_root_diverges_from_the_guards_spelling() {
     let (guard, root) = checkout("scope-root-spelling");
     assert_ne!(root, guard.path(), "the guard must reach its root through a symlinked ancestor");
-    assert_eq!(root, guard.path().canonicalize().unwrap(), "both spellings name one directory");
+    assert_eq!(
+        root,
+        rag_rat_base::paths::canonicalize(guard.path()).unwrap(),
+        "both spellings name one directory"
+    );
     assert_eq!(scope(&root).root(), root, "and the scope resolves to the canonical one");
 }
 
@@ -224,7 +228,7 @@ fn an_entry_that_configures_nothing_does_not_qualify_the_database() {
     std::fs::create_dir_all(dir.join("third_party")).unwrap();
     std::fs::create_dir_all(dir.join("build")).unwrap();
     std::fs::write(dir.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
-    let root = dir.canonicalize().unwrap();
+    let root = rag_rat_base::paths::canonicalize(&dir).unwrap();
     let database = format!(
         r#"[{{"directory":{d},"file":{indexed},"command":""}},
            {{"directory":{d},"file":{vendored},"command":"cc -c dep.c"}}]"#,
@@ -265,7 +269,7 @@ fn a_database_naming_one_indexed_file_among_vendored_ones_is_pinned() {
 
     assert_eq!(
         clangd.resolve_layout(&scope).sole_marker_dir(),
-        Some(dir.canonicalize().unwrap().join("build").as_path()),
+        Some(rag_rat_base::paths::canonicalize(&dir).unwrap().join("build").as_path()),
         "one indexed entry qualifies the database, wherever it sits in the list",
     );
 }
@@ -347,7 +351,7 @@ fn a_non_git_checkout_behaves_exactly_as_before() {
     assert_eq!(scope.ceiling(), scope.root(), "no checkout ⇒ no widening");
     assert_eq!(
         clangd.resolve_layout(&scope).sole_marker_dir(),
-        Some(dir.canonicalize().unwrap().as_path()),
+        Some(rag_rat_base::paths::canonicalize(&dir).unwrap().as_path()),
     );
 }
 
@@ -370,7 +374,7 @@ fn sources_under_a_hidden_directory_can_warm_the_session() {
 
     assert_eq!(
         clangd.warmup_document(&scope, &layout),
-        Some(dir.canonicalize().unwrap().join(".cache/generated/main.c")),
+        Some(rag_rat_base::paths::canonicalize(&dir).unwrap().join(".cache/generated/main.c")),
         "a hidden directory the checkout indexes is an ordinary source location",
     );
     assert!(clangd.checkout_can_signal_readiness(&scope, &layout), "so it is not blocked");
@@ -394,7 +398,7 @@ fn a_document_the_checkout_does_not_index_is_never_warmed_on() {
 
     assert_eq!(
         clangd.warmup_document(&scope, &layout),
-        Some(dir.canonicalize().unwrap().join("src/main.c")),
+        Some(rag_rat_base::paths::canonicalize(&dir).unwrap().join("src/main.c")),
         "the indexed source is chosen, never the one under clangd's own index",
     );
 }
@@ -456,7 +460,7 @@ fn a_build_directory_database_governing_indexed_sources_is_pinned() {
 
     assert_eq!(
         layout.sole_marker_dir(),
-        Some(dir.canonicalize().unwrap().join("build").as_path()),
+        Some(rag_rat_base::paths::canonicalize(&dir).unwrap().join("build").as_path()),
         "it governs `src/`, which this checkout indexes",
     );
 }
@@ -482,7 +486,7 @@ fn a_database_above_the_index_root_is_found_by_the_ancestor_leg() {
 
     assert_eq!(
         layout.sole_marker_dir(),
-        Some(checkout.canonicalize().unwrap().as_path()),
+        Some(rag_rat_base::paths::canonicalize(checkout).unwrap().as_path()),
         "the ancestor leg reaches the checkout top",
     );
     assert!(
@@ -535,8 +539,16 @@ fn the_ceiling_is_the_enclosing_checkout_not_the_index_root() {
 
     let scope = scope(&root);
 
-    assert_eq!(scope.ceiling(), checkout.canonicalize().unwrap(), "the ceiling is the checkout");
-    assert_eq!(scope.root(), root.canonicalize().unwrap(), "the root is left where it was");
+    assert_eq!(
+        scope.ceiling(),
+        rag_rat_base::paths::canonicalize(checkout).unwrap(),
+        "the ceiling is the checkout"
+    );
+    assert_eq!(
+        scope.root(),
+        rag_rat_base::paths::canonicalize(&root).unwrap(),
+        "the root is left where it was"
+    );
 }
 
 /// Outside a git checkout there is no boundary but the configured one, and inventing a wider one
@@ -578,7 +590,7 @@ fn a_linked_worktree_is_its_own_ceiling_not_the_main_checkout() {
 
     assert_eq!(
         scope.ceiling(),
-        linked.canonicalize().unwrap(),
+        rag_rat_base::paths::canonicalize(&linked).unwrap(),
         "a linked worktree is its own checkout, not a subdirectory of main",
     );
 }
@@ -890,7 +902,7 @@ fn the_warmup_search_refuses_a_document_the_checkout_does_not_index() {
 
     assert_eq!(
         ts.warmup_document(&scope, &ts.resolve_layout(&scope)),
-        Some(dir.canonicalize().unwrap().join(".cache/generated/main.ts")),
+        Some(rag_rat_base::paths::canonicalize(&dir).unwrap().join(".cache/generated/main.ts")),
     );
 }
 
@@ -1695,7 +1707,7 @@ fn the_ancestor_leg_never_leaves_the_checkout() {
 
     assert_eq!(
         clangd.resolve_layout(&scope).sole_marker_dir(),
-        Some(checkout.canonicalize().unwrap().join("build").as_path()),
+        Some(rag_rat_base::paths::canonicalize(checkout).unwrap().join("build").as_path()),
         "a database above the checkout is not this checkout's, and must not disqualify the pin",
     );
 }
@@ -1728,7 +1740,7 @@ fn a_real_linked_worktree_inside_the_checkout_is_not_this_checkouts_project() {
     let scope = super::CheckoutScope::resolve(&main, &corpus);
     assert_eq!(
         clangd.resolve_layout(&scope).sole_marker_dir(),
-        Some(main.canonicalize().unwrap().join("build").as_path()),
+        Some(rag_rat_base::paths::canonicalize(&main).unwrap().join("build").as_path()),
         "one database and nothing nested ⇒ pinned",
     );
 
@@ -1757,12 +1769,12 @@ fn a_real_linked_worktree_inside_the_checkout_is_not_this_checkouts_project() {
     let linked_scope = super::CheckoutScope::resolve(&linked, &linked_corpus);
     assert_eq!(
         linked_scope.ceiling(),
-        linked.canonicalize().unwrap(),
+        rag_rat_base::paths::canonicalize(&linked).unwrap(),
         "the linked worktree is its own checkout, not a subdirectory of main",
     );
     assert_eq!(
         clangd.resolve_layout(&linked_scope).sole_marker_dir(),
-        Some(linked.canonicalize().unwrap().join("build").as_path()),
+        Some(rag_rat_base::paths::canonicalize(&linked).unwrap().join("build").as_path()),
         "and it resolves its own database, not main's",
     );
 }
@@ -1789,7 +1801,7 @@ fn completeness_covers_the_ancestor_chain_and_ignores_sibling_subtrees() {
     let scope = super::CheckoutScope::resolve(&root, &corpus);
     assert_eq!(
         clangd.resolve_layout(&scope).sole_marker_dir(),
-        Some(root.canonicalize().unwrap().join("build").as_path()),
+        Some(rag_rat_base::paths::canonicalize(&root).unwrap().join("build").as_path()),
         "a sibling subtree of the index root is outside the question being asked",
     );
 

--- a/crates/rag-rat-oracle/src/test_support.rs
+++ b/crates/rag-rat-oracle/src/test_support.rs
@@ -525,7 +525,7 @@ pub struct PrefixCorpus {
 impl PrefixCorpus {
     pub fn new(root: &Path, indexed: &[&str]) -> Self {
         Self {
-            root: root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+            root: rag_rat_base::paths::canonicalize_or_simplified(root),
             indexed: indexed.iter().map(PathBuf::from).collect(),
         }
     }


### PR DESCRIPTION
## The problem

On Windows `std::fs::canonicalize` always answers an extended-length *verbatim* path — `\\?\C:\Users\…`. `Config::load` normalized its root through it, and neither consumer of that root accepts the spelling: `git worktree add \\?\C:\…\linked` fails outright (`fatal: could not create leading directories of '//?/C:/…': Invalid argument`), and gix reports `workdir()` in the ordinary `C:\…` form, so the worktree overlay's subdir derivation — `config.root` stripped against the workdir — matched nothing and the refresh silently scoped itself at the repo root instead of the configured subdir. The linked-worktree overlay therefore did not work on Windows for any config loaded from disk.

## The fix

Every filesystem canonicalization in the workspace now goes through one seam, `rag_rat_base::paths`. `canonicalize` drops the verbatim prefix wherever the plain spelling names the same file and keeps it where it is load-bearing (UNC shares, paths past `MAX_PATH`, reserved DOS names, components with a trailing dot or space); `simplified` is the same rule with no I/O, for a path another library handed us; `canonicalize_or_simplified` is the canonicalize-else-keep-the-original pattern with the fallback arm simplified too, so the invariant does not hold only when the directory happens to exist. All three are byte-for-byte `std` behaviour on Unix. The rule comes from `dunce`, the crate `gix-discover` already runs its discovered directory through — sharing it makes our roots equal to gix's by construction rather than similar by intent.

`clippy.toml` `disallowed-methods` now rejects `Path::canonicalize` and `std::fs::canonicalize` with a `reason` naming the replacement, so a new call site cannot reintroduce a verbatim path. The sweep covers the whole workspace rather than just the config root because the canonicalized paths form one comparison lattice and are compared against each other — the overlay strips both sides of the config root, config discovery compares a canonicalized gix workdir against a canonicalized common-dir-derived main root, the lock and worktree-id helpers hash the canonical spelling into durable keys, and `remove.rs` matches a canonicalized argument against recorded `repo_roots`. Normalizing the root alone would have started failing those strips in the other direction; partial normalization is a different bug, not a smaller one.

Indexes written by an older binary already hold the verbatim spelling in durable keys, so migration **V097** rekeys them: every `worktree_id` scope key, `repo_roots.root`, the path-valued meta keys, and the `worktree_overlay_basis` keys whose suffix is a `worktree_id`. Left stale those values fall out of the active scope and GC prunes them as a dead checkout, and the git-history gate forces a full revwalk plus a blame-cache wipe. The rekey decides droppability from the **stored string**, not from the host: a store carrying Windows spellings is reachable from a non-Windows binary (one repo directory reachable from both a Windows and a WSL/container mount is one SQLite file), and a host-gated body paired with an unconditional ledger stamp would let the first opener record the migration as applied without converting anything. The sweep commits inside the same transaction as its `schema_version` row, so a converted store is never briefly stamped as compatible with a pre-V097 binary — which is what fences an older build off rows it would read as dead checkouts.

## Verification

Local gates, each run to completion with its exit code checked: `cargo build --all-targets`, `cargo nextest run --workspace`, `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, the two `--features eval` clippy legs, and `cargo +nightly fmt --all --check`.

Windows behaviour is only observable on a Windows runner, so it was measured with a dispatched `ci-cross-platform.yml` run rather than argued. At this branch's head `test (windows-latest)` reports `4438 tests run: 4437 passed, 1 failed, 7 skipped`; the most recent `main` run fails 18 distinct tests on the same leg, across the git-driven `index::corpus`, `index::ignore_rules` and `rag-rat-oracle backend` fixtures. The one remaining failure, `rag-rat-base test_git::tests::the_ambient_failure_mode_is_real`, is in that `main` set too: its fixture writes a `#!/bin/sh` pre-commit hook Git for Windows does not execute, so the marker file never appears. It predates this issue and is tracked as #1025. `test (macos-latest)`, both `clippy` legs and both `build` legs are green.

The tests added here were confirmed to have *executed* on the Windows runner by name in the job log rather than assumed to have compiled in. They are deliberately cross-platform rather than `#[cfg(windows)]`, and are written to bite: they check the spelling textually and then drive the two real consumers (`git worktree add`, and `strip_prefix` against gix's `workdir()`), because a test that only compares two paths our own code produced would pass on both sides of the bug. `windows_verbatim_droppability_matches_dunce` is the one that can only run there — it pins the rekey rule against `dunce`, the authority it reimplements, so the two cannot drift.

Every guard was mutation-tested: dropping `files` from the covered tables, dropping or adding a path-valued meta key, skipping the overlay-basis or `repo_roots.root` rekey, reintroducing a host gate on the production pass, dropping the reserved-DOS-name check from the rekey rule, forcing V097's ledger row to read as a checksum mismatch, relaxing the `Newer` refusal on either route that applies schema, and taking V097 back out of `LEDGER_ATOMIC_MIGRATIONS`. Each fails a *different* assertion, and restoring the code passes. The lint seam was checked the same way — planting a raw `Path::canonicalize` and a raw `std::fs::canonicalize` each produced `error: use of a disallowed method` under `-D warnings`.

## Outstanding

- The lint is checked by `--all-targets` on whichever platform clippy runs, so a call site inside a `#[cfg(windows)]` body is only caught by the Windows clippy leg. That leg is green here, but the per-PR matrix is Linux-only, so a future Windows-gated addition would not be flagged per-PR.
- `index/remove.rs::resolve_removable_repo` now simplifies its two non-canonicalizing fallback arms as well. On Windows that widens matching for an argument the caller spelled verbatim — intended, and it cannot select a *different* repo (the lookup is an exact recorded-root match and the simplified spelling names the same directory), but it is the one place where the change does more than normalize our own output.
- `rekeyed_from_verbatim` is a textual reimplementation of `dunce`'s droppability rule, kept because the answer is about a persisted string rather than about this host's filesystem. The parity test pins the two together on the Windows leg, but only over the corpus in that test — a `dunce` release that changed the rule for a case the corpus does not name would not be caught. Live canonicalization is unaffected either way; it still goes through the crate.
- The reimplementation is deliberately conservative where a canonicalized path cannot go: a repeated or trailing separator makes it decline the rewrite, where `dunce` (parsing through `Path::components`) would collapse it and strip. `std::fs::canonicalize` emits neither, so the two cannot disagree on a value rag-rat actually stored — but a hand-edited store could hold one, and there the rekey leaves the value alone.
- A `worktree_id` is persisted through `to_string_lossy`, so a stored spelling can reach the rekey rule *already lossy*. For a checkout path containing an unpaired UTF-16 surrogate, `dunce` keeps the verbatim prefix (it judges a component through `to_str()`, which fails) — both before and after this change — but the stored string is well-formed UTF-8 by the time the rule reads it, with U+FFFD where the surrogate was, and U+FFFD passes every check. The rule therefore rewrites a value production still spells verbatim, moving that row out of the active scope and the GC live set. The ambiguity is irreducible: declining every U+FFFD would break the opposite case, a component *genuinely named* with U+FFFD, which production does simplify. The rewrite stands and the case is pinned in the rekey corpus.
- `dunce` 1.0.5 lists only the ASCII DOS device names, so it misses `COM¹`/`COM²`/`COM³` and the `LPT` equivalents, which Windows also reserves. The rule mirrors that list, so here the rule and production **agree** and no row is rekeyed to a spelling production does not produce; the cost is inherited from `canonicalize`, which strips a prefix that is load-bearing for such a path. Widening the local list rather than fixing it upstream would break that agreement, so this is pinned as an expectation rather than patched.
- `sync serve` / `sync init` are the one resident writer the schema-version fence does not reach: they open the index once and run the accept loop on that connection for the process's lifetime. That is outside V097's hazard specifically — no table is registered for table-sync, `repo_roots` is written only by the indexing path, and the loop runs no gc and derives no live-worktree set — but a future data-converting migration over a table the op-log projection or table-sync touches must re-check that rather than inherit the conclusion.
- `dunce` is marked passively-maintained by its author. Promoting it to a direct dependency brings it under `deny.toml`'s `unmaintained = "workspace"` scope, so a future RustSec unmaintained advisory would fail CI where it would previously have been tolerated transitively. If that happens, the crate is roughly 200 dependency-free lines with no `unsafe` and could be vendored into `paths.rs`.

Fixes #1048
