### PR TITLE
fix(sync): stop ingest destroying unsent local work (#1056)

### DIFF
--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -861,6 +861,76 @@ pub(crate) fn unsent_work_blocking_replay(
     })
 }
 
+/// How much doubt a caller acts on when the row's state cannot be established either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RowDoubt {
+    /// Defer on ANY doubt. The refold runs at store open, with no driver to have authored local
+    /// work first, so an unprovable row is treated as unsafe to write over.
+    DeferOnAnyDoubt,
+    /// Defer on any doubt EXCEPT an unprovable verdict against a `Remove`, which is applied.
+    ///
+    /// The live ingest path takes this, and the exemption is deliberately that narrow. Holding a
+    /// deletion back on a verdict that may never resolve is the convergence wedge
+    /// [`apply_row_op`] keeps `Remove` clear of — a row deleted after a column change would become
+    /// undeletable across the skew.
+    ///
+    /// An `Upsert` gets NO exemption. It is already version-gated, so deferring one costs nothing a
+    /// skew was not costing anyway, and applying it on an unprovable verdict destroys exactly the
+    /// unsent edit this guard exists to protect. The confidence split alone is the wrong axis: it
+    /// is the OP KIND that decides whether the convergence argument applies at all.
+    DeferExceptUnprovableRemoval,
+}
+
+/// Everything that must be settled BEFORE `op` is handed to [`apply_row_op`], in the order it has
+/// to be settled in.
+///
+/// Both the live ingest path and the refold need this exact sequence, and the ordering is easy to
+/// get right in one and wrong in the other — so it lives here once. The payload goes first:
+/// whatever [`payload_verdict`] decides, no row read can change, and filing a version gap or a
+/// terminal payload under a row-state reason would move it into the retry family replayed at every
+/// store open, where nothing could redeem it. Only when the payload leaves the question open does
+/// the ROW get a say.
+pub(crate) fn pre_apply(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    stream: StreamId,
+    op: &RowOp,
+    doubt: RowDoubt,
+) -> anyhow::Result<PreApply> {
+    match payload_verdict(spec, repo_id, op) {
+        PayloadVerdict::Gap(reason) => return Ok(PreApply::Park(reason)),
+        // Terminal on its own merits. Hand it to `apply_row_op`, which quarantines it without
+        // writing — one writer of that verdict rather than two, and a terminal payload must not
+        // enter a retry family it can never leave.
+        PayloadVerdict::Rejected(_) => return Ok(PreApply::Apply),
+        PayloadVerdict::RowDecides(_) => {},
+    }
+    let Some(deferral) = unsent_work_blocking_replay(tx, spec, repo_id, stream, op)? else {
+        return Ok(PreApply::Apply);
+    };
+    // The one case a caller may act through: a deletion held back on a verdict that may never
+    // resolve. Everything else defers, including an unprovable verdict against an `Upsert` — see
+    // [`RowDoubt::DeferExceptUnprovableRemoval`] for why the op kind, not the confidence, is what
+    // makes the difference.
+    let unprovable_removal =
+        !deferral.is_proven_unsent_work() && matches!(op, RowOp::Remove { .. });
+    Ok(match doubt {
+        RowDoubt::DeferExceptUnprovableRemoval if unprovable_removal => PreApply::Apply,
+        RowDoubt::DeferOnAnyDoubt | RowDoubt::DeferExceptUnprovableRemoval =>
+            PreApply::Park(deferral),
+    })
+}
+
+/// The outcome of [`pre_apply`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreApply {
+    /// Do not apply: record this reason and leave the entry outstanding.
+    Park(PendingReason),
+    /// Nothing stands in the way — hand it to [`apply_row_op`].
+    Apply,
+}
+
 /// Claim `row_pk` as a COMPLETE projection: `hash` covers every synced column this binary knows,
 /// stamped with the TABLE's spec version, which is what defines that column set. Deliberately not
 /// the store-global projector version — that would make an unrelated table's registration mark this

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -131,6 +131,11 @@ pub(crate) fn produce_and_author(
             }
         }
     }
+    // Local work is now published, so anything ingest deferred behind it is unblocked — replay it
+    // here rather than leaving it for the next store open. This is where author-before-apply
+    // actually holds: a remote op deferred to protect a local edit gets its rematch immediately
+    // after that edit is authored, and loses on the merits instead of by default.
+    refold::replay_deferred_entries(tx, ctx.registry)?;
     Ok(authored)
 }
 
@@ -174,6 +179,39 @@ pub(crate) fn ingest(
                 else {
                     return Ok(IngestOutcome::Parked("table not in scope"));
                 };
+                // NEVER apply over unsent local work. A raw local write does not advance the row
+                // clock, so the LWW comparison below cannot see it: this op would simply win and
+                // record its OWN hash as published, after which the producer sees no delta and the
+                // local change is gone with nothing left to author it from.
+                //
+                // Deferring is safe to do HERE, which it was not before #1005: a deferral now
+                // carries its own refold trigger, so the entry is retried once the local work is
+                // authored rather than being parked and forgotten. The chain still advances — the
+                // entry is stored either way — and convergence stays on the merits, because the
+                // local edit is authored at `MAX(lamport) + 1` counting this parked entry and so
+                // wins the comparison this op would otherwise have won by default.
+                //
+                // `DeferExceptUnprovableRemoval`, unlike the refold's blanket caution: a deletion
+                // must not be held back on a verdict that may never resolve, or a row deleted after
+                // a column change becomes undeletable across the skew. That exemption is for
+                // `Remove` only — an unprovable verdict against an `Upsert` still defers, because
+                // applying it would destroy the very edit this guard exists to protect.
+                if let apply::PreApply::Park(deferral) = apply::pre_apply(
+                    tx,
+                    spec,
+                    ctx.repo_id,
+                    stream,
+                    &op,
+                    apply::RowDoubt::DeferExceptUnprovableRemoval,
+                )? {
+                    store::mark_entry_pending(
+                        tx,
+                        &entry_hash,
+                        deferral,
+                        refold::TABLE_SYNC_PROJECTOR_VERSION,
+                    )?;
+                    return Ok(IngestOutcome::Retained(deferral.as_db_str()));
+                }
                 match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
                     // A received op that lost on the merits still landed: the entry is
                     // stored, nothing is outstanding, and redelivery stays idempotent.
@@ -269,7 +307,11 @@ mod tests {
             out
         }
 
-        fn ingest_all(&mut self, entries: &[Vec<u8>], from: &DevicePublic) {
+        fn delete_row(&self) {
+            self.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
+        }
+
+        fn ingest_all(&mut self, entries: &[Vec<u8>], from: &DevicePublic) -> Vec<IngestOutcome> {
             // The receiver has folded the author's DeviceAdd, so it is an effective writer here —
             // otherwise the #935 authority gate would drop every entry as Unauthorized.
             enroll_writer(&self.conn, AccountId::from_bytes([42; 32]), from.fingerprint());
@@ -281,10 +323,10 @@ mod tests {
                 registry: REGISTRY,
                 now_ms: 0,
             };
-            for bytes in entries {
-                ingest(&tx, &ctx, "demo/1", bytes, from).unwrap();
-            }
+            let out = entries.iter().map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from).unwrap());
+            let out = out.collect();
             tx.commit().unwrap();
+            out
         }
     }
 
@@ -324,6 +366,105 @@ mod tests {
         assert!(b.produce().is_empty(), "a received row never echoes back");
         // And the author does not re-emit its own already-published row.
         assert!(a.produce().is_empty(), "a published row is not re-authored");
+    }
+
+    #[test]
+    fn a_remote_upsert_does_not_clobber_an_unpublished_local_edit() {
+        // The ingest path's half of the unsent-local-work problem. A raw local write does not
+        // advance the row clock, so the LWW comparison cannot see it: a remote op simply wins and
+        // records its OWN hash as published, after which the producer sees no delta and the local
+        // edit is gone with nothing left to author it from.
+        //
+        // The refold has guarded this since #1002 because it runs at store open with no driver to
+        // order it. Ingest has the identical exposure and no guard.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'base')", []).unwrap();
+        b.ingest_all(&a.produce(), &a.pubkey());
+        assert_eq!(b.title().as_deref(), Some("base"), "both devices start converged");
+
+        // B writes locally and does not get to author before A's next entry arrives.
+        b.set_title("unsent-B");
+        a.set_title("from-A");
+        let from_a = a.produce();
+        assert_eq!(from_a.len(), 1);
+        b.ingest_all(&from_a, &a.pubkey());
+
+        assert_eq!(b.title().as_deref(), Some("unsent-B"), "the unsent local edit survives");
+        assert_eq!(
+            b.produce().len(),
+            1,
+            "and is still authorable, so it competes on the merits instead of vanishing",
+        );
+    }
+
+    #[test]
+    fn a_remote_upsert_does_not_resurrect_a_row_deleted_locally_but_not_yet_authored() {
+        // The delete half, and the subtler one: the row is GONE, so there is no current state for a
+        // comparison to catch — but the surviving published identity is exactly what the producer's
+        // `Remove` branch keys on. A remote upsert recreates the row AND re-records its published
+        // hash, after which the producer sees no delta and the deletion is undone for good.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'base')", []).unwrap();
+        b.ingest_all(&a.produce(), &a.pubkey());
+
+        // B deletes locally and does not get to author the removal.
+        b.delete_row();
+        a.set_title("from-A");
+        b.ingest_all(&a.produce(), &a.pubkey());
+
+        assert_eq!(b.title(), None, "the unauthored local deletion survives");
+        assert_eq!(b.produce().len(), 1, "and is still authorable, so it reaches peers");
+    }
+
+    #[test]
+    fn two_devices_with_unsent_edits_converge_through_the_deferral() {
+        // Deferring at ingest must not cost convergence — it has to change WHEN an op is applied,
+        // never whether the devices agree. Both devices hold an unsent edit, and B receives A's
+        // entry before it has authored its own, so B defers.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'base')", []).unwrap();
+        b.ingest_all(&a.produce(), &a.pubkey());
+
+        a.set_title("from-A");
+        b.set_title("from-B");
+
+        // A authors first. B, still holding its own unsent edit, defers rather than clobbering it.
+        let from_a = a.produce();
+        assert_eq!(b.ingest_all(&from_a, &a.pubkey()), vec![IngestOutcome::Retained(
+            crate::table_sync::store::PendingReason::DeferredUnsentEdit.as_db_str()
+        )],);
+        assert_eq!(b.title().as_deref(), Some("from-B"), "B's edit is intact");
+
+        // B authors, which takes `MAX(lamport) + 1` counting the entry it parked — so B's edit is
+        // causally later — and settles that entry in the same pass.
+        let from_b = b.produce();
+        assert_eq!(from_b.len(), 1);
+        a.ingest_all(&from_b, &b.pubkey());
+
+        assert_eq!(
+            (a.title().as_deref(), b.title().as_deref()),
+            (Some("from-B"), Some("from-B")),
+            "both devices converge on the causally-later edit, not on a coin flip",
+        );
+        for device in [&a, &b] {
+            assert_eq!(
+                device
+                    .conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM table_sync_entries WHERE pending_reason IS NOT NULL",
+                        [],
+                        |r| r.get::<_, i64>(0)
+                    )
+                    .unwrap(),
+                0,
+                "and nothing is left outstanding on either side",
+            );
+        }
+        // Steady state: neither device has anything more to say.
+        assert!(a.produce().is_empty() && b.produce().is_empty());
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -81,10 +81,11 @@ const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 /// this store and could re-create the legacy state after we stamped" is the obvious objection.
 /// There are exactly TWO writers of a pending mark, and neither can:
 ///
-/// - **Ingest** ([`super::engine`]) marks from `ApplyOutcome::Unprojectable`, which is
-///   [`super::apply::PayloadVerdict::Gap`] — decided on the payload alone, so it is a version gap
-///   by construction and never a deferral, whatever the row holds. It cannot write a misclassified
-///   mark, in any binary.
+/// - **Ingest** ([`super::engine`]) reaches a version gap only through
+///   [`super::apply::PayloadVerdict::Gap`], decided on the payload alone — so the reason it records
+///   there means the same thing under every vocabulary, whatever the row holds. (Since #1056 it
+///   records deferrals too, but only reasons from THIS vocabulary: a binary predating a vocabulary
+///   has no way to name its states, so it cannot write them.)
 /// - **[`repark`]** only runs inside a pass, and a pass is gated on [`refold_owed`]. An older
 ///   binary's triggers are all version-based, so once the projector stamp is current and every
 ///   pending entry sits at that version, its refold does not run at all — which is precisely the
@@ -126,12 +127,38 @@ pub(crate) fn refold_stale_projections_against(
     // `refold_owed` already excludes a newer stamp; re-assert inside the write txn so this stays
     // honest if that predicate ever changes.
     assert_projector_not_newer(&tx)?;
-    for pending in store::pending_entries(&tx, owed.worklist())? {
-        replay_pending_entry(&tx, registry, &pending)?;
-    }
+    replay_worklist(&tx, registry, owed.worklist())?;
     stamp_fold_versions(&tx)?;
     tx.commit()?;
     Ok(true)
+}
+
+/// Replay entries deferred behind LOCAL ROW STATE, inside the CALLER's transaction.
+///
+/// The producer's counterpart to the store-open pass, and the reason a deferral is a usable state
+/// rather than one that only clears on restart: the moment local work is authored, the thing those
+/// entries were blocked behind is gone, so this is exactly when they are worth another look.
+///
+/// Running it here is also what makes "author local before applying remote" hold BY CONSTRUCTION at
+/// this seam, instead of being a convention every future driver has to remember. It is deliberately
+/// narrowed to the deferral family — authoring says nothing about a version gap — and deliberately
+/// does not stamp: it is not a full fold, and claiming one would let a genuine gap go unreplayed.
+pub(crate) fn replay_deferred_entries(
+    tx: &Transaction<'_>,
+    registry: &[TableSpec],
+) -> anyhow::Result<()> {
+    replay_worklist(tx, registry, Worklist::Deferrals)
+}
+
+fn replay_worklist(
+    tx: &Transaction<'_>,
+    registry: &[TableSpec],
+    worklist: Worklist,
+) -> anyhow::Result<()> {
+    for pending in store::pending_entries(tx, worklist)? {
+        replay_pending_entry(tx, registry, &pending)?;
+    }
+    Ok(())
 }
 
 /// What a refold pass is owed, and therefore how much of the pending set it has to replay.
@@ -259,34 +286,25 @@ fn replay_pending_entry(
     else {
         return repark(tx, pending, PendingReason::TableNotInScope);
     };
-    // Settle the PAYLOAD question before the ROW question. Whatever the payload alone decides, the
-    // row cannot change — so consulting the guard first would file a version gap, or a payload
-    // terminal on its own merits, under the deferral family instead: replayed at every open until
-    // some unrelated local edit happened to be authored, with the real reason no longer recorded
-    // anywhere. The verdict is pure, so asking it first is free.
-    match apply::payload_verdict(spec, &context.repo_id, &op) {
-        apply::PayloadVerdict::Gap(reason) => return repark(tx, pending, reason),
-        // Terminal. Falls through to the apply path below, which records the quarantine — one
-        // writer of that verdict rather than two.
-        apply::PayloadVerdict::Rejected(_) => {},
-        // Only here does the row have a say. NEVER replay over an unsent local edit: a raw local
-        // write does not advance the row clock, so the LWW comparison cannot see it and this older
-        // entry would simply win — silently destroying a change no peer has ever seen, at store
-        // open, before anything has had a chance to author it. Park it on WHICH local state is in
-        // the way: once the producer authors that edit (at a lamport above this entry's, since
-        // authoring counts parked entries), a later replay lands and loses on the merits — and
-        // until then the deferral reason is what brings the entry back for another look at every
-        // open, since no version bump can signal that the row moved.
-        apply::PayloadVerdict::RowDecides(_) =>
-            if let Some(deferral) = apply::unsent_work_blocking_replay(
-                tx,
-                spec,
-                &context.repo_id,
-                pending.stream_id,
-                &op,
-            )? {
-                return repark(tx, pending, deferral);
-            },
+    // NEVER replay over unsent local work. A raw local write does not advance the row clock, so the
+    // LWW comparison cannot see it and this older entry would simply win — silently destroying a
+    // change no peer has ever seen, at store open, before anything has had a chance to author it.
+    // Park it on WHICH state is in the way: once the producer authors that edit (at a lamport above
+    // this entry's, since authoring counts parked entries), a later replay lands and loses on the
+    // merits — and until then the deferral reason is what brings the entry back for another look,
+    // since no version bump can signal that the row moved.
+    //
+    // `DeferOnAnyDoubt`: nothing ordered a producer before this pass, so a row whose state cannot
+    // be established either way is treated as unsafe to write over.
+    if let apply::PreApply::Park(reason) = apply::pre_apply(
+        tx,
+        spec,
+        &context.repo_id,
+        pending.stream_id,
+        &op,
+        apply::RowDoubt::DeferOnAnyDoubt,
+    )? {
+        return repark(tx, pending, reason);
     }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
     match apply::apply_row_op(tx, spec, &context.repo_id, &op, meta)? {
@@ -840,6 +858,52 @@ mod tests {
     }
 
     #[test]
+    fn ingest_defers_an_upsert_whose_row_state_cannot_be_established() {
+        // The live path's exemption is for `Remove` ONLY. An unprovable verdict against an UPSERT
+        // still defers: the row may hold an unsent raw edit, and a winning upsert rewrites every
+        // synced column and records its own hash as published — destroying the edit with nothing
+        // left to author it from, which is exactly #1056. The convergence argument that lets a
+        // deletion through does not reach an upsert, because an upsert is version-gated anyway, so
+        // deferring one costs nothing the skew was not costing already.
+        let mut a = Device::new();
+        let mut b = Device::new();
+
+        // B publishes r1 under the OLD column set, edits it raw, then loses its own winning entry —
+        // the shape retention/GC leaves behind if it drops a winner without first refreshing the
+        // row's publication record.
+        b.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'mine', NULL)", [])
+            .unwrap();
+        assert_eq!(b.produce(OLD_REGISTRY, "repo").len(), 1, "r1 is published under the old spec");
+        b.conn.execute("UPDATE t_demo SET title = 'edited' WHERE id = 'r1'", []).unwrap();
+        b.conn.execute("DELETE FROM table_sync_entries", []).unwrap();
+
+        // A authors twice, so the entry that matters outranks B's row clock and would win.
+        a.conn
+            .execute("INSERT INTO t_demo(id, title, later_col) VALUES ('r1', 'a1', 'wide')", [])
+            .unwrap();
+        let mut entries = a.produce(NEW_REGISTRY, "repo");
+        a.conn.execute("UPDATE t_demo SET title = 'a2' WHERE id = 'r1'", []).unwrap();
+        entries.extend(a.produce(NEW_REGISTRY, "repo"));
+
+        // Ingested under the WIDER registry, so the payload projects cleanly and the only thing in
+        // question is the row.
+        b.enroll(a.pubkey().fingerprint());
+        let outcomes = b.ingest(NEW_REGISTRY, "repo", &entries, &a.pubkey());
+        assert!(
+            outcomes.iter().all(|outcome| *outcome
+                == IngestOutcome::Retained(PendingReason::DeferredUnresolvedWinner.as_db_str())),
+            "each upsert is deferred rather than applied: {outcomes:?}",
+        );
+        assert_eq!(b.row().unwrap().0, "edited", "the possibly-unsent local edit survives");
+        assert_eq!(
+            b.produce(NEW_REGISTRY, "repo").len(),
+            1,
+            "and is still authorable, so it competes on the merits",
+        );
+    }
+
+    #[test]
     fn the_refold_defers_when_the_rows_winner_cannot_be_resolved_at_all() {
         // The UNPROVABLE arm of the same guard. When a row's winning entry cannot be resolved, the
         // projection comparison is unavailable and there is no way to tell an untouched row from an
@@ -1228,6 +1292,12 @@ mod tests {
     fn a_remove_crosses_a_spec_version_skew_unimpeded() {
         // A remove names only the row identity, so no column set is involved and its version is
         // never acted on. Gating it would delay deletions across a skew for no benefit.
+        //
+        // This is also the case that pins ingest's one guard exemption
+        // (`RowDoubt::DeferExceptUnprovableRemoval`): B's row was published under the wider column
+        // set, so the unsent-work guard cannot resolve its winner under the narrower spec and
+        // returns `DeferredUnresolvedWinner`. Deferring on that would make a row deleted after a
+        // column change undeletable until B upgrades.
         let mut a = Device::new();
         let mut b = Device::new();
         a.conn
@@ -1756,18 +1826,44 @@ mod tests {
     }
 
     #[test]
-    fn a_deferral_marked_at_the_current_version_is_retried_on_the_next_open() {
-        // The #1005 bug. An entry deferred behind local row state is redeemed by the ROW changing —
-        // the edit gets authored, the unreadable cell repaired — which no projector version can
-        // express and no upgrade implies. Without a trigger keyed on the deferral itself, an entry
-        // parked by THIS binary is never looked at again, and redelivery cannot rescue it (it
-        // short-circuits on `entry_exists`).
+    fn authoring_the_local_edit_settles_the_deferral_in_the_same_pass() {
+        // The producer is the deferral's natural redeemer: the moment the local work is published,
+        // the thing the entry was blocked behind is gone. Doing it inside that pass is what makes
+        // author-before-apply hold by construction, and it means a deferral does not have to wait
+        // for a restart to clear (#1056).
         let mut a = Device::new();
         let mut b = Device::new();
         defer_over_an_unsent_edit(&mut a, &mut b);
 
-        // Authoring the edit publishes the row, so nothing stands in the replay's way any more.
         assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1, "the local edit is authored");
+        assert_eq!(b.pending_count(), 0, "and the deferred entry settles in that same pass");
+        assert_eq!(
+            b.row().unwrap().0,
+            "unsent",
+            "losing the LWW comparison to the edit it was protecting, rather than by default",
+        );
+        assert!(
+            !refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap(),
+            "leaving nothing for the next store open to do"
+        );
+    }
+
+    #[test]
+    fn a_deferral_marked_at_the_current_version_is_retried_on_the_next_open() {
+        // The #1005 bug, on the path the producer does NOT redeem. An entry deferred behind local
+        // row state is redeemed by the ROW changing, which no projector version can express and no
+        // upgrade implies — so without a trigger keyed on the deferral itself, an entry parked by
+        // THIS binary is never looked at again, and redelivery cannot rescue it (it short-circuits
+        // on `entry_exists`).
+        //
+        // Redemption here is the local row being DISCARDED, not authored — the row was purely local
+        // (no apply ever published it), so once it is gone there is nothing left to protect.
+        // Nothing produces, so the store-open trigger is the only thing that can settle it.
+        let mut a = Device::new();
+        let mut b = Device::new();
+        defer_over_an_unsent_edit(&mut a, &mut b);
+
+        b.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
 
         assert!(
             refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap(),
@@ -1775,9 +1871,9 @@ mod tests {
         );
         assert_eq!(b.pending_count(), 0, "and the entry finally settles, on the merits");
         assert_eq!(
-            b.row().unwrap().0,
-            "unsent",
-            "losing the LWW comparison to the edit it was protecting"
+            b.row(),
+            Some(("v1".to_string(), Some("wide".to_string()))),
+            "the replayed entry lands in full once nothing is in its way",
         );
     }
 
@@ -1827,23 +1923,25 @@ mod tests {
         );
 
         // From here the ordinary deferral machinery takes over, and the entry is no longer
-        // stranded.
+        // stranded: authoring the edit settles it.
         assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1);
-        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
         assert_eq!(b.pending_count(), 0);
     }
 
     #[test]
-    fn ingest_classifies_on_the_payload_alone_and_never_writes_a_deferral() {
-        // What makes ONE store-global vocabulary stamp sufficient. The worry it has to answer is an
-        // older binary sharing the store and re-creating the legacy state after we stamped; the
-        // answer is that only a refold pass can write a stale classification, and an older binary's
-        // pass cannot run once the projector stamp and every pending mark are current.
+    fn ingest_marks_an_unprojectable_payload_as_a_version_gap_even_over_unsent_work() {
+        // Two properties at once, and they are the same property.
         //
-        // That argument rests on the OTHER writer — ingest — never producing a deferral, which it
-        // cannot, because it classifies from the payload alone and never looks at the row. This
-        // pins that: the row here holds an unsent local edit, so a row-aware ingest would have
-        // something to find, and finding it would silently break the reachability argument above.
+        // The ORDERING: an entry this binary cannot project is a version gap whatever the row
+        // holds, so the payload has to be settled before the row is consulted. The row here
+        // holds an unsent local edit, so the guard would fire — and filing that as a
+        // deferral would erase the version gap and move the entry into the family replayed
+        // at every store open, where nothing could redeem it.
+        //
+        // The VOCABULARY argument that lets one store-global stamp cover a shared store also rests
+        // on this: a version-gap reason means the same thing under every vocabulary, so ingest
+        // recording one is safe in any binary. Ingest also records deferrals now, but only ones
+        // this vocabulary can name.
         let mut a = Device::new();
         let mut b = Device::new();
         let entries = author_wide_row(&mut a);
@@ -1919,12 +2017,10 @@ mod tests {
                 TABLE_SYNC_PROJECTOR_VERSION
             )),
         );
-        assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1, "the removal is authored");
-
         // SETTLEMENT is the observable here, not the row. The authored `Remove` takes
         // `MAX(lamport) + 1` counting the parked entries, so the row stays deleted whether or not
         // they are ever replayed — a content assertion would pass with the retry deleted.
-        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.produce(NEW_REGISTRY, "repo").len(), 1, "the removal is authored");
         assert_eq!(b.pending_count(), 0, "both deferred upserts lose to the tombstone and clear");
         assert_eq!(b.row(), None);
     }
@@ -2360,11 +2456,12 @@ mod tests {
             1,
             "this opener authors the edit"
         );
-        assert!(
-            second.refold(NEW_REGISTRY).unwrap(),
-            "and is the one owed the deferred entry's replay"
+        assert_eq!(
+            second.pending_count(),
+            0,
+            "and settles the deferral the OTHER opener recorded — the mark and its trigger are \
+             file state, not connection state",
         );
-        assert_eq!(second.pending_count(), 0);
         assert_eq!(second.row().unwrap().0, "unsent");
     }
 

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -121,6 +121,28 @@ impl PendingReason {
     /// Every non-deferral variant is a version gap, INCLUDING `PartialAfterImage` (a broken
     /// producer its own doc says will not clear here) and `NoStreamContext`: as deferrals those
     /// would retry forever with nothing able to redeem them.
+    /// Whether this deferral rests on PROOF that local work would be destroyed, as opposed to an
+    /// inability to establish the row's state either way.
+    ///
+    /// The difference decides what the LIVE ingest path does. `DeferredUnresolvedWinner` is the one
+    /// reason that is merely unprovable — the row was published under a different column set and
+    /// its winning op cannot be projected — and acting on it at ingest would delay a deletion
+    /// across a version skew, which is the convergence wedge [`super::apply::apply_row_op`]
+    /// deliberately keeps `Remove` out of. The refold pays that cost because it runs at store
+    /// open with no driver to have ordered it; ingest does not, because it is the path a driver
+    /// orders.
+    pub(crate) fn is_proven_unsent_work(self) -> bool {
+        match self {
+            Self::DeferredUnsentEdit | Self::DeferredUnsentDelete | Self::DeferredUnreadableRow =>
+                true,
+            Self::DeferredUnresolvedWinner => false,
+            other => {
+                debug_assert!(!other.is_deferral(), "every deferral must state its confidence");
+                false
+            },
+        }
+    }
+
     pub(crate) fn is_deferral(self) -> bool {
         match self {
             Self::DeferredUnsentEdit


### PR DESCRIPTION
Fixes #1056. The last of the five robustness gaps deferred from #893/#896.

## The bug

A raw local write does not advance `sync_row_clocks` — only authoring-and-self-applying does — so whole-row LWW cannot see an unsent local edit at all. It compares the incoming op against the clock of whatever was last *published*, and wins.

`refold.rs` has guarded this since #1002, because it runs at store open where an edit made just before the last exit is exactly what is sitting there. **`ingest` had the identical exposure and no guard.** Two failing reproductions were written first:

- A remote upsert overwrites an unpublished local edit and records *its own* hash as published. The producer then sees no delta, and the edit is gone with nothing left to author it from.
- A remote upsert recreates a row deleted locally but not yet authored, re-recording the hash. The deletion is undone for good.

## Why the guard, and not the driver contract

The recorded answer to this gap was a **driver invariant**: the transport must call `produce_and_author` before `ingest` each cycle. That was written before #1005, and it has two problems — it is a convention no code enforces, and it puts correctness in a component that does not exist yet.

#1005 changed what is available. Deferred entries now carry a retry trigger of their own, keyed on the deferral rather than on any projector version, which makes deferring at ingest safe for the first time: before it, an entry parked by the guard at the current version was never reconsidered.

## Three things that fall out

**The payload-before-row ordering now lives in one place.** Both callers need the same sequence, and getting it right in one and wrong in the other is easy — it happened here. The first cut of the ingest guard ran *before* the payload verdict, so a version-gapped op over a dirty row would have been filed as a deferral, moving it into the family replayed at every store open where nothing could redeem it. `apply::pre_apply` owns the order now, so there is one place to get it right.

**The two callers act on different amounts of doubt.** The refold defers on any doubt: nothing ordered a producer before it. Ingest defers on any doubt *except* an unprovable verdict against a `Remove`, which it applies — holding a deletion back on a verdict that may never resolve is the convergence wedge `apply_row_op` deliberately keeps `Remove` clear of, and a row deleted after a column change would become undeletable across the skew.

The exemption stops precisely there. An `Upsert` is version-gated already, so deferring one costs nothing the skew was not costing anyway, while applying it on an unprovable verdict destroys exactly the edit the guard exists to protect. Both directions are pinned by a test.

**`produce_and_author` replays the deferral family after it publishes.** The refold otherwise runs only at store open, so a deferral would wait for a restart even after the local work it was blocked behind had been authored. Running it at that seam is what makes author-before-apply hold *by construction* rather than as a convention.

Convergence is unchanged and stays on the merits: a local edit is authored at `MAX(lamport) + 1` counting the parked entry, so the deferred remote op loses a comparison it would previously have won by default. A two-device test drives both sides holding unsent edits through the deferral to a common value.

## Verification

Seven mutations were applied and each was killed by the test written for it: removing the ingest guard, removing the post-produce replay, reversing the payload/row order, flipping each caller's doubt posture, and widening then dropping the `Remove` exemption.

Gates: nightly fmt, both CI clippy legs (`--no-default-features` and `--all-features`, `-D warnings`), `cargo nextest run --workspace --no-default-features` (4408 passed), and `cargo test -p rag-rat-oplog` for the coverage job's runner.