### PR TITLE
docs(using-rag-rat): a memory states what is true, not what shipped

### DIFF
--- a/.agents/skills/using-rag-rat/SKILL.md
+++ b/.agents/skills/using-rag-rat/SKILL.md
@@ -88,6 +88,22 @@ so they surface for **every** agent that queries it — Claude Code, Codex, any 
 the one that wrote them. Your harness's private memory is invisible to the others. rag-rat is the
 **cross-agent memory layer**.
 
+**Write the present tense, not a changelog.** A memory is read by someone about to change the code,
+so it must say **what is true now and what to do about it**. Narrating what shipped is unactionable:
+"this was fixed in #123", "the predicate used to fail open", "stage 2 landed the split" all cost the
+reader attention and tell them nothing they can act on. Worse, a memory written as history goes stale
+the moment the next change lands, and it teaches the reader to distrust the rest of the entry.
+
+The same applies when you **update** one. If the thing a memory warned about has been fixed, do not
+append a status section — rewrite the body to state the rule that now holds, and delete the warning.
+If nothing actionable survives, `memory_mark_obsolete` it. A memory whose top half is a list of
+completed work is one nobody finishes reading.
+
+Keep: invariants, the reasoning behind a decision, traps and their failure modes, what to reach for,
+what is still unresolved. Drop: PR/stage narration, "used to be", anything whose only value is that
+it happened. Referencing an issue or test *name* is fine when it is a pointer the reader can follow —
+it is the story that does not belong.
+
 Do it well:
 - **`memory_search` first** to avoid duplicates.
 - **Anchor to the tightest stable target:** prefer an `id` binding (the `sym_<hex>` handle —
@@ -96,7 +112,7 @@ Do it well:
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why
   this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
   `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
-  what.
+  what, and not what changed.
 - **`memory_update` / `memory_mark_obsolete`** when a memory is wrong or superseded — don't leave
   stale guidance. After a large refactor, **`memory_doctor`** flags `gone` anchors and
   **`memory_rebind`** re-anchors them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ How to do it well:
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why it's
   this way / why not the other), `Risk` / `BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
   `FFIBoundary`. Write a concrete title, and a body with the *why* and *how to apply* — not just *what*.
+- **Write the present tense, not a changelog.** A memory says what is true NOW and what to do about
+  it. "Fixed in #123", "used to fail open", "stage 2 landed the split" are unactionable: they cost
+  the reader attention, go stale on the next change, and teach them to distrust the rest of the
+  entry. When updating a memory whose warning no longer applies, rewrite the body to state the rule
+  that now holds — do not append a status section — and `memory_mark_obsolete` it if nothing
+  actionable survives. An issue or test *name* is a fine pointer; the story is not.
 - **`memory_search` first** to avoid duplicates; **`memory_update` / `memory_mark_obsolete`** when a
   memory is wrong or superseded (don't leave stale guidance).
 - **After large refactors**, run `rag-rat memory doctor` and re-anchor anything it flags `gone`

--- a/plugin/skills/using-rag-rat/SKILL.md
+++ b/plugin/skills/using-rag-rat/SKILL.md
@@ -88,6 +88,22 @@ so they surface for **every** agent that queries it — Claude Code, Codex, any 
 the one that wrote them. Your harness's private memory is invisible to the others. rag-rat is the
 **cross-agent memory layer**.
 
+**Write the present tense, not a changelog.** A memory is read by someone about to change the code,
+so it must say **what is true now and what to do about it**. Narrating what shipped is unactionable:
+"this was fixed in #123", "the predicate used to fail open", "stage 2 landed the split" all cost the
+reader attention and tell them nothing they can act on. Worse, a memory written as history goes stale
+the moment the next change lands, and it teaches the reader to distrust the rest of the entry.
+
+The same applies when you **update** one. If the thing a memory warned about has been fixed, do not
+append a status section — rewrite the body to state the rule that now holds, and delete the warning.
+If nothing actionable survives, `memory_mark_obsolete` it. A memory whose top half is a list of
+completed work is one nobody finishes reading.
+
+Keep: invariants, the reasoning behind a decision, traps and their failure modes, what to reach for,
+what is still unresolved. Drop: PR/stage narration, "used to be", anything whose only value is that
+it happened. Referencing an issue or test *name* is fine when it is a pointer the reader can follow —
+it is the story that does not belong.
+
 Do it well:
 - **`memory_search` first** to avoid duplicates.
 - **Anchor to the tightest stable target:** prefer an `id` binding (the `sym_<hex>` handle —
@@ -96,7 +112,7 @@ Do it well:
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why
   this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
   `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
-  what.
+  what, and not what changed.
 - **`memory_update` / `memory_mark_obsolete`** when a memory is wrong or superseded — don't leave
   stale guidance. After a large refactor, **`memory_doctor`** flags `gone` anchors and
   **`memory_rebind`** re-anchors them.


### PR DESCRIPTION
A memory is read by someone about to change the code, so it has to say what holds **now** and what to do about it. Narrating history — "fixed in #123", "used to fail open", "stage 2 landed the split" — costs the reader attention without telling them anything actionable, goes stale as soon as the next change lands, and teaches them to distrust the rest of the entry.

The update path is where this goes wrong most easily. When the thing a memory warned about gets fixed, appending a status section leaves the stale warning in place above it and doubles the length; the correct move is to rewrite the body to state the rule that now holds, or `memory_mark_obsolete` it when nothing actionable survives.

The guidance names what to keep (invariants, the reasoning behind a decision, traps and their failure modes, what is still unresolved) and what to drop (PR/stage narration, "used to be", anything whose only value is that it happened), and is explicit that an issue or test *name* is a fine pointer — it is the story that does not belong.

## Files

- `.agents/skills/using-rag-rat/SKILL.md` — the source of truth; `.claude/skills/` and `.codex/skills/` are symlinks to it.
- `plugin/skills/using-rag-rat/SKILL.md` — the shipped plugin copy, byte-identical to the above before this change and kept so. There is no CI check that these two agree, so they have to be edited together.
- `AGENTS.md` — the matching bullets in the repo's own memory guidance, so it does not contradict the skill it ships.

Docs only; no code or test changes.