### PR TITLE
refactor(oracle): declare a backend's project as one model, and its marker pin with it

### DIFF
--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -45,26 +45,19 @@ pub struct LiveBackend {
     /// This is the same file the backend's `prerequisite_blocked` gate looks for, because it is
     /// the same question: a checkout with no such project emits no readiness signal, so the
     /// backend could only ever sit in `Warming`.
-    pub(crate) project_marker: Option<ProjectMarker>,
+    pub(crate) project_model: Option<ProjectModel>,
 }
 
-/// A backend's project marker, and how it relates to the documents it governs.
+/// What makes a checkout a PROJECT for one backend: how its marker is read, where that marker has
+/// to sit, and what the operator loses while it is missing.
+///
+/// One declaration rather than three fields plus a hardcoded flag: the reading decides how many
+/// names the marker can have and whether the discovered directory is handed to the server, and
+/// those were previously spread across the registry, `spawn_args`, and the prerequisite hint.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ProjectMarker {
-    /// The filenames that declare this project, any one of which is enough. First match wins.
-    ///
-    /// Several because a build system often accepts several spellings of the same declaration —
-    /// Gradle takes `build.gradle.kts` or `build.gradle`, and a checkout using the one the backend
-    /// did not name would read as having no project at all: its readiness signal never fires, so
-    /// the session could only ever sit in `Warming` while its prerequisite gate reported the
-    /// project missing.
-    ///
-    /// A `ProjectScope::Checkout` marker declares exactly ONE, and a test pins that. It is not a
-    /// sentinel — it is PARSED, as a `compile_commands.json` compilation database, to decide
-    /// whether it configures an indexed file and whether it can be pinned with
-    /// `--compile-commands-dir`. A second name there would mean a second format and a second
-    /// reader, which is a different change from widening a presence test.
-    pub(crate) files: &'static [&'static str],
+pub(crate) struct ProjectModel {
+    /// How the marker is read — see [`MarkerKind`]. Independent of `scope`.
+    pub(crate) kind: MarkerKind,
     scope: ProjectScope,
     /// What the operator loses while this marker is missing, and what to do about it — the tail of
     /// the prerequisite hint. The two progress-signalled backends share the gate and the sentence
@@ -73,9 +66,68 @@ pub(crate) struct ProjectMarker {
     pub(crate) hint_detail: &'static str,
 }
 
+/// How a backend's project marker is read, which is what decides how many names it may have.
+///
+/// Distinct from `layout::MarkerReading`, which is a per-FILE outcome (is this database loadable,
+/// and does it govern anything indexed). This is the per-BACKEND declaration.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MarkerKind {
+    /// PRESENCE alone declares the project, so any of these names will do; first match wins.
+    ///
+    /// Several because a build system often accepts several spellings of the same declaration —
+    /// Gradle takes `build.gradle.kts` or `build.gradle`, and a checkout using the one the backend
+    /// did not name would read as having no project at all: its readiness signal never fires, so
+    /// the session could only ever sit in `Warming` while its prerequisite gate reported the
+    /// project missing.
+    Sentinel { files: &'static [&'static str] },
+    /// The marker is PARSED as a specific file format, so it has exactly one name: the name and
+    /// the reader that understands it are one decision, and a second name would mean a second
+    /// format and a second reader. Today the only such marker is a `compile_commands.json`
+    /// compilation database, read to decide whether it configures an indexed file.
+    ///
+    /// `pin` is the flag that hands the directory holding it to the server. It lives here rather
+    /// than in the spawn arguments because it is meaningless without this marker: clangd discovers
+    /// a database only in an opened file's ancestor directories and their `build/` subdirectory,
+    /// so a database anywhere else is invisible to it, and passing the directory found is what
+    /// makes every layout behave the same.
+    Parsed { file: &'static str, pin: &'static str },
+}
+
+impl ProjectModel {
+    /// Every name that would satisfy this marker. Borrowed from `self`, which is `Copy` — hold the
+    /// model in a binding rather than calling this on a temporary.
+    pub(crate) fn files(&self) -> &[&'static str] {
+        match &self.kind {
+            MarkerKind::Sentinel { files } => files,
+            MarkerKind::Parsed { file, .. } => std::slice::from_ref(file),
+        }
+    }
+
+    /// The single name this marker is parsed from, or `None` when presence alone declares it.
+    pub(crate) fn parsed_file(&self) -> Option<&'static str> {
+        match self.kind {
+            MarkerKind::Parsed { file, .. } => Some(file),
+            MarkerKind::Sentinel { .. } => None,
+        }
+    }
+
+    /// The flag that hands the discovered marker directory to the server, if this marker has one.
+    fn pin_flag(&self) -> Option<&'static str> {
+        match self.kind {
+            MarkerKind::Parsed { pin, .. } => Some(pin),
+            MarkerKind::Sentinel { .. } => None,
+        }
+    }
+}
+
 /// Where a project marker has to sit relative to a document for that document to belong to it.
 /// The two live backends genuinely differ, and assuming either shape for the other misclassifies
 /// ordinary layouts.
+///
+/// Deliberately separate from [`MarkerKind`]. The two coincide today — the sentinel is
+/// enclosing, the parsed one is checkout-wide — but they are different questions, and a Gradle
+/// sentinel is enclosing while nothing forces a sentinel to be. Fusing them would have to be undone
+/// by the first backend that breaks the pairing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ProjectScope {
     /// The marker governs its own SUBTREE: a document belongs to it only when the marker sits in
@@ -106,7 +158,7 @@ impl LiveBackend {
                 // rust-analyzer reports load/index quiescence explicitly, for any checkout.
                 readiness: ReadinessPolicy::ServerStatus,
                 language_ids: &[("rs", "rust")],
-                project_marker: None,
+                project_model: None,
             }),
             OracleTool::TsLsp => Some(Self {
                 tool,
@@ -121,8 +173,8 @@ impl LiveBackend {
                 // tsconfig.json, where no such cycle is ever emitted.
                 readiness: ReadinessPolicy::WorkDoneProgress,
                 language_ids: &[("tsx", "typescriptreact"), ("ts", "typescript")],
-                project_marker: Some(ProjectMarker {
-                    files: &["tsconfig.json"],
+                project_model: Some(ProjectModel {
+                    kind: MarkerKind::Sentinel { files: &["tsconfig.json"] },
                     scope: ProjectScope::Enclosing,
                     hint_detail: "Asked mid-load, typescript-language-server resolves an imported \
                                   callee to the import statement instead of the definition. Add a \
@@ -162,8 +214,11 @@ impl LiveBackend {
                 // that index from the compilation database. Without one it answers with the
                 // header declaration and emits no progress at all (measured) — the same
                 // no-signal state a tsconfig-less TypeScript checkout is in.
-                project_marker: Some(ProjectMarker {
-                    files: &["compile_commands.json"],
+                project_model: Some(ProjectModel {
+                    kind: MarkerKind::Parsed {
+                        file: "compile_commands.json",
+                        pin: "--compile-commands-dir",
+                    },
                     scope: ProjectScope::Checkout,
                     hint_detail: "Without a compilation database clangd resolves a call into \
                                   another translation unit only to the callee's header \
@@ -209,29 +264,23 @@ impl LiveBackend {
         self.languages.contains(&language)
     }
 
-    /// Whether this backend's project marker is PARSED rather than merely present.
-    ///
-    /// A parsed marker is read as a specific file format (today: a `compile_commands.json`
-    /// compilation database), so its name and its reader are one decision — which is why it
-    /// declares a single name while a presence-tested marker may declare several.
-    #[cfg(test)]
-    pub(crate) fn marker_is_parsed(&self) -> bool {
-        self.project_marker.is_some_and(|marker| marker.scope == ProjectScope::Checkout)
-    }
-
     /// Resolve this checkout's project layout — the one filesystem scan a session performs.
     pub fn resolve_layout(&self, checkout: &CheckoutScope<'_>) -> ProjectLayout {
-        let Some(marker) = self.project_marker else {
+        let Some(model) = self.project_model else {
             return ProjectLayout::default();
         };
-        match marker.scope {
+        match model.scope {
             // An enclosing-scoped marker is answered per document by walking UP, which is cheap
             // and needs no precomputed set.
             ProjectScope::Enclosing => ProjectLayout::default(),
             // The governing marker is PARSED, so the scan takes the one name it declares. An
-            // empty declaration is a registry bug (a test pins it); treat it as "no project"
+            // empty NAME is a registry bug (`every_declared_marker_name_is_usable` pins it, since
+            // the type guarantees one name but not a non-empty one); treat it as "no project"
             // rather than scanning for a nameless file, which would match every directory.
-            ProjectScope::Checkout => match marker.files.first() {
+            // Only a PARSED marker names a file this scan can look for — `marker_sites` searches
+            // for one filename. A checkout-scoped SENTINEL would need a multi-name site scan,
+            // which nothing declares; no layout rather than a wrong one.
+            ProjectScope::Checkout => match model.parsed_file() {
                 Some(file) => ProjectLayout::from_marker_sites(file, marker_sites(checkout, file)),
                 None => ProjectLayout::default(),
             },
@@ -262,11 +311,11 @@ impl LiveBackend {
         match self.readiness {
             ReadinessPolicy::ServerStatus => true,
             ReadinessPolicy::WorkDoneProgress =>
-                self.project_marker.is_some_and(|marker| match marker.scope {
+                self.project_model.is_some_and(|model| match model.scope {
                     ProjectScope::Enclosing => documents::enclosing_project_dir(
                         checkout,
                         &checkout.root().join(path),
-                        marker.files,
+                        model.files(),
                     )
                     .is_some(),
                     // Readiness, not resolution — [`Trust::Possible`] for the same reason as
@@ -275,7 +324,7 @@ impl LiveBackend {
                         checkout,
                         &checkout.root().join(path),
                         layout,
-                        marker,
+                        model,
                         Trust::Possible,
                     ),
                 }),
@@ -303,12 +352,12 @@ impl LiveBackend {
             // Session-level quiescence needs no document.
             ReadinessPolicy::ServerStatus => None,
             ReadinessPolicy::WorkDoneProgress =>
-                self.project_marker.and_then(|marker| match marker.scope {
+                self.project_model.and_then(|model| match model.scope {
                     ProjectScope::Enclosing => documents::find_document_in_project(
                         checkout,
                         checkout.root(),
                         self.languages,
-                        marker.files,
+                        model.files(),
                         false,
                     ),
                     // The marker can sit anywhere, so the two halves are searched independently
@@ -334,7 +383,7 @@ impl LiveBackend {
                                 checkout,
                                 document,
                                 layout,
-                                marker,
+                                model,
                                 Trust::Possible,
                             )
                         },
@@ -346,19 +395,30 @@ impl LiveBackend {
     /// The argv this backend's server is spawned with for `root`: the manifest's static arguments
     /// plus any that depend on the checkout.
     ///
+    /// The checkout-dependent part is the marker PIN: a backend whose marker is parsed declares the
+    /// flag that hands the directory holding it to the server (`MarkerKind::Parsed::pin`), and
+    /// it is appended when the layout found exactly one such directory.
+    ///
     /// clangd is the reason this is not just the static list. It discovers a compilation database
     /// only in an opened file's ancestor directories and their `build/` subdirectory, so a
     /// database anywhere else — `out/`, `cmake-build-debug/`, any project-specific name — is
     /// invisible to it. Passing the directory we found makes every layout behave the same, and
     /// keeps the prerequisite gate honest: it accepts a database wherever it sits precisely
     /// because the session is then told where that is.
+    ///
+    /// The flag is declared rather than written here: it is meaningless without the marker it
+    /// points at, so a second backend with a discovered artifact would otherwise have to be
+    /// special-cased in this shared method, or silently receive clangd's flag.
     pub(crate) fn spawn_args(&self, layout: &ProjectLayout) -> Vec<OsString> {
         let mut args: Vec<OsString> = self.stdio_args.iter().map(OsString::from).collect();
-        if let Some(dir) = layout.sole_marker_dir() {
+        if let Some(pin) = self.project_model.and_then(|model| model.pin_flag())
+            && let Some(dir) = layout.sole_marker_dir()
+        {
             // Built as an OsString, never through `Path::display()`: on Unix a path is bytes, and
             // formatting a non-UTF-8 component would substitute replacement characters and hand
             // the server a directory that does not exist.
-            let mut arg = OsString::from("--compile-commands-dir=");
+            let mut arg = OsString::from(pin);
+            arg.push("=");
             arg.push(dir.as_os_str());
             args.push(arg);
         }
@@ -377,15 +437,15 @@ impl LiveBackend {
         checkout: &CheckoutScope<'_>,
         absolute: &Path,
         layout: &ProjectLayout,
-        marker: ProjectMarker,
+        model: ProjectModel,
         trust: Trust,
     ) -> bool {
         if layout.is_empty() {
             return false;
         }
-        // The governing marker's single parsed name; an empty declaration is a registry bug, and
-        // resolving nothing is the safe reading of it.
-        let Some(file) = marker.files.first() else {
+        // Only a PARSED marker has a database to point the session at; a sentinel declares no
+        // file this gate could read.
+        let Some(file) = model.parsed_file() else {
             return false;
         };
         layout.sole_marker_dir().is_some()
@@ -404,7 +464,7 @@ impl LiveBackend {
         path: &str,
         layout: &ProjectLayout,
     ) -> bool {
-        match self.project_marker {
+        match self.project_model {
             Some(marker) if marker.scope == ProjectScope::Checkout => self.session_resolves(
                 checkout,
                 &checkout.root().join(path),

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -695,6 +695,57 @@ fn enclosing_tsconfig_walks_up_to_the_nearest_project_and_stops_at_the_root() {
 }
 
 #[test]
+fn every_declared_marker_name_is_usable() {
+    // `MarkerKind::Parsed` guarantees a parsed marker has exactly ONE name — that part of the old
+    // invariant is now in the type. What the type does not say is that a name is non-empty, and an
+    // empty one is worse than useless: `dir.join("")` is the directory itself, so a nameless
+    // sentinel would match every directory in the checkout, and an empty pin would hand the server
+    // a bare `=<dir>`. Every reader fails closed on it, but nothing should ever declare one.
+    for backend in LiveBackend::all() {
+        let Some(model) = backend.project_model else {
+            continue;
+        };
+        let names = model.files();
+        assert!(!names.is_empty(), "{:?} declares a marker with no name", backend.tool);
+        for name in names {
+            assert!(!name.is_empty(), "{:?} declares an empty marker name", backend.tool);
+        }
+        if let super::registry::MarkerKind::Parsed { pin, .. } = model.kind {
+            assert!(!pin.is_empty(), "{:?} declares an empty marker pin flag", backend.tool);
+        }
+    }
+}
+
+#[test]
+fn only_a_backend_that_declares_a_pin_receives_one() {
+    // The marker pin is a property of the MARKER, not of spawning: it is meaningless without the
+    // file it points at. Writing `--compile-commands-dir` into the shared argv builder meant any
+    // backend whose layout happened to find a sole marker directory would receive clangd's flag —
+    // harmless only because clangd is the one backend that produces such a layout today (#1042).
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
+    let (_dir_guard, dir) = checkout("pin-is-declared");
+    std::fs::write(dir.join("compile_commands.json"), COMPDB).unwrap();
+    std::fs::write(dir.join("main.c"), "int m(void){return 0;}\n").unwrap();
+
+    // A layout that DOES name a sole marker directory.
+    let layout = clangd.resolve_layout(&scope(&dir));
+    assert!(layout.sole_marker_dir().is_some(), "the fixture really pins a directory");
+
+    assert!(
+        clangd.spawn_args(&layout).contains(&compdb_arg(&dir)),
+        "the backend that declares a pin gets it: {:?}",
+        clangd.spawn_args(&layout),
+    );
+    assert_eq!(
+        ts.spawn_args(&layout),
+        vec![OsString::from("--stdio")],
+        "a backend whose marker is a sentinel declares no pin, so it receives none even from a \
+         layout that has one",
+    );
+}
+
+#[test]
 fn any_declared_marker_name_identifies_a_project() {
     // A build system often accepts several spellings of the same declaration — Gradle takes
     // `build.gradle.kts` or `build.gradle`. With one name per marker a checkout using the other
@@ -789,29 +840,6 @@ fn the_prerequisite_hint_names_every_spelling_that_would_satisfy_the_marker() {
 }
 
 #[test]
-fn a_governing_marker_declares_exactly_one_name() {
-    // A `Checkout`-scoped marker is not a sentinel: it is PARSED, as a `compile_commands.json`
-    // compilation database, to decide whether it configures an indexed file and whether it can be
-    // pinned with `--compile-commands-dir`. A second name there would mean a second FORMAT and a
-    // second reader — widening the presence test buys nothing without them, and the scan silently
-    // takes the first name. If you are adding one, that reader is what you also have to write.
-    for backend in LiveBackend::all() {
-        let Some(marker) = backend.project_marker else {
-            continue;
-        };
-        assert!(!marker.files.is_empty(), "{:?} declares a marker with no name", backend.tool);
-        if backend.marker_is_parsed() {
-            assert_eq!(
-                marker.files.len(),
-                1,
-                "{:?} declares a PARSED marker with several names, but only the first is read",
-                backend.tool,
-            );
-        }
-    }
-}
-
-#[test]
 fn a_warmup_document_is_found_at_any_depth_and_only_inside_a_project() {
     // A project can sit arbitrarily deep in a monorepo; a depth limit would silently disable
     // those checkouts entirely, which is worse than the walk it saves.
@@ -881,7 +909,7 @@ fn a_server_status_backend_needs_no_warmup_document_and_is_never_blocked_on_one(
         rust.open_signals_readiness(&scope(&dir), "src/lib.rs", &rust.resolve_layout(&scope(&dir))),
         "any document will do"
     );
-    assert!(rust.project_marker.is_none(), "session-level readiness needs no project");
+    assert!(rust.project_model.is_none(), "session-level readiness needs no project");
 }
 
 #[test]
@@ -917,7 +945,11 @@ fn a_backends_project_marker_is_the_file_its_prerequisite_looks_for() {
     // could pass the gate and still have nothing to warm on (or vice versa).
     let (_dir_guard, dir) = checkout("clangd-marker");
     let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
-    assert_eq!(clangd.project_marker.map(|m| m.files), Some(&["compile_commands.json"][..]),);
+    assert_eq!(
+        clangd.project_model.and_then(|m| m.parsed_file()),
+        Some("compile_commands.json"),
+        "the compilation database is PARSED, so it declares exactly one name",
+    );
     assert!(
         !clangd.checkout_can_signal_readiness(&scope(&dir), &clangd.resolve_layout(&scope(&dir))),
         "no compdb ⇒ no signal possible"

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -296,15 +296,16 @@ impl ToolManifest {
                 // with no marker at all: joining an empty list renders "found no  project under",
                 // which names nothing while looking like it does. Every other reader of an empty
                 // declaration already fails closed; this is the one that has to say so in prose.
-                let (marker, detail) = backend.project_marker.map_or(
+                let (marker, detail) = backend.project_model.map_or(
                     (hint_marker_names(&[]), "Add one to enable it."),
-                    |marker| {
-                        let detail = if marker.files.is_empty() {
+                    |model| {
+                        let names = model.files();
+                        let detail = if names.is_empty() {
                             "Add one to enable it."
                         } else {
-                            marker.hint_detail
+                            model.hint_detail
                         };
-                        (hint_marker_names(marker.files), detail)
+                        (hint_marker_names(names), detail)
                     },
                 );
                 if backend.checkout_can_signal_readiness(checkout, layout) {


### PR DESCRIPTION
Completes the declaration half of #1042 stage 3, following #1068.

## What was spread out

A backend's project was three fields plus a flag written into the shared argv builder: the marker names, where the marker had to sit, the hint text, and `--compile-commands-dir` hardcoded in `spawn_args` for whichever backend happened to produce a layout with a sole marker directory. That last part is harmless only because clangd is the one backend that produces such a layout — a second one would have silently received clangd's flag.

## One model

`ProjectModel` carries all of it, with the names inside a `MarkerKind`:

- `Sentinel { files }` — presence alone declares the project, so any of several names will do
- `Parsed { file, pin }` — the marker is read as a specific format, so it has exactly one name, and the flag that hands its directory to the server is declared beside it

Putting the names inside the kind makes **"a parsed marker has exactly one name" a property of the type**, so the test that asserted it is deleted rather than merely passing. What the type does *not* give is a non-empty name — an empty one would make `dir.join("")` match every directory in the checkout, and an empty pin would hand the server a bare `=<dir>` — so that half keeps a test.

## What stays separate

`ProjectScope` remains its own field. Where a marker must sit relative to a document and whether it is parsed are different questions that merely coincide today: the sentinel is enclosing, the parsed one is checkout-wide, but a Gradle sentinel is enclosing and nothing forces a sentinel to be. Fusing them would give the single-name rule for free and then have to be undone by the first backend that breaks the pairing.

The combination this makes newly representable — a checkout-wide sentinel — fails closed wherever it could appear: the site scan searches for one filename, so it yields no layout rather than a wrong one.

## Verification

4503 tests pass; `cargo +nightly fmt --check` and both clippy configurations exit 0. Behaviour is unchanged for both shipped backends — same argv, same prerequisite hint text, same layout and resolution decisions — and the new pin test fails if the flag goes back to being shared rather than declared.

## Stage 3 after this

Done. Remaining on #1042 is stage 4, the behaviour changes, each on its own merits.