### PR TITLE
docs: document Go language support

### DIFF
--- a/.agents/skills/using-rag-rat/SKILL.md
+++ b/.agents/skills/using-rag-rat/SKILL.md
@@ -22,8 +22,8 @@ Prefer these over `grep`/`cat`/file sweeps when browsing or understanding code:
 
 - **`semantic_search`** — "where is this concept implemented?" Current source chunks with inline
   graph, git, and papertrail.
-- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python), with any bound
-  memories attached.
+- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python/Swift/Go), with
+  any bound memories attached.
 - **`impact_surface`** — the **coding preflight before editing any non-trivial symbol**: callers,
   callees, tests, git history, papertrail, and the repo memories crossing that call path. Run it
   before you change something load-bearing — it's how you avoid missing an invariant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Reach for these first:
 
 - **`semantic_search`** — "where is this concept implemented?" Returns current source chunks with
   inline graph (callers/callees), git, and GitHub papertrail, all validated against current source.
-- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python), with any bound
-  memories attached.
+- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python/Swift/Go), with
+  any bound memories attached.
 - **`impact_surface`** — the coding preflight before editing a symbol: graph callers/callees,
   tests, git history, papertrail, and **repo memories** crossing the call path. Run it before
   changing anything non-trivial.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sequenceDiagram
   are *not* assistant memory: they are versioned, local, source-anchored facts about **this**
   repository that any future agent retrieves with evidence.
 - **A real code graph.** tree-sitter callers/callees/imports across Rust, TypeScript/TSX, Kotlin,
-  C/C++, Python, and Swift — with an optional [compiler-grade SCIP oracle](docs/oracle.md) for
+  C/C++, Python, Swift, and Go — with an optional [compiler-grade SCIP oracle](docs/oracle.md) for
   configured toolchains that upgrades edges to `Compiler` confidence and ranks the load-bearing
   symbols.
 - **History as evidence.** Git history, lazy chunk blame, and cached GitHub issue/PR/review

--- a/docs/config/targets.md
+++ b/docs/config/targets.md
@@ -10,11 +10,13 @@ rust = ["crates/app/src"]
 typescript = ["apps/mobile/src"]
 kotlin = ["apps/wear-bridge/src"]
 cpp = ["include", "src"]
+go = ["cmd", "internal"]
 markdown = ["docs"]
 ```
 
 A simple binding indexes each language's default extensions in the listed directories
-(`rust` → `.rs`, `typescript` → `.ts`/`.tsx`, `python` → `.py`/`.pyi`, `c` → `.c`/`.h`, etc.).
+(`rust` → `.rs`, `typescript` → `.ts`/`.tsx`, `python` → `.py`/`.pyi`, `c` → `.c`/`.h`,
+`go` → `.go`, etc.).
 The one ambiguous case is the `.h` header: with no binding it is detected as **C** (the safe
 default), but an explicit `cpp` binding also claims `.h` in its directories and indexes those headers
 as **C++**. This is what lets a C++ library whose API lives in `.h` files (most of them) get header
@@ -33,14 +35,14 @@ include = ["**/*.ts"]
 exclude = ["**/*.map"]
 ```
 
-Supported languages are `rust`, `typescript`, `kotlin`, `c`, `cpp`, `python`, `swift`, and
-`markdown`. Rust, TypeScript/TSX, Kotlin, C, C++, Python, and Swift source use tree-sitter structural
-indexing when files are under the parser size cap.
+Supported languages are `rust`, `typescript`, `kotlin`, `c`, `cpp`, `python`, `swift`, `go`, and
+`markdown`. Rust, TypeScript/TSX, Kotlin, C, C++, Python, Swift, and Go source use tree-sitter
+structural indexing when files are under the parser size cap.
 Markdown uses heading-section chunking and does not use tree-sitter. Supported target kinds are
 `source`, `generated`, `docs`, and `tests`; generated targets are indexed with coarse chunks and
 still obey `include_generated` filtering.
 
-Parser grammar dependencies are exact-pinned in `Cargo.toml`: `tree-sitter` 0.26.9,
+Parser grammar dependencies are exact-pinned in `Cargo.toml`: `tree-sitter` 0.26.11,
 `tree-sitter-rust` 0.24.2, `tree-sitter-typescript` 0.23.2, `tree-sitter-kotlin-ng` 1.1.0,
-`tree-sitter-c` 0.24.2, `tree-sitter-cpp` 0.23.4, `tree-sitter-python` 0.25.0, and
-`tree-sitter-swift` 0.7.3.
+`tree-sitter-c` 0.24.2, `tree-sitter-cpp` 0.23.4, `tree-sitter-python` 0.25.0,
+`tree-sitter-swift` 0.7.3, and `tree-sitter-go` 0.25.0.

--- a/plugin/skills/using-rag-rat/SKILL.md
+++ b/plugin/skills/using-rag-rat/SKILL.md
@@ -22,8 +22,8 @@ Prefer these over `grep`/`cat`/file sweeps when browsing or understanding code:
 
 - **`semantic_search`** — "where is this concept implemented?" Current source chunks with inline
   graph, git, and papertrail.
-- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python), with any bound
-  memories attached.
+- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python/Swift/Go), with
+  any bound memories attached.
 - **`impact_surface`** — the **coding preflight before editing any non-trivial symbol**: callers,
   callees, tests, git history, papertrail, and the repo memories crossing that call path. Run it
   before you change something load-bearing — it's how you avoid missing an invariant.


### PR DESCRIPTION
Go joined the language registry in #994 but the docs still enumerated eight languages. This updates every place that lists what rag-rat can parse.

- **README** — Go in the code-graph language list.
- **docs/config/targets.md** — `go` in the supported-language list and the `[target_bindings]` example, `.go` in the default-extension mapping, `tree-sitter-go` 0.25.0 in the grammar pins. Also corrects the `tree-sitter` core pin, which had drifted out of date (0.26.9 → 0.26.11).
- **AGENTS.md** and the `using-rag-rat` skill (both the `.agents/` and `plugin/` copies) — Go and Swift added to the `symbol_lookup` language list, which was also missing Swift.

`docs/oracle.md` is unchanged: there is no SCIP oracle backend for Go, so the tool list there is still accurate.

Docs only, no code changes.