### PR TITLE
refactor(db): reach migration steps through the migrations module

### DIFF
--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -981,11 +981,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
-    use rag_rat_db::schema::{
-        apply_distill_anchor_selection, apply_distill_enriched_context,
-        apply_distill_evidence_source_part, apply_distill_record_store,
-        apply_distill_safe_input_snapshot,
-    };
+    use rag_rat_db::schema::migrations;
     use rag_rat_llm::chat::{ChatModel, GuidedJson};
     use rusqlite::Connection;
 
@@ -1032,11 +1028,11 @@ mod tests {
 
     fn fixture() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
-        apply_distill_record_store(&conn).unwrap();
-        apply_distill_anchor_selection(&conn).unwrap();
-        apply_distill_safe_input_snapshot(&conn).unwrap();
-        apply_distill_enriched_context(&conn).unwrap();
-        apply_distill_evidence_source_part(&conn).unwrap();
+        migrations::apply_distill_record_store(&conn).unwrap();
+        migrations::apply_distill_anchor_selection(&conn).unwrap();
+        migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
+        migrations::apply_distill_enriched_context(&conn).unwrap();
+        migrations::apply_distill_evidence_source_part(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1322,11 +1318,11 @@ mod tests {
     fn stale_success_does_not_delete_or_poison_new_work() {
         let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
         let conn = Connection::open(&path).unwrap();
-        apply_distill_record_store(&conn).unwrap();
-        apply_distill_anchor_selection(&conn).unwrap();
-        apply_distill_safe_input_snapshot(&conn).unwrap();
-        apply_distill_enriched_context(&conn).unwrap();
-        apply_distill_evidence_source_part(&conn).unwrap();
+        migrations::apply_distill_record_store(&conn).unwrap();
+        migrations::apply_distill_anchor_selection(&conn).unwrap();
+        migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
+        migrations::apply_distill_enriched_context(&conn).unwrap();
+        migrations::apply_distill_evidence_source_part(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1511,11 +1507,11 @@ mod tests {
     fn model_executes_after_the_read_transaction_is_released() {
         let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
         let conn = Connection::open(&path).unwrap();
-        apply_distill_record_store(&conn).unwrap();
-        apply_distill_anchor_selection(&conn).unwrap();
-        apply_distill_safe_input_snapshot(&conn).unwrap();
-        apply_distill_enriched_context(&conn).unwrap();
-        apply_distill_evidence_source_part(&conn).unwrap();
+        migrations::apply_distill_record_store(&conn).unwrap();
+        migrations::apply_distill_anchor_selection(&conn).unwrap();
+        migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
+        migrations::apply_distill_enriched_context(&conn).unwrap();
+        migrations::apply_distill_evidence_source_part(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -856,7 +856,7 @@ fn has_test_code_backfill_is_case_sensitive() {
     )
     .unwrap();
     conn.execute("UPDATE files SET has_test_code = 0", []).unwrap();
-    schema::apply_files_has_test_code(&conn).unwrap();
+    schema::migrations::apply_files_has_test_code(&conn).unwrap();
     let flag = |id: i64| -> i64 {
         conn.query_row("SELECT has_test_code FROM files WHERE id = ?1", [id], |r| r.get(0)).unwrap()
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/migrations.rs
@@ -96,7 +96,8 @@ fn migration_034_adds_content_anchored_clone_graph_tables() {
     // now HAS the table — that is V037's job, verified by
     // `migration_037_adds_content_anchored_clone_subblock_postings`.)
     let v034_only = rusqlite::Connection::open_in_memory().expect("open v034-only conn");
-    rag_rat_db::schema::apply_clone_graph_tables(&v034_only).expect("apply V034 clone-graph DDL");
+    rag_rat_db::schema::migrations::apply_clone_graph_tables(&v034_only)
+        .expect("apply V034 clone-graph DDL");
     assert!(
         !conn_table_exists(&v034_only, "clone_subblock_postings"),
         "the persisted postings table is deferred to V037 — the V034 DDL must NOT create it"

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
@@ -387,7 +387,7 @@ fn migration_restamps_fresh_legacy_stamps_but_leaves_stale_ones() {
     .unwrap();
 
     // Re-run the applier (idempotent): re-seeds (files unchanged) and re-stamps legacy -> new.
-    rag_rat_db::schema::apply_content_digest_state(&conn).unwrap();
+    rag_rat_db::schema::migrations::apply_content_digest_state(&conn).unwrap();
 
     let meta = |key: &str| -> String {
         conn.query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |r| r.get(0)).unwrap()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -155,7 +155,7 @@ fn migration_043_adds_generation_and_reconverges_from_torn_state() {
         "generation is absent before V043 runs"
     );
 
-    schema::apply_files_generation(&conn).unwrap();
+    schema::migrations::apply_files_generation(&conn).unwrap();
 
     assert!(
         conn_table_columns(&conn, "files").contains(&"generation".to_string()),
@@ -173,7 +173,7 @@ fn migration_043_adds_generation_and_reconverges_from_torn_state() {
     );
     assert_eq!(generation, 0, "existing rows carry generation 0");
     // Torn scratch re-converged (dropped + rebuilt), and a replay short-circuits on the sentinel.
-    schema::apply_files_generation(&conn).expect("replay is a no-op");
+    schema::migrations::apply_files_generation(&conn).expect("replay is a no-op");
     // The widened UNIQUE now admits a second generation of the same scope.
     conn.execute(
         "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, repo_id, \

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -657,7 +657,7 @@ fn migration_063_persists_mirror_resume_state() {
     assert!(
         conn_table_columns(&conn, "papertrail_items").contains(&"full_rewalk_seen".to_string())
     );
-    schema::apply_papertrail_mirror_resume_state(&conn).unwrap();
+    schema::migrations::apply_papertrail_mirror_resume_state(&conn).unwrap();
     assert_eq!(conn_table_columns(&conn, "papertrail_sync_cursor"), columns, "V063 is idempotent");
 }
 
@@ -684,7 +684,7 @@ fn migration_067_persists_binding_health() {
         [],
     )
     .unwrap();
-    schema::apply_papertrail_binding_health(&conn).unwrap();
+    schema::migrations::apply_papertrail_binding_health(&conn).unwrap();
     let (probe, mirror, full): (Option<i64>, Option<i64>, Option<i64>) = conn
         .query_row(
             "SELECT last_successful_probe_ms, last_successful_mirror_ms, last_full_sync_ms
@@ -847,7 +847,7 @@ fn migration_045_duplicates_children_per_owning_repo_and_keeps_orphans() {
     )
     .unwrap();
 
-    schema::apply_github_child_key_widening(&conn).unwrap();
+    schema::migrations::apply_github_child_key_widening(&conn).unwrap();
 
     // The shared children now exist once per OWNING repo.
     for (table, id) in
@@ -1276,8 +1276,11 @@ fn seeded_pre_v060_legacy_db() -> rusqlite::Connection {
 fn migration_060_backfills_papertrail_from_the_legacy_github_tables() {
     let conn = seeded_pre_v060_legacy_db();
 
-    schema::apply_papertrail_provider_neutral_schema(&conn, &crate::index::migration_hooks())
-        .unwrap();
+    schema::migrations::apply_papertrail_provider_neutral_schema(
+        &conn,
+        &crate::index::migration_hooks(),
+    )
+    .unwrap();
 
     // Items: issue #1 (both repos, verbatim repo_id) + ONE change_request #2 (shadow deduped,
     // pulls copy wins so merged_at survives).
@@ -1514,8 +1517,11 @@ fn migration_060_backfills_papertrail_from_the_legacy_github_tables() {
     assert_eq!(refs[0].item_key, "1");
 
     // Replay converges: a second apply is a clean no-op (nothing legacy left to backfill).
-    schema::apply_papertrail_provider_neutral_schema(&conn, &crate::index::migration_hooks())
-        .unwrap();
+    schema::migrations::apply_papertrail_provider_neutral_schema(
+        &conn,
+        &crate::index::migration_hooks(),
+    )
+    .unwrap();
     let items_after: i64 =
         conn.query_row("SELECT COUNT(*) FROM papertrail_items", [], |r| r.get(0)).unwrap();
     assert_eq!(items_after, 3, "re-apply neither duplicates nor drops migrated rows");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/records.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/records.rs
@@ -780,7 +780,7 @@ fn drive_by_records_survive_a_v083_upgrade_via_the_backfill() {
     assert!(read().is_empty(), "a pre-V083 chunk (NULL symbol_id) resolves to no record");
 
     // The V083 backfill re-links the pre-migration chunk by line-range containment.
-    rag_rat_db::schema::apply_chunk_symbol_id(conn).unwrap();
+    rag_rat_db::schema::migrations::apply_chunk_symbol_id(conn).unwrap();
     assert_eq!(read(), vec!["5".to_string()], "the backfill restores the record on the old chunk");
 
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -129,7 +129,8 @@ fn v038_registry_ddl_is_self_contained_and_introduces_the_registry() {
     let bare = rusqlite::Connection::open_in_memory().expect("open");
     assert!(!conn_table_exists(&bare, "repos"), "no registry before the migration runs");
 
-    schema::apply_repos_registry(&bare).expect("V038 DDL applies standalone on a bare conn");
+    schema::migrations::apply_repos_registry(&bare)
+        .expect("V038 DDL applies standalone on a bare conn");
 
     for table in ["repos", "repo_roots", "repo_meta"] {
         assert!(conn_table_exists(&bare, table), "V038 creates {table}");
@@ -553,7 +554,7 @@ fn migration_039_relocates_per_repo_meta_and_leaves_global_keys() {
     upsert_meta(&conn, "reconcile_meta", "last_embedding_reconcile_started_at_ms", "1000"); // stays
 
     // Re-run the relocation (the tables were empty when apply() first ran it).
-    schema::apply_move_per_repo_meta(&conn).expect("relocate");
+    schema::migrations::apply_move_per_repo_meta(&conn).expect("relocate");
 
     for (key, value) in [
         ("source_root", "/src/repo"),
@@ -636,15 +637,15 @@ fn v039_relocation_runs_standalone_and_is_idempotent() {
          CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
     )
     .unwrap();
-    schema::apply_repos_registry(&bare).expect("V038 registry");
+    schema::migrations::apply_repos_registry(&bare).expect("V038 registry");
     // `git_commit` is a genuinely per-repo key V039 relocates; the reencode cursor moves too. (The
     // `fts_*` trio + `content_revision` are RECLASSIFIED GLOBAL by V040, so V039 no longer
     // relocates them — covered by `v039_leaves_reclassified_global_keys_in_index_meta`.)
     upsert_meta(&bare, "index_meta", "git_commit", "abc123");
     upsert_meta(&bare, "reconcile_meta", "vector_int8_reencode_cursor", "7\nm");
 
-    schema::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
-    schema::apply_move_per_repo_meta(&bare).expect("V039 relocation is idempotent");
+    schema::migrations::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
+    schema::migrations::apply_move_per_repo_meta(&bare).expect("V039 relocation is idempotent");
 
     assert_eq!(
         rag_rat_db::meta::repo_meta(&bare, LEGACY_REPO_ID, "git_commit").unwrap().as_deref(),
@@ -683,7 +684,7 @@ fn v039_leaves_reclassified_global_keys_in_index_meta() {
          CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
     )
     .unwrap();
-    schema::apply_repos_registry(&bare).expect("V038 registry");
+    schema::migrations::apply_repos_registry(&bare).expect("V038 registry");
     // The 4 reclassified-global index_meta keys, plus one genuinely-per-repo key as a positive
     // control that DOES relocate.
     for key in ["content_revision", "fts_dirty", "fts_source_revision", "fts_synced_at_ms"] {
@@ -691,7 +692,7 @@ fn v039_leaves_reclassified_global_keys_in_index_meta() {
     }
     upsert_meta(&bare, "index_meta", "source_root", "/src/repo");
 
-    schema::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
+    schema::migrations::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
 
     // The 4 global keys STAY in index_meta and never enter repo_meta.
     for key in ["content_revision", "fts_dirty", "fts_source_revision", "fts_synced_at_ms"] {
@@ -1004,12 +1005,13 @@ fn register_repo_adoption_is_atomic_on_a_mid_sequence_failure() {
 
 // --- V040: repo_id scoping on the core tables (memory-sync phase A3) ---
 
-/// The pre-V040 (post-V039) shape of every core table [`schema::apply_repo_id_core_scoping`]
-/// transforms, plus the V038 registry it relocates meta under — built in ISOLATION so the migration
-/// is exercised against its own inputs, not the full ladder (the directory's "assert deferred
-/// absence / rebuild behavior in isolation" rule). `files`/`packages`/… carry NO `repo_id`;
-/// `parser_failures` is id-keyed; `git_commits` is `hash`-PK with `commit_fts` external content and
-/// a `git_file_changes(commit_hash)` FK — exactly what V040 rebuilds.
+/// The pre-V040 (post-V039) shape of every core table
+/// [`schema::migrations::apply_repo_id_core_scoping`] transforms, plus the V038 registry it
+/// relocates meta under — built in ISOLATION so the migration is exercised against its own inputs,
+/// not the full ladder (the directory's "assert deferred absence / rebuild behavior in isolation"
+/// rule). `files`/`packages`/… carry NO `repo_id`; `parser_failures` is id-keyed; `git_commits` is
+/// `hash`-PK with `commit_fts` external content and a `git_file_changes(commit_hash)` FK — exactly
+/// what V040 rebuilds.
 fn seed_pre_v040_core_schema(conn: &rusqlite::Connection) {
     conn.execute_batch(
         "
@@ -1076,7 +1078,7 @@ fn seed_pre_v040_core_schema(conn: &rusqlite::Connection) {
         ",
     )
     .unwrap();
-    schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
+    schema::migrations::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
 }
 
 /// Seed one git commit + its file change + its FTS entry into a pre-V040 fixture, returning the
@@ -1180,7 +1182,7 @@ fn migration_040_git_rebuild_preserves_rows_commit_fts_and_reconverges_from_torn
     )
     .unwrap();
 
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("V040 converges from the torn state");
 
     // The scratch tables are gone; the transform completed.
@@ -1209,7 +1211,7 @@ fn migration_040_git_rebuild_preserves_rows_commit_fts_and_reconverges_from_torn
     assert_eq!(fc_repo, LEGACY_REPO_ID);
 
     // Idempotent re-run (the all-or-nothing sentinel short-circuits once files carries repo_id).
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("re-apply is a clean no-op");
 
     // Adoption re-points git_commits.repo_id → real, and the ON UPDATE CASCADE carries the change
@@ -1248,7 +1250,8 @@ fn migration_040_reunites_active_model_provenance_meta_into_repo_meta() {
     upsert_meta(&conn, "index_meta", "active_embedding_remote_config", "{\"endpoint\":\"x\"}");
     upsert_meta(&conn, "index_meta", "generated_flags_version", "1"); // machine-level, stays
 
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks()).unwrap();
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+        .unwrap();
 
     for key in ["active_embedding_model_provisional", "active_embedding_remote_config"] {
         assert!(
@@ -1326,7 +1329,7 @@ fn migration_040_backfills_an_adopted_pre_v040_db_under_the_real_repo_id() {
     .unwrap();
     conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
 
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("V040 applies on an adopted DB");
 
     for table in [
@@ -1462,7 +1465,7 @@ fn migration_040_realigns_logical_symbol_ids_and_carries_bound_memories() {
     let old_id = 424_242_i64; // an arbitrary pre-fold id
     seed_pre_v040_logical_symbol_with_a_bound_memory(&conn, old_id);
 
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("V040 applies");
 
     // The symbol's id was re-derived (repo_id folded in), so it CHANGED from the pre-fold value.
@@ -1493,7 +1496,7 @@ fn adoption_realigns_logical_symbol_ids_so_pre_v040_memories_survive() {
     let old_id = 999_001_i64;
     seed_pre_v040_logical_symbol_with_a_bound_memory(&conn, old_id);
 
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("V040 applies (unadopted → placeholder id)");
     let placeholder_id = bound_logical_symbol_id(&conn);
     assert_ne!(placeholder_id, old_id, "V040 already realigned under the placeholder repo_id");
@@ -1548,7 +1551,7 @@ fn register_repo_upgrades_a_local_only_id_to_a_portable_id_in_place() {
     .unwrap();
     seed_pre_v040_logical_symbol_with_a_bound_memory(&conn, 777_001);
 
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("V040 applies (unadopted → placeholder id)");
 
     // First registration: a cut shallow clone adopts under a machine-local id AND records its
@@ -1626,7 +1629,7 @@ fn upgrade_blocks_until_the_outgoing_local_lock_holder_finishes() {
         [],
     )
     .unwrap();
-    schema::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_core_scoping(&conn, &crate::index::migration_hooks())
         .expect("V040 applies");
     let local_id = "local:aaaa1111bbbb";
     register_repo(
@@ -2763,8 +2766,9 @@ fn an_identity_less_open_refuses_to_sole_pick_on_a_multi_repo_db() {
 // --- V041: repo_id scoping on the GitHub papertrail tables (memory-sync phase A4) ---
 
 /// The pre-V041 shape of the seven GitHub tables + `github_fts` (no `repo_id`) plus the V038
-/// registry, built in ISOLATION so [`schema::apply_github_repo_id_scoping`] is exercised against
-/// its own inputs (the directory's "assert deferred absence / rebuild behavior in isolation" rule).
+/// registry, built in ISOLATION so [`schema::migrations::apply_github_repo_id_scoping`] is
+/// exercised against its own inputs (the directory's "assert deferred absence / rebuild behavior in
+/// isolation" rule).
 fn seed_pre_v041_github_schema(conn: &rusqlite::Connection) {
     conn.execute_batch(
         "
@@ -2811,7 +2815,7 @@ fn seed_pre_v041_github_schema(conn: &rusqlite::Connection) {
         ",
     )
     .unwrap();
-    schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
+    schema::migrations::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
 }
 
 /// Fresh `apply` produces the repo-scoped papertrail tables directly (the V060 baseline shape —
@@ -2871,7 +2875,8 @@ fn migration_041_github_rebuild_preserves_rows_and_reconverges_from_torn_state()
     // drop it and re-converge rather than fail on CREATE.
     conn.execute_batch("CREATE TABLE github_fts_new(bogus INTEGER);").unwrap();
 
-    schema::apply_github_repo_id_scoping(&conn).expect("V041 converges from the torn state");
+    schema::migrations::apply_github_repo_id_scoping(&conn)
+        .expect("V041 converges from the torn state");
 
     assert!(!conn_table_exists(&conn, "github_fts_new"), "scratch table gone");
     assert!(
@@ -2896,7 +2901,7 @@ fn migration_041_github_rebuild_preserves_rows_and_reconverges_from_torn_state()
     assert_eq!(matched, 1, "github_fts still MATCHes after the rebuild");
 
     // Idempotent re-run (the sentinel short-circuits once github_fts carries repo_id).
-    schema::apply_github_repo_id_scoping(&conn).expect("re-apply is a clean no-op");
+    schema::migrations::apply_github_repo_id_scoping(&conn).expect("re-apply is a clean no-op");
 }
 
 /// Full-schema adoption of the papertrail: `register_repo` re-points the placeholder papertrail
@@ -2989,7 +2994,7 @@ fn migration_041_backfills_an_adopted_pre_v041_db_under_the_real_repo_id() {
     .unwrap();
     conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
 
-    schema::apply_github_repo_id_scoping(&conn).expect("V041 applies on an adopted DB");
+    schema::migrations::apply_github_repo_id_scoping(&conn).expect("V041 applies on an adopted DB");
 
     for table in ["github_refs", "github_issues", "github_fts"] {
         let (total, under_real): (i64, i64) = conn
@@ -3051,7 +3056,7 @@ fn migration_041_leaves_github_rows_at_the_placeholder_on_a_consolidated_db() {
     .unwrap();
     conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
 
-    schema::apply_github_repo_id_scoping(&conn)
+    schema::migrations::apply_github_repo_id_scoping(&conn)
         .expect("V041 must not abort the upgrade on a consolidated DB");
 
     for table in ["github_refs", "github_issues", "github_fts"] {
@@ -3252,21 +3257,22 @@ fn pk_includes_repo_id(conn: &rusqlite::Connection, table: &str) -> bool {
 
 /// The pre-V042 shape of the clone / oracle / reconcile / memory periphery tables (NO `repo_id`),
 /// built by calling the real table-creating DDL fns in ISOLATION — so
-/// [`schema::apply_repo_id_periphery_scoping`] runs against its own genuine inputs (the directory's
-/// "assert deferred absence / rebuild behavior in isolation, not the full ladder" rule). Calling
-/// the real DDL fns (not hand-copied `CREATE TABLE`s) keeps the fixture drift-free as those tables
-/// evolve. The core / GitHub tables are deliberately NOT scoped here (V040 / V041 are not run):
-/// this fixture drives only V042, so [`register_repo`] adoption is exercised in the full-ladder
-/// test below, where every direct-scoped column exists.
+/// [`schema::migrations::apply_repo_id_periphery_scoping`] runs against its own genuine inputs (the
+/// directory's "assert deferred absence / rebuild behavior in isolation, not the full ladder"
+/// rule). Calling the real DDL fns (not hand-copied `CREATE TABLE`s) keeps the fixture drift-free
+/// as those tables evolve. The core / GitHub tables are deliberately NOT scoped here (V040 / V041
+/// are not run): this fixture drives only V042, so [`register_repo`] adoption is exercised in the
+/// full-ladder test below, where every direct-scoped column exists.
 fn seed_pre_v042_periphery_schema(conn: &rusqlite::Connection) {
     schema::apply_baseline(conn)
         .expect("baseline: repo_memories/bindings/tags/fts + reconcile_attempts + core tables");
-    schema::apply_oracle_tables(conn).expect("oracle_runs + edge_oracle");
-    schema::apply_scip_moniker_anchors(conn).expect("logical_symbol_monikers");
-    schema::apply_clone_fingerprint_tables(conn).expect("clone_token_df + clone_refinements");
-    schema::apply_clone_graph_tables(conn).expect("clone_graph_generations");
-    schema::apply_dream_findings(conn).expect("dream_findings");
-    schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
+    schema::migrations::apply_oracle_tables(conn).expect("oracle_runs + edge_oracle");
+    schema::migrations::apply_scip_moniker_anchors(conn).expect("logical_symbol_monikers");
+    schema::migrations::apply_clone_fingerprint_tables(conn)
+        .expect("clone_token_df + clone_refinements");
+    schema::migrations::apply_clone_graph_tables(conn).expect("clone_graph_generations");
+    schema::migrations::apply_dream_findings(conn).expect("dream_findings");
+    schema::migrations::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
 }
 
 /// Fresh `apply` runs V042 (the schema tip): every periphery table gains a direct `repo_id` and the
@@ -3339,7 +3345,7 @@ fn migration_042_periphery_rebuild_preserves_rows_and_reconverges_from_torn_stat
     // TORN STATE: a prior V042 pass crashed after creating a rebuild scratch table.
     conn.execute_batch("CREATE TABLE clone_token_df_new(bogus INTEGER);").unwrap();
 
-    schema::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
         .expect("V042 converges from the torn state");
 
     assert!(!conn_table_exists(&conn, "clone_token_df_new"), "scratch table swept");
@@ -3374,7 +3380,7 @@ fn migration_042_periphery_rebuild_preserves_rows_and_reconverges_from_torn_stat
     assert_eq!(matched, 1, "repo_memory_fts still MATCHes the seeded memory after the rebuild");
 
     // Idempotent re-run (the repo_memories.repo_id sentinel short-circuits).
-    schema::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
         .expect("re-apply is a clean no-op");
 }
 
@@ -3411,7 +3417,7 @@ fn migration_042_backfills_an_adopted_pre_v042_db_under_the_real_repo_id() {
     .unwrap();
     conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
 
-    schema::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
         .expect("V042 applies on an adopted DB");
 
     let df_repo: String = conn
@@ -3476,7 +3482,7 @@ fn migration_042_leaves_periphery_rows_at_the_placeholder_on_a_consolidated_db()
     .unwrap();
     conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
 
-    schema::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
+    schema::migrations::apply_repo_id_periphery_scoping(&conn, &crate::index::migration_hooks())
         .expect("V042 must not abort the upgrade on a consolidated DB");
 
     for table in ["repo_memories", "clone_token_df", "repo_memory_fts"] {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -32,8 +32,8 @@ fn migration_052_adds_oplog_storage_tables() {
     )
     .unwrap();
     assert!(!conn_table_exists(&conn, "oplog_entries"), "dropped before the isolated apply");
-    schema::apply_oplog_storage(&conn).unwrap();
-    schema::apply_oplog_storage(&conn).expect("replay is a no-op");
+    schema::migrations::apply_oplog_storage(&conn).unwrap();
+    schema::migrations::apply_oplog_storage(&conn).expect("replay is a no-op");
     for table in OPLOG_TABLES {
         assert!(conn_table_exists(&conn, table), "the isolated applier recreates {table}");
     }
@@ -92,8 +92,8 @@ fn migration_053_scopes_the_oplog_by_stream_and_adds_fork_evidence() {
          CREATE TABLE oplog_entries(entry_hash BLOB PRIMARY KEY) STRICT;",
     )
     .unwrap();
-    schema::apply_oplog_stream_scoping(&conn).unwrap();
-    schema::apply_oplog_stream_scoping(&conn).expect("replay reconverges");
+    schema::migrations::apply_oplog_stream_scoping(&conn).unwrap();
+    schema::migrations::apply_oplog_stream_scoping(&conn).expect("replay reconverges");
     for table in
         ["oplog_entries", "oplog_projected_nodes", "oplog_projected_edges", "oplog_fork_evidence"]
     {
@@ -162,8 +162,8 @@ fn migration_054_adds_the_single_row_device_identity_table() {
         !conn_table_exists(&conn, "oplog_device_identity"),
         "dropped before the isolated apply"
     );
-    schema::apply_oplog_device_identity(&conn).unwrap();
-    schema::apply_oplog_device_identity(&conn).expect("replay is a no-op");
+    schema::migrations::apply_oplog_device_identity(&conn).unwrap();
+    schema::migrations::apply_oplog_device_identity(&conn).expect("replay is a no-op");
     assert!(
         conn_table_columns(&conn, "oplog_device_identity").contains(&"seed".to_string()),
         "the isolated applier recreates the table"
@@ -243,8 +243,8 @@ fn migration_056_adds_the_git_change_couplings_table() {
     // no-op.
     conn.execute_batch("DROP TABLE git_change_couplings;").unwrap();
     assert!(!conn_table_exists(&conn, "git_change_couplings"), "dropped before the isolated apply");
-    schema::apply_git_change_couplings(&conn).unwrap();
-    schema::apply_git_change_couplings(&conn).expect("replay is a no-op");
+    schema::migrations::apply_git_change_couplings(&conn).unwrap();
+    schema::migrations::apply_git_change_couplings(&conn).expect("replay is a no-op");
     assert!(
         conn_table_exists(&conn, "git_change_couplings"),
         "the isolated applier recreates the table"
@@ -374,8 +374,8 @@ fn migration_057_adds_the_external_symbols_table() {
     // EXISTS).
     conn.execute_batch("DROP TABLE external_symbols;").unwrap();
     assert!(!conn_table_exists(&conn, "external_symbols"), "dropped before the isolated apply");
-    schema::apply_external_symbols(&conn).unwrap();
-    schema::apply_external_symbols(&conn).expect("replay is a no-op");
+    schema::migrations::apply_external_symbols(&conn).unwrap();
+    schema::migrations::apply_external_symbols(&conn).expect("replay is a no-op");
     assert!(
         conn_table_columns(&conn, "external_symbols").contains(&"moniker".to_string()),
         "the isolated applier recreates the table"
@@ -419,15 +419,15 @@ fn migration_058_adds_the_oplog_device_x25519_columns() {
     // ladder's end state) — the x25519 columns are absent — then the V058 applier adds them, and a
     // replay is an idempotent no-op (add_column_if_missing).
     let isolated = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_oplog_device_identity(&isolated).unwrap();
+    schema::migrations::apply_oplog_device_identity(&isolated).unwrap();
     for column in ["x25519_secret", "x25519_public"] {
         assert!(
             !conn_table_columns(&isolated, "oplog_device_identity").contains(&column.to_string()),
             "the V054 table alone lacks the {column} column"
         );
     }
-    schema::apply_oplog_device_x25519(&isolated).unwrap();
-    schema::apply_oplog_device_x25519(&isolated).expect("replay is a no-op");
+    schema::migrations::apply_oplog_device_x25519(&isolated).unwrap();
+    schema::migrations::apply_oplog_device_x25519(&isolated).expect("replay is a no-op");
     for column in ["x25519_secret", "x25519_public"] {
         assert!(
             conn_table_columns(&isolated, "oplog_device_identity").contains(&column.to_string()),
@@ -483,8 +483,8 @@ fn migration_059_creates_the_account_candidate_dag() {
     // replay is an idempotent no-op (every statement is CREATE ... IF NOT EXISTS).
     let isolated = rusqlite::Connection::open_in_memory().unwrap();
     assert!(!conn_table_exists(&isolated, "account_entries"), "bare DB lacks account_entries");
-    schema::apply_account_candidate_dag(&isolated).unwrap();
-    schema::apply_account_candidate_dag(&isolated).expect("replay is a no-op");
+    schema::migrations::apply_account_candidate_dag(&isolated).unwrap();
+    schema::migrations::apply_account_candidate_dag(&isolated).expect("replay is a no-op");
     for table in ["account_entries", "account_entry_status", "account_pre_verify"] {
         assert!(conn_table_exists(&isolated, table), "the isolated V059 applier creates {table}");
     }
@@ -519,8 +519,9 @@ fn migration_064_creates_account_authority_shadow_tables() {
         assert!(conn_table_exists(&conn, table), "V064 creates {table}");
     }
     let isolated = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_account_authority_projection(&isolated).unwrap();
-    schema::apply_account_authority_projection(&isolated).expect("V064 replay is idempotent");
+    schema::migrations::apply_account_authority_projection(&isolated).unwrap();
+    schema::migrations::apply_account_authority_projection(&isolated)
+        .expect("V064 replay is idempotent");
     assert!(conn_table_exists(&isolated, "account_auth_state"));
     let seq_type: String = isolated
         .query_row(
@@ -577,7 +578,8 @@ fn migration_065_adds_historical_authority_boundaries() {
             );
         }
     }
-    schema::apply_account_authority_boundaries(&conn).expect("V065 replay is idempotent");
+    schema::migrations::apply_account_authority_boundaries(&conn)
+        .expect("V065 replay is idempotent");
 }
 
 #[test]
@@ -603,7 +605,7 @@ fn migration_066_adds_the_content_candidate_dag() {
     ] {
         assert!(columns.contains(&column.to_string()), "V066 adds content_entries.{column}");
     }
-    schema::apply_content_candidate_dag(&conn).expect("V066 replay is idempotent");
+    schema::migrations::apply_content_candidate_dag(&conn).expect("V066 replay is idempotent");
     let insert = |hash: u8, seq_width: usize| {
         conn.execute(
             "INSERT INTO content_entries(
@@ -784,8 +786,8 @@ fn migration_069_adds_the_local_account_pointer() {
         !conn_table_exists(&isolated, "oplog_local_account"),
         "bare DB lacks oplog_local_account before the isolated apply",
     );
-    schema::apply_oplog_local_account(&isolated).unwrap();
-    schema::apply_oplog_local_account(&isolated).expect("replay is a no-op");
+    schema::migrations::apply_oplog_local_account(&isolated).unwrap();
+    schema::migrations::apply_oplog_local_account(&isolated).expect("replay is a no-op");
     assert!(
         conn_table_columns(&isolated, "oplog_local_account")
             .contains(&"genesis_entry_hash".to_string()),
@@ -869,8 +871,8 @@ fn migration_070_adds_the_content_projected_tables() {
         !conn_table_exists(&isolated, "content_projected_nodes"),
         "bare DB lacks content_projected_nodes before the isolated apply",
     );
-    schema::apply_content_projected_tables(&isolated).unwrap();
-    schema::apply_content_projected_tables(&isolated).expect("replay is a no-op");
+    schema::migrations::apply_content_projected_tables(&isolated).unwrap();
+    schema::migrations::apply_content_projected_tables(&isolated).expect("replay is a no-op");
     assert!(
         conn_table_columns(&isolated, "content_projected_edges").contains(&"spec_json".to_string()),
         "the isolated applier recreates the tables",
@@ -920,8 +922,8 @@ fn migration_071_indexes_edge_target_qname() {
     // Idempotent applier: drop it, re-run twice — CREATE INDEX IF NOT EXISTS reconverges.
     conn.execute("DROP INDEX idx_edges_target_qname", []).unwrap();
     assert_eq!(index_on(&conn), 0, "index dropped");
-    schema::apply_edge_target_qname_index(&conn).unwrap();
-    schema::apply_edge_target_qname_index(&conn).expect("replay is a no-op");
+    schema::migrations::apply_edge_target_qname_index(&conn).unwrap();
+    schema::migrations::apply_edge_target_qname_index(&conn).expect("replay is a no-op");
     assert_eq!(index_on(&conn), 1, "the isolated applier recreates the index");
 
     // A forward migrate over a ledger truncated below V071 replays the step and records V071.
@@ -991,8 +993,8 @@ fn migration_072_queues_pending_refold() {
         !conn_table_exists(&isolated, "content_streams_pending_refold"),
         "bare DB lacks content_streams_pending_refold before the isolated apply",
     );
-    schema::apply_content_streams_pending_refold(&isolated).unwrap();
-    schema::apply_content_streams_pending_refold(&isolated).expect("replay is a no-op");
+    schema::migrations::apply_content_streams_pending_refold(&isolated).unwrap();
+    schema::migrations::apply_content_streams_pending_refold(&isolated).expect("replay is a no-op");
     assert!(
         conn_table_columns(&isolated, "content_streams_pending_refold")
             .contains(&"stream_id".to_string()),
@@ -1026,13 +1028,13 @@ fn migration_047_deferred_absence_and_reconverges_from_torn_state() {
         "torn table lacks the sentinel column"
     );
 
-    schema::apply_memory_model_failures_table(&conn).unwrap();
+    schema::migrations::apply_memory_model_failures_table(&conn).unwrap();
 
     assert!(
         conn_table_columns(&conn, "memory_model_failures").contains(&"reason".to_string()),
         "V047 drops the torn scratch table and creates the real shape"
     );
-    schema::apply_memory_model_failures_table(&conn).expect("replay is a no-op");
+    schema::migrations::apply_memory_model_failures_table(&conn).expect("replay is a no-op");
     conn.execute(
         "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, model_id, \
          prompt_version, reason, failed_at_ms) VALUES \
@@ -1074,7 +1076,7 @@ fn migration_046_deferred_absence_and_reconverges_from_torn_state() {
     // whose end state always has the table): the sentinel table is absent before V046 runs.
     assert!(!conn_table_exists(&conn, "memory_reality"), "memory_reality absent before V046 runs");
 
-    schema::apply_memory_verification_tables(&conn).unwrap();
+    schema::migrations::apply_memory_verification_tables(&conn).unwrap();
 
     assert!(conn_table_exists(&conn, "memory_reality"), "V046 creates memory_reality");
     assert!(conn_table_exists(&conn, "memory_summaries"), "V046 creates memory_summaries");
@@ -1083,7 +1085,7 @@ fn migration_046_deferred_absence_and_reconverges_from_torn_state() {
         "the torn scratch table was dropped and recreated with the real shape"
     );
     // Replay short-circuits on the sentinel.
-    schema::apply_memory_verification_tables(&conn).expect("replay is a no-op");
+    schema::migrations::apply_memory_verification_tables(&conn).expect("replay is a no-op");
 
     // memory_reality PK (repo_id, memory_id): one row per memory; a duplicate is rejected.
     conn.execute(
@@ -1222,14 +1224,14 @@ fn migration_087_adds_table_sync_tables() {
         assert!(!schema::table_exists(&bare, t).unwrap(), "pre-V087 has no {t}");
     }
 
-    schema::apply_table_sync_tables(&bare).unwrap();
+    schema::migrations::apply_table_sync_tables(&bare).unwrap();
 
     for t in added {
         assert!(schema::table_exists(&bare, t).unwrap(), "V087 adds {t}");
     }
     // The applier is idempotent (CREATE TABLE IF NOT EXISTS) — a second run is a no-op, not an
     // error.
-    schema::apply_table_sync_tables(&bare).unwrap();
+    schema::migrations::apply_table_sync_tables(&bare).unwrap();
     // The whole-row LWW clock is keyed per row; a duplicate row key collides on the composite PK.
     bare.execute(
         "INSERT INTO sync_row_clocks(repo_id, table_name, row_pk, lamport, device_fingerprint) \
@@ -1304,7 +1306,7 @@ fn migration_088_caches_the_generation_posting_row_count() {
     }
     conn.execute_batch("ALTER TABLE clone_graph_generations DROP COLUMN postings_row_count;")
         .unwrap();
-    schema::apply_clone_postings_row_count(&conn).unwrap();
+    schema::migrations::apply_clone_postings_row_count(&conn).unwrap();
     let backfilled: i64 = conn
         .query_row(
             "SELECT postings_row_count FROM clone_graph_generations WHERE generation = 7",
@@ -1315,7 +1317,7 @@ fn migration_088_caches_the_generation_posting_row_count() {
     assert_eq!(backfilled, 3, "the backfill counts the generation's actual postings");
 
     // Additive + idempotent: a re-apply keeps the column and its value.
-    schema::apply_clone_postings_row_count(&conn).unwrap();
+    schema::migrations::apply_clone_postings_row_count(&conn).unwrap();
     let after_reapply: i64 = conn
         .query_row(
             "SELECT postings_row_count FROM clone_graph_generations WHERE generation = 7",
@@ -1330,8 +1332,8 @@ fn migration_088_caches_the_generation_posting_row_count() {
 #[test]
 fn migration_089_adds_sync_invites() {
     let bare = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_sync_invites(&bare).unwrap();
-    schema::apply_sync_invites(&bare).expect("replay is a no-op");
+    schema::migrations::apply_sync_invites(&bare).unwrap();
+    schema::migrations::apply_sync_invites(&bare).expect("replay is a no-op");
     assert!(conn_table_exists(&bare, "sync_invites"));
     assert!(
         !conn_table_exists(&bare, "account_candidate_reservations"),
@@ -1373,8 +1375,8 @@ fn migration_089_adds_sync_invites() {
 #[test]
 fn migration_090_adds_account_candidate_reservations() {
     let bare = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_account_candidate_reservations(&bare).unwrap();
-    schema::apply_account_candidate_reservations(&bare).expect("replay is a no-op");
+    schema::migrations::apply_account_candidate_reservations(&bare).unwrap();
+    schema::migrations::apply_account_candidate_reservations(&bare).expect("replay is a no-op");
     assert!(conn_table_exists(&bare, "account_candidate_reservations"));
     assert!(
         bare.execute(
@@ -1405,7 +1407,7 @@ fn migration_090_adds_account_candidate_reservations() {
 #[test]
 fn migration_092_normalizes_invite_receipts() {
     let bare = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_sync_invites(&bare).unwrap();
+    schema::migrations::apply_sync_invites(&bare).unwrap();
     bare.execute(
         "INSERT INTO sync_invites(
              nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms,
@@ -1417,8 +1419,8 @@ fn migration_092_normalizes_invite_receipts() {
         [],
     )
     .unwrap();
-    schema::apply_sync_invites_normalized_receipts(&bare).unwrap();
-    schema::apply_sync_invites_normalized_receipts(&bare).expect("replay is a no-op");
+    schema::migrations::apply_sync_invites_normalized_receipts(&bare).unwrap();
+    schema::migrations::apply_sync_invites_normalized_receipts(&bare).expect("replay is a no-op");
     let (role, receipt, legacy): (String, Vec<u8>, Vec<u8>) = bare
         .query_row(
             "SELECT role, receipt_signed, receipt_bytes FROM sync_invites
@@ -1446,7 +1448,7 @@ fn migration_092_normalizes_invite_receipts() {
         [],
     )
     .unwrap();
-    schema::apply_sync_invites_normalized_receipts(&bare).unwrap();
+    schema::migrations::apply_sync_invites_normalized_receipts(&bare).unwrap();
     let manifest: Vec<u8> = bare
         .query_row(
             "SELECT receipt_entries FROM sync_invites
@@ -1478,8 +1480,8 @@ fn migration_095_records_the_table_spec_version() {
     assert_eq!(schema::LATEST_SCHEMA_VERSION, 95, "move this pin with the next schema migration");
 
     let bare = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_table_sync_tables(&bare).unwrap();
-    schema::apply_table_sync_projection_state(&bare).unwrap();
+    schema::migrations::apply_table_sync_tables(&bare).unwrap();
+    schema::migrations::apply_table_sync_projection_state(&bare).unwrap();
     assert!(
         schema::column_exists(&bare, "sync_published_rows", "projector_version").unwrap(),
         "V093 records the store-global projector version"
@@ -1495,8 +1497,8 @@ fn migration_095_records_the_table_spec_version() {
     )
     .unwrap();
 
-    schema::apply_table_sync_spec_version(&bare).unwrap();
-    schema::apply_table_sync_spec_version(&bare).expect("replay is a no-op");
+    schema::migrations::apply_table_sync_spec_version(&bare).unwrap();
+    schema::migrations::apply_table_sync_spec_version(&bare).expect("replay is a no-op");
     let carried: Option<i64> = bare
         .query_row(
             "SELECT spec_version FROM sync_published_rows WHERE row_pk = 'carried'",
@@ -1594,7 +1596,7 @@ fn migration_093_adds_table_sync_projection_state() {
     // Absence is asserted against the PRE-V093 DDL in isolation, never against the full ladder
     // (which now ends at V093 and would make the check vacuous).
     let bare = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_table_sync_tables(&bare).unwrap();
+    schema::migrations::apply_table_sync_tables(&bare).unwrap();
     assert!(
         !schema::column_exists(&bare, "table_sync_entries", "pending_reason").unwrap(),
         "the pending mark arrives with V093, not before"
@@ -1605,8 +1607,8 @@ fn migration_093_adds_table_sync_projection_state() {
     );
     assert!(!schema::table_exists(&bare, "table_sync_streams").unwrap());
 
-    schema::apply_table_sync_projection_state(&bare).unwrap();
-    schema::apply_table_sync_projection_state(&bare).expect("replay is a no-op");
+    schema::migrations::apply_table_sync_projection_state(&bare).unwrap();
+    schema::migrations::apply_table_sync_projection_state(&bare).expect("replay is a no-op");
 
     assert!(schema::column_exists(&bare, "table_sync_entries", "pending_reason").unwrap());
     assert!(
@@ -1620,9 +1622,9 @@ fn migration_093_adds_table_sync_projection_state() {
     // still gains the rest: the ladder records V093 as applied and never re-runs it, so a
     // group-guarded add would leave a column missing on a store that reports itself current.
     let partial = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_table_sync_tables(&partial).unwrap();
+    schema::migrations::apply_table_sync_tables(&partial).unwrap();
     partial.execute("ALTER TABLE table_sync_entries ADD COLUMN pending_reason TEXT", []).unwrap();
-    schema::apply_table_sync_projection_state(&partial).unwrap();
+    schema::migrations::apply_table_sync_projection_state(&partial).unwrap();
     assert!(
         schema::column_exists(&partial, "table_sync_entries", "quarantine_reason").unwrap(),
         "a partially-migrated store still gains the columns it is missing"
@@ -1662,7 +1664,7 @@ fn migration_093_adds_table_sync_projection_state() {
 #[test]
 fn migration_091_adds_account_candidate_reservation_targets() {
     let bare = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_account_candidate_reservations(&bare).unwrap();
+    schema::migrations::apply_account_candidate_reservations(&bare).unwrap();
     bare.execute(
         "INSERT INTO account_candidate_reservations(
              reservation_id, account_id, reserved_entries, reserved_bytes, expires_at_ms
@@ -1670,8 +1672,9 @@ fn migration_091_adds_account_candidate_reservation_targets() {
         [],
     )
     .unwrap();
-    schema::apply_account_candidate_reservation_targets(&bare).unwrap();
-    schema::apply_account_candidate_reservation_targets(&bare).expect("replay is a no-op");
+    schema::migrations::apply_account_candidate_reservation_targets(&bare).unwrap();
+    schema::migrations::apply_account_candidate_reservation_targets(&bare)
+        .expect("replay is a no-op");
     let targets: i64 = bare
         .query_row(
             "SELECT reserved_targets FROM account_candidate_reservations
@@ -1806,7 +1809,7 @@ fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
     assert_eq!(sibling_revision, 21, "the run clocks its owning repo");
     assert_eq!(revision(), 6, "a sibling repo's linked-worktree run stays isolated");
 
-    schema::apply_lens_enrichment_revision(&conn).unwrap();
+    schema::migrations::apply_lens_enrichment_revision(&conn).unwrap();
     assert_eq!(trigger_count("oracle_runs_lens_revision_"), 3);
     assert_eq!(trigger_count("git_file_changes_lens_revision_"), 0);
     conn.execute(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/distill.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/distill.rs
@@ -96,7 +96,7 @@ fn migration_073_backfills_state_normalized_from_the_provider_truthful_pair() {
     insert("2", "merged", None); // GitLab merged MR
     insert("3", "closed", None); // closed unmerged
     insert("4", "open", None);
-    rag_rat_db::schema::apply_papertrail_distill_substrate(&conn).unwrap();
+    rag_rat_db::schema::migrations::apply_papertrail_distill_substrate(&conn).unwrap();
     let normalized = |key: &str| -> String {
         conn.query_row(
             "SELECT state_normalized FROM papertrail_items WHERE item_key = ?1",
@@ -113,7 +113,7 @@ fn migration_073_backfills_state_normalized_from_the_provider_truthful_pair() {
     conn.execute("UPDATE papertrail_items SET state_normalized = 'closed' WHERE item_key = '4'", [
     ])
     .unwrap();
-    rag_rat_db::schema::apply_papertrail_distill_substrate(&conn).unwrap();
+    rag_rat_db::schema::migrations::apply_papertrail_distill_substrate(&conn).unwrap();
     assert_eq!(normalized("4"), "closed", "replay does not re-derive a stamped row");
 }
 
@@ -446,7 +446,7 @@ fn migration_078_distinguishes_candidates_from_selections() {
     // Exercise the real V077 -> V078 upgrade with existing rows. Row-id order is the deterministic
     // tie-break within each thread; a second thread starts its own zero-based ordinal sequence.
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_distill_record_store(&legacy).unwrap();
+    schema::migrations::apply_distill_record_store(&legacy).unwrap();
     legacy
         .execute_batch(
             "
@@ -472,7 +472,7 @@ fn migration_078_distinguishes_candidates_from_selections() {
                  INTEGER NOT NULL DEFAULT 0 CHECK(candidate_ordinal >= 0);",
         )
         .unwrap();
-    schema::apply_distill_anchor_selection(&legacy).unwrap();
+    schema::migrations::apply_distill_anchor_selection(&legacy).unwrap();
 
     let upgraded: Vec<UpgradedAnchor> = legacy
         .prepare(
@@ -544,7 +544,7 @@ fn migration_078_distinguishes_candidates_from_selections() {
         "candidate ordinals are unique within a thread",
     );
     legacy.execute("UPDATE papertrail_distill_anchors SET selected = 1 WHERE id = 2", []).unwrap();
-    schema::apply_distill_anchor_selection(&legacy).unwrap();
+    schema::migrations::apply_distill_anchor_selection(&legacy).unwrap();
     let selected: i64 = legacy
         .query_row("SELECT selected FROM papertrail_distill_anchors WHERE id = 2", [], |row| {
             row.get(0)
@@ -582,12 +582,12 @@ fn migration_079_builds_safe_input_snapshots() {
     // `LATEST_SCHEMA_VERSION` pin moved to `migration_083_*`, the new tip; this uses only the
     // symbolic checks (the hardcoded-LATEST footgun).
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_distill_record_store(&legacy).unwrap();
-    schema::apply_distill_anchor_selection(&legacy).unwrap();
+    schema::migrations::apply_distill_record_store(&legacy).unwrap();
+    schema::migrations::apply_distill_anchor_selection(&legacy).unwrap();
     assert!(!conn_table_columns(&legacy, "papertrail_distill").contains(&"prompt_version".into()));
     assert!(!schema::table_exists(&legacy, "papertrail_distill_sources").unwrap());
 
-    schema::apply_distill_safe_input_snapshot(&legacy).unwrap();
+    schema::migrations::apply_distill_safe_input_snapshot(&legacy).unwrap();
     let distill_columns = conn_table_columns(&legacy, "papertrail_distill");
     assert!(distill_columns.contains(&"prompt_version".into()));
     assert!(distill_columns.contains(&"model_input_hash".into()));
@@ -661,7 +661,7 @@ fn migration_079_builds_safe_input_snapshots() {
     // Torn replay: both columns and the source table survived, while the unit table/index did not.
     // The additive applier must converge without touching existing source rows.
     legacy.execute_batch("DROP TABLE papertrail_distill_units;").unwrap();
-    schema::apply_distill_safe_input_snapshot(&legacy).unwrap();
+    schema::migrations::apply_distill_safe_input_snapshot(&legacy).unwrap();
     assert!(schema::table_exists(&legacy, "papertrail_distill_units").unwrap());
     let sources: i64 = legacy
         .query_row("SELECT COUNT(*) FROM papertrail_distill_sources", [], |row| row.get(0))
@@ -686,13 +686,13 @@ fn migration_080_builds_enriched_context_snapshots() {
     // The `LATEST_SCHEMA_VERSION` pin lives on `migration_083_*`, the current tip; this uses
     // only the symbolic checks (the hardcoded-LATEST footgun).
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_distill_record_store(&legacy).unwrap();
-    schema::apply_distill_anchor_selection(&legacy).unwrap();
-    schema::apply_distill_safe_input_snapshot(&legacy).unwrap();
+    schema::migrations::apply_distill_record_store(&legacy).unwrap();
+    schema::migrations::apply_distill_anchor_selection(&legacy).unwrap();
+    schema::migrations::apply_distill_safe_input_snapshot(&legacy).unwrap();
     assert!(!schema::table_exists(&legacy, "papertrail_distill_fix_diffs").unwrap());
     assert!(!schema::table_exists(&legacy, "papertrail_distill_xrefs").unwrap());
 
-    schema::apply_distill_enriched_context(&legacy).unwrap();
+    schema::migrations::apply_distill_enriched_context(&legacy).unwrap();
     for table in ["papertrail_distill_fix_diffs", "papertrail_distill_xrefs"] {
         assert!(schema::table_exists(&legacy, table).unwrap(), "V080 table `{table}` exists");
     }
@@ -767,7 +767,7 @@ fn migration_080_builds_enriched_context_snapshots() {
     // Torn replay: the diff table survived, the xref table did not. The additive applier must
     // converge without touching existing rows.
     legacy.execute_batch("DROP TABLE papertrail_distill_xrefs;").unwrap();
-    schema::apply_distill_enriched_context(&legacy).unwrap();
+    schema::migrations::apply_distill_enriched_context(&legacy).unwrap();
     assert!(schema::table_exists(&legacy, "papertrail_distill_xrefs").unwrap());
     let diffs: i64 = legacy
         .query_row("SELECT COUNT(*) FROM papertrail_distill_fix_diffs", [], |row| row.get(0))
@@ -794,13 +794,13 @@ fn migration_081_adds_evidence_source_part() {
     // The evidence table predates the column: build the record store (V077) without V081, then
     // apply V081 and confirm the column appears.
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
-    schema::apply_distill_record_store(&legacy).unwrap();
+    schema::migrations::apply_distill_record_store(&legacy).unwrap();
     assert!(
         !schema::column_exists(&legacy, "papertrail_distill_evidence", "source_part").unwrap(),
         "V077 evidence has no source_part",
     );
 
-    schema::apply_distill_evidence_source_part(&legacy).unwrap();
+    schema::migrations::apply_distill_evidence_source_part(&legacy).unwrap();
     assert!(
         schema::column_exists(&legacy, "papertrail_distill_evidence", "source_part").unwrap(),
         "V081 adds the source_part column",
@@ -842,7 +842,7 @@ fn migration_081_adds_evidence_source_part() {
 
     // Torn replay: the column already exists, so re-applying is a no-op, not a duplicate-column
     // error, and existing rows survive.
-    schema::apply_distill_evidence_source_part(&legacy).unwrap();
+    schema::migrations::apply_distill_evidence_source_part(&legacy).unwrap();
     let rows: i64 = legacy
         .query_row("SELECT COUNT(*) FROM papertrail_distill_evidence", [], |row| row.get(0))
         .unwrap();
@@ -1006,8 +1006,8 @@ fn migration_082_accounts_for_content_refold_work() {
 
     // A full-ladder replay recomputes the same source-derived stats and leaves queue metadata
     // intact.
-    schema::apply_content_refold_queue_and_stats(&conn).unwrap();
-    schema::apply_content_refold_queue_and_stats(&conn).unwrap();
+    schema::migrations::apply_content_refold_queue_and_stats(&conn).unwrap();
+    schema::migrations::apply_content_refold_queue_and_stats(&conn).unwrap();
     let replay_stats: Vec<(Vec<u8>, i64, i64)> = conn
         .prepare(
             "SELECT stream_id, candidate_count, candidate_bytes
@@ -1197,7 +1197,7 @@ fn migration_084_links_chunks_to_symbols() {
         )
         .unwrap();
 
-    schema::apply_chunk_symbol_id(&legacy).unwrap();
+    schema::migrations::apply_chunk_symbol_id(&legacy).unwrap();
     assert!(
         schema::column_exists(&legacy, "chunks", "symbol_id").unwrap(),
         "V084 adds the symbol_id column",
@@ -1246,7 +1246,7 @@ fn migration_084_links_chunks_to_symbols() {
 
     // Torn replay: the column already exists and every chunk is already linked, so re-applying is a
     // no-op — it neither errors nor overwrites a resolved symbol_id.
-    schema::apply_chunk_symbol_id(&legacy).unwrap();
+    schema::migrations::apply_chunk_symbol_id(&legacy).unwrap();
     let relinked: Vec<(Option<String>, Option<i64>)> = legacy
         .prepare("SELECT symbol_path, symbol_id FROM chunks ORDER BY id")
         .unwrap()
@@ -1305,7 +1305,7 @@ fn migration_085_adds_origin_and_edge_present() {
         assert!(!schema::column_exists(&legacy, t, c).unwrap(), "pre-V085 {t} has no {c}");
     }
 
-    schema::apply_sync_origin_and_edge_tombstone(&legacy).unwrap();
+    schema::migrations::apply_sync_origin_and_edge_tombstone(&legacy).unwrap();
 
     for (t, c) in added {
         assert!(schema::column_exists(&legacy, t, c).unwrap(), "V085 adds {t}.{c}");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/memory_features.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/memory_features.rs
@@ -246,7 +246,7 @@ fn migration_050_adds_the_postings_path_index_and_delta_counter() {
     // treated as delta-ready.
     conn.execute_batch("ALTER TABLE clone_graph_generations DROP COLUMN delta_files_applied;")
         .unwrap();
-    schema::apply_clone_delta_maintenance(&conn).unwrap();
+    schema::migrations::apply_clone_delta_maintenance(&conn).unwrap();
     let postings_written: i64 = conn
         .query_row(
             "SELECT postings_written FROM clone_graph_generations WHERE generation = 1",
@@ -295,7 +295,7 @@ fn migration_051_adds_clone_df_epoch_and_backfills_existing_generations() {
     )
     .unwrap();
     conn.execute_batch("DROP TABLE clone_df_epoch;").unwrap();
-    schema::apply_clone_df_epoch(&conn).unwrap();
+    schema::migrations::apply_clone_df_epoch(&conn).unwrap();
     let epoch_rows = |conn: &rusqlite::Connection| -> Vec<(i64, i64, i64)> {
         conn.prepare(
             "SELECT build_generation, token_hash, df FROM clone_df_epoch
@@ -322,7 +322,7 @@ fn migration_051_adds_clone_df_epoch_and_backfills_existing_generations() {
         [],
     )
     .unwrap();
-    schema::apply_clone_df_epoch(&conn).unwrap();
+    schema::migrations::apply_clone_df_epoch(&conn).unwrap();
     assert_eq!(
         epoch_rows(&conn),
         vec![(7, 101, 3), (7, 102, 9)],

--- a/crates/rag-rat-db/src/schema/baseline.rs
+++ b/crates/rag-rat-db/src/schema/baseline.rs
@@ -1,4 +1,6 @@
-use super::*;
+use rusqlite::Connection;
+
+use super::migrations;
 
 pub fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     drop_legacy_ai_prototype_tables(conn)?;
@@ -467,41 +469,41 @@ pub fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
         ",
     )?;
     // The view + its INSTEAD OF triggers exist only when no legacy `edges` TABLE is present
-    // (fresh DB, or post-V020): `migrate_edges` below touches `edges`, which on a fresh DB must
-    // already resolve to the view. On a pre-V020 DB the legacy table is still in place here and
-    // `apply_edge_string_interning` converts it later in the ladder.
-    ensure_edges_data_indexes(conn)?;
-    ensure_edges_view(conn)?;
-    migrate_files(conn)?;
-    migrate_chunks(conn)?;
-    migrate_edges(conn)?;
-    apply_embedding_vector_metadata(conn)?;
-    apply_derived_artifact_reconcile_metadata(conn)?;
-    apply_edge_source_target_spans(conn)?;
-    apply_embedding_policy_and_input_hash(conn)?;
-    apply_logical_symbol_groups(conn)?;
+    // (fresh DB, or post-V020): `migrations::migrate_edges` below touches `edges`, which on a fresh
+    // DB must already resolve to the view. On a pre-V020 DB the legacy table is still in place
+    // here and `migrations::apply_edge_string_interning` converts it later in the ladder.
+    migrations::ensure_edges_data_indexes(conn)?;
+    migrations::ensure_edges_view(conn)?;
+    migrations::migrate_files(conn)?;
+    migrations::migrate_chunks(conn)?;
+    migrations::migrate_edges(conn)?;
+    migrations::apply_embedding_vector_metadata(conn)?;
+    migrations::apply_derived_artifact_reconcile_metadata(conn)?;
+    migrations::apply_edge_source_target_spans(conn)?;
+    migrations::apply_embedding_policy_and_input_hash(conn)?;
+    migrations::apply_logical_symbol_groups(conn)?;
     // The provider-neutral papertrail tables (V060). The baseline produces the CURRENT schema
     // directly — no legacy github_* tables are created — so a routine `migrate_forward` (which
     // re-runs the baseline) can never resurrect the dropped legacy cache. The V009/V041/V044/V045
     // github migrations in the ladder each no-op when the legacy tables are absent.
-    create_papertrail_tables(conn)?;
+    migrations::create_papertrail_tables(conn)?;
     // V073 (#702): the distillation substrate — closing edges + item/comment outcome columns.
     // Additive over the V060 shape; the baseline converges to the current schema directly.
     migrations::apply_papertrail_distill_substrate(conn)?;
-    apply_symbol_facts(conn)?;
-    apply_repo_memories(conn)?;
-    apply_repo_memory_call_paths(conn)?;
-    apply_repo_memory_call_path_edges(conn)?;
-    apply_graph_file_lookup_indexes(conn)?;
+    migrations::apply_symbol_facts(conn)?;
+    migrations::apply_repo_memories(conn)?;
+    migrations::apply_repo_memory_call_paths(conn)?;
+    migrations::apply_repo_memory_call_path_edges(conn)?;
+    migrations::apply_graph_file_lookup_indexes(conn)?;
     interned_qualified_name_indexes(conn)?;
-    apply_clone_fingerprint_tables(conn)?;
+    migrations::apply_clone_fingerprint_tables(conn)?;
     // V032 (#231): converge the clone substrate to its BLOB-packed shape. The line above
     // (re)creates `symbol_token_postings` from V029's DDL; this transform adds the
     // `symbol_fingerprints.token_bag` column and DROPs the postings table — so the baseline
     // produces the CURRENT schema directly, and a routine `migrate_forward` (which re-runs the
     // baseline) cannot leave the postings table behind it. R5: V029's DDL is not edited; the
     // convergence lives here, not in the checksummed migration body.
-    apply_token_bag_blob(conn)?;
+    migrations::apply_token_bag_blob(conn)?;
     Ok(())
 }
 
@@ -515,7 +517,7 @@ pub fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
 /// data-preserving — destructive conversions fire only when the legacy shape is actually present.
 fn drop_legacy_ai_prototype_tables(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch("DROP TABLE IF EXISTS embeddings;")?;
-    if !column_exists(conn, "chunk_summaries", "prompt_version")? {
+    if !migrations::column_exists(conn, "chunk_summaries", "prompt_version")? {
         conn.execute_batch("DROP TABLE IF EXISTS chunk_summaries;")?;
     }
     Ok(())
@@ -528,13 +530,13 @@ fn drop_legacy_ai_prototype_tables(conn: &Connection) -> rusqlite::Result<()> {
 /// absent until V028 adds + backfills it, which is where V028 creates these same indexes. Guarding
 /// here keeps `apply_baseline` from referencing a not-yet-added column on an older DB.
 fn interned_qualified_name_indexes(conn: &Connection) -> rusqlite::Result<()> {
-    if column_exists(conn, "symbols", "qualified_name_id")? {
+    if migrations::column_exists(conn, "symbols", "qualified_name_id")? {
         conn.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_symbols_qualified_name_id
                 ON symbols(qualified_name_id);",
         )?;
     }
-    if column_exists(conn, "logical_symbols", "qualified_name_id")? {
+    if migrations::column_exists(conn, "logical_symbols", "qualified_name_id")? {
         conn.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name_id
                 ON logical_symbols(qualified_name_id);",

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -907,7 +907,7 @@ pub(crate) fn apply_contentless_chunk_fts(conn: &Connection) -> rusqlite::Result
 /// probe (the query_warm regression). A DB already at the schema tip opens as `Compatible` and
 /// never re-runs the view bootstrap, so without this ladder step only freshly migrated indexes
 /// would pick up the cheap form.
-pub fn apply_edges_view_scalar_suppression(conn: &Connection) -> rusqlite::Result<()> {
+pub(crate) fn apply_edges_view_scalar_suppression(conn: &Connection) -> rusqlite::Result<()> {
     ensure_edges_view(conn)
 }
 
@@ -920,7 +920,7 @@ pub fn apply_edges_view_scalar_suppression(conn: &Connection) -> rusqlite::Resul
 /// kinds (#200) and suppressed unresolved candidates (V068). Idempotent — the ADD is guarded, the
 /// UPDATE only ever promotes `hidden = 0` rows the predicate says are invisible, and the view
 /// refresh is DROP + CREATE.
-pub fn apply_edges_hidden_flag(conn: &Connection) -> rusqlite::Result<()> {
+pub(crate) fn apply_edges_hidden_flag(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "edges_data", "hidden", "INTEGER NOT NULL DEFAULT 0")?;
     conn.execute_batch(
         "UPDATE edges_data SET hidden = 1
@@ -4916,7 +4916,7 @@ fn backfill_chunk_symbol_ids(conn: &Connection) -> rusqlite::Result<()> {
 /// (not INT) so a `u64` epoch round-trips without the `i64` narrowing hazard. `UNIQUE(kind,
 /// entry_hash)` + `INSERT OR IGNORE` (the write path) keep a hot seal-path retry from re-appending
 /// the same evidence for one op. Purely additive; CREATE ... IF NOT EXISTS, nothing to backfill.
-pub fn apply_sync_security_events(conn: &Connection) -> rusqlite::Result<()> {
+pub(crate) fn apply_sync_security_events(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS sync_security_events(
              id              INTEGER PRIMARY KEY,

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -1,34 +1,13 @@
 mod baseline;
-mod migrations;
+// The individual migration STEPS (`apply_*`) are reached through this module rather than
+// re-exported: `migrations::apply_oplog_storage(conn)` says where the step comes from, whereas a
+// bare `apply_oplog_storage(conn)` at a call site in another crate reads like a local function.
+// The general-purpose schema predicates below are re-exported, since they are not ladder steps.
+pub mod migrations;
 mod purge;
 mod registry;
 // The schema surface the engine crates consume (everything else stays crate-internal):
 pub use baseline::{apply_baseline, rebuild_commit_fts};
-pub(crate) use migrations::*;
-// Migration steps and table lists the engine's schema tests exercise directly:
-pub use migrations::{
-    apply_account_authority_boundaries, apply_account_authority_projection,
-    apply_account_candidate_dag, apply_account_candidate_reservation_targets,
-    apply_account_candidate_reservations, apply_chunk_symbol_id, apply_clone_delta_maintenance,
-    apply_clone_df_epoch, apply_clone_fingerprint_tables, apply_clone_graph_tables,
-    apply_clone_postings_row_count, apply_content_candidate_dag, apply_content_digest_state,
-    apply_content_projected_tables, apply_content_refold_queue_and_stats,
-    apply_content_streams_pending_refold, apply_distill_anchor_selection,
-    apply_distill_enriched_context, apply_distill_evidence_source_part, apply_distill_record_store,
-    apply_distill_safe_input_snapshot, apply_dream_findings, apply_edge_string_interning,
-    apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
-    apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
-    apply_github_repo_id_scoping, apply_lens_enrichment_revision,
-    apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
-    apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
-    apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
-    apply_papertrail_binding_health, apply_papertrail_distill_substrate,
-    apply_papertrail_mirror_resume_state, apply_papertrail_provider_neutral_schema,
-    apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
-    apply_scip_moniker_anchors, apply_sync_invites, apply_sync_invites_normalized_receipts,
-    apply_sync_origin_and_edge_tombstone, apply_table_sync_projection_state,
-    apply_table_sync_spec_version, apply_table_sync_tables,
-};
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
 // `multiple_real_repos` lost its V042-era seam-guard callers (real `repo_id` predicates
@@ -840,7 +819,7 @@ fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
     }
     if baseline_owed {
         conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
-        record_migration(
+        migrations::record_migration(
             conn,
             MIGRATION_001_ID,
             MIGRATION_001_CHECKSUM,
@@ -871,7 +850,7 @@ pub fn apply(conn: &Connection, hooks: &MigrationHooks) -> rusqlite::Result<()> 
     // #585: record which binary brought the schema current, so a stranded fleet is diagnosable.
     // Best-effort: the schema is already applied, and provenance is diagnostic — a stamp failure
     // must not fail the migration (the reader tolerates an absent record).
-    let _ = record_migration_provenance(conn);
+    let _ = migrations::record_migration_provenance(conn);
     Ok(())
 }
 
@@ -917,13 +896,13 @@ fn apply_and_record_migration(
 ) -> rusqlite::Result<()> {
     if !matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID) {
         step.apply.run(conn, hooks)?;
-        return record_migration(conn, step.id, step.checksum, step.description);
+        return migrations::record_migration(conn, step.id, step.checksum, step.description);
     }
 
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     step.apply.run(&tx, hooks)?;
     (hooks.backfill_authority_projection)(&tx)?;
-    record_migration(&tx, step.id, step.checksum, step.description)?;
+    migrations::record_migration(&tx, step.id, step.checksum, step.description)?;
     tx.commit()
 }
 
@@ -932,565 +911,565 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         id: MIGRATION_002_ID,
         checksum: MIGRATION_002_CHECKSUM,
         description: MIGRATION_002_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_embedding_vector_metadata),
+        apply: MigrationFn::Plain(migrations::apply_embedding_vector_metadata),
     },
     Migration {
         id: MIGRATION_003_ID,
         checksum: MIGRATION_003_CHECKSUM,
         description: MIGRATION_003_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_derived_artifact_reconcile_metadata),
+        apply: MigrationFn::Plain(migrations::apply_derived_artifact_reconcile_metadata),
     },
     Migration {
         id: MIGRATION_004_ID,
         checksum: MIGRATION_004_CHECKSUM,
         description: MIGRATION_004_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edge_source_target_spans),
+        apply: MigrationFn::Plain(migrations::apply_edge_source_target_spans),
     },
     Migration {
         id: MIGRATION_005_ID,
         checksum: MIGRATION_005_CHECKSUM,
         description: MIGRATION_005_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edge_evidence_and_resolution),
+        apply: MigrationFn::Plain(migrations::apply_edge_evidence_and_resolution),
     },
     Migration {
         id: MIGRATION_006_ID,
         checksum: MIGRATION_006_CHECKSUM,
         description: MIGRATION_006_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_embedding_policy_and_input_hash),
+        apply: MigrationFn::Plain(migrations::apply_embedding_policy_and_input_hash),
     },
     Migration {
         id: MIGRATION_007_ID,
         checksum: MIGRATION_007_CHECKSUM,
         description: MIGRATION_007_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_logical_symbol_groups),
+        apply: MigrationFn::Plain(migrations::apply_logical_symbol_groups),
     },
     Migration {
         id: MIGRATION_008_ID,
         checksum: MIGRATION_008_CHECKSUM,
         description: MIGRATION_008_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_commit_addressable_worktrees),
+        apply: MigrationFn::Plain(migrations::apply_commit_addressable_worktrees),
     },
     Migration {
         id: MIGRATION_009_ID,
         checksum: MIGRATION_009_CHECKSUM,
         description: MIGRATION_009_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_github_ref_sync),
+        apply: MigrationFn::Plain(migrations::apply_github_ref_sync),
     },
     Migration {
         id: MIGRATION_010_ID,
         checksum: MIGRATION_010_CHECKSUM,
         description: MIGRATION_010_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_symbol_facts),
+        apply: MigrationFn::Plain(migrations::apply_symbol_facts),
     },
     Migration {
         id: MIGRATION_011_ID,
         checksum: MIGRATION_011_CHECKSUM,
         description: MIGRATION_011_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_repo_memories),
+        apply: MigrationFn::Plain(migrations::apply_repo_memories),
     },
     Migration {
         id: MIGRATION_012_ID,
         checksum: MIGRATION_012_CHECKSUM,
         description: MIGRATION_012_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_repo_memory_call_paths),
+        apply: MigrationFn::Plain(migrations::apply_repo_memory_call_paths),
     },
     Migration {
         id: MIGRATION_013_ID,
         checksum: MIGRATION_013_CHECKSUM,
         description: MIGRATION_013_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_graph_file_lookup_indexes),
+        apply: MigrationFn::Plain(migrations::apply_graph_file_lookup_indexes),
     },
     Migration {
         id: MIGRATION_014_ID,
         checksum: MIGRATION_014_CHECKSUM,
         description: MIGRATION_014_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_memory_binding_signals),
+        apply: MigrationFn::Plain(migrations::apply_memory_binding_signals),
     },
     Migration {
         id: MIGRATION_015_ID,
         checksum: MIGRATION_015_CHECKSUM,
         description: MIGRATION_015_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_repo_memory_call_path_edges),
+        apply: MigrationFn::Plain(migrations::apply_repo_memory_call_path_edges),
     },
     Migration {
         id: MIGRATION_016_ID,
         checksum: MIGRATION_016_CHECKSUM,
         description: MIGRATION_016_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_symbol_line_spans),
+        apply: MigrationFn::Plain(migrations::apply_symbol_line_spans),
     },
     Migration {
         id: MIGRATION_017_ID,
         checksum: MIGRATION_017_CHECKSUM,
         description: MIGRATION_017_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edge_callee_byte_range),
+        apply: MigrationFn::Plain(migrations::apply_edge_callee_byte_range),
     },
     Migration {
         id: MIGRATION_018_ID,
         checksum: MIGRATION_018_CHECKSUM,
         description: MIGRATION_018_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_oracle_tables),
+        apply: MigrationFn::Plain(migrations::apply_oracle_tables),
     },
     Migration {
         id: MIGRATION_019_ID,
         checksum: MIGRATION_019_CHECKSUM,
         description: MIGRATION_019_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_scip_moniker_anchors),
+        apply: MigrationFn::Plain(migrations::apply_scip_moniker_anchors),
     },
     Migration {
         id: MIGRATION_020_ID,
         checksum: MIGRATION_020_CHECKSUM,
         description: MIGRATION_020_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edge_string_interning),
+        apply: MigrationFn::Plain(migrations::apply_edge_string_interning),
     },
     Migration {
         id: MIGRATION_021_ID,
         checksum: MIGRATION_021_CHECKSUM,
         description: MIGRATION_021_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_symbol_scope_path),
+        apply: MigrationFn::Plain(migrations::apply_symbol_scope_path),
     },
     Migration {
         id: MIGRATION_022_ID,
         checksum: MIGRATION_022_CHECKSUM,
         description: MIGRATION_022_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_per_package_import_scope),
+        apply: MigrationFn::Plain(migrations::apply_per_package_import_scope),
     },
     Migration {
         id: MIGRATION_023_ID,
         checksum: MIGRATION_023_CHECKSUM,
         description: MIGRATION_023_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edges_view_refresh),
+        apply: MigrationFn::Plain(migrations::apply_edges_view_refresh),
     },
     Migration {
         id: MIGRATION_024_ID,
         checksum: MIGRATION_024_CHECKSUM,
         description: MIGRATION_024_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_files_has_test_code),
+        apply: MigrationFn::Plain(migrations::apply_files_has_test_code),
     },
     Migration {
         id: MIGRATION_025_ID,
         checksum: MIGRATION_025_CHECKSUM,
         description: MIGRATION_025_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_chunk_text_compression_tables),
+        apply: MigrationFn::Plain(migrations::apply_chunk_text_compression_tables),
     },
     Migration {
         id: MIGRATION_026_ID,
         checksum: MIGRATION_026_CHECKSUM,
         description: MIGRATION_026_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_contentless_chunk_fts),
+        apply: MigrationFn::Plain(migrations::apply_contentless_chunk_fts),
     },
     Migration {
         id: MIGRATION_027_ID,
         checksum: MIGRATION_027_CHECKSUM,
         description: MIGRATION_027_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_drop_chunks_text),
+        apply: MigrationFn::Plain(migrations::apply_drop_chunks_text),
     },
     Migration {
         id: MIGRATION_028_ID,
         checksum: MIGRATION_028_CHECKSUM,
         description: MIGRATION_028_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_intern_symbol_qualified_names),
+        apply: MigrationFn::Plain(migrations::apply_intern_symbol_qualified_names),
     },
     Migration {
         id: MIGRATION_029_ID,
         checksum: MIGRATION_029_CHECKSUM,
         description: MIGRATION_029_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_fingerprint_tables),
+        apply: MigrationFn::Plain(migrations::apply_clone_fingerprint_tables),
     },
     Migration {
         id: MIGRATION_030_ID,
         checksum: MIGRATION_030_CHECKSUM,
         description: MIGRATION_030_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_refinements_lcs_sampled),
+        apply: MigrationFn::Plain(migrations::apply_clone_refinements_lcs_sampled),
     },
     Migration {
         id: MIGRATION_031_ID,
         checksum: MIGRATION_031_CHECKSUM,
         description: MIGRATION_031_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edge_oracle_content_anchor),
+        apply: MigrationFn::Plain(migrations::apply_edge_oracle_content_anchor),
     },
     Migration {
         id: MIGRATION_032_ID,
         checksum: MIGRATION_032_CHECKSUM,
         description: MIGRATION_032_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_token_bag_blob),
+        apply: MigrationFn::Plain(migrations::apply_token_bag_blob),
     },
     Migration {
         id: MIGRATION_033_ID,
         checksum: MIGRATION_033_CHECKSUM,
         description: MIGRATION_033_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_dream_findings),
+        apply: MigrationFn::Plain(migrations::apply_dream_findings),
     },
     Migration {
         id: MIGRATION_034_ID,
         checksum: MIGRATION_034_CHECKSUM,
         description: MIGRATION_034_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_graph_tables),
+        apply: MigrationFn::Plain(migrations::apply_clone_graph_tables),
     },
     Migration {
         id: MIGRATION_035_ID,
         checksum: MIGRATION_035_CHECKSUM,
         description: MIGRATION_035_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_symbols_is_test),
+        apply: MigrationFn::Plain(migrations::apply_symbols_is_test),
     },
     Migration {
         id: MIGRATION_036_ID,
         checksum: MIGRATION_036_CHECKSUM,
         description: MIGRATION_036_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_embedding_content_cache),
+        apply: MigrationFn::Plain(migrations::apply_embedding_content_cache),
     },
     Migration {
         id: MIGRATION_037_ID,
         checksum: MIGRATION_037_CHECKSUM,
         description: MIGRATION_037_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_subblock_postings_tables),
+        apply: MigrationFn::Plain(migrations::apply_clone_subblock_postings_tables),
     },
     Migration {
         id: MIGRATION_038_ID,
         checksum: MIGRATION_038_CHECKSUM,
         description: MIGRATION_038_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_repos_registry),
+        apply: MigrationFn::Plain(migrations::apply_repos_registry),
     },
     Migration {
         id: MIGRATION_039_ID,
         checksum: MIGRATION_039_CHECKSUM,
         description: MIGRATION_039_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_move_per_repo_meta),
+        apply: MigrationFn::Plain(migrations::apply_move_per_repo_meta),
     },
     Migration {
         id: MIGRATION_040_ID,
         checksum: MIGRATION_040_CHECKSUM,
         description: MIGRATION_040_DESCRIPTION,
-        apply: MigrationFn::WithHooks(apply_repo_id_core_scoping),
+        apply: MigrationFn::WithHooks(migrations::apply_repo_id_core_scoping),
     },
     Migration {
         id: MIGRATION_041_ID,
         checksum: MIGRATION_041_CHECKSUM,
         description: MIGRATION_041_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_github_repo_id_scoping),
+        apply: MigrationFn::Plain(migrations::apply_github_repo_id_scoping),
     },
     Migration {
         id: MIGRATION_042_ID,
         checksum: MIGRATION_042_CHECKSUM,
         description: MIGRATION_042_DESCRIPTION,
-        apply: MigrationFn::WithHooks(apply_repo_id_periphery_scoping),
+        apply: MigrationFn::WithHooks(migrations::apply_repo_id_periphery_scoping),
     },
     Migration {
         id: MIGRATION_043_ID,
         checksum: MIGRATION_043_CHECKSUM,
         description: MIGRATION_043_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_files_generation),
+        apply: MigrationFn::Plain(migrations::apply_files_generation),
     },
     Migration {
         id: MIGRATION_044_ID,
         checksum: MIGRATION_044_CHECKSUM,
         description: MIGRATION_044_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_github_natural_key_widening),
+        apply: MigrationFn::Plain(migrations::apply_github_natural_key_widening),
     },
     Migration {
         id: MIGRATION_045_ID,
         checksum: MIGRATION_045_CHECKSUM,
         description: MIGRATION_045_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_github_child_key_widening),
+        apply: MigrationFn::Plain(migrations::apply_github_child_key_widening),
     },
     Migration {
         id: MIGRATION_046_ID,
         checksum: MIGRATION_046_CHECKSUM,
         description: MIGRATION_046_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_memory_verification_tables),
+        apply: MigrationFn::Plain(migrations::apply_memory_verification_tables),
     },
     Migration {
         id: MIGRATION_047_ID,
         checksum: MIGRATION_047_CHECKSUM,
         description: MIGRATION_047_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_memory_model_failures_table),
+        apply: MigrationFn::Plain(migrations::apply_memory_model_failures_table),
     },
     Migration {
         id: MIGRATION_048_ID,
         checksum: MIGRATION_048_CHECKSUM,
         description: MIGRATION_048_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_memory_payload_json),
+        apply: MigrationFn::Plain(migrations::apply_memory_payload_json),
     },
     Migration {
         id: MIGRATION_049_ID,
         checksum: MIGRATION_049_CHECKSUM,
         description: MIGRATION_049_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_repo_node_edges),
+        apply: MigrationFn::Plain(migrations::apply_repo_node_edges),
     },
     Migration {
         id: MIGRATION_050_ID,
         checksum: MIGRATION_050_CHECKSUM,
         description: MIGRATION_050_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_delta_maintenance),
+        apply: MigrationFn::Plain(migrations::apply_clone_delta_maintenance),
     },
     Migration {
         id: MIGRATION_051_ID,
         checksum: MIGRATION_051_CHECKSUM,
         description: MIGRATION_051_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_df_epoch),
+        apply: MigrationFn::Plain(migrations::apply_clone_df_epoch),
     },
     Migration {
         id: MIGRATION_052_ID,
         checksum: MIGRATION_052_CHECKSUM,
         description: MIGRATION_052_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_oplog_storage),
+        apply: MigrationFn::Plain(migrations::apply_oplog_storage),
     },
     Migration {
         id: MIGRATION_053_ID,
         checksum: MIGRATION_053_CHECKSUM,
         description: MIGRATION_053_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_oplog_stream_scoping),
+        apply: MigrationFn::Plain(migrations::apply_oplog_stream_scoping),
     },
     Migration {
         id: MIGRATION_054_ID,
         checksum: MIGRATION_054_CHECKSUM,
         description: MIGRATION_054_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_oplog_device_identity),
+        apply: MigrationFn::Plain(migrations::apply_oplog_device_identity),
     },
     Migration {
         id: MIGRATION_055_ID,
         checksum: MIGRATION_055_CHECKSUM,
         description: MIGRATION_055_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_binding_downgrade_marker),
+        apply: MigrationFn::Plain(migrations::apply_binding_downgrade_marker),
     },
     Migration {
         id: MIGRATION_056_ID,
         checksum: MIGRATION_056_CHECKSUM,
         description: MIGRATION_056_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_git_change_couplings),
+        apply: MigrationFn::Plain(migrations::apply_git_change_couplings),
     },
     Migration {
         id: MIGRATION_057_ID,
         checksum: MIGRATION_057_CHECKSUM,
         description: MIGRATION_057_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_external_symbols),
+        apply: MigrationFn::Plain(migrations::apply_external_symbols),
     },
     Migration {
         id: MIGRATION_058_ID,
         checksum: MIGRATION_058_CHECKSUM,
         description: MIGRATION_058_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_oplog_device_x25519),
+        apply: MigrationFn::Plain(migrations::apply_oplog_device_x25519),
     },
     Migration {
         id: MIGRATION_059_ID,
         checksum: MIGRATION_059_CHECKSUM,
         description: MIGRATION_059_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_account_candidate_dag),
+        apply: MigrationFn::Plain(migrations::apply_account_candidate_dag),
     },
     Migration {
         id: MIGRATION_060_ID,
         checksum: MIGRATION_060_CHECKSUM,
         description: MIGRATION_060_DESCRIPTION,
-        apply: MigrationFn::WithHooks(apply_papertrail_provider_neutral_schema),
+        apply: MigrationFn::WithHooks(migrations::apply_papertrail_provider_neutral_schema),
     },
     Migration {
         id: MIGRATION_061_ID,
         checksum: MIGRATION_061_CHECKSUM,
         description: MIGRATION_061_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_papertrail_ref_item_kind),
+        apply: MigrationFn::Plain(migrations::apply_papertrail_ref_item_kind),
     },
     Migration {
         id: MIGRATION_062_ID,
         checksum: MIGRATION_062_CHECKSUM,
         description: MIGRATION_062_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_papertrail_comment_cursor),
+        apply: MigrationFn::Plain(migrations::apply_papertrail_comment_cursor),
     },
     Migration {
         id: MIGRATION_063_ID,
         checksum: MIGRATION_063_CHECKSUM,
         description: MIGRATION_063_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_papertrail_mirror_resume_state),
+        apply: MigrationFn::Plain(migrations::apply_papertrail_mirror_resume_state),
     },
     Migration {
         id: MIGRATION_064_ID,
         checksum: MIGRATION_064_CHECKSUM,
         description: MIGRATION_064_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_account_authority_projection),
+        apply: MigrationFn::Plain(migrations::apply_account_authority_projection),
     },
     Migration {
         id: MIGRATION_065_ID,
         checksum: MIGRATION_065_CHECKSUM,
         description: MIGRATION_065_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_account_authority_boundaries),
+        apply: MigrationFn::Plain(migrations::apply_account_authority_boundaries),
     },
     Migration {
         id: MIGRATION_066_ID,
         checksum: MIGRATION_066_CHECKSUM,
         description: MIGRATION_066_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_content_candidate_dag),
+        apply: MigrationFn::Plain(migrations::apply_content_candidate_dag),
     },
     Migration {
         id: MIGRATION_067_ID,
         checksum: MIGRATION_067_CHECKSUM,
         description: MIGRATION_067_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_papertrail_binding_health),
+        apply: MigrationFn::Plain(migrations::apply_papertrail_binding_health),
     },
     Migration {
         id: MIGRATION_068_ID,
         checksum: MIGRATION_068_CHECKSUM,
         description: MIGRATION_068_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edges_view_refresh),
+        apply: MigrationFn::Plain(migrations::apply_edges_view_refresh),
     },
     Migration {
         id: MIGRATION_069_ID,
         checksum: MIGRATION_069_CHECKSUM,
         description: MIGRATION_069_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_oplog_local_account),
+        apply: MigrationFn::Plain(migrations::apply_oplog_local_account),
     },
     Migration {
         id: MIGRATION_070_ID,
         checksum: MIGRATION_070_CHECKSUM,
         description: MIGRATION_070_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_content_projected_tables),
+        apply: MigrationFn::Plain(migrations::apply_content_projected_tables),
     },
     Migration {
         id: MIGRATION_071_ID,
         checksum: MIGRATION_071_CHECKSUM,
         description: MIGRATION_071_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edge_target_qname_index),
+        apply: MigrationFn::Plain(migrations::apply_edge_target_qname_index),
     },
     Migration {
         id: MIGRATION_072_ID,
         checksum: MIGRATION_072_CHECKSUM,
         description: MIGRATION_072_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_content_streams_pending_refold),
+        apply: MigrationFn::Plain(migrations::apply_content_streams_pending_refold),
     },
     Migration {
         id: MIGRATION_073_ID,
         checksum: MIGRATION_073_CHECKSUM,
         description: MIGRATION_073_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_papertrail_distill_substrate),
+        apply: MigrationFn::Plain(migrations::apply_papertrail_distill_substrate),
     },
     Migration {
         id: MIGRATION_074_ID,
         checksum: MIGRATION_074_CHECKSUM,
         description: MIGRATION_074_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edges_view_scalar_suppression),
+        apply: MigrationFn::Plain(migrations::apply_edges_view_scalar_suppression),
     },
     Migration {
         id: MIGRATION_075_ID,
         checksum: MIGRATION_075_CHECKSUM,
         description: MIGRATION_075_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_edges_hidden_flag),
+        apply: MigrationFn::Plain(migrations::apply_edges_hidden_flag),
     },
     Migration {
         id: MIGRATION_076_ID,
         checksum: MIGRATION_076_CHECKSUM,
         description: MIGRATION_076_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_sync_security_events),
+        apply: MigrationFn::Plain(migrations::apply_sync_security_events),
     },
     Migration {
         id: MIGRATION_077_ID,
         checksum: MIGRATION_077_CHECKSUM,
         description: MIGRATION_077_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_distill_record_store),
+        apply: MigrationFn::Plain(migrations::apply_distill_record_store),
     },
     Migration {
         id: MIGRATION_078_ID,
         checksum: MIGRATION_078_CHECKSUM,
         description: MIGRATION_078_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_distill_anchor_selection),
+        apply: MigrationFn::Plain(migrations::apply_distill_anchor_selection),
     },
     Migration {
         id: MIGRATION_079_ID,
         checksum: MIGRATION_079_CHECKSUM,
         description: MIGRATION_079_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_distill_safe_input_snapshot),
+        apply: MigrationFn::Plain(migrations::apply_distill_safe_input_snapshot),
     },
     Migration {
         id: MIGRATION_080_ID,
         checksum: MIGRATION_080_CHECKSUM,
         description: MIGRATION_080_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_distill_enriched_context),
+        apply: MigrationFn::Plain(migrations::apply_distill_enriched_context),
     },
     Migration {
         id: MIGRATION_081_ID,
         checksum: MIGRATION_081_CHECKSUM,
         description: MIGRATION_081_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_distill_evidence_source_part),
+        apply: MigrationFn::Plain(migrations::apply_distill_evidence_source_part),
     },
     Migration {
         id: MIGRATION_082_ID,
         checksum: MIGRATION_082_CHECKSUM,
         description: MIGRATION_082_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_content_refold_queue_and_stats),
+        apply: MigrationFn::Plain(migrations::apply_content_refold_queue_and_stats),
     },
     Migration {
         id: MIGRATION_083_ID,
         checksum: MIGRATION_083_CHECKSUM,
         description: MIGRATION_083_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_logical_group_reason_by_evidence),
+        apply: MigrationFn::Plain(migrations::apply_logical_group_reason_by_evidence),
     },
     Migration {
         id: MIGRATION_084_ID,
         checksum: MIGRATION_084_CHECKSUM,
         description: MIGRATION_084_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_chunk_symbol_id),
+        apply: MigrationFn::Plain(migrations::apply_chunk_symbol_id),
     },
     Migration {
         id: MIGRATION_085_ID,
         checksum: MIGRATION_085_CHECKSUM,
         description: MIGRATION_085_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_sync_origin_and_edge_tombstone),
+        apply: MigrationFn::Plain(migrations::apply_sync_origin_and_edge_tombstone),
     },
     Migration {
         id: MIGRATION_086_ID,
         checksum: MIGRATION_086_CHECKSUM,
         description: MIGRATION_086_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_content_digest_state),
+        apply: MigrationFn::Plain(migrations::apply_content_digest_state),
     },
     Migration {
         id: MIGRATION_087_ID,
         checksum: MIGRATION_087_CHECKSUM,
         description: MIGRATION_087_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_table_sync_tables),
+        apply: MigrationFn::Plain(migrations::apply_table_sync_tables),
     },
     Migration {
         id: MIGRATION_088_ID,
         checksum: MIGRATION_088_CHECKSUM,
         description: MIGRATION_088_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_clone_postings_row_count),
+        apply: MigrationFn::Plain(migrations::apply_clone_postings_row_count),
     },
     Migration {
         id: MIGRATION_089_ID,
         checksum: MIGRATION_089_CHECKSUM,
         description: MIGRATION_089_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_sync_invites),
+        apply: MigrationFn::Plain(migrations::apply_sync_invites),
     },
     Migration {
         id: MIGRATION_090_ID,
         checksum: MIGRATION_090_CHECKSUM,
         description: MIGRATION_090_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_account_candidate_reservations),
+        apply: MigrationFn::Plain(migrations::apply_account_candidate_reservations),
     },
     Migration {
         id: MIGRATION_091_ID,
         checksum: MIGRATION_091_CHECKSUM,
         description: MIGRATION_091_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_account_candidate_reservation_targets),
+        apply: MigrationFn::Plain(migrations::apply_account_candidate_reservation_targets),
     },
     Migration {
         id: MIGRATION_092_ID,
         checksum: MIGRATION_092_CHECKSUM,
         description: MIGRATION_092_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_sync_invites_normalized_receipts),
+        apply: MigrationFn::Plain(migrations::apply_sync_invites_normalized_receipts),
     },
     Migration {
         id: MIGRATION_093_ID,
         checksum: MIGRATION_093_CHECKSUM,
         description: MIGRATION_093_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_table_sync_projection_state),
+        apply: MigrationFn::Plain(migrations::apply_table_sync_projection_state),
     },
     Migration {
         id: MIGRATION_094_ID,
         checksum: MIGRATION_094_CHECKSUM,
         description: MIGRATION_094_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_lens_enrichment_revision),
+        apply: MigrationFn::Plain(migrations::apply_lens_enrichment_revision),
     },
     Migration {
         id: MIGRATION_095_ID,
         checksum: MIGRATION_095_CHECKSUM,
         description: MIGRATION_095_DESCRIPTION,
-        apply: MigrationFn::Plain(apply_table_sync_spec_version),
+        apply: MigrationFn::Plain(migrations::apply_table_sync_spec_version),
     },
 ];
 
@@ -1514,7 +1493,7 @@ pub fn migrate_forward(conn: &Connection, hooks: &MigrationHooks) -> anyhow::Res
     // and never breaks the loser-discipline "nothing owed ⇒ write nothing" guarantee below.
     crate::content_digest::register_content_digest_fold(conn)?;
     let applied: std::collections::HashSet<String> =
-        applied_migrations(conn)?.into_iter().map(|migration| migration.id).collect();
+        migrations::applied_migrations(conn)?.into_iter().map(|migration| migration.id).collect();
     if applied.contains(MIGRATION_001_ID)
         && ADDITIVE_MIGRATIONS.iter().all(|step| applied.contains(step.id))
     {
@@ -1529,7 +1508,7 @@ pub fn migrate_forward(conn: &Connection, hooks: &MigrationHooks) -> anyhow::Res
     // #585: this path only runs when a forward migration actually happened (early-returned above
     // otherwise) — stamp who did it (the shared-store stranding path). Best-effort: the migration
     // has committed; a diagnostic stamp failure must not fail it (the reader tolerates absence).
-    let _ = record_migration_provenance(conn);
+    let _ = migrations::record_migration_provenance(conn);
     Ok(())
 }
 
@@ -1572,35 +1551,35 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
         });
     }
 
-    let migrations = applied_migrations(conn)?;
-    if migrations.iter().any(|migration| migration.id == DIRTY_MIGRATION_ID) {
+    let applied = migrations::applied_migrations(conn)?;
+    if applied.iter().any(|migration| migration.id == DIRTY_MIGRATION_ID) {
         return Ok(SchemaStatus {
             state: SchemaState::Dirty,
-            current_version: known_version(&migrations),
+            current_version: migrations::known_version(&applied),
             latest_version: LATEST_SCHEMA_VERSION,
-            migrations,
+            migrations: applied,
             message: "dirty or partial schema migration detected; rebuild the derived index with \
                       `rag-rat index --full`"
                 .to_string(),
         });
     }
-    if migrations.iter().any(migration_checksum_mismatch) {
+    if applied.iter().any(migrations::migration_checksum_mismatch) {
         return Ok(SchemaStatus {
             state: SchemaState::Dirty,
-            current_version: known_version(&migrations),
+            current_version: migrations::known_version(&applied),
             latest_version: LATEST_SCHEMA_VERSION,
-            migrations,
+            migrations: applied,
             message: "schema migration checksum mismatch; refusing to open, rebuild the derived \
                       index with `rag-rat index --full`"
                 .to_string(),
         });
     }
-    if migrations.iter().any(|migration| !known_migration(&migration.id)) {
+    if applied.iter().any(|migration| !migrations::known_migration(&migration.id)) {
         return Ok(SchemaStatus {
             state: SchemaState::Newer,
-            current_version: known_version(&migrations),
+            current_version: migrations::known_version(&applied),
             latest_version: LATEST_SCHEMA_VERSION,
-            migrations,
+            migrations: applied,
             // #484/#585: on a shared global DB one upgraded agent migrates the schema and every
             // process still on an older binary lands here — the refusal must carry the remedy AND
             // name this binary's schema ceiling + WHO migrated the store (from provenance), because
@@ -1611,17 +1590,17 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
                  supports up to schema v{LATEST_SCHEMA_VERSION}, so upgrade rag-rat or restart \
                  sessions/servers still running an older binary{}{}",
                 hot_upgrade_caveat(),
-                migration_provenance_note(conn),
+                migrations::migration_provenance_note(conn),
             ),
         });
     }
-    let current_version = known_version(&migrations);
+    let current_version = migrations::known_version(&applied);
     if current_version < LATEST_SCHEMA_VERSION {
         return Ok(SchemaStatus {
             state: SchemaState::Older,
             current_version,
             latest_version: LATEST_SCHEMA_VERSION,
-            migrations,
+            migrations: applied,
             message: "index schema is older than this rag-rat; it migrates forward automatically \
                       on open (or rebuild with `rag-rat index --full`)"
                 .to_string(),
@@ -1631,7 +1610,7 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
         state: SchemaState::Compatible,
         current_version,
         latest_version: LATEST_SCHEMA_VERSION,
-        migrations,
+        migrations: applied,
         message: "schema is compatible".to_string(),
     })
 }
@@ -1690,8 +1669,9 @@ pub fn ensure_compatible_or_migrate(
 
 /// Registering a migration takes six coordinated edits — the `MIGRATION_0NN_{ID,CHECKSUM,
 /// DESCRIPTION}` consts, the [`ADDITIVE_MIGRATIONS`] entry, [`LATEST_SCHEMA_VERSION`], and three
-/// separate recognizers in `migrations.rs` ([`known_version`], [`known_migration`],
-/// [`migration_checksum_mismatch`]) — and only the first two fail to compile when forgotten.
+/// separate recognizers in `migrations.rs` ([`migrations::known_version`],
+/// [`migrations::known_migration`], [`migrations::migration_checksum_mismatch`]) — and only the
+/// first two fail to compile when forgotten.
 ///
 /// These tests make the remaining four mechanical by ranging over the shipped ladder itself, so a
 /// new migration is checked automatically. The `known_migration` arm is the one that is otherwise
@@ -1721,10 +1701,11 @@ mod migration_arming {
         }
     }
 
-    /// The version [`known_version`] assigns to `id` on its own, or `None` when no arm claims it.
+    /// The version [`migrations::known_version`] assigns to `id` on its own, or `None` when no arm
+    /// claims it.
     /// No migration maps to 0, so the `unwrap_or(0)` floor is an unambiguous "unarmed".
     fn armed_version(id: &str) -> Option<u32> {
-        match known_version(&[ledger_row(id, "")]) {
+        match migrations::known_version(&[ledger_row(id, "")]) {
             0 => None,
             version => Some(version),
         }
@@ -1745,7 +1726,7 @@ mod migration_arming {
     fn every_shipped_migration_is_a_known_migration() {
         for (id, _) in shipped_ladder() {
             assert!(
-                known_migration(id),
+                migrations::known_migration(id),
                 "{id} is missing from `known_migration`, so its own ledger row reads as written \
                  by a future binary and `status` refuses the store as `Newer`",
             );
@@ -1753,20 +1734,26 @@ mod migration_arming {
         // The dirty marker is not a migration and has no version or checksum arm, but it rides the
         // same roster: drop it and a crashed migration's marker reads as `Newer` instead of
         // `Dirty`, which names the wrong remedy.
-        assert!(known_migration(DIRTY_MIGRATION_ID), "the dirty marker stays a recognized id");
+        assert!(
+            migrations::known_migration(DIRTY_MIGRATION_ID),
+            "the dirty marker stays a recognized id"
+        );
     }
 
     #[test]
     fn every_shipped_migration_has_a_checksum_arm() {
         for (id, checksum) in shipped_ladder() {
             assert!(
-                !migration_checksum_mismatch(&ledger_row(id, checksum)),
+                !migrations::migration_checksum_mismatch(&ledger_row(id, checksum)),
                 "{id} at its shipped checksum must not read as tampered",
             );
             // The load-bearing direction: the `_ => false` catch-all silently accepts ANY checksum
             // for an unarmed id, so a store whose migration body changed under it opens clean.
             assert!(
-                migration_checksum_mismatch(&ledger_row(id, &format!("{checksum}-tampered"))),
+                migrations::migration_checksum_mismatch(&ledger_row(
+                    id,
+                    &format!("{checksum}-tampered")
+                )),
                 "{id} has no `migration_checksum_mismatch` arm, so a changed migration body is \
                  never detected",
             );

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -8,7 +8,8 @@
 //! Phase 1 is **eval-only**: no CLI command, no MCP tool (those are #69). It reads a `.scip`,
 //! joins occurrences against edge candidates, writes `edge_oracle` side rows, and emits
 //! precision/recall metrics. The heuristic resolution on the `edges` row is **never** overwritten —
-//! both coexist so eval can diff them (see [`rag_rat_db::schema::apply_oracle_tables`]).
+//! both coexist so eval can diff them (see
+//! [`rag_rat_db::schema::migrations::apply_oracle_tables`]).
 //!
 //! Layout mirrors `index/ai/`:
 //! - `scip.rs`  — `.scip` reader: per-document `position_encoding`-aware occurrence + definition

--- a/crates/rag-rat-oracle/src/tests/edge_view.rs
+++ b/crates/rag-rat-oracle/src/tests/edge_view.rs
@@ -153,7 +153,7 @@ fn v020_converts_a_legacy_edges_table() {
     )
     .unwrap();
 
-    schema::apply_edge_string_interning(&conn).unwrap();
+    schema::migrations::apply_edge_string_interning(&conn).unwrap();
 
     let (to_name, evidence, resolution): (String, String, String) = conn
         .query_row("SELECT to_name, evidence, resolution FROM edges WHERE id = 7", [], |row| {

--- a/crates/rag-rat-papertrail/src/distill_read.rs
+++ b/crates/rag-rat-papertrail/src/distill_read.rs
@@ -497,9 +497,9 @@ mod tests {
 
     fn conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
-        rag_rat_db::schema::apply_distill_record_store(&conn).unwrap();
+        rag_rat_db::schema::migrations::apply_distill_record_store(&conn).unwrap();
         // V078 adds the anchor `selected` flag that `records_for_symbol` gates on.
-        rag_rat_db::schema::apply_distill_anchor_selection(&conn).unwrap();
+        rag_rat_db::schema::migrations::apply_distill_anchor_selection(&conn).unwrap();
         conn
     }
 

--- a/crates/rag-rat-papertrail/src/evidence.rs
+++ b/crates/rag-rat-papertrail/src/evidence.rs
@@ -464,7 +464,7 @@ mod payload_tests {
     #[test]
     fn attach_records_populates_hits_from_the_store_and_leaves_bare_hits_bare() {
         let conn = Connection::open_in_memory().unwrap();
-        rag_rat_db::schema::apply_distill_record_store(&conn).unwrap();
+        rag_rat_db::schema::migrations::apply_distill_record_store(&conn).unwrap();
         conn.execute_batch(
             "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
         )


### PR DESCRIPTION
## What

`schema/mod.rs` re-exported the ~54 individual `apply_*` migration-ladder steps by name, on top of a `pub(crate) use migrations::*` glob. Callers now reach them through the module instead: `schema::migrations::apply_oplog_storage(conn)`.

## Why

Two costs to the old shape:

- a call site in another crate read `schema::apply_oplog_storage(conn)`, which looks like a local function rather than one step of the schema ladder;
- every new migration had to be threaded into a hand-maintained alphabetical list that nothing enforced.

`column_exists`, `table_exists`, and `rebuild_repo_memory_fts_with_repo_id` stay on the `schema` surface — they are general-purpose predicates, not ladder steps.

## Public surface is unchanged

Making the module public would otherwise have widened the API by three steps the old re-export list deliberately omitted — `apply_edges_view_scalar_suppression`, `apply_edges_hidden_flag`, and `apply_sync_security_events`. They are now `pub(crate)`, so the exported set is the same 57 items as before.

`rag_rat_db::schema::apply_*` paths are source-incompatible for any out-of-workspace consumer; every in-workspace caller is migrated in this change.

## Also

`baseline.rs` picked its migration helpers out of the same glob via `use super::*`; it now names what it imports. In `status`, the local holding the applied-migration ledger is renamed off `migrations`, which now also names the module.

## Verification

No behavior change: the ladder, its order, and every migration id and checksum are untouched.

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` — exit 0
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — exit 0
- `cargo nextest run --workspace` — 4415 passed, 7 skipped
- `cargo test -p rag-rat-db -p rag-rat-papertrail -p rag-rat-oracle` — passed
- `cargo doc --workspace --no-deps` — exit 0, no new unresolved links