### PR TITLE
feat(sync): retain and promote gapped table-sync chain entries

### DIFF
--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -573,6 +573,17 @@ mod tests {
             params![vec![seed; 32], stream_id, vec![seed; 32], vec![seed; 8]],
         )
         .unwrap();
+        // The gapped half of the log is swept through the same directory, so it needs its own seed
+        // row or the assertion below passes on an empty table.
+        conn.execute(
+            "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+             lamport, prev_hash, signed_bytes, gapped_at_ms) VALUES (?1, ?2, ?3, 2, ?4, ?5, 0)",
+            params![vec![seed ^ 0xff; 32], stream_id, vec![seed; 32], vec![seed; 32], vec![
+                seed;
+                8
+            ]],
+        )
+        .unwrap();
         stream_id
     }
 
@@ -622,6 +633,7 @@ mod tests {
             ("clone_subblock_postings", "build_generation", generation_in.clone()),
             ("clone_df_epoch", "build_generation", generation_in),
             ("table_sync_entries", "stream_id", blob_literal(stream_id)),
+            ("table_sync_gapped_entries", "stream_id", blob_literal(stream_id)),
         ];
         for (table, column, in_body) in checks {
             let count: i64 = conn
@@ -811,6 +823,17 @@ mod tests {
             )
             .unwrap();
         assert_eq!(a_entries, 1, "the sibling's stream-keyed entries survive the scoped purge");
+        let a_gapped: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM table_sync_gapped_entries WHERE stream_id = {}",
+                    blob_literal(&a_stream)
+                ),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(a_gapped, 1, "the sibling's entries awaiting a predecessor survive it too");
         let edge_exists = |id: i64| -> bool {
             conn.query_row("SELECT EXISTS(SELECT 1 FROM edges_data WHERE id = ?1)", [id], |row| {
                 row.get(0)

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1473,12 +1473,116 @@ fn migration_092_normalizes_invite_receipts() {
     assert_eq!(recorded, 1, "the forward migration records V092");
 }
 
+/// V096 (#1058) adds the table holding entries whose chain predecessor has not arrived.
+///
+/// Asserted against the migration's own DDL on a bare connection, not the full ladder's end state:
+/// the directory rule for this suite is that a table's arrival is proved by the step that creates
+/// it, so the assertion keeps meaning something when a later migration also touches it.
+#[test]
+fn migration_096_holds_entries_awaiting_a_chain_predecessor() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 96, "move this pin with the next schema migration");
+
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    assert!(
+        !schema::table_exists(&bare, "table_sync_gapped_entries").unwrap(),
+        "the table arrives with V096, not before"
+    );
+    schema::migrations::apply_table_sync_gapped_entries(&bare).unwrap();
+    schema::migrations::apply_table_sync_gapped_entries(&bare).expect("replay is a no-op");
+    assert!(schema::table_exists(&bare, "table_sync_gapped_entries").unwrap());
+
+    // A held entry always cites a predecessor — a genesis can never gap — so the column is NOT
+    // NULL.
+    let without_predecessor = bare.execute(
+        "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+         lamport, prev_hash, signed_bytes, gapped_at_ms)
+         VALUES (X'01', X'02', X'03', 1, NULL, X'04', 0)",
+        [],
+    );
+    assert!(without_predecessor.is_err(), "a held entry always names the predecessor it waits on");
+
+    // Two equivocating siblings at ONE lamport must both be storable, or whichever arrived first
+    // would block the legitimate one. Identity is the entry hash alone.
+    bare.execute(
+        "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+         lamport, prev_hash, signed_bytes, gapped_at_ms)
+         VALUES (X'01', X'02', X'03', 1, X'09', X'04', 0)",
+        [],
+    )
+    .unwrap();
+    bare.execute(
+        "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+         lamport, prev_hash, signed_bytes, gapped_at_ms)
+         VALUES (X'99', X'02', X'03', 1, X'09', X'04', 0)",
+        [],
+    )
+    .expect("a second entry at the same lamport is a fork to resolve later, not a refusal now");
+
+    // Both indexes carry explicit rationale in the DDL — one serves the promote walks, the other
+    // the cap's count and eviction — and no behavioral test can observe a missing index, only a
+    // slower one. Pin them.
+    for index in [
+        "table_sync_gapped_entries_child",
+        "table_sync_gapped_entries_chain_lamport",
+        "table_sync_gapped_entries_predecessor",
+    ] {
+        let present: i64 = bare
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1 AND \
+                 tbl_name = 'table_sync_gapped_entries'",
+                [index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(present, 1, "{index} is created with the table");
+    }
+    // The predecessor index must actually be CHOSEN, not merely present: the two chain indexes both
+    // lead with device_fingerprint, so without it these two per-acceptance probes fall back to the
+    // stream_id prefix and scan every held row on the stream. A plan assertion is the only way to
+    // see that — a behavioral test observes the same answer either way, just slower.
+    for probe in [
+        "SELECT entry_hash FROM table_sync_gapped_entries WHERE stream_id = X'01' AND prev_hash = \
+         X'02'",
+        "SELECT entry_hash FROM table_sync_gapped_entries WHERE stream_id = X'01' AND prev_hash = \
+         X'02' AND device_fingerprint != X'03'",
+    ] {
+        let plan: String =
+            bare.query_row(&format!("EXPLAIN QUERY PLAN {probe}"), [], |row| row.get(3)).unwrap();
+        assert!(
+            plan.contains("table_sync_gapped_entries_predecessor"),
+            "the predecessor probe must seek the predecessor index, not scan the stream: {plan}"
+        );
+    }
+
+    // STRICT, per the schema convention for every new table: a held entry's lamport and hashes are
+    // compared as stored, so a silently-coerced value would misorder or mis-key a promotion.
+    let ddl: String = bare
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = \
+             'table_sync_gapped_entries'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(ddl.to_ascii_uppercase().contains("STRICT"), "the table is STRICT: {ddl}");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '096_table_sync_gapped_entries'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V096");
+}
+
 /// V095 (#1002) records the TABLE's spec version on each published row, so an unrelated projector
 /// bump no longer marks every table's rows incomparable.
 #[test]
 fn migration_095_records_the_table_spec_version() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 95, "move this pin with the next schema migration");
-
     let bare = rusqlite::Connection::open_in_memory().unwrap();
     schema::migrations::apply_table_sync_tables(&bare).unwrap();
     schema::migrations::apply_table_sync_projection_state(&bare).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
@@ -46,12 +46,33 @@ fn seed_stream(conn: &rusqlite::Connection, repo_id: &str, seed: u8) -> Vec<u8> 
         rusqlite::params![vec![seed; 32], stream_id, vec![seed; 32], vec![seed; 8]],
     )
     .unwrap();
+    conn.execute(
+        "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+         lamport, prev_hash, signed_bytes, gapped_at_ms) VALUES (?1, ?2, ?3, 2, ?4, ?5, 0)",
+        rusqlite::params![vec![seed ^ 0xff; 32], stream_id, vec![seed; 32], vec![seed; 32], vec![
+            seed;
+            8
+        ]],
+    )
+    .unwrap();
     stream_id
 }
 
 fn entries_on(conn: &rusqlite::Connection, stream_id: &[u8]) -> i64 {
     conn.query_row(
         "SELECT COUNT(*) FROM table_sync_entries WHERE stream_id = ?1",
+        rusqlite::params![stream_id],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+/// Entries held awaiting a predecessor on `stream_id`. Counted separately from [`entries_on`]: they
+/// live in their own table precisely because they are NOT on the accepted chain, so a purge that
+/// swept one and not the other would be invisible to that count.
+fn gapped_on(conn: &rusqlite::Connection, stream_id: &[u8]) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM table_sync_gapped_entries WHERE stream_id = ?1",
         rusqlite::params![stream_id],
         |row| row.get(0),
     )
@@ -124,11 +145,18 @@ fn rm_from_a_linked_worktree_purges_the_shared_stream_log_and_spares_the_sibling
         "and the stream-keyed entry log goes with the directory that placed it, whichever \
          checkout drove the removal",
     );
+    assert_eq!(
+        gapped_on(conn, &shared_stream),
+        0,
+        "including the entries still awaiting a predecessor — they are signed operations on the \
+         same derived stream id, so retaining them would let a re-registration replay them back",
+    );
 
     // SIBLING PRESERVATION: the other repo in the shared store keeps both halves. Its entries carry
     // no `repo_id`, so only the captured stream ids could have spared them.
     assert_eq!(directory_rows(conn, &sibling_repo_id), 1, "the sibling's directory row survives");
     assert_eq!(entries_on(conn, &sibling_stream), 1, "and so does its entry log");
+    assert_eq!(gapped_on(conn, &sibling_stream), 1, "and its entries awaiting a predecessor");
 
     let _ = fs::remove_dir_all(&linked);
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1381,6 +1381,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_093_ID => Some(93),
             MIGRATION_094_ID => Some(94),
             MIGRATION_095_ID => Some(95),
+            MIGRATION_096_ID => Some(96),
             _ => None,
         })
         .max()
@@ -1485,6 +1486,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_093_ID
             | MIGRATION_094_ID
             | MIGRATION_095_ID
+            | MIGRATION_096_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1586,6 +1588,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_093_ID => migration.checksum != MIGRATION_093_CHECKSUM,
         MIGRATION_094_ID => migration.checksum != MIGRATION_094_CHECKSUM,
         MIGRATION_095_ID => migration.checksum != MIGRATION_095_CHECKSUM,
+        MIGRATION_096_ID => migration.checksum != MIGRATION_096_CHECKSUM,
         _ => false,
     }
 }
@@ -6559,6 +6562,68 @@ pub fn apply_table_sync_spec_version(conn: &Connection) -> rusqlite::Result<()> 
              DROP TABLE sync_published_rows_pre_v095;",
         )?;
     }
+    tx.commit()
+}
+
+/// V096 (#1058): retention for a table-sync entry whose chain predecessor has not arrived.
+///
+/// A verified entry that links to a predecessor this device does not hold used to be DROPPED, so a
+/// chain delivered out of causal order — the normal condition on a transport — could only converge
+/// through redelivery in exact order. It is now retained here until the predecessor is accepted,
+/// then promoted through the ordinary accept-and-apply path.
+///
+/// This is deliberately its OWN table rather than a status column on `table_sync_entries`, because
+/// six queries read that table as "the accepted chain" and every one of them must keep excluding an
+/// entry that is not on a chain: the authoring Lamport clock and the lamport-advance bound (a
+/// retained entry must not drag either), the chain tail (the promote target), entry existence (how
+/// fork is told from gap), the LWW winner lookup, and the refold's pending set. A status column
+/// would put a filter on each, and the one that got missed would fail silently.
+///
+/// `prev_hash` is NOT NULL: a genesis has no predecessor and so can never gap.
+///
+/// There is deliberately no `UNIQUE(stream_id, device_fingerprint, lamport)`. Two equivocating
+/// entries at one lamport must both be storable, or the first one retained blocks the legitimate
+/// one; identity here is the entry hash, and the conflict is resolved when the predecessor arrives
+/// and one of them takes the successor slot. Accepted entries keep their own uniqueness — a losing
+/// sibling never reaches `table_sync_entries`.
+pub fn apply_table_sync_gapped_entries(conn: &Connection) -> rusqlite::Result<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS table_sync_gapped_entries(
+             entry_hash         BLOB    NOT NULL PRIMARY KEY,
+             stream_id          BLOB    NOT NULL,
+             device_fingerprint BLOB    NOT NULL,
+             lamport            INTEGER NOT NULL,
+             prev_hash          BLOB    NOT NULL,
+             signed_bytes       BLOB    NOT NULL,
+             gapped_at_ms       INTEGER NOT NULL
+         ) STRICT;
+         -- Both walks of the promote loop: the child of the entry just accepted, and the siblings
+         -- of its predecessor (which the acceptance just proved to be forks). The trailing
+         -- (lamport, entry_hash) is the total order those walks take siblings in, so the index
+         -- answers the ordering too instead of the query sorting a temp b-tree per probe.
+         CREATE INDEX IF NOT EXISTS table_sync_gapped_entries_child
+             ON table_sync_gapped_entries(
+                 stream_id, device_fingerprint, prev_hash, lamport, entry_hash);
+         -- The per-chain cap's count and its eviction victim, from an index tail instead of a \
+         scan.
+         CREATE INDEX IF NOT EXISTS table_sync_gapped_entries_chain_lamport
+             ON table_sync_gapped_entries(stream_id, device_fingerprint, lamport);
+         -- Children of a hash ACROSS devices: the abandoned-subtree walk and the cross-chain
+         -- citation sweep, both of which run per accepted entry. The two indexes above lead with
+         -- device_fingerprint and so answer neither — SQLite would fall back to the stream_id
+         -- prefix and scan every held row on the stream, once per acceptance, which is quadratic
+         -- over a reverse-delivered chain and is NOT bounded by the per-chain cap when several
+         -- devices share the stream.
+         --
+         -- It carries device_fingerprint and entry_hash so it COVERS both probes. Without them the
+         -- planner prefers the wider child index — which it can only use for its stream_id prefix,
+         -- i.e. the scan this index exists to avoid — because that one is covering and this one
+         -- would not be. Verified with EXPLAIN QUERY PLAN, not assumed.
+         CREATE INDEX IF NOT EXISTS table_sync_gapped_entries_predecessor
+             ON table_sync_gapped_entries(
+                 stream_id, prev_hash, device_fingerprint, entry_hash);",
+    )?;
     tx.commit()
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 95;
+pub const LATEST_SCHEMA_VERSION: u32 = 96;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -704,6 +704,19 @@ const MIGRATION_095_DESCRIPTION: &str =
      spec_version rather than the store-global projector version, so an unrelated projector bump \
      no longer marks every table's rows incomparable. The table is necessarily empty (no table is \
      registered), so it is rebuilt into its final shape rather than carrying a dead column";
+
+const MIGRATION_096_ID: &str = "096_table_sync_gapped_entries";
+const MIGRATION_096_CHECKSUM: &str = "sha256:rag-rat-table-sync-gapped-entries-v96";
+const MIGRATION_096_DESCRIPTION: &str =
+    "Retention for table-sync entries whose chain predecessor has not arrived (#1058): \
+     table_sync_gapped_entries holds a verified entry that links to an unheld predecessor until \
+     that predecessor is accepted, at which point it is promoted through the ordinary accept and \
+     apply path. Previously such an entry was dropped, so a chain delivered out of causal order \
+     could only converge through redelivery in exact order. Deliberately its own table rather \
+     than a status column: six queries read table_sync_entries as the accepted chain — the \
+     authoring Lamport clock, the lamport-advance bound, the chain tail, entry existence, the LWW \
+     winner lookup, and the refold's pending set — and every one of them must keep excluding an \
+     entry that is not on a chain";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1470,6 +1483,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_095_CHECKSUM,
         description: MIGRATION_095_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_table_sync_spec_version),
+    },
+    Migration {
+        id: MIGRATION_096_ID,
+        checksum: MIGRATION_096_CHECKSUM,
+        description: MIGRATION_096_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_table_sync_gapped_entries),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -174,6 +174,15 @@ const TRANSITIVE_SCOPED_TABLES: &[TransitiveTable] = &[
         id_column: "stream_id",
         parent_ids: purge_ids::STREAMS,
     },
+    // Entries held awaiting a chain predecessor. Same reasoning as the accepted log above, and for
+    // the same reason it must not be exempted: these are signed operations on a stream whose id is
+    // derived, so retaining them across a re-registration of the repo would replay a removed
+    // repo's history back into it.
+    TransitiveTable {
+        table: "table_sync_gapped_entries",
+        id_column: "stream_id",
+        parent_ids: purge_ids::STREAMS,
+    },
 ];
 
 /// Every base table (never a view, never an FTS shadow table) that carries a `repo_id` column, in

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -39,8 +39,25 @@ pub(crate) enum IngestOutcome {
     /// `&str` is the reason. Forward-compatible: the chain advanced, the payload is retained.
     Retained(&'static str),
     AlreadyPresent,
-    /// A chain gap or fork — the transport milestone resolves it (backfill / fork evidence).
-    Parked(&'static str),
+    /// The entry's chain predecessor has not arrived, so it is RETAINED and will be promoted when
+    /// the predecessor is accepted. Not an error: out-of-order delivery is the normal condition on
+    /// a transport.
+    AwaitingPredecessor,
+    /// Already retained awaiting its predecessor. Weaker than [`Self::AlreadyPresent`] — a retained
+    /// entry can still be evicted by the per-chain cap, so a frontier must not treat it as settled.
+    AlreadyAwaiting,
+    /// The entry's predecessor is missing AND it is further ahead than everything the chain already
+    /// holds, so the per-chain cap dropped it. NOT held — nothing will promote it. RETRYABLE once
+    /// the entries between it and the tail have arrived.
+    HeldChainFull,
+    /// The entry conflicts with the stored chain — an equivocation. Fork EVIDENCE (proving it to a
+    /// peer) is the transport milestone's.
+    Forked,
+    /// A held entry discarded because the entry it cites was judged a fork. It was never itself
+    /// classified: nothing will ever place its predecessor on the chain, so it could not have been
+    /// promoted, and it cites a hash no future acceptance produces, so nothing would look at it
+    /// again.
+    AbandonedBehindFork,
     /// A type mismatch — stored, unprojectable, surfaced.
     Quarantined(String),
     /// The signing device is not a roster-effective writer (off-roster, removed, or read-only), so
@@ -139,6 +156,15 @@ pub(crate) fn produce_and_author(
     Ok(authored)
 }
 
+/// **The caller MUST roll back on `Err`.** Everything here runs in the caller's transaction and
+/// nothing is safe to commit after a failure: the entry may be stored with its payload neither
+/// applied nor marked, and a promotion in flight takes an entry out of the held table before
+/// re-ingesting it, so committing past an error can lose it. That contract predates promotion — an
+/// `accept` followed by a failing apply had it already — and promotion widens what is lost rather
+/// than changing the rule. No `SAVEPOINT` is taken: it would make this one function's atomicity
+/// self-contained while every sibling in the module still depends on caller rollback, which is a
+/// worse thing to reason about than one uniform rule.
+///
 /// Verify, store, and apply one received entry for `scope_id`'s stream, signed by `pubkey`. A scope
 /// may carry several tables (overlay, distill), so the target spec is resolved from the decoded
 /// op's table against every registry entry in the scope — not fixed by the caller. The op's table
@@ -150,7 +176,118 @@ pub(crate) fn ingest(
     scope_id: &str,
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
-) -> anyhow::Result<IngestOutcome> {
+) -> anyhow::Result<IngestReport> {
+    let device = pubkey.fingerprint();
+    let stream = scope_stream_id(ctx.repo_id, ctx.account_id, scope_id);
+    let (outcome, mut tail) = ingest_one(tx, ctx, scope_id, signed_bytes, pubkey)?;
+    let mut promoted = Vec::new();
+    // Each accepted entry settles the held CHILDREN of two hashes, and both sets must be drained
+    // or rows sit in the table forever, keyed to a hash no probe will ever revisit:
+    //
+    //  1. the children of its PREDECESSOR — its own siblings. The acceptance just filled that
+    //     successor slot, so each is now provably an equivocation.
+    //  2. the children of the accepted entry ITSELF — the chain advance.
+    //
+    // Both are the same operation, so both go through `drain_children`: take every held child of a
+    // hash, re-ingest each, and report which one (if any) took the slot. Draining must CONTINUE
+    // past a child that fails to store — a rejected child leaves the slot open, and stopping there
+    // would strand a valid successor queued behind it and halt the chain.
+    //
+    // Iterative, not recursive: a long chain delivered in reverse must heal without growing the
+    // stack in proportion to its length.
+    while let Some(accepted) = tail {
+        if let Some(prev) = accepted.prev_hash {
+            // Cannot advance the chain: the slot is already held by `accepted`.
+            drain_children(tx, ctx, scope_id, pubkey, stream, device, &prev, &mut promoted)?;
+        }
+        // A held entry on ANOTHER device's chain citing this hash is structurally impossible (a
+        // chain links only within its own device), and accepting this entry is the only moment that
+        // is decidable — `classify` keys the tail on the citing device's chain, so it would report
+        // `Gap` forever. Sweep those now or they hold that chain's capacity until eviction.
+        let foreign =
+            store::discard_foreign_chain_citations(tx, stream, device, &accepted.entry_hash)?;
+        promoted.extend(std::iter::repeat_n(IngestOutcome::AbandonedBehindFork, foreign));
+        tail = drain_children(
+            tx,
+            ctx,
+            scope_id,
+            pubkey,
+            stream,
+            device,
+            &accepted.entry_hash,
+            &mut promoted,
+        )?;
+    }
+    Ok(IngestReport { outcome, promoted })
+}
+
+/// What one entry's arrival did, plus everything its acceptance unblocked.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct IngestReport {
+    pub outcome: IngestOutcome,
+    /// Outcomes of the entries promoted out of the gapped table by this arrival, in promotion
+    /// order. Reported individually rather than counted: promotion settles the CHAIN question, so
+    /// a promoted entry can still be retained, quarantined, or deferred on its PAYLOAD.
+    pub promoted: Vec<IngestOutcome>,
+}
+
+/// The entry an acceptance put at the chain tail — what a promotion probe keys on.
+#[derive(Debug, Clone, Copy)]
+struct AcceptedEntry {
+    entry_hash: [u8; 32],
+    prev_hash: Option<[u8; 32]>,
+}
+
+/// Re-ingest every held child of `parent_hash`, returning the one that took the successor slot.
+///
+/// At most one can: once a child is stored, the rest classify as equivocations. But the loop must
+/// run to exhaustion either way. Stopping at the first child that fails to store would leave a
+/// VALID successor queued behind an invalid one — the invalid child sorts first (a lamport at or
+/// below the tail is a `Conflict`, and it is a lower lamport), takes the slot's only probe, and the
+/// legitimate entry behind it is never examined again. The chain would stop advancing there.
+///
+/// A child that does not store is a fork, and its own held descendants are abandoned with it:
+/// nothing will ever put its hash on the chain, so they can never promote, and they cite a hash no
+/// future acceptance produces, so no probe would reach them either.
+#[allow(clippy::too_many_arguments)]
+fn drain_children(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+    scope_id: &str,
+    pubkey: &DevicePublic,
+    stream: crate::stream::StreamId,
+    device: crate::op::DeviceFingerprint,
+    parent_hash: &[u8; 32],
+    promoted: &mut Vec<IngestOutcome>,
+) -> anyhow::Result<Option<AcceptedEntry>> {
+    let mut took_the_slot = None;
+    while let Some(child) = store::take_gapped_child(tx, stream, device, parent_hash)? {
+        let (outcome, stored) = ingest_one(tx, ctx, scope_id, &child.signed_bytes, pubkey)?;
+        promoted.push(outcome);
+        match stored {
+            Some(entry) => took_the_slot = Some(entry),
+            None => {
+                let abandoned = store::discard_gapped_descendants(tx, stream, &child.entry_hash)?;
+                promoted.extend(std::iter::repeat_n(IngestOutcome::AbandonedBehindFork, abandoned));
+            },
+        }
+    }
+    Ok(took_the_slot)
+}
+
+/// Ingest exactly one entry, with no promotion. Returns the accepted entry when this call STORED
+/// one, which is what drives [`ingest`]'s loop.
+///
+/// The tail is returned explicitly rather than inferred from the outcome variant. Several outcomes
+/// imply storage (`Applied`, `Retained`, `Quarantined`), and a future one that also stores must not
+/// silently fail to drive promotion.
+fn ingest_one(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+    scope_id: &str,
+    signed_bytes: &[u8],
+    pubkey: &DevicePublic,
+) -> anyhow::Result<(IngestOutcome, Option<AcceptedEntry>)> {
     // Same refusal as the producer: an older binary must not re-park, under its own version, an
     // entry a newer projector already understood and folded.
     refold::assert_projector_not_newer(tx)?;
@@ -170,14 +307,15 @@ pub(crate) fn ingest(
             pubkey,
             ctx.now_ms,
         )? {
-            AcceptOutcome::Stored { op, meta, entry_hash } => {
+            AcceptOutcome::Stored { op, meta, entry_hash, prev_hash } => {
+                let accepted = Some(AcceptedEntry { entry_hash, prev_hash });
                 // `accept_row_entry` already validated the op's table is in `scope_tables`, so
                 // exactly one spec matches; the fallback is defensive, never
                 // reached.
                 let Some(spec) =
                     ctx.registry.iter().find(|s| s.scope_id == scope_id && s.name == op.table())
                 else {
-                    return Ok(IngestOutcome::Parked("table not in scope"));
+                    return Ok((IngestOutcome::Retained("table not in scope"), accepted));
                 };
                 // NEVER apply over unsent local work. A raw local write does not advance the row
                 // clock, so the LWW comparison below cannot see it: this op would simply win and
@@ -210,9 +348,9 @@ pub(crate) fn ingest(
                         deferral,
                         refold::TABLE_SYNC_PROJECTOR_VERSION,
                     )?;
-                    return Ok(IngestOutcome::Retained(deferral.as_db_str()));
+                    return Ok((IngestOutcome::Retained(deferral.as_db_str()), accepted));
                 }
-                match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
+                let outcome = match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
                     // A received op that lost on the merits still landed: the entry is
                     // stored, nothing is outstanding, and redelivery stays idempotent.
                     ApplyOutcome::Applied | ApplyOutcome::Superseded => IngestOutcome::Applied,
@@ -234,13 +372,21 @@ pub(crate) fn ingest(
                         )?;
                         IngestOutcome::Retained(reason.as_db_str())
                     },
-                }
+                };
+                (outcome, accepted)
             },
-            AcceptOutcome::StoredInert(reason) => IngestOutcome::Retained(reason.as_db_str()),
-            AcceptOutcome::AlreadyPresent => IngestOutcome::AlreadyPresent,
-            AcceptOutcome::MissingPredecessor => IngestOutcome::Parked("missing predecessor"),
-            AcceptOutcome::Fork => IngestOutcome::Parked("fork"),
-            AcceptOutcome::Unauthorized => IngestOutcome::Unauthorized,
+            AcceptOutcome::StoredInert { reason, entry_hash, prev_hash } => (
+                IngestOutcome::Retained(reason.as_db_str()),
+                Some(AcceptedEntry { entry_hash, prev_hash }),
+            ),
+            // Nothing was stored by these, so none of them advances a chain and none can unblock a
+            // retained successor.
+            AcceptOutcome::AlreadyPresent => (IngestOutcome::AlreadyPresent, None),
+            AcceptOutcome::GapRetained => (IngestOutcome::AwaitingPredecessor, None),
+            AcceptOutcome::GapChainFull => (IngestOutcome::HeldChainFull, None),
+            AcceptOutcome::AlreadyGapped => (IngestOutcome::AlreadyAwaiting, None),
+            AcceptOutcome::Fork => (IngestOutcome::Forked, None),
+            AcceptOutcome::Unauthorized => (IngestOutcome::Unauthorized, None),
         },
     )
 }
@@ -311,6 +457,35 @@ mod tests {
             self.conn.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
         }
 
+        /// Deliver `entries` in the given order, returning the FULL report per entry — including
+        /// what each arrival promoted out of the gapped table.
+        fn ingest_reports(
+            &mut self,
+            entries: &[Vec<u8>],
+            from: &DevicePublic,
+        ) -> Vec<IngestReport> {
+            enroll_writer(&self.conn, AccountId::from_bytes([42; 32]), from.fingerprint());
+            let tx = self.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: AccountId::from_bytes([42; 32]),
+                device: &self.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            let out = entries.iter().map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from).unwrap());
+            let out = out.collect();
+            tx.commit().unwrap();
+            out
+        }
+
+        /// Entries held awaiting a predecessor, across every stream.
+        fn gapped_count(&self) -> i64 {
+            self.conn
+                .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |r| r.get(0))
+                .unwrap()
+        }
+
         fn ingest_all(&mut self, entries: &[Vec<u8>], from: &DevicePublic) -> Vec<IngestOutcome> {
             // The receiver has folded the author's DeviceAdd, so it is an effective writer here —
             // otherwise the #935 authority gate would drop every entry as Unauthorized.
@@ -323,7 +498,9 @@ mod tests {
                 registry: REGISTRY,
                 now_ms: 0,
             };
-            let out = entries.iter().map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from).unwrap());
+            let out = entries
+                .iter()
+                .map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from).unwrap().outcome);
             let out = out.collect();
             tx.commit().unwrap();
             out
@@ -349,6 +526,567 @@ mod tests {
             ],
         )
         .unwrap();
+    }
+
+    /// Three rows authored in order on A, then delivered to B in REVERSE. Before entries awaiting
+    /// a predecessor were retained, everything after the gap was dropped and only redelivery in
+    /// exact causal order could recover it.
+    #[test]
+    fn a_chain_delivered_in_reverse_converges() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let mut entries = Vec::new();
+        for (id, title) in [("r1", "one"), ("r2", "two"), ("r3", "three")] {
+            a.conn.execute("INSERT INTO t_demo(id, title) VALUES (?1, ?2)", [id, title]).unwrap();
+            entries.extend(a.produce());
+        }
+        assert_eq!(entries.len(), 3, "one entry per authored row");
+
+        entries.reverse();
+        let reports = b.ingest_reports(&entries, &a.pubkey());
+
+        // The first two arrive with no predecessor and are held; the third completes the chain and
+        // drags both forward behind it.
+        assert_eq!(reports[0].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(reports[1].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(reports[2].outcome, IngestOutcome::Applied);
+        assert_eq!(
+            reports[2].promoted,
+            vec![IngestOutcome::Applied, IngestOutcome::Applied],
+            "the genesis promotes both retained successors, in chain order",
+        );
+        let titles: Vec<String> = b
+            .conn
+            .prepare("SELECT title FROM t_demo ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(titles, ["one", "two", "three"], "every row lands");
+        assert_eq!(b.gapped_count(), 0, "and nothing is left held");
+    }
+
+    /// A long chain delivered in reverse converges in ONE delivery pass, at a write cost linear in
+    /// its length.
+    ///
+    /// Scoped to what the instrument can actually see. `total_changes` counts rows written, so it
+    /// catches a promote path that writes per-promotion work proportional to the chain (the
+    /// quadratic shape), but it cannot see read cost — a purely-reading rescan would be invisible
+    /// here, and nothing in this test would catch it. The depth is likewise chosen to exercise the
+    /// iterative walk, not to prove recursion would overflow: a few hundred frames would not.
+    #[test]
+    fn a_long_chain_delivered_in_reverse_converges_at_linear_write_cost() {
+        const ROWS: usize = 200;
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let mut entries = Vec::new();
+        for i in 0..ROWS {
+            a.conn
+                .execute("INSERT INTO t_demo(id, title) VALUES (?1, 't')", [format!("r{i:04}")])
+                .unwrap();
+            entries.extend(a.produce());
+        }
+        assert_eq!(entries.len(), ROWS);
+        entries.reverse();
+
+        let before = b.conn.total_changes();
+        let reports = b.ingest_reports(&entries, &a.pubkey());
+        let writes = b.conn.total_changes() - before;
+
+        assert_eq!(reports[ROWS - 1].promoted.len(), ROWS - 1, "one promotion per held entry");
+        let rows: i64 = b.conn.query_row("SELECT COUNT(*) FROM t_demo", [], |r| r.get(0)).unwrap();
+        assert_eq!(rows as usize, ROWS, "every row lands");
+        assert_eq!(b.gapped_count(), 0, "and nothing is left held");
+        // Each entry costs a bounded number of writes: retain, take (delete), insert, apply, plus
+        // the row-clock and published-row bookkeeping. A per-promotion write-amplifying rescan
+        // blows past this by orders of magnitude; the bound is loose enough not to be a churn
+        // magnet.
+        assert!(
+            writes < (ROWS as u64) * 40,
+            "delivery cost {writes} writes for {ROWS} entries — superlinear in the chain length",
+        );
+    }
+
+    /// Redelivery of a held entry must not duplicate it, and must not be reported as settled: the
+    /// per-chain cap can still evict it, unlike an accepted entry.
+    #[test]
+    fn a_redelivered_held_entry_is_recognized_and_not_duplicated() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let second = a.produce();
+
+        let first = b.ingest_reports(&second, &a.pubkey());
+        assert_eq!(first[0].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(b.gapped_count(), 1);
+
+        let again = b.ingest_reports(&second, &a.pubkey());
+        assert_eq!(
+            again[0].outcome,
+            IngestOutcome::AlreadyAwaiting,
+            "a redelivered held entry is recognized, and reported distinctly from AlreadyPresent",
+        );
+        assert_eq!(b.gapped_count(), 1, "and is not held twice");
+
+        // It still promotes once the predecessor lands.
+        let done = b.ingest_reports(&genesis, &a.pubkey());
+        assert_eq!(done[0].promoted, vec![IngestOutcome::Applied]);
+        assert_eq!(b.gapped_count(), 0);
+    }
+
+    /// Entries awaiting a predecessor are NOT on the accepted chain, so they must not move the
+    /// stream's Lamport clock. If they did, one far-ahead held entry would drag local authoring
+    /// with it — exactly what the lamport-advance bound exists to stop a single entry doing.
+    #[test]
+    fn a_held_entry_does_not_advance_the_stream_lamport_clock() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let _genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let second = a.produce();
+
+        // B holds A's second entry (lamport 1) without its predecessor, then authors its own row.
+        b.ingest_reports(&second, &a.pubkey());
+        assert_eq!(b.gapped_count(), 1, "the entry is held, not accepted");
+        b.conn.execute("INSERT INTO t_demo(id, title) VALUES ('own', 'mine')", []).unwrap();
+        let mine = b.produce();
+        assert_eq!(mine.len(), 1);
+
+        let lamport: i64 = b
+            .conn
+            .query_row(
+                "SELECT lamport FROM table_sync_entries WHERE device_fingerprint = ?1",
+                rusqlite::params![b.pubkey().fingerprint().to_bytes().as_slice()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            lamport, 0,
+            "B's own genesis takes lamport 0 — the held entry's lamport 1 is invisible to the \
+             clock",
+        );
+    }
+
+    /// The promote loop must drain the SIBLINGS of the entry it just accepted, not only that
+    /// entry's child.
+    ///
+    /// Two held entries cite the same predecessor. When it arrives, one takes the successor slot;
+    /// the other is now provably an equivocation — but it is still keyed to a predecessor whose
+    /// slot is filled, so a loop that probes only the ADVANCING tail would never look at it again
+    /// and it would sit in the table forever, re-examined on every future promotion.
+    #[test]
+    fn a_promotion_drains_the_sibling_it_just_proved_to_be_a_fork() {
+        use crate::entry;
+        use crate::table_sync::row_op;
+
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let second = a.produce();
+
+        // A second successor of the genesis, signed by the same device — an equivocation.
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let genesis_hash: [u8; 32] = a
+            .conn
+            .query_row(
+                "SELECT entry_hash FROM table_sync_entries ORDER BY lamport LIMIT 1",
+                [],
+                |r| r.get::<_, Vec<u8>>(0),
+            )
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let sibling = entry::sign_entry_from_op_bytes(
+            a.local.secret(),
+            stream,
+            Some(genesis_hash),
+            9,
+            row_op::encode(&row_op::RowOp::Remove {
+                table: "t_demo".into(),
+                pk: vec![row_op::TypedValue::Text("r9".into())],
+                spec_version: 1,
+            }),
+        );
+
+        // Both successors arrive before the genesis and are held.
+        let held =
+            b.ingest_reports(&[second[0].clone(), sibling.signed_bytes.clone()], &a.pubkey());
+        assert_eq!(held[0].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(held[1].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(b.gapped_count(), 2);
+
+        let report = b.ingest_reports(&genesis, &a.pubkey());
+        assert_eq!(report[0].outcome, IngestOutcome::Applied);
+        assert!(
+            report[0].promoted.contains(&IngestOutcome::Forked),
+            "the losing sibling is judged, not left held: {:?}",
+            report[0].promoted,
+        );
+        assert_eq!(
+            b.gapped_count(),
+            0,
+            "and the table is empty — nothing is stranded behind a filled successor slot",
+        );
+    }
+
+    /// A promoted entry goes through the SAME gates as a freshly delivered one — it is fed back
+    /// through the whole accept-and-apply path, not written straight into its table.
+    ///
+    /// The observable is the unsent-work guard: B holds an entry that would overwrite a local edit
+    /// no peer has seen. When the predecessor arrives and promotes it, it must DEFER, exactly as it
+    /// would have on direct delivery. A promote path that wrote the row directly would clobber the
+    /// edit and this would read "from-A".
+    #[test]
+    fn a_promoted_entry_still_defers_to_unsent_local_work() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'base')", []).unwrap();
+        b.ingest_all(&a.produce(), &a.pubkey());
+
+        // A's next two entries: an unrelated row, then the edit to r1 that would overwrite B.
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let filler = a.produce();
+        a.set_title("from-A");
+        let edit = a.produce();
+
+        // B makes its own unsent edit, then receives A's LAST entry first — so it is held.
+        b.set_title("from-B");
+        let held = b.ingest_reports(&edit, &a.pubkey());
+        assert_eq!(held[0].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(b.gapped_count(), 1);
+
+        // The predecessor arrives and promotes it. The guard must still fire.
+        let report = b.ingest_reports(&filler, &a.pubkey());
+        assert_eq!(
+            report[0].promoted,
+            vec![IngestOutcome::Retained(
+                crate::table_sync::store::PendingReason::DeferredUnsentEdit.as_db_str()
+            )],
+            "the promoted entry defers rather than applying",
+        );
+        assert_eq!(b.title().as_deref(), Some("from-B"), "B's unsent edit survives promotion");
+        assert_eq!(b.gapped_count(), 0, "and the entry left the held table — it is stored now");
+    }
+
+    /// Held entries are a CHAIN state, not a projection state: they carry no pending reason and
+    /// must not make a refold owed. Their redemption trigger is a predecessor's arrival, not a
+    /// projector-version bump — and a refold owed on every open is the per-open cost #1005's
+    /// narrowing exists to avoid.
+    #[test]
+    fn held_entries_do_not_make_a_refold_owed() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let _genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let second = a.produce();
+
+        // Settle any refold the fresh store owes for unrelated reasons (a first-open version
+        // stamp), so what this test observes afterwards is attributable to the held entry alone.
+        refold::refold_stale_projections_against(&b.conn, REGISTRY).unwrap();
+
+        b.ingest_reports(&second, &a.pubkey());
+        assert_eq!(b.gapped_count(), 1, "an entry is held");
+
+        let pending: i64 = b
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE pending_reason IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(pending, 0, "it is not recorded as a projection gap");
+        assert!(
+            !refold::refold_stale_projections_against(&b.conn, REGISTRY).unwrap(),
+            "and no refold is owed while it waits",
+        );
+    }
+
+    /// A held entry whose predecessor turns out to be a FORK is abandoned with it.
+    ///
+    /// Two successors of the genesis, X and Y, plus a held entry W citing X. When the genesis
+    /// arrives, one of X/Y takes the successor slot and the other is judged a fork — and a fork is
+    /// never stored, so nothing will ever put its hash on the chain. W therefore can never be
+    /// promoted, and it is keyed to a hash no future acceptance produces, so no later probe would
+    /// examine it either. Draining only the siblings themselves would leave it in the table
+    /// permanently.
+    #[test]
+    fn a_held_entry_behind_a_fork_is_abandoned_with_it() {
+        use crate::entry;
+        use crate::table_sync::row_op;
+
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let winner = a.produce();
+
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let genesis_hash: [u8; 32] = a
+            .conn
+            .query_row(
+                "SELECT entry_hash FROM table_sync_entries ORDER BY lamport LIMIT 1",
+                [],
+                |r| r.get::<_, Vec<u8>>(0),
+            )
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let remove = |id: &str| {
+            row_op::encode(&row_op::RowOp::Remove {
+                table: "t_demo".into(),
+                pk: vec![row_op::TypedValue::Text(id.into())],
+                spec_version: 1,
+            })
+        };
+        // The losing sibling, at a HIGHER lamport than the winner so the drain order is fixed.
+        let loser = entry::sign_entry_from_op_bytes(
+            a.local.secret(),
+            stream,
+            Some(genesis_hash),
+            50,
+            remove("r_loser"),
+        );
+        // And a child of the loser — held behind an entry that will never be stored.
+        let orphan = entry::sign_entry_from_op_bytes(
+            a.local.secret(),
+            stream,
+            Some(loser.entry.entry_hash),
+            60,
+            remove("r_orphan"),
+        );
+
+        let held = b.ingest_reports(
+            &[winner[0].clone(), loser.signed_bytes.clone(), orphan.signed_bytes.clone()],
+            &a.pubkey(),
+        );
+        assert!(held.iter().all(|r| r.outcome == IngestOutcome::AwaitingPredecessor));
+        assert_eq!(b.gapped_count(), 3, "all three wait on predecessors");
+
+        let report = b.ingest_reports(&genesis, &a.pubkey());
+        assert!(
+            report[0].promoted.contains(&IngestOutcome::Forked),
+            "the losing sibling is judged: {:?}",
+            report[0].promoted,
+        );
+        assert!(
+            report[0].promoted.contains(&IngestOutcome::AbandonedBehindFork),
+            "and its held child is abandoned with it, not left keyed to a hash that never lands: \
+             {:?}",
+            report[0].promoted,
+        );
+        assert_eq!(b.gapped_count(), 0, "nothing is stranded");
+    }
+
+    /// Draining must continue PAST a child that fails to store, or a valid successor queued behind
+    /// an invalid one is stranded and the chain stops advancing.
+    ///
+    /// Two children cite the genesis: one at a lamport at/below the tail (an equivocation) and the
+    /// real successor above it. The invalid one sorts first, so a drain that stopped at the first
+    /// non-storing child would take the genesis's only probe, leave the successor slot open with
+    /// nothing left to fill it, and halt there — the successor is keyed to a hash no later
+    /// acceptance revisits.
+    #[test]
+    fn a_rejected_child_does_not_strand_the_valid_successor_behind_it() {
+        use crate::entry;
+        use crate::table_sync::row_op;
+
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let successor = a.produce();
+
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let genesis_hash: [u8; 32] = a
+            .conn
+            .query_row(
+                "SELECT entry_hash FROM table_sync_entries ORDER BY lamport LIMIT 1",
+                [],
+                |r| r.get::<_, Vec<u8>>(0),
+            )
+            .unwrap()
+            .try_into()
+            .unwrap();
+        // Lamport 0 ties the genesis's own lamport, so this classifies at/below the tail — a
+        // conflict — and sorts BEFORE the real successor at lamport 1.
+        let invalid = entry::sign_entry_from_op_bytes(
+            a.local.secret(),
+            stream,
+            Some(genesis_hash),
+            0,
+            row_op::encode(&row_op::RowOp::Remove {
+                table: "t_demo".into(),
+                pk: vec![row_op::TypedValue::Text("r_bogus".into())],
+                spec_version: 1,
+            }),
+        );
+
+        let held =
+            b.ingest_reports(&[invalid.signed_bytes.clone(), successor[0].clone()], &a.pubkey());
+        assert!(held.iter().all(|r| r.outcome == IngestOutcome::AwaitingPredecessor));
+        assert_eq!(b.gapped_count(), 2);
+
+        let report = b.ingest_reports(&genesis, &a.pubkey());
+        assert!(
+            report[0].promoted.contains(&IngestOutcome::Forked),
+            "the invalid child is judged: {:?}",
+            report[0].promoted,
+        );
+        assert!(
+            report[0].promoted.contains(&IngestOutcome::Applied),
+            "and the drain continues past it to the real successor: {:?}",
+            report[0].promoted,
+        );
+        assert_eq!(
+            b.conn
+                .query_row("SELECT title FROM t_demo WHERE id = 'r2'", [], |r| r
+                    .get::<_, String>(0))
+                .ok()
+                .as_deref(),
+            Some("two"),
+            "the successor's row lands — the chain did not halt on the rejected child",
+        );
+        assert_eq!(b.gapped_count(), 0, "nothing is stranded");
+    }
+
+    /// An entry citing a predecessor from ANOTHER device's chain can never be honest — a chain
+    /// links only within its own device. It is retained on arrival (until the cited hash is held,
+    /// it is indistinguishable from an ordinary missing predecessor), and accepting that hash is
+    /// the only moment the impossibility becomes decidable: `classify` keys the tail on the citing
+    /// device's own chain, so re-examining it later reports `Gap` forever.
+    #[test]
+    fn a_held_entry_citing_another_devices_chain_is_discarded_when_that_entry_lands() {
+        use crate::entry;
+        use crate::table_sync::row_op;
+
+        let mut a = Device::new();
+        let c = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let genesis = a.produce();
+        let a_genesis_hash: [u8; 32] = a
+            .conn
+            .query_row("SELECT entry_hash FROM table_sync_entries LIMIT 1", [], |r| {
+                r.get::<_, Vec<u8>>(0)
+            })
+            .unwrap()
+            .try_into()
+            .unwrap();
+
+        // Device C signs an entry citing A's hash — a cross-chain link.
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let cross = entry::sign_entry_from_op_bytes(
+            c.local.secret(),
+            stream,
+            Some(a_genesis_hash),
+            5,
+            row_op::encode(&row_op::RowOp::Remove {
+                table: "t_demo".into(),
+                pk: vec![row_op::TypedValue::Text("r_cross".into())],
+                spec_version: 1,
+            }),
+        );
+
+        // It arrives BEFORE A's entry, so nothing yet distinguishes it from a real gap.
+        let held = b.ingest_reports(std::slice::from_ref(&cross.signed_bytes), &c.pubkey());
+        assert_eq!(held[0].outcome, IngestOutcome::AwaitingPredecessor);
+        assert_eq!(b.gapped_count(), 1);
+
+        b.ingest_reports(&genesis, &a.pubkey());
+        assert_eq!(
+            b.gapped_count(),
+            0,
+            "accepting the cited entry retires the cross-chain citation, which nothing else would",
+        );
+
+        // The OTHER delivery order is decidable on arrival, and must not be retained at all: the
+        // cited hash is already held, so the link is provably cross-chain right then. Retaining it
+        // would create exactly the row the sweep above exists to clean up.
+        let mut fresh = Device::new();
+        fresh.ingest_reports(&genesis, &a.pubkey());
+        let late = fresh.ingest_reports(std::slice::from_ref(&cross.signed_bytes), &c.pubkey());
+        assert_eq!(
+            late[0].outcome,
+            IngestOutcome::Forked,
+            "a citation of an already-held foreign entry is judged on arrival, not held",
+        );
+        assert_eq!(fresh.gapped_count(), 0);
+    }
+
+    /// A held entry citing a REJECTED entry is abandoned even when it is on a different device's
+    /// chain.
+    ///
+    /// This is the case no later event could clean up: the cross-chain sweep fires only on an
+    /// ACCEPTED hash, and a rejected sibling's hash is never accepted — so a device-filtered
+    /// descendant walk would leave the row held until eviction or a repo purge.
+    #[test]
+    fn a_foreign_citation_of_a_rejected_entry_is_abandoned_with_it() {
+        use crate::entry;
+        use crate::table_sync::row_op;
+
+        let mut a = Device::new();
+        let c = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'one')", []).unwrap();
+        let genesis = a.produce();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
+        let winner = a.produce();
+
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let genesis_hash: [u8; 32] = a
+            .conn
+            .query_row(
+                "SELECT entry_hash FROM table_sync_entries ORDER BY lamport LIMIT 1",
+                [],
+                |r| r.get::<_, Vec<u8>>(0),
+            )
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let remove = |id: &str| {
+            row_op::encode(&row_op::RowOp::Remove {
+                table: "t_demo".into(),
+                pk: vec![row_op::TypedValue::Text(id.into())],
+                spec_version: 1,
+            })
+        };
+        // A's losing sibling, and a citation of it signed by a DIFFERENT device.
+        let loser = entry::sign_entry_from_op_bytes(
+            a.local.secret(),
+            stream,
+            Some(genesis_hash),
+            50,
+            remove("r_loser"),
+        );
+        let foreign = entry::sign_entry_from_op_bytes(
+            c.local.secret(),
+            stream,
+            Some(loser.entry.entry_hash),
+            60,
+            remove("r_foreign"),
+        );
+
+        b.ingest_reports(&[winner[0].clone(), loser.signed_bytes.clone()], &a.pubkey());
+        b.ingest_reports(std::slice::from_ref(&foreign.signed_bytes), &c.pubkey());
+        assert_eq!(b.gapped_count(), 3, "all three wait on predecessors");
+
+        b.ingest_reports(&genesis, &a.pubkey());
+        assert_eq!(
+            b.gapped_count(),
+            0,
+            "the loser is judged and the OTHER device's citation of it goes too — nothing else \
+             could retire that row, since its predecessor is never accepted",
+        );
     }
 
     #[test]
@@ -562,7 +1300,7 @@ mod tests {
             };
             for bytes in &entries {
                 assert_eq!(
-                    ingest(&tx, &ctx, "multi/1", bytes, &a_dev.secret().public()).unwrap(),
+                    ingest(&tx, &ctx, "multi/1", bytes, &a_dev.secret().public()).unwrap().outcome,
                     IngestOutcome::Applied,
                 );
             }

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -555,7 +555,7 @@ mod tests {
             };
             let out = entries
                 .iter()
-                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap())
+                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap().outcome)
                 .collect();
             tx.commit().unwrap();
             out
@@ -2384,7 +2384,7 @@ mod tests {
             };
             let out = entries
                 .iter()
-                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap())
+                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap().outcome)
                 .collect();
             tx.commit().unwrap();
             out

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -9,8 +9,19 @@
 //! [`author_row_entry`] mints a local entry (lamport = one past the highest on the stream);
 //! [`accept_row_entry`] verifies and chain-classifies a foreign entry, stores it if the chain is
 //! continuous, then decides whether its payload applies — so one bad payload never wedges the
-//! chain. Full fork evidence and out-of-order backfill are the transport milestone's job — here a
-//! gap or conflict is simply reported, not durably quarantined.
+//! chain.
+//!
+//! An entry whose predecessor has NOT arrived is held in `table_sync_gapped_entries` and promoted
+//! once the predecessor is accepted, because out-of-order delivery is the normal condition on a
+//! transport rather than an error. That table is deliberately separate: six queries here read
+//! `table_sync_entries` as "the accepted chain" — the authoring Lamport clock, the lamport-advance
+//! bound, [`chain_tail`], [`entry_exists`], the winning-entry lookup, and the refold's pending set
+//! — and every one of them must keep excluding an entry that is not on a chain. A held entry is a
+//! CHAIN state and carries no `pending_reason`; do not conflate it with the PROJECTION state that
+//! column tracks.
+//!
+//! Fork EVIDENCE (proving an equivocation to a peer) remains the transport milestone's job — a
+//! conflict is reported here, not durably quarantined.
 
 use anyhow::Context;
 use rusqlite::{OptionalExtension, Transaction, params};
@@ -179,16 +190,35 @@ pub(crate) enum AcceptOutcome {
         op: RowOp,
         meta: OpMeta,
         entry_hash: [u8; 32],
+        /// Where this entry sits on its chain — what a gapped successor cites. `None` for a
+        /// genesis.
+        prev_hash: Option<[u8; 32]>,
     },
     /// Stored and retained, but NOT applied — an undecodable payload, a future op-kind, or a table
     /// not in this scope. The chain still advanced, and the entry is marked pending so a later
     /// binary replays it.
-    StoredInert(PendingReason),
+    StoredInert {
+        reason: PendingReason,
+        entry_hash: [u8; 32],
+        prev_hash: Option<[u8; 32]>,
+    },
     AlreadyPresent,
     /// The lamport advances past the tail but the entry does not link to it (a gap): the
-    /// predecessor has not arrived. Routine under out-of-order delivery; the transport retries
-    /// after backfill.
-    MissingPredecessor,
+    /// predecessor has not arrived. Routine under out-of-order delivery, which is the NORMAL
+    /// condition on a transport — so the entry is RETAINED in `table_sync_gapped_entries` and
+    /// promoted once its predecessor is accepted, rather than dropped and left to redelivery in
+    /// exact causal order.
+    GapRetained,
+    /// A gapped entry already held. Deliberately distinct from [`Self::AlreadyPresent`]: that one
+    /// is a durable promise, whereas a gapped entry can still be evicted by the per-chain cap, so
+    /// a caller must not build a sync frontier on this as if the entry were settled.
+    AlreadyGapped,
+    /// The entry gapped AND is further ahead than every entry the chain is already holding, so the
+    /// per-chain cap dropped it rather than a nearer one. Reported rather than folded into
+    /// [`Self::GapRetained`]: the entry is NOT held, and a caller that treats it as held would wait
+    /// forever for a promotion that cannot come. RETRYABLE — once the entries between it and the
+    /// tail arrive and promote, there is room and it is no longer the furthest ahead.
+    GapChainFull,
     /// The entry conflicts with the stored chain (a second genesis, or a lamport at/behind the
     /// tail) — an equivocation the transport milestone will quarantine with evidence.
     Fork,
@@ -296,6 +326,14 @@ pub(crate) fn accept_row_entry(
     if entry_exists(tx, &verified.entry_hash)? {
         return Ok(AcceptOutcome::AlreadyPresent);
     }
+    // Dedupe against the gapped table HERE, beside the accepted-entry check and BEFORE the
+    // authority gate, so a redelivered gapped entry reports the same way whether or not its
+    // device is still roster-effective — the dedup-precedence-over-authority ordering the
+    // accepted path already has. In the `Gap` arm below instead, a removed device's redelivery
+    // would report `Unauthorized`.
+    if gapped_entry_exists(tx, &verified.entry_hash)? {
+        return Ok(AcceptOutcome::AlreadyGapped);
+    }
     // Authority gate (#935): the signing device must be a roster-effective WRITER of the account.
     // Placed AFTER `entry_exists` so an entry stored while the device WAS a writer still reports
     // `AlreadyPresent` after its removal (dedup precedence over authority), and BEFORE
@@ -315,29 +353,39 @@ pub(crate) fn accept_row_entry(
     }
     match classify(tx, expected_stream, &verified)? {
         ChainFit::Ok => {},
-        ChainFit::Gap => return Ok(AcceptOutcome::MissingPredecessor),
+        ChainFit::Gap =>
+            return Ok(if retain_gapped_entry(tx, &verified, signed_bytes, now_ms)? {
+                AcceptOutcome::GapRetained
+            } else {
+                AcceptOutcome::GapChainFull
+            }),
         ChainFit::Conflict => return Ok(AcceptOutcome::Fork),
     }
     // Classify the payload BEFORE storing, so the entry lands with its projection state recorded in
     // the same INSERT — no store-then-mark window, and no second write.
+    let inert = |reason| AcceptOutcome::StoredInert {
+        reason,
+        entry_hash: verified.entry_hash,
+        prev_hash: verified.prev_hash,
+    };
     let outcome = match row_op::decode(&verified.op_bytes) {
-        Err(_) => AcceptOutcome::StoredInert(PendingReason::UndecodablePayload),
-        Ok(DecodedRowOp::Unknown { .. }) =>
-            AcceptOutcome::StoredInert(PendingReason::UnknownOpKind),
+        Err(_) => inert(PendingReason::UndecodablePayload),
+        Ok(DecodedRowOp::Unknown { .. }) => inert(PendingReason::UnknownOpKind),
         Ok(DecodedRowOp::Known(op)) =>
             if expected_tables.contains(&op.table()) {
                 AcceptOutcome::Stored {
                     op,
                     meta: OpMeta { lamport: verified.lamport, device: verified.device_fingerprint },
                     entry_hash: verified.entry_hash,
+                    prev_hash: verified.prev_hash,
                 }
             } else {
-                AcceptOutcome::StoredInert(PendingReason::TableNotInScope)
+                inert(PendingReason::TableNotInScope)
             },
     };
     // Chain-continuous: store now so a bad payload can never wedge the device's chain.
     let pending = match &outcome {
-        AcceptOutcome::StoredInert(reason) => Some(*reason),
+        AcceptOutcome::StoredInert { reason, .. } => Some(*reason),
         // A `Stored` op may still fail to project on an unknown COLUMN, which only the
         // registry-aware applier sees; the caller marks it pending via `entry_hash` in that case.
         _ => None,
@@ -363,8 +411,18 @@ fn classify(
         // when a chain already exists is a second head — an equivocation.
         (None, None) => ChainFit::Ok,
         (None, Some(_)) => ChainFit::Conflict,
-        // A non-genesis whose device has no chain yet: its predecessor has not been delivered.
-        (Some(_), None) => ChainFit::Gap,
+        // A non-genesis whose device has no chain yet. Its predecessor has not been delivered —
+        // UNLESS we already hold it, in which case it belongs to a DIFFERENT device's chain and
+        // this link is structurally impossible: `author_row_entry` always sets `prev_hash` from the
+        // signer's OWN chain tail, so a cross-chain citation can never be honest. Reporting `Gap`
+        // there would retain an entry that no arrival can ever redeem, because this arm keys the
+        // tail on the signer's chain and would keep returning `Gap` forever.
+        (Some(prev), None) =>
+            if entry_exists(tx, &prev)? {
+                ChainFit::Conflict
+            } else {
+                ChainFit::Gap
+            },
         (Some(prev), Some((tail_lamport, tail_hash))) =>
             if prev == tail_hash && verified.lamport > tail_lamport {
                 ChainFit::Ok
@@ -411,6 +469,254 @@ fn entry_exists(tx: &Transaction<'_>, entry_hash: &[u8; 32]) -> anyhow::Result<b
         )
         .optional()?
         .is_some())
+}
+
+/// A verified entry held in `table_sync_gapped_entries`, awaiting its chain predecessor.
+pub(crate) struct GappedEntry {
+    pub entry_hash: [u8; 32],
+    pub prev_hash: [u8; 32],
+    pub signed_bytes: Vec<u8>,
+}
+
+/// The most gapped entries held for one `(stream, device)` chain.
+///
+/// Only a roster-effective WRITER reaches the retention below — the authority gate in
+/// [`accept_row_entry`] runs first — so this bounds a misbehaving ROSTER MEMBER, whose remedy is
+/// device removal. That is the same posture [`MAX_LAMPORT_ADVANCE`] documents for in-window lamport
+/// griefing, not a defense against arbitrary peers.
+const MAX_GAPPED_PER_CHAIN: usize = 4096;
+
+fn gapped_entry_exists(tx: &Transaction<'_>, entry_hash: &[u8; 32]) -> anyhow::Result<bool> {
+    Ok(tx
+        .query_row(
+            "SELECT 1 FROM table_sync_gapped_entries WHERE entry_hash = ?1",
+            params![entry_hash.as_slice()],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+/// Hold a verified entry whose predecessor has not arrived, keeping the chain's NEAREST-TAIL
+/// `MAX_GAPPED_PER_CHAIN` entries when the cap is reached.
+///
+/// The policy is "retain the entries closest to the tail", because those promote soonest — an entry
+/// far ahead of the clock needs everything between it and the tail to arrive first. That is why the
+/// cap evicts rather than simply refusing: a peer that filled the table early must not be able to
+/// block the near-tail entry the chain is actually waiting on.
+///
+/// The newcomer competes on the same footing as the rows already held, so an arrival that is ITSELF
+/// the furthest-ahead is the one refused. Evicting the stored maximum unconditionally would invert
+/// the policy exactly when it matters — a table full of near-tail entries would be hollowed out one
+/// row at a time by a stream of ever-higher-lamport arrivals.
+///
+/// Returns whether the entry is now held.
+fn retain_gapped_entry(
+    tx: &Transaction<'_>,
+    verified: &VerifiedEntry,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> anyhow::Result<bool> {
+    let stream_bytes = verified.stream_id.to_bytes();
+    let device_bytes = verified.device_fingerprint.to_bytes();
+    // `classify` returns `Gap` only for an entry that HAS a predecessor — a genesis never gaps — so
+    // the NOT NULL column always has a value here.
+    let prev_hash = verified.prev_hash.context("a gapped entry always has a predecessor")?;
+    let held: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM table_sync_gapped_entries
+          WHERE stream_id = ?1 AND device_fingerprint = ?2",
+        params![stream_bytes.as_slice(), device_bytes.as_slice()],
+        |row| row.get(0),
+    )?;
+    if usize::try_from(held)? >= MAX_GAPPED_PER_CHAIN {
+        let (furthest_hash, furthest_lamport) = tx.query_row(
+            "SELECT entry_hash, lamport FROM table_sync_gapped_entries
+              WHERE stream_id = ?1 AND device_fingerprint = ?2
+              ORDER BY lamport DESC, entry_hash DESC LIMIT 1",
+            params![stream_bytes.as_slice(), device_bytes.as_slice()],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
+        )?;
+        // Rank on `(lamport, entry_hash)`, the SAME total order the victim was chosen by. On
+        // lamport alone a tie at the cap boundary would resolve as "whoever is already held wins",
+        // which is insertion order again — the property the hash tie-break exists to remove.
+        if (i64::try_from(verified.lamport)?, verified.entry_hash.as_slice())
+            >= (furthest_lamport, furthest_hash.as_slice())
+        {
+            // The arrival is the furthest-ahead of the whole set: it is the one the policy drops.
+            return Ok(false);
+        }
+        tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
+            furthest_hash
+        ])?;
+    }
+    tx.execute(
+        "INSERT INTO table_sync_gapped_entries(
+             entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+             gapped_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            verified.entry_hash.as_slice(),
+            stream_bytes.as_slice(),
+            device_bytes.as_slice(),
+            i64::try_from(verified.lamport)?,
+            prev_hash.as_slice(),
+            signed_bytes,
+            now_ms,
+        ],
+    )?;
+    Ok(true)
+}
+
+/// Discard every held entry on `stream` that descends from `root` — the subtree behind an entry
+/// that has just been judged a fork, or abandoned behind one.
+///
+/// A fork is never stored, so nothing will ever put `root`'s hash on the chain, so an entry citing
+/// it can never be promoted; and because it is keyed to a hash no future acceptance will produce,
+/// no later probe would look at it again either. Without this sweep such an entry sits in the table
+/// until the per-chain cap or a repo purge removes it, occupying a slot a promotable entry could
+/// have used.
+///
+/// The walk is scoped to the STREAM, not to the rejected entry's device. A citation from another
+/// device's chain is structurally impossible, but it is retained anyway (until the cited hash is
+/// held, nothing distinguishes it from an ordinary missing predecessor) — and for a REJECTED hash
+/// there is no later event that could retire it, because [`discard_foreign_chain_citations`] fires
+/// only on an ACCEPTED one. A device-filtered walk here would leave exactly those rows stranded.
+///
+/// Stream scope is also the safety boundary: a stream id is derived from `(repo_id, account_id,
+/// scope_id)`, so staying within one stream stays within the repo whose write lock the caller
+/// holds. Sweeping by `prev_hash` alone would reach other repos' rows in a shared database.
+///
+/// Iterative over a worklist, for the same reason promotion is: the abandoned subtree can be as
+/// deep as the chain is long.
+///
+/// Returns how many entries were discarded.
+pub(crate) fn discard_gapped_descendants(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    root: &[u8; 32],
+) -> anyhow::Result<usize> {
+    let stream_bytes = stream.to_bytes();
+    let mut discarded = 0;
+    let mut worklist = vec![*root];
+    while let Some(parent) = worklist.pop() {
+        let children: Vec<Vec<u8>> = tx
+            .prepare(
+                "SELECT entry_hash FROM table_sync_gapped_entries
+                  WHERE stream_id = ?1 AND prev_hash = ?2",
+            )?
+            .query_map(params![stream_bytes.as_slice(), parent.as_slice()], |row| row.get(0))?
+            .collect::<rusqlite::Result<_>>()?;
+        for child in children {
+            tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
+                child
+            ])?;
+            worklist.push(fixed32(child)?);
+            discarded += 1;
+        }
+    }
+    Ok(discarded)
+}
+
+/// Discard held entries on OTHER devices' chains that cite `hash` as their predecessor, together
+/// with everything behind them.
+///
+/// A chain is per `(stream, device)` and [`author_row_entry`] always links to the signer's OWN
+/// tail, so an entry citing a predecessor from a different device's chain can never be honest. Such
+/// an entry is nonetheless retained on arrival, because until the cited hash is held there is no
+/// way to tell it from an ordinary missing predecessor.
+///
+/// Accepting the cited entry is the moment that becomes decidable, and it is also the ONLY moment:
+/// [`classify`] keys the tail on the citing device's own chain, so re-examining the entry later
+/// would just report `Gap` again forever. Without this sweep it occupies that chain's hold capacity
+/// until eviction or a repo purge.
+///
+/// A citation from a different STREAM is deliberately NOT swept, and this is the one residual the
+/// sweep leaves. Reaching it would mean matching on `prev_hash` without the `stream_id` equality,
+/// and a stream id is derived from `(repo_id, account_id, scope_id)` — so that query would delete
+/// rows belonging to OTHER REPOS in a shared database, under a write lock scoped to this one.
+/// Trading a bounded capacity leak for a cross-repo write outside its lock is the wrong direction.
+/// The leak is charged to the malformed signer's own chain, is capped by `MAX_GAPPED_PER_CHAIN`,
+/// and is reclaimed by the deferred retention/GC horizon over this table. (The reverse arrival
+/// order is already handled: [`classify`] consults `entry_exists`, which is not stream-scoped, so a
+/// citation of an already-held entry is judged on arrival rather than retained.)
+///
+/// Returns how many entries were discarded.
+pub(crate) fn discard_foreign_chain_citations(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    own_device: DeviceFingerprint,
+    hash: &[u8; 32],
+) -> anyhow::Result<usize> {
+    let stream_bytes = stream.to_bytes();
+    let own_bytes = own_device.to_bytes();
+    let citations: Vec<Vec<u8>> = tx
+        .prepare(
+            "SELECT entry_hash FROM table_sync_gapped_entries
+              WHERE stream_id = ?1 AND prev_hash = ?2 AND device_fingerprint != ?3",
+        )?
+        .query_map(
+            params![stream_bytes.as_slice(), hash.as_slice(), own_bytes.as_slice()],
+            |row| row.get(0),
+        )?
+        .collect::<rusqlite::Result<_>>()?;
+    let mut discarded = 0;
+    for entry_hash in citations {
+        tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
+            entry_hash
+        ])?;
+        discarded += 1;
+        // Everything queued behind it is orphaned by the same argument.
+        discarded += discard_gapped_descendants(tx, stream, &fixed32(entry_hash)?)?;
+    }
+    Ok(discarded)
+}
+
+/// Remove and return one gapped entry of `(stream, device)` whose predecessor is `prev_hash`.
+///
+/// TAKE, not read: the caller feeds the entry straight back through [`accept_row_entry`], which
+/// re-verifies it and re-classifies it against the now-advanced chain. Leaving it here would either
+/// duplicate it on acceptance or strand it when it turns out to be a fork.
+///
+/// Ordered by `(lamport, entry_hash)`, so which of two equivocating siblings takes the successor
+/// slot is a property of the ENTRIES rather than of insertion order. The hash tie-break is
+/// load-bearing, not decoration: the schema deliberately admits two siblings at one lamport
+/// (§`table_sync_gapped_entries`), and on lamport alone SQLite's choice between them falls back to
+/// physical row order — so two replicas holding the same pair could accept different successors and
+/// project different rows, with each then classifying the other's winner as a fork.
+pub(crate) fn take_gapped_child(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+    prev_hash: &[u8; 32],
+) -> anyhow::Result<Option<GappedEntry>> {
+    let stream_bytes = stream.to_bytes();
+    let device_bytes = device.to_bytes();
+    let row = tx
+        .query_row(
+            "SELECT entry_hash, prev_hash, signed_bytes FROM table_sync_gapped_entries
+              WHERE stream_id = ?1 AND device_fingerprint = ?2 AND prev_hash = ?3
+              ORDER BY lamport, entry_hash LIMIT 1",
+            params![stream_bytes.as_slice(), device_bytes.as_slice(), prev_hash.as_slice()],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((entry_hash, prev, signed_bytes)) = row else {
+        return Ok(None);
+    };
+    tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
+        entry_hash.as_slice()
+    ])?;
+    Ok(Some(GappedEntry {
+        entry_hash: fixed32(entry_hash)?,
+        prev_hash: fixed32(prev)?,
+        signed_bytes,
+    }))
 }
 
 /// Store a chain-continuous entry, carrying its projection state (`pending`: `None` = fully
@@ -746,6 +1052,7 @@ mod tests {
             op: op("r1"),
             meta: OpMeta { lamport: 0, device: secret.public().fingerprint() },
             entry_hash: signed.entry.entry_hash,
+            prev_hash: None,
         });
     }
 
@@ -868,7 +1175,11 @@ mod tests {
                 0
             )
             .unwrap(),
-            AcceptOutcome::StoredInert(PendingReason::TableNotInScope),
+            AcceptOutcome::StoredInert {
+                reason: PendingReason::TableNotInScope,
+                entry_hash: first.entry.entry_hash,
+                prev_hash: None,
+            },
         );
         // The chain is not wedged: the next entry (which links to the first) still stores +
         // applies.
@@ -914,7 +1225,11 @@ mod tests {
                 0
             )
             .unwrap(),
-            AcceptOutcome::StoredInert(PendingReason::UndecodablePayload),
+            AcceptOutcome::StoredInert {
+                reason: PendingReason::UndecodablePayload,
+                entry_hash: garbage.entry.entry_hash,
+                prev_hash: None,
+            },
         );
         // One bad payload does not wedge the chain: the next valid entry still applies.
         assert!(matches!(
@@ -1020,8 +1335,9 @@ mod tests {
     }
 
     #[test]
-    fn a_gap_is_reported_not_stored() {
-        // A second-position entry (lamport 1) arriving before the genesis is a missing predecessor.
+    fn a_gap_is_retained_awaiting_its_predecessor() {
+        // A second-position entry (lamport 1) arriving before the genesis has a missing
+        // predecessor: it is held rather than dropped, so reverse delivery can still converge.
         let mut b = conn();
         let secret = DeviceSecret::from_seed(&[1; 32]);
         let second = {
@@ -1044,7 +1360,321 @@ mod tests {
                 0
             )
             .unwrap(),
-            AcceptOutcome::MissingPredecessor,
+            AcceptOutcome::GapRetained,
+        );
+        let held: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            held, 1,
+            "and it is HELD, not merely reported — the verdict alone is not the fix"
+        );
+        let accepted: i64 =
+            tx.query_row("SELECT COUNT(*) FROM table_sync_entries", [], |r| r.get(0)).unwrap();
+        assert_eq!(accepted, 0, "but it is not on the accepted chain");
+    }
+
+    /// Two entries citing the SAME predecessor, both arriving before it. Both are held — neither
+    /// can be classified yet, because the predecessor that would make one of them a second
+    /// successor is not here. The equivocation only becomes visible on promotion.
+    #[test]
+    fn two_siblings_awaiting_one_predecessor_are_both_held() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let (genesis, first) = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let genesis = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            let first = author_row_entry(&tx, stream(), &secret, &op("r2"), 0).unwrap();
+            tx.commit().unwrap();
+            (genesis, first)
+        };
+        let sibling = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            Some(genesis.entry.entry_hash),
+            first.entry.lamport + 1,
+            row_op::encode(&op("r_sibling")),
+        );
+
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        for bytes in [&first.signed_bytes, &sibling.signed_bytes] {
+            assert_eq!(
+                accept_row_entry(&tx, account(), stream(), &["t"], bytes, &secret.public(), 0)
+                    .unwrap(),
+                AcceptOutcome::GapRetained,
+            );
+        }
+        let held: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(held, 2, "both siblings are held; neither can be judged without the parent");
+    }
+
+    /// The cap evicts the FURTHEST-AHEAD held entry, not the newcomer. Refusing the newcomer would
+    /// let whoever filled the table first block the near-tail entry the chain actually needs.
+    #[test]
+    fn the_cap_evicts_the_furthest_ahead_held_entry() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        let stream_bytes = stream().to_bytes();
+        let device_bytes = secret.public().fingerprint().to_bytes();
+        // Fill the chain to the cap with synthetic held rows at high lamports.
+        for i in 0..MAX_GAPPED_PER_CHAIN {
+            let mut hash = [0u8; 32];
+            hash[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            tx.execute(
+                "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+                 lamport, prev_hash, signed_bytes, gapped_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0)",
+                params![
+                    hash.as_slice(),
+                    stream_bytes.as_slice(),
+                    device_bytes.as_slice(),
+                    i64::try_from(1_000_000 + i).unwrap(),
+                    [9u8; 32].as_slice(),
+                    [0u8; 4].as_slice(),
+                ],
+            )
+            .unwrap();
+        }
+        let highest = i64::try_from(1_000_000 + MAX_GAPPED_PER_CHAIN - 1).unwrap();
+
+        // A near-tail entry arrives with the table full.
+        let newcomer = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            Some([7u8; 32]),
+            5,
+            row_op::encode(&op("r_new")),
+        );
+        assert_eq!(
+            accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t"],
+                &newcomer.signed_bytes,
+                &secret.public(),
+                0
+            )
+            .unwrap(),
+            AcceptOutcome::GapRetained,
+            "the newcomer is held, not refused",
+        );
+        let still_capped: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(usize::try_from(still_capped).unwrap(), MAX_GAPPED_PER_CHAIN, "the cap holds");
+        let evicted: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_gapped_entries WHERE lamport = ?1",
+                params![highest],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(evicted, 0, "the furthest-ahead entry made room, not the arriving one");
+        let kept: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_gapped_entries WHERE entry_hash = ?1",
+                params![newcomer.entry.entry_hash.as_slice()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(kept, 1, "and the near-tail newcomer is the one held");
+
+        // The OTHER direction: an arrival further ahead than everything held is itself the entry
+        // the policy drops. Evicting the stored maximum for it would invert the policy — a table of
+        // near-tail entries would be hollowed out by a stream of ever-higher-lamport arrivals.
+        let far = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            Some([7u8; 32]),
+            9_000_000,
+            row_op::encode(&op("r_far")),
+        );
+        assert_eq!(
+            accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t"],
+                &far.signed_bytes,
+                &secret.public(),
+                0
+            )
+            .unwrap(),
+            AcceptOutcome::GapChainFull,
+            "the furthest-ahead arrival is refused, and says so rather than reporting itself held",
+        );
+        let far_held: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_gapped_entries WHERE entry_hash = ?1",
+                params![far.entry.entry_hash.as_slice()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(far_held, 0, "it is not held");
+        let survivors: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            usize::try_from(survivors).unwrap(),
+            MAX_GAPPED_PER_CHAIN,
+            "and it displaced nothing",
+        );
+    }
+
+    /// At the cap boundary the arrival's lamport can TIE the furthest-ahead held entry. Ranking on
+    /// lamport alone resolves that as "whoever is already held wins" — insertion order again, the
+    /// property the hash tie-break exists to remove. The comparison therefore uses the same
+    /// `(lamport, entry_hash)` order the eviction victim is chosen by, so two ties on opposite
+    /// sides of the held entry get opposite answers.
+    #[test]
+    fn a_lamport_tie_at_the_cap_boundary_is_broken_by_hash() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        let stream_bytes = stream().to_bytes();
+        let device_bytes = secret.public().fingerprint().to_bytes();
+        // Fill to the cap. Every row sits at the SAME lamport with a mid-range hash, so a real
+        // signed entry at that lamport can sort on either side of the furthest-ahead one.
+        const BOUNDARY: i64 = 500;
+        for i in 0..MAX_GAPPED_PER_CHAIN {
+            let mut hash = [0x80u8; 32];
+            hash[8..16].copy_from_slice(&(i as u64).to_be_bytes());
+            tx.execute(
+                "INSERT INTO table_sync_gapped_entries(entry_hash, stream_id, device_fingerprint, \
+                 lamport, prev_hash, signed_bytes, gapped_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0)",
+                params![
+                    hash.as_slice(),
+                    stream_bytes.as_slice(),
+                    device_bytes.as_slice(),
+                    BOUNDARY,
+                    [9u8; 32].as_slice(),
+                    [0u8; 4].as_slice(),
+                ],
+            )
+            .unwrap();
+        }
+        let furthest: Vec<u8> = tx
+            .query_row(
+                "SELECT entry_hash FROM table_sync_gapped_entries
+                  WHERE stream_id = ?1 AND lamport = ?2 ORDER BY entry_hash DESC LIMIT 1",
+                params![stream_bytes.as_slice(), BOUNDARY],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        let (mut lower, mut higher) = (None, None);
+        for nonce in 0u32..256 {
+            let tie = entry::sign_entry_from_op_bytes(
+                &secret,
+                stream(),
+                Some([7u8; 32]),
+                u64::try_from(BOUNDARY).unwrap(),
+                row_op::encode(&op(&format!("tie{nonce}"))),
+            );
+            if tie.entry.entry_hash.as_slice() < furthest.as_slice() {
+                lower.get_or_insert(tie);
+            } else {
+                higher.get_or_insert(tie);
+            }
+            if lower.is_some() && higher.is_some() {
+                break;
+            }
+        }
+        let (lower, higher) =
+            (lower.expect("a lower-hash tie"), higher.expect("a higher-hash tie"));
+
+        assert_eq!(
+            accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t"],
+                &higher.signed_bytes,
+                &secret.public(),
+                0
+            )
+            .unwrap(),
+            AcceptOutcome::GapChainFull,
+            "a tie sorting ABOVE the furthest held entry is the one dropped",
+        );
+        assert_eq!(
+            accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t"],
+                &lower.signed_bytes,
+                &secret.public(),
+                0
+            )
+            .unwrap(),
+            AcceptOutcome::GapRetained,
+            "a tie sorting BELOW it displaces it instead",
+        );
+    }
+
+    /// Which of two same-lamport siblings takes the successor slot must be a property of the
+    /// ENTRIES, not of the order they happened to be inserted in. On lamport alone, SQLite falls
+    /// back to physical row order, so two replicas holding the same pair could accept different
+    /// successors and project different rows.
+    #[test]
+    fn the_sibling_taken_first_does_not_depend_on_insertion_order() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let genesis = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let g = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            tx.commit().unwrap();
+            g
+        };
+        let sib = |id: &str| {
+            entry::sign_entry_from_op_bytes(
+                &secret,
+                stream(),
+                Some(genesis.entry.entry_hash),
+                7,
+                row_op::encode(&op(id)),
+            )
+        };
+        let (one, two) = (sib("r_one"), sib("r_two"));
+
+        // Two stores, same pair of siblings, opposite insertion orders.
+        let taken_by = |order: [&crate::entry::SignedEntry; 2]| {
+            let mut b = conn();
+            let tx = b.transaction().unwrap();
+            for e in order {
+                accept_row_entry(
+                    &tx,
+                    account(),
+                    stream(),
+                    &["t"],
+                    &e.signed_bytes,
+                    &secret.public(),
+                    0,
+                )
+                .unwrap();
+            }
+            take_gapped_child(
+                &tx,
+                stream(),
+                secret.public().fingerprint(),
+                &genesis.entry.entry_hash,
+            )
+            .unwrap()
+            .expect("a sibling is available")
+            .entry_hash
+        };
+
+        assert_eq!(
+            taken_by([&one, &two]),
+            taken_by([&two, &one]),
+            "the same pair yields the same winner whichever arrived first",
         );
     }
 


### PR DESCRIPTION
Closes #1058. Part of #892 (wire-readiness requirement 4).

## The gap

A verified table-sync entry whose chain predecessor had not arrived was **dropped**. Out-of-order delivery is the normal condition on a transport, not an edge case, so a chain delivered tail-first never converged: everything after the gap was lost, and only redelivery in exact causal order recovered it.

Such an entry is now held in `table_sync_gapped_entries` (schema V096) and promoted once its predecessor is accepted.

## Design

**Its own table, not a status column.** Six queries read `table_sync_entries` as "the accepted chain" — the authoring Lamport clock, the lamport-advance bound, the chain tail, entry existence, the winning-entry lookup, and the refold's pending set. Each must keep excluding an entry that is not on a chain; a separate table gives all six the right answer by construction rather than by six filters, one of which would eventually be missed.

**Held entries do not advance the Lamport clock.** If they did, one far-ahead entry would drag local authoring with it — what the lamport-advance bound exists to stop a single entry doing. This is the distinction from *pending* entries, which are stored and do count: pending is a projection state, held is a chain state, and the two are redeemed by different events.

**Promotion re-runs the full accept-and-apply path** rather than writing rows directly, so a promoted entry cannot skip a gate a fresh one passes — including the unsent-local-work deferral (#1005) and quarantine recording. The loop is iterative, so a long reverse-delivered chain heals without recursion.

**Accepting an entry settles three sets, and all three are drained.** Its child is the chain advance. Its siblings cite a predecessor whose successor slot the acceptance just filled, so each is re-ingested and judged a conflict. And the descendants of each sibling so judged are abandoned with it: a fork is never stored, so it can never become anyone's predecessor, and an entry citing it is keyed to a hash no future acceptance produces. Draining any one set alone strands rows in the table permanently.

**Sibling order is `(lamport, entry_hash)`.** The schema deliberately admits two siblings at one lamport; on lamport alone the choice between them falls back to physical row order, so two replicas holding the same pair could accept different successors and project different rows, each then classifying the other's winner as a fork.

**Bounded, not reclaimed.** A per-chain cap retains the entries nearest the tail, since those promote soonest. The arrival competes on the same footing as the rows already held, so one that is itself the furthest ahead is refused and says so rather than reporting itself held — evicting the stored maximum unconditionally would invert the policy exactly when it matters, hollowing out a table of near-tail entries under a stream of ever-higher-lamport arrivals. Only a roster-effective writer can occupy the table at all (the authority gate precedes chain classification), so the flood surface is roster members, whose remedy is device removal.

No TTL ships here; reclamation belongs with retention and compaction, together with #1020's constraint that a row's publication record must be refreshed before its winner is dropped.

**Purge.** Held entries are swept with their repo like the accepted log, for the same reason (#1004): the stream id is derived, so retaining them would let a re-registration replay a removed repo's operations back into it. All three pinned enumeration sites are updated, including the sibling-preservation direction the worktree rule requires.

## Out of scope

Fork *evidence* — proving an equivocation to a peer — is unchanged.

## Verification

Every new test was checked against a mutation that reverts the behavior it names; each one fails.

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` — exit 0
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — exit 0
- `cargo nextest run --workspace` — 4428 passed, 7 skipped
- `cargo test -p rag-rat-db -p rag-rat-oplog` — passed (the coverage job's runner)