### PR TITLE
chore(mcp): upgrade rmcp to 3.0 for MCP 2026-07-28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,12 +5583,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "3797d226787327b35b0b6f9e878fe55f3af2bb4daf916c0411079885454042f0"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "chrono",
  "futures",
  "pastey",
@@ -5595,13 +5601,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 # when installed in the OS store; minimal Linux images must include a CA bundle. The transport is
 # driven on the papertrail module's private runtime at the sync boundary.
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-rmcp = { version = "2.2.0", features = ["transport-io"] }
+rmcp = { version = "3.0.1", features = ["transport-io"] }
 rusqlite = { version = "0.40", features = ["bundled", "functions"] }
 rayon = "1.12"
 regex = "1.13"

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -429,6 +429,12 @@ fn discover_config_optional(explicit: Option<&str>) -> anyhow::Result<Option<Con
 /// taking repo intelligence down for the whole session (#603). A config that is PRESENT but invalid
 /// — or an explicit `--config` path that is missing — is still a loud error.
 fn run_mcp(explicit: Option<&str>, json: bool) -> anyhow::Result<()> {
+    // FIRST, before any other startup work: this process's environ already advertises it as a
+    // hot-upgrade target, and the fleet trigger reads environs. Everything below — config
+    // discovery, logging, the Tokio runtime the real handler needs — is time in which an
+    // unhandled SIGUSR1 would kill the server outright instead of upgrading it.
+    #[cfg(unix)]
+    rag_rat_mcp::upgrade::suppress_sigusr1_until_armed();
     let output_format =
         if json { rag_rat_core::OutputFormat::Json } else { rag_rat_core::OutputFormat::Toon };
     let config = discover_config_optional(explicit)?;

--- a/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
+++ b/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
@@ -113,6 +113,25 @@ fn sigusr1_is_survivable_before_and_without_an_initialize_handshake() {
     session.stop();
 }
 
+/// A set-but-EMPTY `RAG_RAT_UPGRADE_BIN` disables hot-upgrade for this process (`install_path`
+/// filters it out) while still making it a fleet target: the scan predicate matches any
+/// `RAG_RAT_UPGRADE_BIN=` entry, value included or not. That gap between "can upgrade" and "will be
+/// signaled" is exactly where a server must still defend itself.
+#[test]
+fn sigusr1_is_survivable_with_an_empty_upgrade_bin() {
+    let env = TestEnv::setup();
+    let mut session = env.spawn_mcp(&[("RAG_RAT_UPGRADE_BIN", "")]);
+    session.initialize();
+    let before = session.call_semantic_search();
+    assert!(before.contains("chunk_id"), "tool call works before the signal: {before}");
+
+    session.send_sigusr1();
+    session.assert_still_running("an empty RAG_RAT_UPGRADE_BIN must not leave SIGUSR1 fatal");
+    let after = session.call_semantic_search();
+    assert!(after.contains("chunk_id"), "server still serves after SIGUSR1: {after}");
+    session.stop();
+}
+
 /// The dormant server (launched outside any indexed repo) never hot-upgrades — with no config
 /// there is no handoff directory. It is still a `rag-rat mcp` process that a globally-registered
 /// launcher hands `RAG_RAT_UPGRADE_BIN`, so it is a fleet target like any other and must absorb

--- a/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
+++ b/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
@@ -73,6 +73,69 @@ fn sigusr1_exec_failure_exits_nonzero() {
     assert!(!status.success(), "exec failure must exit non-zero, got {status:?}");
 }
 
+/// `fleet::trigger` selects its targets by reading other processes' environ: a `rag-rat mcp`
+/// carrying `RAG_RAT_UPGRADE_BIN` is taken as proof that a `SIGUSR1` handler is installed, and is
+/// signaled on that basis. A server carrying that variable must therefore NEVER leave the signal on
+/// its default disposition, which terminates the process — mid-request, and with no diagnostic —
+/// instead of upgrading it.
+///
+/// This covers the two states where there is nothing to upgrade *to*: before the client has said
+/// anything at all, and after it opened a session through the stateless lifecycle (protocol
+/// 2026-07-28 drops `initialize` and carries the version + capabilities in each request's `_meta`,
+/// so the server never learns the peer info an `exec` handoff would need). Both must absorb the
+/// signal and keep serving.
+#[test]
+fn sigusr1_is_survivable_before_and_without_an_initialize_handshake() {
+    let env = TestEnv::setup();
+    let sentinel = env.root.join("must-not-run.marker");
+    let wrapper = env.write_upgrade_wrapper(&sentinel);
+
+    let mut session = env.spawn_mcp(&[("RAG_RAT_UPGRADE_BIN", wrapper.to_str().unwrap())]);
+
+    // (1) Signal arrives while the server is still blocked waiting for the client's first message.
+    // `ping` is the one request MCP permits before `initialize`, so it proves the server is up and
+    // serving without moving it out of the pre-handshake state the signal has to survive.
+    session.ping();
+    session.send_sigusr1();
+    session.assert_still_running("pre-handshake SIGUSR1 must not terminate the server");
+
+    // (2) The client then opens a session WITHOUT `initialize`. Serving must be unaffected.
+    let text = session.call_semantic_search_stateless();
+    assert!(text.contains("chunk_id"), "stateless session serves tool calls: {text}");
+
+    // (3) Signal again, now that the server knows the session has no handoff state.
+    session.send_sigusr1();
+    session.assert_still_running("SIGUSR1 on a stateless session must not terminate the server");
+    let text = session.call_semantic_search_stateless();
+    assert!(text.contains("chunk_id"), "stateless session still serves after SIGUSR1: {text}");
+
+    assert!(!sentinel.exists(), "a session with no handoff state must not `exec` the new binary");
+    session.stop();
+}
+
+/// The dormant server (launched outside any indexed repo) never hot-upgrades — with no config
+/// there is no handoff directory. It is still a `rag-rat mcp` process that a globally-registered
+/// launcher hands `RAG_RAT_UPGRADE_BIN`, so it is a fleet target like any other and must absorb
+/// `SIGUSR1` rather than die on it.
+#[test]
+fn sigusr1_does_not_kill_a_dormant_server() {
+    let elsewhere = unique_dir("hot-upgrade-dormant");
+    fs::create_dir_all(&*elsewhere).unwrap();
+    let installed = elsewhere.join("rag-rat-installed");
+    fs::write(&installed, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut session = Session::spawn_dormant(&elsewhere, &installed);
+    let notice = session.call_semantic_search_stateless();
+    assert!(notice.contains("no_index"), "server is dormant: {notice}");
+
+    session.send_sigusr1();
+    session.assert_still_running("SIGUSR1 must not terminate a dormant server");
+    let notice = session.call_semantic_search_stateless();
+    assert!(notice.contains("no_index"), "dormant server still serves after SIGUSR1: {notice}");
+    session.stop();
+}
+
 struct TestEnv {
     root: ScratchRoot,
     config_path: PathBuf,
@@ -183,10 +246,76 @@ impl Session {
             .to_string()
     }
 
+    /// Issue a `semantic_search` through the STATELESS lifecycle — no `initialize`, with the
+    /// protocol version and client capabilities riding in the request's own `_meta`. A server
+    /// reached this way never learns its peer's `initialize` params.
+    fn call_semantic_search_stateless(&mut self) -> String {
+        let id = self.take_id();
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo":
+                        {"name": "rag-rat-upgrade-test", "version": "0.1"},
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                },
+                "name": "semantic_search",
+                "arguments": {"query": "search", "limit": 1}
+            }
+        }));
+        let response = self.recv();
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("tool call had no text result: {response}"))
+            .to_string()
+    }
+
+    /// A dormant server: no `--config`, and a working directory with no config to discover, so the
+    /// server activates nothing and every `tools/call` returns the `no_index` notice.
+    fn spawn_dormant(cwd: &Path, install_path: &Path) -> Session {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+            .arg("mcp")
+            .current_dir(cwd)
+            .env("RAG_RAT_UPGRADE_BIN", install_path)
+            .env("RAG_RAT_NO_WATCH", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let reader = BufReader::new(child.stdout.take().unwrap());
+        Session { child, stdin, reader, next_id: 1 }
+    }
+
+    /// The one request MCP permits before `initialize`. Used to prove the server is up and
+    /// serving while still in the pre-handshake state.
+    fn ping(&mut self) {
+        let id = self.take_id();
+        self.send(json!({"jsonrpc": "2.0", "id": id, "method": "ping", "params": {}}));
+        let response = self.recv();
+        assert_eq!(response["id"], id, "ping response");
+    }
+
     fn send_sigusr1(&self) {
         let pid = self.child.id();
         let status = Command::new("kill").arg("-USR1").arg(pid.to_string()).status().unwrap();
         assert!(status.success(), "failed to deliver SIGUSR1 to {pid}");
+    }
+
+    /// Give the signal time to be delivered and acted on, then assert the process is still up.
+    /// A default-disposition `SIGUSR1` kills within microseconds, so a short settle is enough;
+    /// the follow-up tool call is what proves it is still *serving*, not merely un-reaped.
+    fn assert_still_running(&mut self, what: &str) {
+        std::thread::sleep(Duration::from_millis(750));
+        assert!(
+            self.child.try_wait().unwrap().is_none(),
+            "{what} (exited with {:?})",
+            self.child.try_wait().unwrap()
+        );
     }
 
     fn wait_for_exit(&mut self, timeout: Duration) -> std::process::ExitStatus {

--- a/crates/rag-rat-core/src/fleet.rs
+++ b/crates/rag-rat-core/src/fleet.rs
@@ -19,6 +19,20 @@ use std::path::Path;
 /// this constant) and used here to read other processes' environ.
 pub const UPGRADE_BIN_ENV: &str = "RAG_RAT_UPGRADE_BIN";
 
+/// Whether THIS process advertises hot-upgrade eligibility — i.e. whether a `trigger` running
+/// elsewhere may decide to send it `SIGUSR1`. The mirror of the scan-side `has_upgrade_env`
+/// predicate, and the thing a server must consult before deciding whether it has to defend itself
+/// against the signal.
+///
+/// Keyed on PRESENCE, deliberately: `has_upgrade_env` matches any `RAG_RAT_UPGRADE_BIN=` entry,
+/// including an empty value, so a process whose variable is set-but-empty is a target even though
+/// it cannot actually upgrade (`install_path` filters empty). Defending has to use the trigger's
+/// rule, not the can-I-upgrade rule — and it must stay the LOOSER of the two, since an older binary
+/// elsewhere in the fleet is running an older copy of the scan predicate.
+pub fn self_advertises_upgrade() -> bool {
+    std::env::var_os(UPGRADE_BIN_ENV).is_some()
+}
+
 /// A candidate process discovered under `/proc`, reduced to what target selection needs.
 // Linux-only: the only consumers are `trigger`/`scan_proc`/`select_targets`, all gated to Linux —
 // without this gate it is dead code under `-D warnings` on macOS/Windows.

--- a/crates/rag-rat-mcp/src/server/runtime.rs
+++ b/crates/rag-rat-mcp/src/server/runtime.rs
@@ -36,6 +36,19 @@ pub async fn run_stdio(
 /// `run_stdio(Config)` signature stays source-compatible, while a globally-registered `rag-rat mcp`
 /// can still stay alive in a non-rag-rat project instead of dying (#603).
 pub async fn run_stdio_dormant(output_format: rag_rat_core::OutputFormat) -> anyhow::Result<()> {
+    // A dormant server never hot-upgrades — with no config there is no handoff directory, and no
+    // index state worth carrying across an `exec`. It is still a `rag-rat mcp` process, though, so
+    // a globally-registered launcher hands it `RAG_RAT_UPGRADE_BIN` like any other, which is
+    // exactly what makes the fleet trigger consider it a signal target. Observe SIGUSR1 so the
+    // trigger cannot terminate it; it keeps serving the dormant notice until the client
+    // disconnects, and the next launch picks up the new binary.
+    #[cfg(unix)]
+    if let Some(mut sigusr1) =
+        crate::upgrade::install_path().and_then(|_| crate::upgrade::arm_sigusr1())
+    {
+        // Detached: the drain's useful lifetime IS the process's, so there is nothing to abort.
+        tokio::spawn(async move { while sigusr1.recv().await.is_some() {} });
+    }
     let running = RagRatService::new_dormant(output_format).serve(rmcp::transport::stdio()).await?;
     running.waiting().await?;
     Ok(())
@@ -63,13 +76,18 @@ async fn run_stdio_unix(
     use std::sync::Arc;
 
     use rmcp::service::serve_directly;
-    use tokio::signal::unix::{SignalKind, signal};
 
     use crate::upgrade::{self, GatedStdin, Upgrade, UpgradeGate};
 
     let gate = UpgradeGate::new();
     let service = RagRatService::new(config.clone(), output_format);
     let inflight = service.inflight();
+
+    // Observe SIGUSR1 before serving, not after — see [`upgrade::arm_sigusr1`]. Only when an
+    // install target is configured, since that env var is precisely what makes this process a
+    // fleet target.
+    let install_path = upgrade::install_path();
+    let sigusr1 = install_path.as_ref().and_then(|_| upgrade::arm_sigusr1());
 
     let transport = (GatedStdin::new(tokio::io::stdin(), Arc::clone(&gate)), tokio::io::stdout());
 
@@ -92,7 +110,6 @@ async fn run_stdio_unix(
     // Keep the index fresh while connected. Its lock fds are CLOEXEC, so a hot-`exec` releases
     // them automatically; on normal EOF the drop runs a final timeout-skip pass. When hot-upgrade
     // is armed, the elected watcher also watches the binary dir to drive the fleet trigger.
-    let install_path = upgrade::install_path();
     let _watcher =
         rag_rat_core::watch::Watcher::spawn_with_fleet(config.clone(), install_path.clone());
 
@@ -107,51 +124,52 @@ async fn run_stdio_unix(
     // terminate the stdio MCP service.
     let _lens_server = crate::lens_server::spawn(config.clone());
 
-    // Arm the SIGUSR1 hot-upgrade handler only when an install target is configured AND the client
-    // reached us through the `initialize` handshake. A peer that used the stateless lifecycle
-    // (protocol 2026-07-28 drops `initialize` and carries its version + capabilities in each
-    // request's `_meta`) leaves `peer_info()` empty: there is no negotiated session state to hand
-    // across the `exec`, and fabricating a default one would resume the successor claiming a
-    // protocol version and capability set the client never sent. Leaving hot-upgrade unarmed is
-    // the safe outcome — SIGUSR1 is ignored and this process keeps serving until the client
-    // disconnects, after which the next launch picks up the new binary.
+    // The signal is already observed; now that the session is understood, decide what it DOES.
+    //
+    // A peer that used the stateless lifecycle — protocol 2026-07-28 drops `initialize` and carries
+    // its version + capabilities in each request's `_meta` — leaves `peer_info()` empty. There is
+    // no negotiated session state to hand across the `exec`, and fabricating a default one would
+    // resume the successor claiming a protocol version and capability set the client never sent, so
+    // such a session consumes the signal without upgrading: it keeps serving until the client
+    // disconnects, after which the next launch picks up the new binary. Consuming rather than
+    // leaving the signal unhandled is what keeps the fleet trigger from killing the server.
     //
     // `peer_info()` yields `Option<Arc<_>>`; deref-and-clone to the owned `InitializeRequestParams`
     // the `Upgrade`/handoff want.
     let peer_info = running.peer().peer_info().map(|p| (*p).clone());
-    if let Some(install_path) = install_path {
-        if let Some(peer_info) = peer_info {
+    if let Some(mut sigusr1) = sigusr1 {
+        // `sigusr1` is armed only when `install_path` is set, so `zip` drops nothing else.
+        let upgrade = install_path.zip(peer_info).map(|(install_path, peer_info)| {
             let negotiated_protocol_version = peer_info.protocol_version.as_str().to_string();
             let handoff_dir = config
                 .database
                 .parent()
                 .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(std::env::temp_dir);
-            let upgrade = Upgrade {
+            Upgrade {
                 gate: Arc::clone(&gate),
                 inflight,
                 install_path,
                 handoff_dir,
                 peer_info,
                 negotiated_protocol_version,
-            };
-            tokio::spawn(async move {
-                let Ok(mut sigusr1) = signal(SignalKind::user_defined1()) else {
-                    eprintln!("hot-upgrade: could not install SIGUSR1 handler; disabled");
-                    return;
-                };
-                // On success `run()` never returns (it `exec`s or exits); on a drain-timeout abort
-                // it returns and we wait for the next signal.
-                while sigusr1.recv().await.is_some() {
-                    upgrade.run().await;
-                }
-            });
-        } else {
+            }
+        });
+        if upgrade.is_none() {
             eprintln!(
                 "hot-upgrade: client connected without `initialize` (stateless lifecycle); no \
-                 session state to hand off, so hot-upgrade stays disabled for this session"
+                 session state to hand off, so SIGUSR1 will be observed and ignored"
             );
         }
+        tokio::spawn(async move {
+            // On success `run()` never returns (it `exec`s or exits); on a drain-timeout abort it
+            // returns and we wait for the next signal.
+            while sigusr1.recv().await.is_some() {
+                if let Some(upgrade) = &upgrade {
+                    upgrade.run().await;
+                }
+            }
+        });
     }
 
     running.waiting().await?;

--- a/crates/rag-rat-mcp/src/server/runtime.rs
+++ b/crates/rag-rat-mcp/src/server/runtime.rs
@@ -107,37 +107,51 @@ async fn run_stdio_unix(
     // terminate the stdio MCP service.
     let _lens_server = crate::lens_server::spawn(config.clone());
 
-    // Arm the SIGUSR1 hot-upgrade handler only when an install target is configured.
+    // Arm the SIGUSR1 hot-upgrade handler only when an install target is configured AND the client
+    // reached us through the `initialize` handshake. A peer that used the stateless lifecycle
+    // (protocol 2026-07-28 drops `initialize` and carries its version + capabilities in each
+    // request's `_meta`) leaves `peer_info()` empty: there is no negotiated session state to hand
+    // across the `exec`, and fabricating a default one would resume the successor claiming a
+    // protocol version and capability set the client never sent. Leaving hot-upgrade unarmed is
+    // the safe outcome — SIGUSR1 is ignored and this process keeps serving until the client
+    // disconnects, after which the next launch picks up the new binary.
+    //
+    // `peer_info()` yields `Option<Arc<_>>`; deref-and-clone to the owned `InitializeRequestParams`
+    // the `Upgrade`/handoff want.
+    let peer_info = running.peer().peer_info().map(|p| (*p).clone());
     if let Some(install_path) = install_path {
-        // rmcp 1.8 changed `peer_info()` from `Option<&_>` to `Option<Arc<_>>`; deref-and-clone to
-        // the owned `InitializeRequestParams` the `Upgrade`/handoff want. `*p` derefs either form,
-        // so this compiles on 1.7 and 1.8 alike.
-        let peer_info = running.peer().peer_info().map(|p| (*p).clone()).unwrap_or_default();
-        let negotiated_protocol_version = peer_info.protocol_version.as_str().to_string();
-        let handoff_dir = config
-            .database
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_else(std::env::temp_dir);
-        let upgrade = Upgrade {
-            gate: Arc::clone(&gate),
-            inflight,
-            install_path,
-            handoff_dir,
-            peer_info,
-            negotiated_protocol_version,
-        };
-        tokio::spawn(async move {
-            let Ok(mut sigusr1) = signal(SignalKind::user_defined1()) else {
-                eprintln!("hot-upgrade: could not install SIGUSR1 handler; disabled");
-                return;
+        if let Some(peer_info) = peer_info {
+            let negotiated_protocol_version = peer_info.protocol_version.as_str().to_string();
+            let handoff_dir = config
+                .database
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_else(std::env::temp_dir);
+            let upgrade = Upgrade {
+                gate: Arc::clone(&gate),
+                inflight,
+                install_path,
+                handoff_dir,
+                peer_info,
+                negotiated_protocol_version,
             };
-            // On success `run()` never returns (it `exec`s or exits); on a drain-timeout abort it
-            // returns and we wait for the next signal.
-            while sigusr1.recv().await.is_some() {
-                upgrade.run().await;
-            }
-        });
+            tokio::spawn(async move {
+                let Ok(mut sigusr1) = signal(SignalKind::user_defined1()) else {
+                    eprintln!("hot-upgrade: could not install SIGUSR1 handler; disabled");
+                    return;
+                };
+                // On success `run()` never returns (it `exec`s or exits); on a drain-timeout abort
+                // it returns and we wait for the next signal.
+                while sigusr1.recv().await.is_some() {
+                    upgrade.run().await;
+                }
+            });
+        } else {
+            eprintln!(
+                "hot-upgrade: client connected without `initialize` (stateless lifecycle); no \
+                 session state to hand off, so hot-upgrade stays disabled for this session"
+            );
+        }
     }
 
     running.waiting().await?;

--- a/crates/rag-rat-mcp/src/server/service.rs
+++ b/crates/rag-rat-mcp/src/server/service.rs
@@ -1,6 +1,6 @@
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Implementation, ListToolsResult, PaginatedRequestParams,
-    ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, Implementation, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, RoleServer, ServerHandler};
@@ -22,14 +22,17 @@ impl ServerHandler for RagRatService {
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         // The catalog (TOOL_NAMES / schema / description) is the single source of truth advertised
         // by `list_tools`, and `call_tool_for_config` (via `call`) is the by-name dispatcher.
         // Forward the raw request arguments straight to the `call()` chokepoint: no per-tool
         // `#[tool]` forwarder and no `Parameters<T>` serialize->deserialize round-trip — the client
         // JSON reaches exactly one deserialize, in `call_tool_with_db`.
         let args = request.arguments.map(Value::Object).unwrap_or(Value::Null);
-        self.call_async(request.name.to_string(), args).await
+        // Every rag-rat tool answers in one round trip: the arguments fully determine the result,
+        // so there is nothing to elicit mid-call. Always the `Complete` arm — a multi-round-trip
+        // `InputRequired` response would stall an agent waiting on a read-only lookup.
+        self.call_async(request.name.to_string(), args).await.map(CallToolResponse::from)
     }
 
     async fn list_tools(
@@ -47,6 +50,10 @@ impl ServerHandler for RagRatService {
                 Tool::new((*name).to_string(), crate::tools::description(name), input_schema)
             })
             .collect();
-        Ok(ListToolsResult { tools, meta: None, next_cursor: None })
+        // `with_all_items` fills the SEP-2322 / SEP-2549 result fields with their protocol
+        // defaults (`result_type: complete`, no TTL, no cache scope). The whole catalog ships in
+        // one page, so there is no cursor; rmcp strips `result_type` again for peers that
+        // negotiated a protocol version predating the field.
+        Ok(ListToolsResult::with_all_items(tools))
     }
 }

--- a/crates/rag-rat-mcp/src/upgrade.rs
+++ b/crates/rag-rat-mcp/src/upgrade.rs
@@ -387,6 +387,36 @@ mod tests {
         assert!(!path.exists(), "temp file is unlinked after read");
     }
 
+    /// The handoff file is a contract between two DIFFERENT binaries: the predecessor writes it,
+    /// then `exec`s the newly installed one, which reads it. Those binaries can be built against
+    /// different rmcp releases, so `peer_info` must stay readable across an rmcp upgrade — the
+    /// whole point of the hot path is resuming without re-`initialize`. A model change that
+    /// renames or newly requires a field inside `InitializeRequestParams` silently downgrades
+    /// every hot-upgrade to a cold restart (`take_handoff` swallows the parse error), which no
+    /// same-version round-trip test can catch. This literal is the exact JSON a predecessor emits.
+    #[test]
+    fn handoff_written_by_a_differently_built_binary_still_deserializes() {
+        let written_by_predecessor = r#"{
+            "format_version": 1,
+            "negotiated_protocol_version": "2025-06-18",
+            "peer_info": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "claude-code", "version": "2.0.0" }
+            },
+            "residue": [],
+            "old_binary_inode": 42,
+            "upgrade_started_unix_ms": 1700000000000
+        }"#;
+        let handoff: HandoffV1 = serde_json::from_str(written_by_predecessor)
+            .expect("a predecessor's handoff must deserialize after an rmcp upgrade");
+        assert_eq!(handoff.format_version, HandoffV1::FORMAT_VERSION);
+        assert_eq!(handoff.negotiated_protocol_version, "2025-06-18");
+        assert_eq!(handoff.peer_info.protocol_version.as_str(), "2025-06-18");
+        assert_eq!(handoff.peer_info.client_info.name, "claude-code");
+        assert!(protocol_supported(&handoff.negotiated_protocol_version));
+    }
+
     #[tokio::test]
     async fn inflight_wait_zero_resolves_after_guards_drop() {
         let inflight = Inflight::new();

--- a/crates/rag-rat-mcp/src/upgrade.rs
+++ b/crates/rag-rat-mcp/src/upgrade.rs
@@ -289,9 +289,13 @@ pub fn take_handoff() -> Option<HandoffV1> {
 ///
 /// [`arm_sigusr1`] replaces this with the real handler as soon as the runtime is up.
 pub fn suppress_sigusr1_until_armed() {
-    if install_path().is_none() {
-        // Not fleet-eligible (the trigger skips processes without the env var), so leave the
-        // default disposition alone rather than silently changing signal behavior for everyone.
+    // Gate on what the TRIGGER considers eligible, not on whether we could actually upgrade. Those
+    // differ: `install_path` rejects a set-but-empty variable, while the scan predicate matches on
+    // presence alone — so an empty value yields a process that is targetable but cannot upgrade,
+    // which is exactly the case that must not die on the signal.
+    if !rag_rat_core::fleet::self_advertises_upgrade() {
+        // Not a target, so leave the default disposition alone rather than silently changing
+        // signal behavior for every `rag-rat mcp`.
         return;
     }
     // SAFETY: `signal(2)` with a valid signal number and the standard `SIG_IGN` disposition. No

--- a/crates/rag-rat-mcp/src/upgrade.rs
+++ b/crates/rag-rat-mcp/src/upgrade.rs
@@ -274,6 +274,57 @@ pub fn take_handoff() -> Option<HandoffV1> {
     }
 }
 
+/// Drop `SIGUSR1` on the floor for now — the FIRST half of the fleet interlock, and the first
+/// thing `rag-rat mcp` should do.
+///
+/// [`rag_rat_core::fleet::trigger`] picks its targets by reading other processes' environ: a
+/// `rag-rat mcp` carrying [`UPGRADE_BIN_ENV`] is taken as proof that a `SIGUSR1` handler is
+/// installed, and is signaled on that basis. That environ is visible from `execve` onward, while
+/// the real handler cannot exist until there is a Tokio runtime to own it — and config discovery,
+/// logging setup, and runtime construction all happen in between. Left alone, a trigger landing in
+/// that gap terminates the server outright (`SIGUSR1`'s default disposition) instead of upgrading
+/// it. Ignoring costs the process at most one upgrade opportunity — it stays on the old binary
+/// until the client disconnects, exactly like a session with nothing to hand off — which is the
+/// documented fallback, and infinitely better than dying.
+///
+/// [`arm_sigusr1`] replaces this with the real handler as soon as the runtime is up.
+pub fn suppress_sigusr1_until_armed() {
+    if install_path().is_none() {
+        // Not fleet-eligible (the trigger skips processes without the env var), so leave the
+        // default disposition alone rather than silently changing signal behavior for everyone.
+        return;
+    }
+    // SAFETY: `signal(2)` with a valid signal number and the standard `SIG_IGN` disposition. No
+    // handler runs and no memory is touched.
+    unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
+}
+
+/// Observe `SIGUSR1` on the Tokio runtime — the SECOND half of the interlock, replacing the
+/// blanket ignore installed by [`suppress_sigusr1_until_armed`] with a stream the server can act
+/// on. Returns `None` when the OS refused, having left the signal ignored rather than fatal.
+///
+/// Call this BEFORE serving. Serving blocks on the client's first message, which may never arrive,
+/// so arming afterwards would leave the process merely ignoring upgrades for an unbounded stretch.
+/// What the signal *does* is decided later, once the session is understood.
+pub(crate) fn arm_sigusr1() -> Option<tokio::signal::unix::Signal> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    match signal(SignalKind::user_defined1()) {
+        Ok(stream) => Some(stream),
+        Err(err) => {
+            eprintln!(
+                "hot-upgrade: could not install SIGUSR1 handler ({err}); ignoring the signal"
+            );
+            // Stay ignored (already the case if `suppress_sigusr1_until_armed` ran): this process
+            // advertises itself as signal-safe through its environ either way, so it must not die
+            // on a signal it turned out it cannot handle. Hot-upgrade is lost for this session.
+            // SAFETY: as in `suppress_sigusr1_until_armed`.
+            unsafe { libc::signal(libc::SIGUSR1, libc::SIG_IGN) };
+            None
+        },
+    }
+}
+
 /// Whether this binary speaks `version` — the resume version gate. An unknown version means the
 /// new binary can't honor the client's negotiated session, so it must not skip `initialize`.
 pub fn protocol_supported(version: &str) -> bool {


### PR DESCRIPTION
Moves the workspace off rmcp 2.2 onto 3.0.1, which adds MCP protocol version 2026-07-28, and closes the hot-upgrade signal hazards that version surfaced.

## API adaptation

- `ServerHandler::call_tool` now returns the multi-round-trip `CallToolResponse` (`Complete` | `InputRequired` | `Task`) instead of `CallToolResult`. Every rag-rat tool answers in one round trip — the arguments fully determine the result, and there is nothing to elicit mid-call — so the handler always returns the `Complete` arm.
- `ListToolsResult` gained `result_type`, `ttl_ms`, and `cache_scope` (SEP-2322 / SEP-2549). Built through `with_all_items` instead of a struct literal so the protocol defaults live in one place; rmcp strips `result_type` again for peers that negotiated an older version.
- rmcp's MSRV moves to 1.88, below the workspace's 1.96.

## The stateless lifecycle, and the SIGUSR1 interlock it broke

Protocol 2026-07-28 drops the `initialize` handshake: a client opens a session by putting its protocol version and capabilities in each request's `_meta`. rmcp's `serve_server` accepts that on stdio, and such a session leaves `peer().peer_info()` empty for its whole lifetime — where under 2.2 it was always populated once `serve()` returned.

`run_stdio_unix` read `peer_info()` to build the handoff a successor process resumes from, defaulting it when absent. That default would have handed the successor a fabricated `initialize`, resuming the session claiming a protocol version and capability set the client never sent.

Declining to arm for such a session turned out to be the wrong fix, and exposed a wider problem. `fleet::trigger` selects its targets by reading other processes' environ: a `rag-rat mcp` carrying `RAG_RAT_UPGRADE_BIN` is taken as proof that a SIGUSR1 handler is installed, and is signaled on that basis. Any server carrying that variable without an installed handler is therefore killed by the trigger — mid-request, no diagnostic — rather than upgraded. Four states were in that condition:

| state | before | after |
|---|---|---|
| `initialize` handshake | upgrades | upgrades |
| stateless session (no `initialize`) | killed by SIGUSR1 | absorbs signal, keeps serving |
| between `execve` and the handler existing | killed by SIGUSR1 | absorbs signal; a pending one upgrades once the session exists |
| dormant server | killed by SIGUSR1 | absorbs signal, keeps serving |
| `RAG_RAT_UPGRADE_BIN` set but empty | killed by SIGUSR1 | absorbs signal, keeps serving |

Only the second is new; the rest predate this change and are fixed here because they are one invariant, not four bugs.

The handler is now installed whenever an install target is configured, and the session decides only what the signal *does* — upgrade when there is handoff state, otherwise consume it. SIGUSR1 is set to `SIG_IGN` as the first act of `rag-rat mcp`, before config discovery, logging, or runtime construction, and replaced by the real handler once the runtime exists; a signal landing in that gap costs one upgrade opportunity rather than the process. The "am I a target" rule now lives once, as `fleet::self_advertises_upgrade`, beside the scan predicate it mirrors — keyed on presence, deliberately looser than "can I actually upgrade", since an older binary elsewhere in the fleet runs an older copy of the scan predicate.

## Tests

Acceptance tests spawn the real binary and signal it in each state above; all fail against the previous arming logic. They use `ping` — the one request MCP permits before `initialize` — to prove the server is serving without leaving the state under test. A separate test pins that a predecessor's handoff JSON still deserializes across an rmcp upgrade: `take_handoff` swallows a parse error and falls back to a cold start, so a model change there would silently downgrade every hot-upgrade to a cold restart.

## Verification

Full workspace suite green (4504 passed), clippy clean under both `--no-default-features` and `--all-features` with `-D warnings`, rustfmt clean.

Exercised against a live stdio server driving real JSON-RPC over a throwaway indexed repo:

| session | `tools/list` | `resultType` |
|---|---|---|
| `initialize` @ 2025-11-25 | 47 tools | absent |
| `initialize` @ 2026-07-28 | 47 tools | `"complete"` |
| no `initialize`, `_meta` only | 47 tools | `"complete"` |

`tools/call` returned real payloads in all three, and unknown-tool errors are unchanged. The hot-upgrade path itself was confirmed end-to-end: same PID, exe inode changed, session resumed with no re-`initialize`.

Fixes #1070