### PR TITLE
feat(oracle): let a project marker have several names

### DIFF
--- a/crates/rag-rat-oracle/src/backend/documents.rs
+++ b/crates/rag-rat-oracle/src/backend/documents.rs
@@ -26,12 +26,12 @@ use super::scope::CheckoutScope;
 pub(super) fn enclosing_project_dir(
     checkout: &CheckoutScope<'_>,
     path: &Path,
-    marker: &str,
+    markers: &[&str],
 ) -> Option<PathBuf> {
     let ceiling = checkout.ceiling();
     let mut dir = path.parent()?;
     loop {
-        if dir.join(marker).exists() {
+        if markers.iter().any(|marker| dir.join(marker).exists()) {
             return Some(dir.to_path_buf());
         }
         if dir == ceiling {
@@ -86,10 +86,10 @@ pub(super) fn find_document_in_project(
     checkout: &CheckoutScope<'_>,
     dir: &Path,
     languages: &[Language],
-    marker: &str,
+    markers: &[&str],
     inside_project: bool,
 ) -> Option<PathBuf> {
-    let inside_project = inside_project || dir.join(marker).exists();
+    let inside_project = inside_project || markers.iter().any(|marker| dir.join(marker).exists());
     let mut subdirectories = Vec::new();
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
         let Ok(kind) = entry.file_type() else {
@@ -107,7 +107,7 @@ pub(super) fn find_document_in_project(
             return Some(path);
         }
     }
-    subdirectories
-        .into_iter()
-        .find_map(|sub| find_document_in_project(checkout, &sub, languages, marker, inside_project))
+    subdirectories.into_iter().find_map(|sub| {
+        find_document_in_project(checkout, &sub, languages, markers, inside_project)
+    })
 }

--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -51,7 +51,20 @@ pub struct LiveBackend {
 /// A backend's project marker, and how it relates to the documents it governs.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ProjectMarker {
-    pub(crate) file: &'static str,
+    /// The filenames that declare this project, any one of which is enough. First match wins.
+    ///
+    /// Several because a build system often accepts several spellings of the same declaration —
+    /// Gradle takes `build.gradle.kts` or `build.gradle`, and a checkout using the one the backend
+    /// did not name would read as having no project at all: its readiness signal never fires, so
+    /// the session could only ever sit in `Warming` while its prerequisite gate reported the
+    /// project missing.
+    ///
+    /// A `ProjectScope::Checkout` marker declares exactly ONE, and a test pins that. It is not a
+    /// sentinel — it is PARSED, as a `compile_commands.json` compilation database, to decide
+    /// whether it configures an indexed file and whether it can be pinned with
+    /// `--compile-commands-dir`. A second name there would mean a second format and a second
+    /// reader, which is a different change from widening a presence test.
+    pub(crate) files: &'static [&'static str],
     scope: ProjectScope,
     /// What the operator loses while this marker is missing, and what to do about it — the tail of
     /// the prerequisite hint. The two progress-signalled backends share the gate and the sentence
@@ -109,7 +122,7 @@ impl LiveBackend {
                 readiness: ReadinessPolicy::WorkDoneProgress,
                 language_ids: &[("tsx", "typescriptreact"), ("ts", "typescript")],
                 project_marker: Some(ProjectMarker {
-                    file: "tsconfig.json",
+                    files: &["tsconfig.json"],
                     scope: ProjectScope::Enclosing,
                     hint_detail: "Asked mid-load, typescript-language-server resolves an imported \
                                   callee to the import statement instead of the definition. Add a \
@@ -150,7 +163,7 @@ impl LiveBackend {
                 // header declaration and emits no progress at all (measured) — the same
                 // no-signal state a tsconfig-less TypeScript checkout is in.
                 project_marker: Some(ProjectMarker {
-                    file: "compile_commands.json",
+                    files: &["compile_commands.json"],
                     scope: ProjectScope::Checkout,
                     hint_detail: "Without a compilation database clangd resolves a call into \
                                   another translation unit only to the callee's header \
@@ -196,6 +209,16 @@ impl LiveBackend {
         self.languages.contains(&language)
     }
 
+    /// Whether this backend's project marker is PARSED rather than merely present.
+    ///
+    /// A parsed marker is read as a specific file format (today: a `compile_commands.json`
+    /// compilation database), so its name and its reader are one decision — which is why it
+    /// declares a single name while a presence-tested marker may declare several.
+    #[cfg(test)]
+    pub(crate) fn marker_is_parsed(&self) -> bool {
+        self.project_marker.is_some_and(|marker| marker.scope == ProjectScope::Checkout)
+    }
+
     /// Resolve this checkout's project layout — the one filesystem scan a session performs.
     pub fn resolve_layout(&self, checkout: &CheckoutScope<'_>) -> ProjectLayout {
         let Some(marker) = self.project_marker else {
@@ -205,8 +228,13 @@ impl LiveBackend {
             // An enclosing-scoped marker is answered per document by walking UP, which is cheap
             // and needs no precomputed set.
             ProjectScope::Enclosing => ProjectLayout::default(),
-            ProjectScope::Checkout =>
-                ProjectLayout::from_marker_sites(marker.file, marker_sites(checkout, marker.file)),
+            // The governing marker is PARSED, so the scan takes the one name it declares. An
+            // empty declaration is a registry bug (a test pins it); treat it as "no project"
+            // rather than scanning for a nameless file, which would match every directory.
+            ProjectScope::Checkout => match marker.files.first() {
+                Some(file) => ProjectLayout::from_marker_sites(file, marker_sites(checkout, file)),
+                None => ProjectLayout::default(),
+            },
         }
     }
 
@@ -238,7 +266,7 @@ impl LiveBackend {
                     ProjectScope::Enclosing => documents::enclosing_project_dir(
                         checkout,
                         &checkout.root().join(path),
-                        marker.file,
+                        marker.files,
                     )
                     .is_some(),
                     // Readiness, not resolution — [`Trust::Possible`] for the same reason as
@@ -280,7 +308,7 @@ impl LiveBackend {
                         checkout,
                         checkout.root(),
                         self.languages,
-                        marker.file,
+                        marker.files,
                         false,
                     ),
                     // The marker can sit anywhere, so the two halves are searched independently
@@ -355,8 +383,13 @@ impl LiveBackend {
         if layout.is_empty() {
             return false;
         }
+        // The governing marker's single parsed name; an empty declaration is a registry bug, and
+        // resolving nothing is the safe reading of it.
+        let Some(file) = marker.files.first() else {
+            return false;
+        };
         layout.sole_marker_dir().is_some()
-            || layout.discoverable_marker_dir(checkout, absolute, marker.file, trust).is_some()
+            || layout.discoverable_marker_dir(checkout, absolute, file, trust).is_some()
     }
 
     /// Whether this session can resolve `path` (repo-relative) — the live pass's per-file gate.

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -681,15 +681,134 @@ fn enclosing_tsconfig_walks_up_to_the_nearest_project_and_stops_at_the_root() {
     std::fs::write(dir.join("packages/app/tsconfig.json"), "{}").unwrap();
 
     assert_eq!(
-        enclosing_project_dir(&scope(&dir), &dir.join("packages/app/src/main.ts"), "tsconfig.json"),
+        enclosing_project_dir(&scope(&dir), &dir.join("packages/app/src/main.ts"), &[
+            "tsconfig.json"
+        ]),
         Some(dir.join("packages/app")),
         "the nearest enclosing project wins",
     );
     assert_eq!(
-        enclosing_project_dir(&scope(&dir), &dir.join("scripts/tool.ts"), "tsconfig.json"),
+        enclosing_project_dir(&scope(&dir), &dir.join("scripts/tool.ts"), &["tsconfig.json"]),
         None,
         "a file under no project has none",
     );
+}
+
+#[test]
+fn any_declared_marker_name_identifies_a_project() {
+    // A build system often accepts several spellings of the same declaration — Gradle takes
+    // `build.gradle.kts` or `build.gradle`. With one name per marker a checkout using the other
+    // spelling reads as having no project at all: the readiness signal never fires, so the session
+    // can only sit in `Warming` while the prerequisite gate reports the project missing (#1042).
+    let (_dir_guard, dir) = checkout("marker-alternates");
+    std::fs::create_dir_all(dir.join("app/src")).unwrap();
+    std::fs::create_dir_all(dir.join("lib/src")).unwrap();
+    // One module declares itself with the first name, the other with the second.
+    std::fs::write(dir.join("app/build.gradle.kts"), "").unwrap();
+    std::fs::write(dir.join("lib/build.gradle"), "").unwrap();
+    let names = &["build.gradle.kts", "build.gradle"];
+
+    assert_eq!(
+        enclosing_project_dir(&scope(&dir), &dir.join("app/src/Main.kt"), names),
+        Some(dir.join("app")),
+        "the first name identifies its project",
+    );
+    assert_eq!(
+        enclosing_project_dir(&scope(&dir), &dir.join("lib/src/Lib.kt"), names),
+        Some(dir.join("lib")),
+        "and so does any other declared name — this is what one name per marker could not do",
+    );
+    assert_eq!(
+        enclosing_project_dir(&scope(&dir), &dir.join("src/Stray.kt"), names),
+        None,
+        "a file under none of them still has no project",
+    );
+}
+
+#[test]
+fn a_warmup_document_is_found_under_a_project_declared_by_any_name() {
+    // The second widened path. The warm-up search is what makes a backend usable on a checkout
+    // whose changed files all sit outside a project, so a name it does not recognise there costs
+    // the same thing as one the ancestor walk misses: the session never warms (#1042).
+    let (_dir_guard, dir) = checkout("warmup-marker-alternates");
+    std::fs::create_dir_all(dir.join("lib/src")).unwrap();
+    // Only the SECOND declared name, and the document sits beneath it.
+    std::fs::write(dir.join("lib/build.gradle"), "").unwrap();
+    std::fs::write(dir.join("lib/src/main.ts"), "export function greet() {}\n").unwrap();
+
+    let found = super::documents::find_document_in_project(
+        &scope(&dir),
+        &dir,
+        &[Language::TypeScript],
+        &["build.gradle.kts", "build.gradle"],
+        false,
+    );
+
+    assert_eq!(
+        found,
+        Some(dir.join("lib/src/main.ts")),
+        "a project declared by any name yields a warm-up document",
+    );
+}
+
+#[test]
+fn the_prerequisite_hint_names_every_spelling_that_would_satisfy_the_marker() {
+    // The third widened path. An operator reading the hint must not be sent to create the one
+    // spelling the backend happened to list first when another would have done (#1042).
+    use crate::manifest::hint_marker_names;
+
+    assert_eq!(
+        hint_marker_names(&["build.gradle.kts", "build.gradle"]),
+        "build.gradle.kts or build.gradle",
+        "every declared name appears",
+    );
+    assert_eq!(
+        hint_marker_names(&["tsconfig.json"]),
+        "tsconfig.json",
+        "and a single-name marker reads exactly as it did before",
+    );
+    assert_eq!(
+        hint_marker_names(&[]),
+        "project",
+        "a marker declaring no name falls back to the generic wording rather than naming nothing",
+    );
+
+    // And through the real hint, for a shipped single-name backend: the rendering above is the
+    // one an operator actually reads.
+    let (_dir_guard, dir) = checkout("hint-single-name");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.ts"), "export function greet() {}\n").unwrap();
+    let corpus = crate::test_support::PrefixCorpus::new(&dir, &["src"]);
+    let hint = crate::ToolManifest::for_tool(OracleTool::TsLsp)
+        .prerequisite_blocked_with(&super::CheckoutScope::resolve(&dir, &corpus), None)
+        .expect("a checkout with no tsconfig blocks the TypeScript backend");
+    assert!(
+        hint.contains("found no tsconfig.json project"),
+        "the shipped single-name hint is unchanged: {hint}",
+    );
+}
+
+#[test]
+fn a_governing_marker_declares_exactly_one_name() {
+    // A `Checkout`-scoped marker is not a sentinel: it is PARSED, as a `compile_commands.json`
+    // compilation database, to decide whether it configures an indexed file and whether it can be
+    // pinned with `--compile-commands-dir`. A second name there would mean a second FORMAT and a
+    // second reader — widening the presence test buys nothing without them, and the scan silently
+    // takes the first name. If you are adding one, that reader is what you also have to write.
+    for backend in LiveBackend::all() {
+        let Some(marker) = backend.project_marker else {
+            continue;
+        };
+        assert!(!marker.files.is_empty(), "{:?} declares a marker with no name", backend.tool);
+        if backend.marker_is_parsed() {
+            assert_eq!(
+                marker.files.len(),
+                1,
+                "{:?} declares a PARSED marker with several names, but only the first is read",
+                backend.tool,
+            );
+        }
+    }
 }
 
 #[test]
@@ -798,7 +917,7 @@ fn a_backends_project_marker_is_the_file_its_prerequisite_looks_for() {
     // could pass the gate and still have nothing to warm on (or vice versa).
     let (_dir_guard, dir) = checkout("clangd-marker");
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    assert_eq!(clangd.project_marker.map(|m| m.file), Some("compile_commands.json"));
+    assert_eq!(clangd.project_marker.map(|m| m.files), Some(&["compile_commands.json"][..]),);
     assert!(
         !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "no compdb ⇒ no signal possible"

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -289,10 +289,24 @@ impl ToolManifest {
                 };
                 // A progress-signalled backend that declared no marker could never signal either,
                 // so it still blocks — with the generic wording, since there is no file to name.
-                let (marker, detail) =
-                    backend.project_marker.map_or(("project", "Add one to enable it."), |marker| {
-                        (marker.file, marker.hint_detail)
-                    });
+                // Every name that would satisfy the marker, so an operator is not sent to create
+                // the one spelling the backend happened to list first when another would do.
+                //
+                // A marker declaring NO name falls back to the generic wording, like a backend
+                // with no marker at all: joining an empty list renders "found no  project under",
+                // which names nothing while looking like it does. Every other reader of an empty
+                // declaration already fails closed; this is the one that has to say so in prose.
+                let (marker, detail) = backend.project_marker.map_or(
+                    (hint_marker_names(&[]), "Add one to enable it."),
+                    |marker| {
+                        let detail = if marker.files.is_empty() {
+                            "Add one to enable it."
+                        } else {
+                            marker.hint_detail
+                        };
+                        (hint_marker_names(marker.files), detail)
+                    },
+                );
                 if backend.checkout_can_signal_readiness(checkout, layout) {
                     return None;
                 }
@@ -431,6 +445,17 @@ fn detect_version_in(program: &str, cwd: Option<&Path>) -> Option<String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let line = stdout.lines().map(str::trim).find(|line| !line.is_empty())?;
     Some(line.to_string())
+}
+
+/// How a project marker's names read in the prerequisite hint: every spelling that would satisfy
+/// it, joined, so an operator is not sent to create the one the backend happened to list first
+/// when another would do.
+///
+/// An empty list renders as the generic word rather than as nothing. Joining it would produce
+/// "found no  project under", which names no file while looking like it does — and every other
+/// reader of an empty declaration already fails closed.
+pub(crate) fn hint_marker_names(files: &[&str]) -> String {
+    if files.is_empty() { "project".to_string() } else { files.join(" or ") }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
First slice of #1042 stage 3, scoped to the part that unblocks #536.

## The blocker

A backend declares its project by one filename. Build systems commonly accept several spellings of the same declaration — Gradle takes `build.gradle.kts` or `build.gradle` — so a checkout using the spelling the backend did not name reads as having no project at all. Its readiness signal never fires, which means the session can only sit in `Warming` while the prerequisite gate reports the project missing.

## The change

`ProjectMarker.file` becomes `files`, matched first-name-wins wherever presence is tested:

- the ancestor walk that assigns a document to a project (`enclosing_project_dir`)
- the warm-up search (`find_document_in_project`)
- the prerequisite hint, which now names every spelling that would satisfy the marker

Both shipped backends declare one name each, so their behaviour is unchanged.

## What stays single-name

A `ProjectScope::Checkout` marker is not a sentinel — it is *parsed*, as a `compile_commands.json` compilation database, to decide whether it configures an indexed file and whether it can be pinned with `--compile-commands-dir`. A second name there means a second format and a second reader, which is a different change; widening the presence test alone would buy nothing, and the scan would silently take the first name. A test pins the invariant with that reasoning attached, so the next person to add one is told what else they would have to write.

This is deliberately not encoded as `Sentinel { files } | Governing { file }`. That would give the invariant for free but fuses two axes that merely coincide today — where a marker must sit relative to a document, and whether it is parsed. Kotlin is a sentinel with `Enclosing` scope; nothing yet forces the pairing.

## Failure direction

Every reader of an empty declaration fails closed: no project rather than a nameless file that would match every directory, and the generic hint wording rather than prose that names nothing while appearing to name something.

## Verification

4502 tests pass; `cargo +nightly fmt --check` and both clippy configurations exit 0. Each of the three widened paths has a test that fails if that path alone is narrowed back to the first name.

## Not in this change

The rest of stage 3: collapsing prerequisite/marker/scope into one `ProjectModel`, and moving `--compile-commands-dir` out of `spawn_args`.