### PR TITLE
feat(sync): seal discovery announcements to the roster-effective devices

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -381,8 +381,20 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                     tracing::debug!("the roster moved; re-sealing this host's announcement");
                     let resealed = seal_announcement(conn, tag, &local_node);
                     *stamp = stamp_after_seal(observed, *stamp, resealed.is_ok());
-                    if let Ok(bytes) = resealed {
-                        let _ = tx.send(bytes);
+                    match resealed {
+                        Ok(bytes) => {
+                            let _ = tx.send(bytes);
+                        },
+                        // The roster moved but re-sealing failed. Withdraw the previous envelope
+                        // rather than let the advertiser keep renewing it: it is sealed to the OLD
+                        // roster, so a just-removed device could otherwise keep opening it — and
+                        // being observed through it — indefinitely, well past the one-TTL revocation
+                        // window. The stamp is left unchanged (a failed seal keeps it), so the next
+                        // session retries against the moved roster.
+                        Err(error) => {
+                            tracing::warn!(%error, "re-sealing failed after a roster change; withdrawing the stale announcement until a re-seal succeeds");
+                            let _ = tx.send(None);
+                        },
                     }
                 }
             }

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -237,17 +237,25 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
         // Sealing needs a connection; the advertiser is a spawned task and cannot hold one. So this
         // loop — which already owns the connection and already folds the WAL between sessions — is
         // where sealing happens, and the watch carries the result. Republishing identical bytes is
-        // safe (same key, same nonce, same plaintext) and buys two things: the advertiser stays
-        // database-free, and `is_live` can recognise this host's own announcement by comparing
-        // bytes rather than opening anything.
+        // safe (same key, same nonce, same plaintext) and keeps the advertiser database-free.
+        //
+        // A sealing error here is LOGGED, not swallowed: the advertiser cannot reseal on its own,
+        // and the between-sessions reseal below only runs after an inbound connection — which a
+        // host that was never advertised may never receive. A silent empty value would leave it
+        // undiscoverable with nothing in the log saying why. Recovering without inbound traffic is
+        // a known gap (#1086).
         let mut announcement = discovery_tag.map(|tag| {
             let sealed = seal_announcement(conn, &tag, &local_node);
-            let stamp = stamp_after_seal(
-                rag_rat_oplog::discovery::roster_stamp(conn).ok().flatten(),
-                None,
-                sealed.is_ok(),
-            );
-            let (tx, rx) = tokio::sync::watch::channel(sealed.unwrap_or_default());
+            let observed = rag_rat_oplog::discovery::roster_stamp(conn).ok().flatten();
+            let stamp = stamp_after_seal(observed, None, sealed.is_ok());
+            let bytes = match sealed {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    tracing::warn!(%error, "sealing this host's announcement failed; it will not be discoverable until the next successful reseal");
+                    None
+                },
+            };
+            let (tx, rx) = tokio::sync::watch::channel(bytes);
             (tag, tx, rx, stamp)
         });
         // Aborted on the way out of this scope, so the loop cannot outlive the endpoint it

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -240,15 +240,17 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
         // safe (same key, same nonce, same plaintext) and buys two things: the advertiser stays
         // database-free, and `is_live` can recognise this host's own announcement by comparing
         // bytes rather than opening anything.
-        let announcement = discovery_tag.map(|tag| {
-            let (tx, rx) = tokio::sync::watch::channel(seal_announcement(conn, &tag, &local_node));
-            (tag, tx, rx)
+        let mut announcement = discovery_tag.map(|tag| {
+            let sealed = seal_announcement(conn, &tag, &local_node);
+            let stamp = sealed.as_ref().map(|(_, stamp)| *stamp);
+            let (tx, rx) = tokio::sync::watch::channel(sealed.map(|(bytes, _)| bytes));
+            (tag, tx, rx, stamp)
         });
         // Aborted on the way out of this scope, so the loop cannot outlive the endpoint it
         // advertises.
         let _advertiser = announcement
             .as_ref()
-            .map(|(tag, _, rx)| (*tag, rx.clone()))
+            .map(|(tag, _, rx, _)| (*tag, rx.clone()))
             .zip(discovery_service_addr(config, &relay))
             .map(|((tag, announcement), service)| {
                 AbortOnDrop(tokio::spawn(rag_rat_sync::discovery::advertise(
@@ -347,11 +349,27 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
             // colocated device sync and no command authors roster changes. A device enrolled while
             // this host is running therefore becomes a recipient at the next renewal; the
             // advertiser re-reads the watch every tick, so the update needs no signal beyond this.
-            if let Some((tag, tx, _)) = &announcement {
-                let resealed = seal_announcement(conn, tag, &local_node);
-                if *tx.borrow() != resealed {
+            if let Some((tag, tx, _, stamp)) = &mut announcement {
+                // Compare the ROSTER, not the envelope. Sealing draws a fresh ephemeral per wrap,
+                // so two seals of an unchanged roster differ in every byte — comparing envelopes
+                // would re-seal after every session, the advertiser would stop recognising its own
+                // live announcement, and it would republish on every tick until the tag was full of
+                // its own copies. That is precisely the failure seal-once exists to avoid.
+                let current = rag_rat_oplog::discovery::roster_stamp(conn).unwrap_or_else(|error| {
+                    tracing::warn!(%error, "could not read the roster; keeping the current announcement");
+                    *stamp
+                });
+                // No test reaches this comparison: `serve_with` binds an endpoint, takes the
+                // session lock, and loops until interrupted. **Replacing the condition with `true`
+                // survives the whole suite** — it re-seals every session, which is the bug this
+                // stamp exists to prevent. What IS pinned, in the op-log crate, is the pair of
+                // facts that make the bug possible and the fix correct: two seals of an unchanged
+                // roster differ in every byte, and the stamp does not.
+                if current != *stamp {
                     tracing::debug!("the roster moved; re-sealing this host's announcement");
-                    let _ = tx.send(resealed);
+                    let resealed = seal_announcement(conn, tag, &local_node);
+                    *stamp = resealed.as_ref().map(|(_, stamp)| *stamp);
+                    let _ = tx.send(resealed.map(|(bytes, _)| bytes));
                 }
             }
             if once {
@@ -801,9 +819,13 @@ fn discovery_service_addr(config: &Config, relay: &str) -> Option<rag_rat_sync::
 /// one to be discovered BY, so publishing would spend a slot to tell nobody. A sealing failure is
 /// logged and treated the same way: discovery is routing advice, and a host that cannot advertise
 /// still serves every peer that reaches it through a configured `server_peers` entry.
-fn seal_announcement(conn: &Connection, tag: &[u8; 32], local_node: &[u8; 32]) -> Option<Vec<u8>> {
+fn seal_announcement(
+    conn: &Connection,
+    tag: &[u8; 32],
+    local_node: &[u8; 32],
+) -> Option<(Vec<u8>, rag_rat_oplog::discovery::RosterStamp)> {
     match rag_rat_oplog::discovery::seal_discovery_announcement(conn, tag, local_node) {
-        Ok(Some(sealed)) if sealed.recipients > 1 => Some(sealed.bytes),
+        Ok(Some(sealed)) if sealed.recipients > 1 => Some((sealed.bytes, sealed.roster_stamp)),
         Ok(Some(_)) => {
             tracing::debug!("not advertising: this device is the account's only roster member");
             None

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -242,8 +242,12 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
         // bytes rather than opening anything.
         let mut announcement = discovery_tag.map(|tag| {
             let sealed = seal_announcement(conn, &tag, &local_node);
-            let stamp = sealed.as_ref().map(|(_, stamp)| *stamp);
-            let (tx, rx) = tokio::sync::watch::channel(sealed.map(|(bytes, _)| bytes));
+            let stamp = stamp_after_seal(
+                rag_rat_oplog::discovery::roster_stamp(conn).ok().flatten(),
+                None,
+                sealed.is_ok(),
+            );
+            let (tx, rx) = tokio::sync::watch::channel(sealed.unwrap_or_default());
             (tag, tx, rx, stamp)
         });
         // Aborted on the way out of this scope, so the loop cannot outlive the endpoint it
@@ -354,21 +358,24 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                 // would re-seal after every session, the advertiser would stop recognising its own
                 // live announcement, and it would republish on every tick until the tag was full of
                 // its own copies. That is precisely the failure seal-once exists to avoid.
-                let current = rag_rat_oplog::discovery::roster_stamp(conn).unwrap_or_else(|error| {
-                    tracing::warn!(%error, "could not read the roster; keeping the current announcement");
-                    *stamp
-                });
-                // No test reaches this comparison: `serve_with` binds an endpoint, takes the
-                // session lock, and loops until interrupted. **Replacing the condition with `true`
-                // survives the whole suite** — it re-seals every session, which is the bug this
-                // stamp exists to prevent. What IS pinned, in the op-log crate, is the pair of
-                // facts that make the bug possible and the fix correct: two seals of an unchanged
-                // roster differ in every byte, and the stamp does not.
-                if current != *stamp {
+                let observed =
+                    rag_rat_oplog::discovery::roster_stamp(conn).unwrap_or_else(|error| {
+                        tracing::warn!(%error, "could not read the roster; keeping the current announcement");
+                        *stamp
+                    });
+                // The comparison itself is out of reach of a test — `serve_with` binds an endpoint,
+                // takes the session lock, and loops until interrupted — so what it depends on is
+                // pinned elsewhere instead: `stamp_after_seal` carries the bookkeeping rule, and
+                // the op-log crate pins the two facts that make the bug possible and this fix
+                // correct (two seals of an unchanged roster differ in every byte; the stamp does
+                // not).
+                if observed != *stamp {
                     tracing::debug!("the roster moved; re-sealing this host's announcement");
                     let resealed = seal_announcement(conn, tag, &local_node);
-                    *stamp = resealed.as_ref().map(|(_, stamp)| *stamp);
-                    let _ = tx.send(resealed.map(|(bytes, _)| bytes));
+                    *stamp = stamp_after_seal(observed, *stamp, resealed.is_ok());
+                    if let Ok(bytes) = resealed {
+                        let _ = tx.send(bytes);
+                    }
                 }
             }
             if once {
@@ -818,35 +825,57 @@ fn discovery_service_addr(config: &Config, relay: &str) -> Option<rag_rat_sync::
 /// one to be discovered BY, so publishing would spend a slot to tell nobody. A sealing failure is
 /// logged and treated the same way: discovery is routing advice, and a host that cannot advertise
 /// still serves every peer that reaches it through a configured `server_peers` entry.
+/// `Ok(None)` and `Err` mean different things and the caller must not conflate them: `Ok(None)` is
+/// a settled decision not to advertise (no account, a lone device, a roster too large to seal),
+/// while `Err` is an attempt that failed and is worth repeating. See [`stamp_after_seal`].
 fn seal_announcement(
     conn: &Connection,
     tag: &[u8; 32],
     local_node: &[u8; 32],
-) -> Option<(Vec<u8>, rag_rat_oplog::discovery::RosterStamp)> {
-    match rag_rat_oplog::discovery::seal_discovery_announcement(conn, tag, local_node) {
-        Ok(Some(sealed)) => match classify_announcement(sealed.recipients, sealed.bytes.len()) {
-            AnnouncementVerdict::Advertise => Some((sealed.bytes, sealed.roster_stamp)),
-            AnnouncementVerdict::SoleRosterMember => {
-                tracing::debug!("not advertising: this device is the account's only roster member");
-                None
-            },
-            AnnouncementVerdict::TooLargeToPublish => {
-                tracing::warn!(
-                    recipients = sealed.recipients,
-                    bytes = sealed.bytes.len(),
-                    max_bytes = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES,
-                    "not advertising: this account's roster is too large to seal into one \
-                     announcement"
-                );
-                None
-            },
-        },
-        Ok(None) => None,
-        Err(error) => {
-            tracing::warn!(%error, "not advertising: sealing this host's announcement failed");
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let Some(sealed) =
+        rag_rat_oplog::discovery::seal_discovery_announcement(conn, tag, local_node)?
+    else {
+        return Ok(None);
+    };
+    Ok(match classify_announcement(sealed.recipients, sealed.bytes.len()) {
+        AnnouncementVerdict::Advertise => Some(sealed.bytes),
+        AnnouncementVerdict::SoleRosterMember => {
+            tracing::debug!("not advertising: this device is the account's only roster member");
             None
         },
-    }
+        AnnouncementVerdict::TooLargeToPublish => {
+            tracing::warn!(
+                recipients = sealed.recipients,
+                bytes = sealed.bytes.len(),
+                max_bytes = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES,
+                "not advertising: this account's roster is too large to seal into one announcement"
+            );
+            None
+        },
+    })
+}
+
+/// The roster stamp to remember after an attempt to seal — the bookkeeping that decides whether the
+/// next session re-seals.
+///
+/// **Record the roster that was OBSERVED, never one derived from the sealing result.** A seal that
+/// deliberately produces no announcement — a lone device, or a roster too large to fit one publish
+/// — still reacted to a real roster, and forgetting it makes every later session see a change that
+/// did not happen. For an oversized roster that is a full re-seal, dozens of X25519 operations, and
+/// a repeated warning after every sync session, forever, on an account that never changed. Taking
+/// the announcement bytes as an input is what made that mistake expressible; this signature cannot
+/// see them.
+///
+/// A FAILED attempt keeps the previous stamp instead, so the next session retries it. That is the
+/// one case where repeating the work is the point: the failure is transient, and recording the new
+/// roster would mean never sealing against it.
+fn stamp_after_seal(
+    observed: Option<rag_rat_oplog::discovery::RosterStamp>,
+    last: Option<rag_rat_oplog::discovery::RosterStamp>,
+    sealed_ok: bool,
+) -> Option<rag_rat_oplog::discovery::RosterStamp> {
+    if sealed_ok { observed } else { last }
 }
 
 /// Why a sealed announcement is, or is not, worth publishing.
@@ -1050,7 +1079,7 @@ mod tests {
         AnnouncementVerdict, DEVICE_SYNC_LAST_META_KEY, DeviceSyncOutcome, classify_announcement,
         decode_node_secret, device_can_serve, device_can_sync, device_sync_due, device_sync_run,
         discovery_node_or_configured, discovery_service_addr, fold_peer_outcomes, join,
-        node_secret, record_device_sync, serve_should_advertise,
+        node_secret, record_device_sync, serve_should_advertise, stamp_after_seal,
     };
 
     fn account_of(conn: &Connection) -> rag_rat_oplog::AccountId {
@@ -1225,6 +1254,37 @@ mod tests {
             AnnouncementVerdict::SoleRosterMember
         );
         assert_eq!(classify_announcement(2, envelope_len(2)), AnnouncementVerdict::Advertise);
+    }
+
+    /// An unchanged roster must never look like a changed one — including when it seals to nothing.
+    ///
+    /// The trap is that "nothing to advertise" has two causes with opposite handling. A lone device
+    /// or an oversized roster is a SETTLED decision about a roster that was really observed, and
+    /// forgetting it makes every subsequent session detect a phantom change and re-seal: for a
+    /// 25-plus-device account that is dozens of X25519 operations and a repeated warning after
+    /// every sync, forever. A transient failure is the opposite — there the previous stamp must
+    /// survive so the next session tries again.
+    #[test]
+    fn the_remembered_roster_is_the_one_observed_not_the_one_successfully_advertised() {
+        let roster = Some([7u8; 32]);
+        let older = Some([3u8; 32]);
+
+        assert_eq!(
+            stamp_after_seal(roster, None, true),
+            roster,
+            "a roster that sealed to no announcement is still a roster we reacted to"
+        );
+        assert_eq!(stamp_after_seal(roster, older, true), roster, "a real change is recorded");
+        assert_eq!(
+            stamp_after_seal(roster, older, false),
+            older,
+            "a failed seal keeps the old stamp so the next session retries"
+        );
+        assert_eq!(
+            stamp_after_seal(roster, None, false),
+            None,
+            "a first attempt that failed leaves nothing recorded, so it is retried"
+        );
     }
 
     /// `[sync] discovery = false` silences the service for BOTH callers, because both resolve its

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -262,7 +262,6 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                         ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
                             config.sync.push_interval_secs,
                         ),
-                        now_ms: time::now_ms,
                     },
                 )))
             });
@@ -677,11 +676,11 @@ pub(crate) fn device_sync_run(
                     // every device that discovers it a dial that can only time out, and occupying
                     // one of the few per-tag slots that a REACHABLE peer needs. Only a node that
                     // accepts connections is worth announcing.
+                    fetch: true,
                     publish: None,
                     ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
                         config.sync.push_interval_secs,
                     ),
-                    now_ms: time::now_ms(),
                 }
             }),
             // Opening happens here, where a connection is available. An announcement sealed to a
@@ -825,16 +824,63 @@ fn seal_announcement(
     local_node: &[u8; 32],
 ) -> Option<(Vec<u8>, rag_rat_oplog::discovery::RosterStamp)> {
     match rag_rat_oplog::discovery::seal_discovery_announcement(conn, tag, local_node) {
-        Ok(Some(sealed)) if sealed.recipients > 1 => Some((sealed.bytes, sealed.roster_stamp)),
-        Ok(Some(_)) => {
-            tracing::debug!("not advertising: this device is the account's only roster member");
-            None
+        Ok(Some(sealed)) => match classify_announcement(sealed.recipients, sealed.bytes.len()) {
+            AnnouncementVerdict::Advertise => Some((sealed.bytes, sealed.roster_stamp)),
+            AnnouncementVerdict::SoleRosterMember => {
+                tracing::debug!("not advertising: this device is the account's only roster member");
+                None
+            },
+            AnnouncementVerdict::TooLargeToPublish => {
+                tracing::warn!(
+                    recipients = sealed.recipients,
+                    bytes = sealed.bytes.len(),
+                    max_bytes = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES,
+                    "not advertising: this account's roster is too large to seal into one \
+                     announcement"
+                );
+                None
+            },
         },
         Ok(None) => None,
         Err(error) => {
             tracing::warn!(%error, "not advertising: sealing this host's announcement failed");
             None
         },
+    }
+}
+
+/// Why a sealed announcement is, or is not, worth publishing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnnouncementVerdict {
+    Advertise,
+    /// No one to be discovered BY, so publishing would spend a slot to tell nobody.
+    SoleRosterMember,
+    /// Past what the service accepts in one publish.
+    TooLargeToPublish,
+}
+
+/// Decide whether a sealed announcement should be published, from its recipient count and size.
+///
+/// **The size rule is the one that fails silently without it.** An envelope grows 80 bytes per
+/// roster-effective device, so an account past roughly 25 of them seals something the service will
+/// refuse — and a refusal looks exactly like a transient one, so the host keeps retrying while
+/// being absent from discovery, with nothing anywhere saying why. Catching it here turns that into
+/// one warning naming the count, the size, and the limit.
+///
+/// It does NOT truncate the recipient list to fit. Which recipients were dropped would decide who
+/// can find this host, and choosing them arbitrarily is a worse failure than not advertising —
+/// splitting the envelope across several announcements is the way past the ceiling.
+///
+/// Named and tested separately for the same reason as [`serve_should_advertise`]: its caller needs
+/// a database with a roster of a given size, and the composition it feeds runs an accept loop until
+/// interrupted.
+fn classify_announcement(recipients: usize, bytes: usize) -> AnnouncementVerdict {
+    if bytes > rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES {
+        AnnouncementVerdict::TooLargeToPublish
+    } else if recipients > 1 {
+        AnnouncementVerdict::Advertise
+    } else {
+        AnnouncementVerdict::SoleRosterMember
     }
 }
 
@@ -1001,10 +1047,10 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        DEVICE_SYNC_LAST_META_KEY, DeviceSyncOutcome, decode_node_secret, device_can_serve,
-        device_can_sync, device_sync_due, device_sync_run, discovery_node_or_configured,
-        discovery_service_addr, fold_peer_outcomes, join, node_secret, record_device_sync,
-        serve_should_advertise,
+        AnnouncementVerdict, DEVICE_SYNC_LAST_META_KEY, DeviceSyncOutcome, classify_announcement,
+        decode_node_secret, device_can_serve, device_can_sync, device_sync_due, device_sync_run,
+        discovery_node_or_configured, discovery_service_addr, fold_peer_outcomes, join,
+        node_secret, record_device_sync, serve_should_advertise,
     };
 
     fn account_of(conn: &Connection) -> rag_rat_oplog::AccountId {
@@ -1138,6 +1184,47 @@ mod tests {
             "--once is a scripted check, not a host; its announcement would outlive the process"
         );
         assert!(!serve_should_advertise(false, false, true));
+    }
+
+    /// The roster size at which a host stops being able to advertise, pinned exactly.
+    ///
+    /// Two properties, and the second is the one that was missing. Sealing to more devices than fit
+    /// one publish is not a hypothetical: an envelope is one version byte plus 80 bytes per
+    /// roster-effective device, so the ceiling arrives at 25 recipients — well inside the roster
+    /// sizes accounts are otherwise built for. Without this branch the oversized publish is refused
+    /// by the service, the refusal is indistinguishable from a transient error, and the host
+    /// retries forever while absent from discovery with nothing explaining why.
+    ///
+    /// Asserted at the boundary on BOTH sides, because an off-by-one here is invisible in
+    /// production — it costs the largest accounts their discovery and nothing else changes.
+    #[test]
+    fn a_roster_too_large_to_seal_into_one_announcement_is_refused_not_truncated() {
+        const VERSION_BYTE: usize = 1;
+        const WRAP_LEN: usize = 32 + 48;
+        let envelope_len = |recipients: usize| VERSION_BYTE + recipients * WRAP_LEN;
+        let max = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES;
+
+        let fits = (1..).take_while(|n| envelope_len(*n) <= max).last().expect("some roster fits");
+        assert_eq!(fits, 25, "the documented recipient ceiling moved");
+
+        assert_eq!(
+            classify_announcement(fits, envelope_len(fits)),
+            AnnouncementVerdict::Advertise,
+            "the largest roster that fits must still advertise"
+        );
+        assert_eq!(
+            classify_announcement(fits + 1, envelope_len(fits + 1)),
+            AnnouncementVerdict::TooLargeToPublish,
+            "one recipient past the limit must be refused, not truncated to fit"
+        );
+
+        // The sole-member rule still applies, and size is judged first: a lone device is not
+        // advertised whatever its envelope weighs.
+        assert_eq!(
+            classify_announcement(1, envelope_len(1)),
+            AnnouncementVerdict::SoleRosterMember
+        );
+        assert_eq!(classify_announcement(2, envelope_len(2)), AnnouncementVerdict::Advertise);
     }
 
     /// `[sync] discovery = false` silences the service for BOTH callers, because both resolve its

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -232,16 +232,31 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
             .transpose()?
             .flatten()
             .map(|secret| rag_rat_sync::discovery::account_tag(&secret));
+        // Seal ONCE per roster change, not once per publish, and hand the advertiser the bytes.
+        //
+        // Sealing needs a connection; the advertiser is a spawned task and cannot hold one. So this
+        // loop — which already owns the connection and already folds the WAL between sessions — is
+        // where sealing happens, and the watch carries the result. Republishing identical bytes is
+        // safe (same key, same nonce, same plaintext) and buys two things: the advertiser stays
+        // database-free, and `is_live` can recognise this host's own announcement by comparing
+        // bytes rather than opening anything.
+        let announcement = discovery_tag.map(|tag| {
+            let (tx, rx) = tokio::sync::watch::channel(seal_announcement(conn, &tag, &local_node));
+            (tag, tx, rx)
+        });
         // Aborted on the way out of this scope, so the loop cannot outlive the endpoint it
         // advertises.
-        let _advertiser =
-            discovery_tag.zip(discovery_service_addr(config, &relay)).map(|(tag, service)| {
+        let _advertiser = announcement
+            .as_ref()
+            .map(|(tag, _, rx)| (*tag, rx.clone()))
+            .zip(discovery_service_addr(config, &relay))
+            .map(|((tag, announcement), service)| {
                 AbortOnDrop(tokio::spawn(rag_rat_sync::discovery::advertise(
                     rag_rat_sync::discovery::Advertise {
                         endpoint: endpoint.clone(),
                         service,
                         tag,
-                        node: local_node,
+                        announcement,
                         ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
                             config.sync.push_interval_secs,
                         ),
@@ -327,6 +342,18 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
             // `-wal` sidecar grows unbounded (passive autocheckpoint is pinned off). Size-gated and
             // best-effort, mirroring the watcher's per-pass fold.
             db.fold_wal();
+            // Re-seal between sessions, where the roster can have moved: an accept-loop ingest is
+            // the only way it changes under a serving host, since the session lock excludes a
+            // colocated device sync and no command authors roster changes. A device enrolled while
+            // this host is running therefore becomes a recipient at the next renewal; the
+            // advertiser re-reads the watch every tick, so the update needs no signal beyond this.
+            if let Some((tag, tx, _)) = &announcement {
+                let resealed = seal_announcement(conn, tag, &local_node);
+                if *tx.borrow() != resealed {
+                    tracing::debug!("the roster moved; re-sealing this host's announcement");
+                    let _ = tx.send(resealed);
+                }
+            }
             if once {
                 break;
             }
@@ -639,6 +666,19 @@ pub(crate) fn device_sync_run(
                     now_ms: time::now_ms(),
                 }
             }),
+            // Opening happens here, where a connection is available. An announcement sealed to a
+            // roster this device is no longer on simply will not open, and is dropped with the
+            // malformed ones — a device that has been removed stops finding its former peers by
+            // discovery, which is the point of sealing them.
+            &|payload| {
+                discovery_tag.and_then(|tag| {
+                    rag_rat_oplog::discovery::open_discovery_announcement(conn, &tag, payload)
+                        .unwrap_or_else(|error| {
+                            tracing::warn!(%error, "could not open a discovered announcement");
+                            None
+                        })
+                })
+            },
         )
         .await;
         let peers = resolved.peers;
@@ -749,6 +789,28 @@ fn discovery_service_addr(config: &Config, relay: &str) -> Option<rag_rat_sync::
                 %error,
                 "skipping peer discovery: [sync] discovery_node_id is not a usable node id"
             );
+            None
+        },
+    }
+}
+
+/// Seal this host's announcement to the account's current roster, or `None` when there is nothing
+/// to advertise.
+///
+/// `None` covers a store with no account and a roster holding only this device — the latter has no
+/// one to be discovered BY, so publishing would spend a slot to tell nobody. A sealing failure is
+/// logged and treated the same way: discovery is routing advice, and a host that cannot advertise
+/// still serves every peer that reaches it through a configured `server_peers` entry.
+fn seal_announcement(conn: &Connection, tag: &[u8; 32], local_node: &[u8; 32]) -> Option<Vec<u8>> {
+    match rag_rat_oplog::discovery::seal_discovery_announcement(conn, tag, local_node) {
+        Ok(Some(sealed)) if sealed.recipients > 1 => Some(sealed.bytes),
+        Ok(Some(_)) => {
+            tracing::debug!("not advertising: this device is the account's only roster member");
+            None
+        },
+        Ok(None) => None,
+        Err(error) => {
+            tracing::warn!(%error, "not advertising: sealing this host's announcement failed");
             None
         },
     }

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -21,10 +21,13 @@
 
 use anyhow::Context;
 use rusqlite::Connection;
+use sha2::{Digest, Sha256};
 
 use super::keywrap::{self, ContentKey, SealedKeyWrap, WrapContext};
 use super::{bootstrap, storage};
+use crate::device::DeviceX25519Public;
 use crate::identity;
+use crate::op::DeviceFingerprint;
 
 /// The envelope's leading byte. Bumping it is a wire break; the fetch side drops what it does not
 /// recognise rather than guessing.
@@ -38,6 +41,18 @@ const WRAP_LEN: usize = 32 + 48;
 /// rather than left to drift.
 const DISCOVERY_KEY_EPOCH: u64 = 0;
 
+/// A digest of the recipient set an announcement was sealed to.
+///
+/// The reason this exists: **sealing is not deterministic.** Every wrap carries a fresh ephemeral,
+/// so two seals of the same node id to an unchanged roster produce different bytes. A caller that
+/// wants to re-seal only when the roster actually moved therefore cannot compare envelopes — that
+/// predicate is true every time, and acting on it means republishing on every tick, which is the
+/// self-inflicted tag exhaustion the whole seal-once design exists to avoid.
+///
+/// Compare these instead. It is a digest, not the roster: fingerprints and public keys stay in this
+/// crate.
+pub type RosterStamp = [u8; 32];
+
 /// A sealed announcement, with the recipient count the caller needs for policy it owns.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SealedAnnouncement {
@@ -47,6 +62,9 @@ pub struct SealedAnnouncement {
     pub bytes: Vec<u8>,
     /// How many devices can open it — the whole roster-effective set, including this one.
     pub recipients: usize,
+    /// The recipient set this was sealed to. Compare against [`roster_stamp`] to decide whether a
+    /// re-seal is owed; see [`RosterStamp`] for why comparing `bytes` cannot work.
+    pub roster_stamp: RosterStamp,
 }
 
 /// Seal `node_id` to every roster-effective device, bound to `tag`.
@@ -81,7 +99,35 @@ pub fn seal_discovery_announcement(
             .with_context(|| format!("sealing a discovery announcement to device {fingerprint}"))?;
         push_wrap(&mut bytes, &sealed);
     }
-    Ok(Some(SealedAnnouncement { bytes, recipients: recipients.len() }))
+    Ok(Some(SealedAnnouncement {
+        bytes,
+        recipients: recipients.len(),
+        roster_stamp: stamp_of(&recipients),
+    }))
+}
+
+/// The current recipient set's stamp, without sealing anything.
+///
+/// Cheap enough to call on a cadence — it is one roster read — which is the point: a long-running
+/// host checks this between sessions and only pays for a re-seal when it changes.
+pub fn roster_stamp(conn: &Connection) -> anyhow::Result<Option<RosterStamp>> {
+    let Some(account) = bootstrap::read_local_account(conn)? else {
+        return Ok(None);
+    };
+    Ok(Some(stamp_of(&storage::list_effective_roster_x25519_pubkeys(conn, account)?)))
+}
+
+/// Digest the recipient set. Order is already stable — the roster read sorts by fingerprint — and
+/// both the fingerprint and the key go in, so a device whose enrolment key changed counts as a
+/// different recipient even at the same fingerprint.
+fn stamp_of(recipients: &[(DeviceFingerprint, DeviceX25519Public)]) -> RosterStamp {
+    let mut hasher = Sha256::new();
+    hasher.update(b"rag-rat/discovery-roster-stamp/1");
+    for (fingerprint, public) in recipients {
+        hasher.update(fingerprint.to_bytes());
+        hasher.update(public.to_bytes());
+    }
+    hasher.finalize().into()
 }
 
 /// Recover the node id from an announcement sealed to this device, or `None`.

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -1,0 +1,173 @@
+//! Sealing a discovery announcement to the account's roster-effective devices (#1080).
+//!
+//! A discovery announcement carries this node's iroh node id so the account's other devices can
+//! dial it. Published in the clear, that hands the shared discovery service — and anyone who can
+//! compute the account's tag, including a device removed from the roster — a list of dialable
+//! identities. Sealed per recipient, it hands them opaque bytes.
+//!
+//! **Why per recipient rather than under one shared account key.** A device that has been offline
+//! for a month and a device that has been removed look identical to the discovery service, so any
+//! scheme keyed on a shared rotating secret revokes the removed device and strands the offline one
+//! in the same stroke. They do not look identical to the PUBLISHER: the offline device is still
+//! roster-effective and its long-term X25519 key never rotates, while the removed device is simply
+//! not in the roster the publisher reads at seal time. Sealing per recipient therefore cuts exactly
+//! along roster membership, with no key epoch, no rotation, and nothing to distribute.
+//!
+//! Revocation applies to what is sealed NEXT. An announcement sealed before a device was removed
+//! stays openable by it until that announcement expires.
+//!
+//! Both halves live here, in the op-log crate, because neither the device's X25519 secret nor the
+//! roster's public keys may leave it — see [`crate::identity`].
+
+use anyhow::Context;
+use rusqlite::Connection;
+
+use super::keywrap::{self, ContentKey, SealedKeyWrap, WrapContext};
+use super::{bootstrap, storage};
+use crate::identity;
+
+/// The envelope's leading byte. Bumping it is a wire break; the fetch side drops what it does not
+/// recognise rather than guessing.
+pub const ANNOUNCEMENT_VERSION: u8 = 1;
+
+/// One sealed wrap on the wire: the ephemeral public key then the tagged ciphertext.
+const WRAP_LEN: usize = 32 + 48;
+
+/// The `key_epoch` slot of the wrap context. Discovery has no epochs — the whole point of sealing
+/// per recipient is that nothing rotates — so it is pinned at zero and covered by the golden vector
+/// rather than left to drift.
+const DISCOVERY_KEY_EPOCH: u64 = 0;
+
+/// A sealed announcement, with the recipient count the caller needs for policy it owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedAnnouncement {
+    /// `version || wrap*`, raw concatenation. Not CBOR: the payload already travels as an opaque
+    /// byte string, so a second CBOR layer would add nothing and cost about 30% against a size
+    /// budget that decides how many announcements fit one response frame.
+    pub bytes: Vec<u8>,
+    /// How many devices can open it — the whole roster-effective set, including this one.
+    pub recipients: usize,
+}
+
+/// Seal `node_id` to every roster-effective device, bound to `tag`.
+///
+/// `Ok(None)` when this store has no account: there is no roster to seal to, and nothing to
+/// discover. Errors only on a real database or crypto failure.
+///
+/// **This node is among the recipients.** Not for its own sake but because a publisher is also a
+/// device: it fetches on its own device-side pass, and a host that could not open announcements it
+/// had itself published would be a confusing hole the first time anyone looked.
+pub fn seal_discovery_announcement(
+    conn: &Connection,
+    tag: &[u8; 32],
+    node_id: &[u8; 32],
+) -> anyhow::Result<Option<SealedAnnouncement>> {
+    let Some(account) = bootstrap::read_local_account(conn)? else {
+        return Ok(None);
+    };
+    let recipients = storage::list_effective_roster_x25519_pubkeys(conn, account)?;
+    if recipients.is_empty() {
+        return Ok(None);
+    }
+
+    // The node id is 32 bytes of material to seal; `ContentKey` is the crate's 32-byte sealable
+    // payload and carries the zeroize-on-drop this wants anyway. It is not a content key.
+    let payload = ContentKey::from_seed(node_id);
+    let mut bytes = Vec::with_capacity(1 + recipients.len() * WRAP_LEN);
+    bytes.push(ANNOUNCEMENT_VERSION);
+    for (fingerprint, recipient_pub) in &recipients {
+        let ctx = wrap_context(account, tag, &recipient_pub.to_bytes());
+        let sealed = keywrap::seal_content_key(&payload, &ctx, recipient_pub)
+            .with_context(|| format!("sealing a discovery announcement to device {fingerprint}"))?;
+        push_wrap(&mut bytes, &sealed);
+    }
+    Ok(Some(SealedAnnouncement { bytes, recipients: recipients.len() }))
+}
+
+/// Recover the node id from an announcement sealed to this device, or `None`.
+///
+/// `None` covers every "not for us, or not ours to read" case: no local account or device, an
+/// unrecognised version, a malformed length, and — the ordinary case — no wrap that opens under
+/// this device's key.
+///
+/// **Silent when a wrap fails its tag.** Every announcement carries one wrap per roster device, so
+/// all but one are expected to fail here. The content path records unwrap failures as security
+/// events; doing that here would write a security event per foreign wrap per announcement per
+/// discovery pass, burying the real ones.
+pub fn open_discovery_announcement(
+    conn: &Connection,
+    tag: &[u8; 32],
+    envelope: &[u8],
+) -> anyhow::Result<Option<[u8; 32]>> {
+    let Some(wraps) = parse_wraps(envelope) else {
+        return Ok(None);
+    };
+    let Some(account) = bootstrap::read_local_account(conn)? else {
+        return Ok(None);
+    };
+    let Some(device) = identity::load_local_device(conn)? else {
+        return Ok(None);
+    };
+    let secret = device.x25519_secret();
+    let ctx = wrap_context(account, tag, &device.x25519_public().to_bytes());
+
+    for wrap in wraps {
+        // Failure here is the expected case, not an error: this device matches at most one wrap.
+        if let Ok(opened) = keywrap::unwrap_content_key(&wrap, secret, &ctx) {
+            let mut node_id = [0u8; 32];
+            node_id.copy_from_slice(opened.as_slice());
+            return Ok(Some(node_id));
+        }
+    }
+    Ok(None)
+}
+
+/// The AAD every wrap is bound to.
+///
+/// The slot that carries a stream id for content keys carries the discovery TAG here, so a wrap
+/// opens only under the tag it was published for and cannot be replayed under another. The account
+/// id is included for the same reason it is there for content keys: one device can belong to
+/// several accounts.
+fn wrap_context(
+    account: super::AccountId,
+    tag: &[u8; 32],
+    recipient_pub: &[u8; 32],
+) -> WrapContext {
+    WrapContext {
+        account_id: account.to_bytes(),
+        stream_id: *tag,
+        key_epoch: DISCOVERY_KEY_EPOCH,
+        recipient_pub: *recipient_pub,
+    }
+}
+
+fn push_wrap(bytes: &mut Vec<u8>, sealed: &SealedKeyWrap) {
+    bytes.extend_from_slice(&sealed.ephemeral_pubkey);
+    bytes.extend_from_slice(&sealed.ciphertext);
+}
+
+/// Split an envelope into its wraps, or `None` if it is not one of ours.
+///
+/// Rejects a wrong version and any length that is not exactly one version byte plus a whole number
+/// of wraps — including the empty case, which no publisher produces. A legacy raw 32-byte node id
+/// fails here on length even if its first byte happens to equal the version.
+fn parse_wraps(envelope: &[u8]) -> Option<Vec<SealedKeyWrap>> {
+    let (&version, rest) = envelope.split_first()?;
+    if version != ANNOUNCEMENT_VERSION || rest.is_empty() || rest.len() % WRAP_LEN != 0 {
+        return None;
+    }
+    Some(
+        rest.chunks_exact(WRAP_LEN)
+            .map(|chunk| {
+                let mut ephemeral_pubkey = [0u8; 32];
+                let mut ciphertext = [0u8; 48];
+                ephemeral_pubkey.copy_from_slice(&chunk[..32]);
+                ciphertext.copy_from_slice(&chunk[32..]);
+                SealedKeyWrap { ephemeral_pubkey, ciphertext }
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -63,6 +63,10 @@ const DISCOVERY_KEY_EPOCH: u64 = 0;
 pub type RosterStamp = [u8; 32];
 
 /// A sealed announcement, with the recipient count the caller needs for policy it owns.
+///
+/// It carries no roster stamp: whether a re-seal is owed is decided by comparing [`roster_stamp`]
+/// across sessions, not by anything a single seal reports — see [`RosterStamp`] for why the
+/// envelope bytes cannot serve that purpose.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SealedAnnouncement {
     /// `version || wrap*`, raw concatenation. Not CBOR: the payload already travels as an opaque
@@ -71,9 +75,6 @@ pub struct SealedAnnouncement {
     pub bytes: Vec<u8>,
     /// How many devices can open it — the whole roster-effective set, including this one.
     pub recipients: usize,
-    /// The recipient set this was sealed to. Compare against [`roster_stamp`] to decide whether a
-    /// re-seal is owed; see [`RosterStamp`] for why comparing `bytes` cannot work.
-    pub roster_stamp: RosterStamp,
 }
 
 /// Seal `node_id` to every roster-effective device, bound to `tag`.
@@ -108,11 +109,7 @@ pub fn seal_discovery_announcement(
             .with_context(|| format!("sealing a discovery announcement to device {fingerprint}"))?;
         push_wrap(&mut bytes, &sealed);
     }
-    Ok(Some(SealedAnnouncement {
-        bytes,
-        recipients: recipients.len(),
-        roster_stamp: stamp_of(&recipients),
-    }))
+    Ok(Some(SealedAnnouncement { bytes, recipients: recipients.len() }))
 }
 
 /// The current recipient set's stamp, without sealing anything.

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -31,6 +31,15 @@ use crate::op::DeviceFingerprint;
 
 /// The envelope's leading byte. Bumping it is a wire break; the fetch side drops what it does not
 /// recognise rather than guessing.
+///
+/// **Version 1 is the first format that ships.** The cleartext 32-byte node id this replaced never
+/// appeared in a released version, so there is no deployed client to stay compatible with and no
+/// transition to provide. That will not be true of the next change: publishers and fetchers share
+/// one tag and one ALPN with no negotiation, so a future format that simply bumped this byte would
+/// partition a mixed fleet — each side silently discarding the other's announcements — for as long
+/// as the upgrade took, with discovery falling back to `server_peers` and nothing reporting why.
+/// A later format therefore needs a transition: publish both encodings for a release, or key the
+/// tag by version so the two populations do not share a namespace.
 pub const ANNOUNCEMENT_VERSION: u8 = 1;
 
 /// One sealed wrap on the wire: the ephemeral public key then the tagged ciphertext.

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -265,6 +265,12 @@ fn the_wrap_context_carries_account_tag_epoch_and_recipient() {
 
 // ---------------------------------------------------------------- envelope shape
 
+/// The size law an envelope obeys — and the reason the publish side has a recipient ceiling at all.
+///
+/// `1 + 80n` is what makes roster size a WIRE constraint: the discovery service caps one publish,
+/// so this growth rate decides how many devices an account can have before its host can no longer
+/// seal an announcement it is able to send. The caller pins the resulting ceiling against its own
+/// limit; this pins the law that ceiling is computed from, so the two cannot drift apart silently.
 #[test]
 fn the_envelope_is_a_version_byte_then_eighty_bytes_per_recipient() {
     let conn = db();

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -168,11 +168,9 @@ fn the_roster_stamp_is_stable_until_the_roster_moves() {
 
     let lone = roster_stamp(&conn).unwrap().expect("an account has a stamp");
     assert_eq!(lone, roster_stamp(&conn).unwrap().unwrap(), "stable across reads");
-    assert_eq!(
-        lone,
-        seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap().roster_stamp,
-        "and matches what a seal reports, so the two cannot drift"
-    );
+    // Sealing does not perturb the stamp: a seal draws fresh ephemerals but reads the same roster.
+    seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    assert_eq!(lone, roster_stamp(&conn).unwrap().unwrap(), "stable across a seal in between");
 
     let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
     let member_fp = add_member(&conn, account, &member_x);

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -147,6 +147,47 @@ fn every_roster_effective_device_can_open_the_announcement() {
     assert_eq!(opened.as_slice(), NODE_ID.as_slice());
 }
 
+/// Sealing is NOT deterministic: each wrap carries a fresh ephemeral. Anything that tries to detect
+/// a roster change by comparing envelope bytes therefore sees a change every time.
+#[test]
+fn two_seals_of_the_same_node_to_the_same_roster_differ() {
+    let conn = db();
+    bootstrap::local_account(&conn, NOW).unwrap();
+
+    let first = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    let second = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    assert_ne!(first.bytes, second.bytes, "a fresh ephemeral per wrap makes every seal differ");
+}
+
+/// The stamp is what a caller compares to decide whether a re-seal is owed, since envelope bytes
+/// cannot serve that purpose. It must be stable across reads and move when the roster does.
+#[test]
+fn the_roster_stamp_is_stable_until_the_roster_moves() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+
+    let lone = roster_stamp(&conn).unwrap().expect("an account has a stamp");
+    assert_eq!(lone, roster_stamp(&conn).unwrap().unwrap(), "stable across reads");
+    assert_eq!(
+        lone,
+        seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap().roster_stamp,
+        "and matches what a seal reports, so the two cannot drift"
+    );
+
+    let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
+    let member_fp = add_member(&conn, account, &member_x);
+    let with_member = roster_stamp(&conn).unwrap().unwrap();
+    assert_ne!(lone, with_member, "enrolling a device moves the stamp");
+
+    close_roster_row(&conn, account, member_fp);
+    assert_eq!(roster_stamp(&conn).unwrap().unwrap(), lone, "removing it moves it back");
+}
+
+#[test]
+fn a_store_with_no_account_has_no_roster_stamp() {
+    assert!(roster_stamp(&db()).unwrap().is_none());
+}
+
 // ---------------------------------------------------------------- revocation
 
 /// The property this whole design exists for: a device off the roster at seal time gets no wrap.

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -1,0 +1,291 @@
+use rag_rat_db::schema;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
+
+use super::*;
+use crate::account::authoring;
+use crate::account::bootstrap::{self, LocalAccountRef};
+use crate::account::envelope::{AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
+use crate::account::fold::CONTROL_LOG;
+use crate::account::keywrap::unwrap_content_key;
+use crate::account::ops::{AccountOp, DeviceRole};
+use crate::device::{DeviceSecret, DeviceX25519Secret};
+use crate::identity::local_device;
+
+const NOW: i64 = 1_700_000_000_000;
+const TAG: [u8; 32] = [0xa7; 32];
+const OTHER_TAG: [u8; 32] = [0xb8; 32];
+const NODE_ID: [u8; 32] = [0x4d; 32];
+
+fn db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::test_hooks()).unwrap();
+    conn
+}
+
+/// Author a control op as the founder and refold, so the roster reflects it.
+///
+/// Mirrors the fixture in `secrets::author`'s tests. Duplicated rather than shared because those
+/// helpers are private to that module; if a third module needs them they should move to a shared
+/// test-support module rather than be copied again.
+fn author_control_op(conn: &Connection, account: super::super::AccountId, op: &AccountOp) {
+    use crate::account::{ops as control_ops, storage};
+
+    let founder = local_device(conn, NOW).unwrap();
+    let LocalAccountRef { genesis_hash, .. } = bootstrap::local_account_ref(conn).unwrap().unwrap();
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+    let tail = authoring::account_chain_tail(&tx, account, founder.fingerprint(), CONTROL_LOG)
+        .unwrap()
+        .expect("control chain is non-empty post-genesis");
+    let header = AccountEntryHeader {
+        account_id: account,
+        log_id: CONTROL_LOG,
+        device_fingerprint: founder.fingerprint(),
+        seq: tail.0 + 1,
+        prev_hash: Some(tail.1),
+        parent_ref: Some(genesis_hash),
+        entry_type: control_ops::entry_type_of(op),
+        op_version: 1,
+        crypto_suite: 0,
+        auth_len: storage::account_effective_count(&tx, account).unwrap(),
+        key_id: None,
+        authority_ref: Some(genesis_hash),
+    };
+    let payload = control_ops::encode(op).unwrap();
+    let signed = sign_account_entry(founder.secret(), &header, &payload).unwrap();
+    let verified = VerifiedAccountEntry {
+        header: signed.header,
+        payload: signed.payload,
+        entry_hash: signed.entry_hash,
+    };
+    storage::insert_candidate(&tx, &verified, &signed.signed_bytes, NOW).unwrap();
+    storage::refold_in_tx(&tx, account, NOW).unwrap();
+    tx.commit().unwrap();
+}
+
+/// Enrol a second device carrying `member_x`, and return its fingerprint.
+fn add_member(
+    conn: &Connection,
+    account: super::super::AccountId,
+    member_x: &DeviceX25519Secret,
+) -> crate::op::DeviceFingerprint {
+    let member_pub = DeviceSecret::from_seed(&[0x2c; 32]).public();
+    let member_fp = member_pub.fingerprint();
+    author_control_op(conn, account, &AccountOp::DeviceAdd {
+        device_fingerprint: member_fp,
+        ed25519_pubkey: member_pub.to_bytes(),
+        x25519_pubkey: member_x.public().to_bytes(),
+        role: DeviceRole::Member,
+        label: None,
+    });
+    member_fp
+}
+
+/// Drop a device from the effective roster by closing its roster row — what the reader this design
+/// depends on actually looks at (`closed_at IS NULL`), without building a full `DeviceRemove` and
+/// its cuts.
+fn close_roster_row(
+    conn: &Connection,
+    account: super::super::AccountId,
+    fp: crate::op::DeviceFingerprint,
+) {
+    conn.execute(
+        "UPDATE account_roster_history SET closed_at = ?3
+         WHERE account_id = ?1 AND device_fingerprint = ?2",
+        rusqlite::params![account.to_bytes().as_slice(), fp.to_bytes().as_slice(), 99i64],
+    )
+    .unwrap();
+}
+
+/// Reconstruct the wrap context a recipient would use, so a test can open a specific wrap with a
+/// key the local store does not hold.
+fn ctx_for(
+    account: super::super::AccountId,
+    tag: &[u8; 32],
+    recipient: &DeviceX25519Secret,
+) -> WrapContext {
+    wrap_context(account, tag, &recipient.public().to_bytes())
+}
+
+fn wraps_of(envelope: &[u8]) -> Vec<SealedKeyWrap> {
+    parse_wraps(envelope).expect("a sealed envelope parses")
+}
+
+// ---------------------------------------------------------------- round trip
+
+/// The sealing device is among the recipients, so it opens its own announcement. A publisher is
+/// also a device — it fetches on its own pass — and a host that could not read what it published
+/// would be a hole nobody would expect.
+#[test]
+fn a_sealed_announcement_opens_on_the_sealing_device() {
+    let conn = db();
+    bootstrap::local_account(&conn, NOW).unwrap();
+
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    assert_eq!(sealed.recipients, 1, "a lone founder is the whole roster");
+
+    let opened = open_discovery_announcement(&conn, &TAG, &sealed.bytes).unwrap();
+    assert_eq!(opened, Some(NODE_ID));
+}
+
+/// Every roster-effective device is a recipient, not just the publisher.
+#[test]
+fn every_roster_effective_device_can_open_the_announcement() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+    let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
+    add_member(&conn, account, &member_x);
+
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    assert_eq!(sealed.recipients, 2, "founder + member");
+
+    // Open as the member, whose key this store does not hold, by reconstructing its context.
+    let ctx = ctx_for(account, &TAG, &member_x);
+    let opened = wraps_of(&sealed.bytes)
+        .iter()
+        .find_map(|wrap| unwrap_content_key(wrap, &member_x, &ctx).ok())
+        .expect("the member has a wrap it can open");
+    assert_eq!(opened.as_slice(), NODE_ID.as_slice());
+}
+
+// ---------------------------------------------------------------- revocation
+
+/// The property this whole design exists for: a device off the roster at seal time gets no wrap.
+#[test]
+fn a_device_removed_before_sealing_gets_no_wrap() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+    let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
+    let member_fp = add_member(&conn, account, &member_x);
+    close_roster_row(&conn, account, member_fp);
+
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    assert_eq!(sealed.recipients, 1, "the removed device is not sealed to");
+
+    let ctx = ctx_for(account, &TAG, &member_x);
+    assert!(
+        wraps_of(&sealed.bytes)
+            .iter()
+            .all(|wrap| unwrap_content_key(wrap, &member_x, &ctx).is_err()),
+        "a removed device must not open anything sealed after its removal"
+    );
+}
+
+/// The honest limit, pinned so nobody claims instant revocation: an announcement sealed WHILE a
+/// device was effective stays readable by it. Revocation governs what is sealed next; the old
+/// announcement stops mattering when it expires at the service.
+#[test]
+fn a_device_removed_after_sealing_still_opens_that_announcement() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+    let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
+    let member_fp = add_member(&conn, account, &member_x);
+
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    close_roster_row(&conn, account, member_fp);
+
+    let ctx = ctx_for(account, &TAG, &member_x);
+    let opened = wraps_of(&sealed.bytes)
+        .iter()
+        .find_map(|wrap| unwrap_content_key(wrap, &member_x, &ctx).ok());
+    assert!(opened.is_some(), "already-published announcements do not become unreadable");
+}
+
+// ---------------------------------------------------------------- AAD binding
+
+/// A wrap is bound to the tag it was published under, so it cannot be replayed beneath another —
+/// including by a legitimate recipient.
+#[test]
+fn a_wrap_does_not_open_under_another_tag() {
+    let conn = db();
+    bootstrap::local_account(&conn, NOW).unwrap();
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+
+    assert_eq!(open_discovery_announcement(&conn, &TAG, &sealed.bytes).unwrap(), Some(NODE_ID));
+    assert_eq!(
+        open_discovery_announcement(&conn, &OTHER_TAG, &sealed.bytes).unwrap(),
+        None,
+        "the tag is AAD; a different tag must not open the wrap"
+    );
+}
+
+/// The remaining context fields are pinned the same way — by showing an opener that differs in one
+/// of them fails. A byte golden would pin the layout but not that these values are the ones fed in.
+#[test]
+fn the_wrap_context_carries_account_tag_epoch_and_recipient() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+    let ctx = wrap_context(account, &TAG, &[0x11; 32]);
+
+    assert_eq!(ctx.account_id, account.to_bytes());
+    assert_eq!(ctx.stream_id, TAG, "the tag occupies the stream-id slot");
+    assert_eq!(ctx.key_epoch, 0, "discovery has no epochs; the slot is pinned at zero");
+    assert_eq!(ctx.recipient_pub, [0x11; 32]);
+}
+
+// ---------------------------------------------------------------- envelope shape
+
+#[test]
+fn the_envelope_is_a_version_byte_then_eighty_bytes_per_recipient() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+    add_member(&conn, account, &DeviceX25519Secret::from_seed(&[0x5c; 32]));
+
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    assert_eq!(sealed.bytes[0], ANNOUNCEMENT_VERSION);
+    assert_eq!(sealed.bytes.len(), 1 + 2 * 80, "one version byte, 80 per recipient");
+    assert_eq!(wraps_of(&sealed.bytes).len(), 2);
+}
+
+/// Anything that is not one of ours is refused at parse, individually and quietly.
+#[test]
+fn parsing_refuses_everything_that_is_not_an_envelope() {
+    let good = 1 + 80;
+    assert!(parse_wraps(&[]).is_none(), "empty");
+    assert!(parse_wraps(&[ANNOUNCEMENT_VERSION]).is_none(), "version with no wraps");
+    assert!(parse_wraps(&vec![9u8; good]).is_none(), "unknown version");
+    assert!(parse_wraps(&vec![ANNOUNCEMENT_VERSION; good + 1]).is_none(), "ragged length");
+    assert!(parse_wraps(&vec![ANNOUNCEMENT_VERSION; good - 1]).is_none(), "short by one");
+
+    // The legacy wire was a bare 32-byte node id. One whose first byte happens to equal the version
+    // must still be refused rather than half-parsed.
+    let mut legacy = [0x77u8; 32];
+    legacy[0] = ANNOUNCEMENT_VERSION;
+    assert!(parse_wraps(&legacy).is_none(), "a legacy node id is not an envelope");
+    assert!(parse_wraps(&[0x77u8; 32]).is_none());
+}
+
+// ---------------------------------------------------------------- absent state
+
+#[test]
+fn a_store_with_no_account_seals_nothing_and_opens_nothing() {
+    let conn = db();
+    assert!(seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().is_none());
+    assert!(
+        open_discovery_announcement(&conn, &TAG, &[ANNOUNCEMENT_VERSION; 81]).unwrap().is_none()
+    );
+}
+
+/// Opening is silent when a wrap is not ours — the ordinary case, once per foreign recipient per
+/// announcement. Recording those as security events, the way the content path records unwrap
+/// failures, would bury the real ones under discovery traffic.
+#[test]
+fn opening_a_foreign_wrap_records_no_security_event() {
+    let conn = db();
+    let account = bootstrap::local_account(&conn, NOW).unwrap();
+    let stranger_x = DeviceX25519Secret::from_seed(&[0x9e; 32]);
+
+    // An envelope sealed to nobody this store knows: one wrap, for a stranger.
+    let payload = ContentKey::from_seed(&NODE_ID);
+    let ctx = ctx_for(account, &TAG, &stranger_x);
+    let sealed = keywrap::seal_content_key(&payload, &ctx, &stranger_x.public()).unwrap();
+    let mut envelope = vec![ANNOUNCEMENT_VERSION];
+    envelope.extend_from_slice(&sealed.ephemeral_pubkey);
+    envelope.extend_from_slice(&sealed.ciphertext);
+
+    assert_eq!(open_discovery_announcement(&conn, &TAG, &envelope).unwrap(), None);
+
+    let events: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sync_security_events", [], |row| row.get(0))
+        .unwrap_or(0);
+    assert_eq!(events, 0, "a foreign wrap is expected, not an incident");
+}

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -20,6 +20,7 @@ mod bootstrap;
 mod candidate;
 mod content;
 mod cut;
+pub mod discovery;
 mod envelope;
 mod fold;
 mod id;

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -89,6 +89,10 @@ mod table_sync;
 // take a `&DeviceSecret`, so — like `sign_content_entry` — they stay account-crate-internal.
 // Keep this crate-root API explicit: adding an account implementation seam must not silently
 // make it a public semver commitment.
+/// Sealing a discovery announcement to the account's roster-effective devices. Both halves
+/// live in the op-log crate because neither the device X25519 secret nor the roster's public
+/// keys may leave it.
+pub use account::discovery;
 pub use account::{
     AccountId, AuthoredDurability, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason,
     AuthorityQuery, CapacityScope, CatchUpReport, ContentCapacityScope, ContentEntryHeader,

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -163,10 +163,14 @@ pub enum PublishState {
 /// What one discovery pass produced. Never an `Err`: see the module docs.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DiscoveryOutcome {
-    /// Node ids advertised for this account, already filtered to well-formed ones. Includes this
-    /// node when it advertises itself — self-exclusion belongs to the composing caller, which
-    /// needs the raw set to decide whether its own announcement is still live.
-    pub peers: Vec<[u8; 32]>,
+    /// The announcement payloads found under this tag: sealed envelopes, de-duplicated and capped.
+    ///
+    /// Returned UNOPENED. Opening needs the account roster and this device's key, which live in
+    /// the op-log crate behind a connection — and a connection is not `Sync`, so an opener
+    /// carried here would travel across an await inside the spawned advertise loop and make
+    /// that future unspawnable. The composing caller opens them; the advertise loop discards
+    /// them.
+    pub announcements: Vec<Vec<u8>>,
     /// What happened to this node's own announcement.
     pub publish: PublishState,
     /// Why the pass produced less than it might have — for logging only. A caller that branches on
@@ -181,9 +185,13 @@ pub struct DiscoveryExchange<'a> {
     /// testable against the real code path.
     pub service: EndpointAddr,
     pub tag: [u8; TAG_LEN],
-    /// `Some(node)` advertises `node`; `None` fetches only — which is what lets a machine behind
-    /// NAT find a server without becoming discoverable itself.
-    pub publish: Option<[u8; 32]>,
+    /// The sealed announcement to publish, or `None` to fetch only — which is what lets a machine
+    /// behind NAT find a host without becoming discoverable itself.
+    ///
+    /// Opaque bytes here on purpose: sealing needs the account roster and the device key, both of
+    /// which live in the op-log crate, so this layer carries the result rather than the
+    /// ingredients.
+    pub publish: Option<&'a [u8]>,
     pub ttl_seconds: u32,
     /// "Now" as a VALUE, not a clock: the exchange reads it exactly once, to judge whether this
     /// node's existing announcement has enough life left to skip republishing.
@@ -262,12 +270,12 @@ async fn exchange_inner(
     // silently ceasing to advertise.
     let publish_state = match publish {
         None => PublishState::NotAttempted,
-        Some(node) if is_live(&announcements, node, *ttl_seconds, *now_ms) =>
+        Some(envelope) if is_live(&announcements, envelope, *ttl_seconds, *now_ms) =>
             PublishState::AlreadyLive,
-        Some(node) => {
+        Some(envelope) => {
             let publish = DiscoveryRequest::Publish {
                 tag: *tag,
-                payload: node.to_vec(),
+                payload: envelope.to_vec(),
                 ttl_seconds: *ttl_seconds,
             };
             // Whatever happens here, the peers fetched above are already in hand and are returned.
@@ -289,16 +297,23 @@ async fn exchange_inner(
         },
     };
 
-    let peers = announcements
+    // DEDUPLICATE, then cap — in that order. Capping first would spend the budget on duplicates: a
+    // publisher holds about two live copies of itself at any moment, so a cap applied to raw
+    // announcements admits roughly half the peers it promises.
+    //
+    // De-duplicating by BYTES works, and only because a publisher seals once per roster change and
+    // republishes the result verbatim: its copies are byte-identical. Were the envelope re-sealed
+    // per publish, each copy would carry a fresh ephemeral and none of this would collapse.
+    let mut seen = std::collections::HashSet::new();
+    let announcements = announcements
         .into_iter()
-        // A malformed payload is dropped INDIVIDUALLY. Failing the batch would let one bad entry —
-        // which any party that can compute the tag may publish — hide every good one.
-        .filter_map(|announcement| <[u8; 32]>::try_from(announcement.payload.as_slice()).ok())
+        .map(|announcement| announcement.payload)
+        .filter(|payload| seen.insert(payload.clone()))
         .take(MAX_ANNOUNCEMENTS)
         .collect();
 
     DiscoveryOutcome {
-        peers,
+        announcements,
         publish: publish_state,
         degraded: (!degraded.is_empty()).then(|| degraded.join("; ")),
     }
@@ -312,8 +327,13 @@ pub struct Advertise {
     /// [`DiscoveryExchange`] takes one: it is what makes an in-process stub testable.
     pub service: EndpointAddr,
     pub tag: [u8; TAG_LEN],
-    /// The node id to advertise — this host's own.
-    pub node: [u8; 32],
+    /// The sealed announcement to publish, re-read on EVERY tick.
+    ///
+    /// A channel rather than a value because the roster moves under a long-running host: a device
+    /// enrolled an hour after it started must become a recipient at the next renewal, not never.
+    /// `None` means there is nothing to advertise — no account, or a roster holding only this
+    /// device, which has no one to be discovered by.
+    pub announcement: tokio::sync::watch::Receiver<Option<Vec<u8>>>,
     pub ttl_seconds: u32,
     /// A clock, not an instant: unlike a single [`exchange`], this loop runs for the host's
     /// lifetime and must read the time afresh on every tick.
@@ -336,18 +356,31 @@ pub struct Advertise {
 /// Publish-only in effect: the fetched peers are discarded, because peers dial a serving host
 /// rather than the other way round.
 pub async fn advertise(params: Advertise) {
-    let Advertise { endpoint, service, tag, node, ttl_seconds, now_ms } = params;
+    let Advertise { endpoint, service, tag, mut announcement, ttl_seconds, now_ms } = params;
     // `.max(4)` keeps the interval positive even if a future TTL floor drops below 4s; a zero
     // period would make `interval` panic.
     let mut ticks =
         tokio::time::interval(Duration::from_secs(u64::from(ttl_seconds).max(4) / TICKS_PER_TTL));
     loop {
         ticks.tick().await;
+        // Re-read per tick, not once at spawn: this is what makes a roster change take effect.
+        //
+        // Scoped so the borrow guard is dropped before the await below. A `watch::Ref` is not
+        // `Send`, and a temporary living to the end of its statement would be held across the
+        // suspension point, making this whole future unspawnable.
+        let envelope = {
+            let borrowed = announcement.borrow_and_update();
+            borrowed.clone()
+        };
+        let Some(envelope) = envelope else {
+            tracing::debug!("nothing to advertise yet; skipping this tick");
+            continue;
+        };
         let outcome = exchange(DiscoveryExchange {
             endpoint: &endpoint,
             service: service.clone(),
             tag,
-            publish: Some(node),
+            publish: Some(&envelope),
             ttl_seconds,
             now_ms: now_ms(),
         })
@@ -361,8 +394,16 @@ pub async fn advertise(params: Advertise) {
     }
 }
 
-/// Whether `node` already has an announcement with comfortably more than [`RENEWAL_THRESHOLD`] of
-/// its TTL left — i.e. one that does not need renewing yet.
+/// Whether this host's own announcement is already live with comfortably more than
+/// [`RENEWAL_THRESHOLD`] of its TTL left — i.e. does not need renewing yet.
+///
+/// Compares the announcement BYTES against the envelope this host is currently publishing. That
+/// works because the envelope is sealed once per roster change and republished verbatim, not
+/// re-sealed per tick — a fresh ephemeral per publish would make every copy differ, the host would
+/// never recognise itself, and it would republish on every tick until the tag was full of its own
+/// announcements. It also earns a property: when the roster moves the envelope changes, so the old
+/// announcement stops matching and the host republishes at the NEXT tick instead of waiting out a
+/// renewal.
 ///
 /// **The margin is the point, and getting it wrong is silent.** `expires_at_ms` is stamped by the
 /// SERVICE when it receives the publish, not by this client when it sends one, so an entry written
@@ -378,13 +419,13 @@ pub async fn advertise(params: Advertise) {
 /// tolerable only because the margin dwarfs any plausible skew. It would not be at zero margin.
 fn is_live(
     announcements: &[wire::WireAnnouncement],
-    node: &[u8; 32],
+    envelope: &[u8],
     ttl_seconds: u32,
     now_ms: i64,
 ) -> bool {
     let headroom_ms = i64::from(ttl_seconds) * 1000 * RENEWAL_THRESHOLD_NUM / RENEWAL_THRESHOLD_DEN;
     announcements.iter().any(|announcement| {
-        announcement.payload.as_slice() == node.as_slice()
+        announcement.payload.as_slice() == envelope
             && announcement.expires_at_ms.saturating_sub(now_ms) > headroom_ms
     })
 }

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -202,10 +202,18 @@ pub enum PublishState {
     /// far enough to try.
     #[default]
     NotAttempted,
-    /// This pass wrote a fresh announcement.
+    /// The service acknowledged storing the announcement.
     Published,
-    /// The service refused or the write failed. Non-fatal: the fetch half still ran.
-    Failed,
+    /// The service RESPONDED and declined — rate-limited, or any non-`Published` answer. The
+    /// announcement is definitely not stored, so a caller renewing on a cadence should try again.
+    Refused,
+    /// No acknowledgement arrived: the publish stream errored or timed out. The announcement **may
+    /// or may not** be stored — the service stamps expiry and stores on RECEIPT, before it answers,
+    /// so a lost or late response says nothing about whether the write landed. A renewing caller
+    /// must treat this as possibly-live and NOT re-append every tick, or a service that stores but
+    /// cannot answer would drive one host to fill the whole tag. Non-fatal: the fetch half still
+    /// ran.
+    Uncertain,
 }
 
 /// What one discovery pass produced. Never an `Err`: see the module docs.
@@ -333,17 +341,22 @@ async fn exchange_inner(
             // Whatever happens here, the peers fetched above are already in hand and are returned.
             match tokio::time::timeout_at(deadline, request(&conn, &publish)).await {
                 Ok(Ok(DiscoveryResponse::Published { .. })) => PublishState::Published,
+                // A response arrived and it was not `Published`: the service saw the request and
+                // declined it, so nothing is stored.
                 Ok(Ok(other)) => {
                     degraded.push(format!("publish refused: {other:?}"));
-                    PublishState::Failed
+                    PublishState::Refused
                 },
+                // No response: the stream errored or the deadline passed. The service stores on
+                // receipt before answering, so the write may already have landed — see
+                // [`PublishState::Uncertain`].
                 Ok(Err(error)) => {
                     degraded.push(format!("publish failed: {error}"));
-                    PublishState::Failed
+                    PublishState::Uncertain
                 },
                 Err(_elapsed) => {
                     degraded.push(format!("publish timed out after {DISCOVERY_TIMEOUT:?}"));
-                    PublishState::Failed
+                    PublishState::Uncertain
                 },
             }
         },
@@ -369,6 +382,22 @@ async fn exchange_inner(
         publish: publish_state,
         degraded: (!degraded.is_empty()).then(|| degraded.join("; ")),
     }
+}
+
+/// Whether a publish outcome means "this announcement may be live", so the advertiser should time
+/// renewal from it rather than re-append on the next tick.
+///
+/// True for both a confirmed publish and an ambiguous one. The ambiguous case is the load-bearing
+/// one: the service stores on receipt before it answers, so a lost or timed-out ack does not mean
+/// the write failed, and re-appending because it went unacknowledged is how a host whose responses
+/// are dropped fills the whole tag (the service appends, never replaces). A `Refused` is the
+/// opposite — the service answered and declined, nothing is stored, so the next tick should retry.
+///
+/// The cost of treating a genuinely-failed `Uncertain` as live is one renewal interval of
+/// undiscoverability before the next republish; the cost of the other error is unbounded slot
+/// churn. This trades the bounded harm for the unbounded one.
+fn records_liveness(state: PublishState) -> bool {
+    matches!(state, PublishState::Published | PublishState::Uncertain)
 }
 
 /// A long-running host's standing advertisement — see [`advertise`].
@@ -427,6 +456,11 @@ pub async fn advertise(params: Advertise) {
     // clock and not the service's `expires_at_ms`: this is a pure "how long since we published"
     // question, so it needs neither a clock that can step backwards nor a comparison across two
     // machines' clocks.
+    //
+    // In memory only, so a restart forgets it — and because a fresh seal is byte-distinct, the
+    // restarted host cannot recognise its still-live announcement and appends another. Bounded and
+    // self-healing after one restart; a crash loop or rapid redeploy is the case that bites.
+    // Persisting or reusing the envelope across restart is #1086.
     let mut published: Option<(Vec<u8>, tokio::time::Instant)> = None;
     loop {
         ticks.tick().await;
@@ -466,7 +500,7 @@ pub async fn advertise(params: Advertise) {
             ttl_seconds,
         })
         .await;
-        if outcome.publish == PublishState::Published {
+        if records_liveness(outcome.publish) {
             published = Some((envelope, attempted_at));
         }
         match outcome.degraded {

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -6,11 +6,20 @@
 //!
 //! **What that does and does not hide.** The tag is a pseudonym the service cannot link to an
 //! account: it is keyed material, not a digest of the account id, so a party holding the account id
-//! — which every host a device has ever dialed does — cannot compute it. What the service DOES see,
-//! under that pseudonym, is the node ids advertised beneath a tag, their expiry timestamps, and the
-//! refreshes that renew them. It can therefore count how many nodes advertise under one tag and
-//! watch when they start and stop renewing. Unlinkability is the guarantee; hiding node count and
-//! liveness from the service is NOT, and code or documentation that implies otherwise is wrong.
+//! — which every host a device has ever dialed does — cannot compute it.
+//!
+//! Announcement payloads are sealed per roster-effective device, so the service reads no node id
+//! out of them. **That does not hide node ids from the service**, and believing otherwise is the
+//! easy mistake here: every publish and every fetch arrives over an authenticated iroh connection,
+//! whose remote id the service can read directly. It therefore learns which node ids publish under
+//! a tag and which node ids ask about one — that is, the account's whole active device set — plus
+//! expiry timestamps and renewal timing. Sealing is aimed at the OTHER reader, the party who can
+//! compute the tag but cannot terminate the connection: a removed device, or anyone the tag leaks
+//! to. Withholding node ids from the service itself would take publishing over a throwaway
+//! endpoint identity, which this does not do.
+//!
+//! So: unlinkability of tag to account is the guarantee. Hiding device count, device identity, or
+//! liveness FROM THE SERVICE is not, and code or documentation that implies otherwise is wrong.
 //!
 //! **Discovery is routing advice, never authority.** A discovered address is dialed exactly like a
 //! configured one and still passes the full mutual roster auth before a single byte of inventory is

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -204,11 +204,14 @@ pub enum PublishState {
     NotAttempted,
     /// The service acknowledged storing the announcement.
     Published,
-    /// The service RESPONDED and declined — rate-limited, or any non-`Published` answer. The
-    /// announcement is definitely not stored, so a caller renewing on a cadence should try again.
+    /// The announcement is definitely NOT stored, so a caller renewing on a cadence should try
+    /// again at once. Two ways to reach here: the service responded and declined (rate-limited, or
+    /// any non-`Published` answer), or the request stream never opened, so the frame never left
+    /// this host. Both mean nothing landed — distinct from [`Uncertain`], where it might have.
     Refused,
-    /// No acknowledgement arrived: the publish stream errored or timed out. The announcement **may
-    /// or may not** be stored — the service stamps expiry and stores on RECEIPT, before it answers,
+    /// No acknowledgement arrived: the publish frame may have been sent but the stream errored, or
+    /// the deadline passed. The announcement **may or may not** be stored — the service stamps
+    /// expiry and stores on RECEIPT, before it answers,
     /// so a lost or late response says nothing about whether the write landed. A renewing caller
     /// must treat this as possibly-live and NOT re-append every tick, or a service that stores but
     /// cannot answer would drive one host to fill the whole tag. Non-fatal: the fetch half still
@@ -347,13 +350,23 @@ async fn exchange_inner(
                     degraded.push(format!("publish refused: {other:?}"));
                     PublishState::Refused
                 },
-                // No response: the stream errored or the deadline passed. The service stores on
-                // receipt before answering, so the write may already have landed — see
+                // The bi-stream never opened, so the frame never left this host: nothing is stored,
+                // exactly like a refusal, so the next tick should retry rather than assume
+                // liveness.
+                Ok(Err(RequestError::NotSent(error))) => {
+                    degraded.push(format!("publish not sent: {error}"));
+                    PublishState::Refused
+                },
+                // The frame may have reached the service before the stream errored. The service
+                // stores on receipt before answering, so the write may already have landed — see
                 // [`PublishState::Uncertain`].
-                Ok(Err(error)) => {
+                Ok(Err(RequestError::MaybeSent(error))) => {
                     degraded.push(format!("publish failed: {error}"));
                     PublishState::Uncertain
                 },
+                // The deadline passed. `open_bi` on an established connection resolves without a
+                // round trip, so a timeout falls in the write or the wait for a reply — the frame
+                // may already have reached the service, so treat it as possibly live.
                 Err(_elapsed) => {
                     degraded.push(format!("publish timed out after {DISCOVERY_TIMEOUT:?}"));
                     PublishState::Uncertain
@@ -391,7 +404,8 @@ async fn exchange_inner(
 /// one: the service stores on receipt before it answers, so a lost or timed-out ack does not mean
 /// the write failed, and re-appending because it went unacknowledged is how a host whose responses
 /// are dropped fills the whole tag (the service appends, never replaces). A `Refused` is the
-/// opposite — the service answered and declined, nothing is stored, so the next tick should retry.
+/// opposite — either the service answered and declined or the frame never left this host, so
+/// nothing is stored and the next tick should retry.
 ///
 /// The cost of treating a genuinely-failed `Uncertain` as live is one renewal interval of
 /// undiscoverability before the next republish; the cost of the other error is unbounded slot
@@ -512,15 +526,42 @@ pub async fn advertise(params: Advertise) {
     }
 }
 
+/// Where a discovery request failed, so a publish can tell "definitely not stored" from "maybe
+/// stored". A fetch does not care and treats both the same.
+enum RequestError {
+    /// The bi-stream never opened, so nothing reached the service — the write is definitively not
+    /// stored and the caller should retry at once rather than assume it might be live.
+    NotSent(anyhow::Error),
+    /// The request frame may have reached the service before the failure. Since the service stores
+    /// on receipt before it answers, the write may already have landed.
+    MaybeSent(anyhow::Error),
+}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSent(error) | Self::MaybeSent(error) => write!(f, "{error}"),
+        }
+    }
+}
+
 /// One request on its own bi-stream. The service reads a single frame, answers, and closes, so a
 /// second request on the same stream would block until the timeout.
+///
+/// The error distinguishes a failure BEFORE any bytes were sent (`open_bi`) from one after the
+/// frame may have reached the service, so a publish can classify the two differently — see
+/// [`PublishState`].
 async fn request(
     conn: &iroh::endpoint::Connection,
     req: &DiscoveryRequest,
-) -> anyhow::Result<DiscoveryResponse> {
-    let (mut send, mut recv) = conn.open_bi().await?;
-    wire::write_frame(&mut send, &req.encode()).await?;
-    send.finish()?;
-    let body = wire::read_frame(&mut recv).await?;
-    Ok(DiscoveryResponse::decode(&body)?)
+) -> Result<DiscoveryResponse, RequestError> {
+    let (mut send, mut recv) =
+        conn.open_bi().await.map_err(|error| RequestError::NotSent(error.into()))?;
+    wire::write_frame(&mut send, &req.encode())
+        .await
+        .map_err(|error| RequestError::MaybeSent(error.into()))?;
+    send.finish().map_err(|error| RequestError::MaybeSent(error.into()))?;
+    let body =
+        wire::read_frame(&mut recv).await.map_err(|error| RequestError::MaybeSent(error.into()))?;
+    DiscoveryResponse::decode(&body).map_err(|error| RequestError::MaybeSent(error.into()))
 }

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -63,13 +63,45 @@ pub const DISCOVERY_TAG_DOMAIN: &[u8] = b"rag-rat/discovery-tag/1";
 /// trade.
 pub const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Most announcements accepted from one fetch.
+/// Most discovered peers one fetch may contribute.
 ///
-/// The service caps this too, but its cap is an environment-overridable deployment default that
-/// this client cannot observe — so it is not something to trust. Each accepted announcement costs a
-/// full dial with two ALPN sessions, which is what makes an unbounded list expensive rather than
-/// merely untidy.
+/// **Counts announcements this device could OPEN, not payloads the service returned** — the
+/// distinction is the whole safety property, and applying this to raw payloads instead is a
+/// silent hole. Anyone who can compute the tag may publish under it, and a device removed from the
+/// roster can compute it forever (that is #1081's business, not this constant's). Capping raw
+/// payloads would let such a device hide every real advertiser behind sixteen pieces of garbage —
+/// far cheaper than filling the service's slots, and invisible, because the cap discards the good
+/// entries before anything tries to open them. Bounding what actually resolves means garbage costs
+/// an attacker one slot per suppressed peer instead of one payload.
+///
+/// The service caps its own per-tag storage too, but that cap is an environment-overridable
+/// deployment default this client cannot observe, so it is not something to trust. Each admitted
+/// peer costs a full dial with two ALPN sessions, which is what makes an unbounded list expensive
+/// rather than merely untidy.
 pub const MAX_ANNOUNCEMENTS: usize = 16;
+
+/// Most raw payloads carried out of one fetch, before anything is opened.
+///
+/// Purely resource control — the bound that keeps a hostile response from costing unbounded work —
+/// and deliberately looser than [`MAX_ANNOUNCEMENTS`], which is the security-relevant one. Set to
+/// the wire decoder's own per-response ceiling so this never silently truncates a well-formed
+/// answer; opening a payload is one X25519 operation per roster device, cheap enough that the real
+/// protection is the frame cap the decoder already enforces.
+pub const MAX_SEALED_ANNOUNCEMENTS: usize = 64;
+
+/// Bytes of sealed announcement the service will accept in one publish.
+///
+/// A MIRROR of the service's `ANNOUNCEMENT_PAYLOAD_MAX_BYTES`, which this client cannot query, so
+/// it can drift: the service is the authority and a publish above its real limit is refused
+/// outright. Mirroring it anyway is what turns "this host quietly stopped being discoverable" into
+/// a diagnosable message, because the alternative failure is genuinely silent — the refusal looks
+/// like every other transient publish error and the host retries it forever.
+///
+/// It binds at a smaller roster than it looks. An envelope is one version byte plus 80 bytes per
+/// roster-effective device, so this permits about **25 recipients**; the service's own frame budget
+/// would not bite until several hundred. An account past that ceiling cannot advertise until the
+/// envelope is split across announcements — see [`crate::discovery`] docs.
+pub const MAX_ANNOUNCEMENT_BYTES: usize = 2048;
 
 /// The tag an account publishes and fetches under.
 ///
@@ -120,8 +152,9 @@ pub fn discovery_secret(conn: &rusqlite::Connection) -> anyhow::Result<Option<[u
 ///
 /// The number that matters for the service's per-tag limit is `ttl / renewal_interval` — how many
 /// live copies of ITSELF one host holds, since the service appends rather than replacing and reaps
-/// only on expiry. A host renews at half-life, so that is **2 copies per host, whatever the TTL**;
-/// the limit is therefore a limit on hosts (roughly four) and no TTL choice moves it.
+/// only on expiry. A host renews at half-life ([`RENEW_AFTER_NUM`]), so that is **2 copies per
+/// host, whatever the TTL**; against a 32-slot cap the limit is therefore a limit on hosts (roughly
+/// sixteen) and no TTL choice moves it.
 ///
 /// What the TTL does change is how long a host that has died lingers in the tag, costing whoever
 /// discovers it one failed dial. Shorter is fresher; the floor and ceiling are the service's.
@@ -133,16 +166,25 @@ pub fn publish_ttl_seconds(push_interval_secs: u64) -> u32 {
 
 /// How often [`advertise`] wakes, as a divisor of the TTL.
 ///
-/// Must be strictly finer than one minus [`RENEWAL_THRESHOLD`]: renewal becomes due once
-/// `1 - threshold` of the TTL has elapsed, and the number of ticks between that moment and expiry
-/// is how many attempts a host gets. At a quarter-TTL tick and a three-quarter threshold that is
-/// three attempts.
-const TICKS_PER_TTL: u64 = 4;
+/// Only ticks where a renewal is actually due cost anything — the rest compare two local values and
+/// go back to sleep — so this is free to be fine, and being fine is what buys retry attempts. The
+/// number of ticks between renewal falling due and the announcement expiring is how many chances a
+/// host gets to recover from a timeout or the service's `RateLimited`; at an eighth-TTL tick and a
+/// half-TTL renewal that is four.
+///
+/// It was NOT free while liveness came from a fetch, when every tick was a full round trip. That
+/// coupling is gone.
+const TICKS_PER_TTL: u64 = 8;
 
-/// Renew once less than three quarters of the TTL remains — see [`is_live`] for why this is
-/// deliberately not the tick period.
-const RENEWAL_THRESHOLD_NUM: i64 = 3;
-const RENEWAL_THRESHOLD_DEN: i64 = 4;
+/// Renew once half the TTL has elapsed.
+///
+/// This fraction is a slot budget, not a comfort margin. The service APPENDS and reaps only on
+/// expiry, so a host holds `ttl / renewal_interval` live copies of itself at any moment — two here,
+/// whatever the TTL. Against a 32-slot per-tag cap that is roughly sixteen advertisers before hosts
+/// start evicting each other. Renewing at a quarter-TTL instead would double the copies and halve
+/// the accounts that fit, for one extra retry attempt that a finer tick supplies for free.
+const RENEW_AFTER_NUM: u32 = 1;
+const RENEW_AFTER_DEN: u32 = 2;
 
 /// What became of this node's own announcement during a pass.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -151,9 +193,6 @@ pub enum PublishState {
     /// far enough to try.
     #[default]
     NotAttempted,
-    /// A live announcement for this node was already present with comfortable time left, so the
-    /// pass did not spend a slot on another copy.
-    AlreadyLive,
     /// This pass wrote a fresh announcement.
     Published,
     /// The service refused or the write failed. Non-fatal: the fetch half still ran.
@@ -185,6 +224,9 @@ pub struct DiscoveryExchange<'a> {
     /// testable against the real code path.
     pub service: EndpointAddr,
     pub tag: [u8; TAG_LEN],
+    /// Ask the service who else is advertising. A serving host sets this `false`: it publishes so
+    /// that peers dial IT, and has no use for the list it would pay a response frame to receive.
+    pub fetch: bool,
     /// The sealed announcement to publish, or `None` to fetch only — which is what lets a machine
     /// behind NAT find a host without becoming discoverable itself.
     ///
@@ -193,17 +235,17 @@ pub struct DiscoveryExchange<'a> {
     /// ingredients.
     pub publish: Option<&'a [u8]>,
     pub ttl_seconds: u32,
-    /// "Now" as a VALUE, not a clock: the exchange reads it exactly once, to judge whether this
-    /// node's existing announcement has enough life left to skip republishing.
-    pub now_ms: i64,
 }
 
-/// Fetch the account's current advertisers and, when asked, make sure this node is among them.
+/// Fetch the account's current advertisers, publish this node's announcement, or both.
 ///
-/// **Fetch first, then publish.** The service APPENDS and never replaces, so publishing blind every
-/// pass accumulates copies of this node until the per-tag cap rejects everyone — see
-/// [`publish_ttl_seconds`]. Fetching first lets the pass skip a publish it does not need, and the
-/// fetch was going to happen anyway.
+/// **Whether to publish is the CALLER's decision, made from its own records** — this function does
+/// what it is told. It is deliberately not inferred from the fetch, which was the obvious design
+/// and is wrong: the service returns a size-bounded, randomly sampled SUBSET of a tag, so a host's
+/// own live announcement is frequently absent from a response. Reading that absence as "not live"
+/// makes the host republish, and because the service appends rather than replaces, each spurious
+/// copy evicts some other host — a feedback loop that removes real peers from discovery precisely
+/// when the tag is busy enough to sample. [`advertise`] keeps the record instead.
 ///
 /// The two halves stay INDEPENDENT in the failure direction: a publish that fails does not discard
 /// the peers already fetched, or one device's rate-limiting would blind it to peers it can reach.
@@ -227,7 +269,7 @@ async fn exchange_inner(
     params: &DiscoveryExchange<'_>,
     deadline: tokio::time::Instant,
 ) -> DiscoveryOutcome {
-    let DiscoveryExchange { endpoint, service, tag, publish, ttl_seconds, now_ms } = params;
+    let DiscoveryExchange { endpoint, service, tag, fetch, publish, ttl_seconds } = params;
     let connecting = endpoint.connect(service.clone(), PEER_DISCOVERY_ALPN);
     let conn = match tokio::time::timeout_at(deadline, connecting).await {
         Ok(Ok(conn)) => conn,
@@ -248,30 +290,31 @@ async fn exchange_inner(
     };
 
     let mut degraded = Vec::new();
-    let fetch = DiscoveryRequest::Fetch { tag: *tag };
-    let announcements = match tokio::time::timeout_at(deadline, request(&conn, &fetch)).await {
-        Ok(Ok(DiscoveryResponse::Fetched { announcements })) => announcements,
-        Ok(Ok(other)) => {
-            degraded.push(format!("fetch refused: {other:?}"));
-            Vec::new()
-        },
-        Ok(Err(error)) => {
-            degraded.push(format!("fetch failed: {error}"));
-            Vec::new()
-        },
-        Err(_elapsed) => {
-            degraded.push(format!("fetch timed out after {DISCOVERY_TIMEOUT:?}"));
-            Vec::new()
-        },
+    let announcements = if *fetch {
+        let request = DiscoveryRequest::Fetch { tag: *tag };
+        match tokio::time::timeout_at(deadline, self::request(&conn, &request)).await {
+            Ok(Ok(DiscoveryResponse::Fetched { announcements })) => announcements,
+            Ok(Ok(other)) => {
+                degraded.push(format!("fetch refused: {other:?}"));
+                Vec::new()
+            },
+            Ok(Err(error)) => {
+                degraded.push(format!("fetch failed: {error}"));
+                Vec::new()
+            },
+            Err(_elapsed) => {
+                degraded.push(format!("fetch timed out after {DISCOVERY_TIMEOUT:?}"));
+                Vec::new()
+            },
+        }
+    } else {
+        Vec::new()
     };
 
-    // Reached even when the fetch failed above — an empty announcement list then reads as "this
-    // node is not live", which republishes. Publishing a copy we did not need is far cheaper than
-    // silently ceasing to advertise.
+    // Reached whatever the fetch did — the two halves are independent, and a publish the caller
+    // asked for is owed regardless of whether anyone answered the other question.
     let publish_state = match publish {
         None => PublishState::NotAttempted,
-        Some(envelope) if is_live(&announcements, envelope, *ttl_seconds, *now_ms) =>
-            PublishState::AlreadyLive,
         Some(envelope) => {
             let publish = DiscoveryRequest::Publish {
                 tag: *tag,
@@ -297,19 +340,19 @@ async fn exchange_inner(
         },
     };
 
-    // DEDUPLICATE, then cap — in that order. Capping first would spend the budget on duplicates: a
-    // publisher holds about two live copies of itself at any moment, so a cap applied to raw
-    // announcements admits roughly half the peers it promises.
-    //
     // De-duplicating by BYTES works, and only because a publisher seals once per roster change and
     // republishes the result verbatim: its copies are byte-identical. Were the envelope re-sealed
     // per publish, each copy would carry a fresh ephemeral and none of this would collapse.
+    //
+    // Bounded at [`MAX_SEALED_ANNOUNCEMENTS`], NOT at the peer cap. The peer cap belongs to the
+    // caller, after opening — see [`MAX_ANNOUNCEMENTS`] for why applying it to unopened payloads
+    // hands a suppression primitive to anyone who can compute the tag.
     let mut seen = std::collections::HashSet::new();
     let announcements = announcements
         .into_iter()
         .map(|announcement| announcement.payload)
         .filter(|payload| seen.insert(payload.clone()))
-        .take(MAX_ANNOUNCEMENTS)
+        .take(MAX_SEALED_ANNOUNCEMENTS)
         .collect();
 
     DiscoveryOutcome {
@@ -335,9 +378,6 @@ pub struct Advertise {
     /// device, which has no one to be discovered by.
     pub announcement: tokio::sync::watch::Receiver<Option<Vec<u8>>>,
     pub ttl_seconds: u32,
-    /// A clock, not an instant: unlike a single [`exchange`], this loop runs for the host's
-    /// lifetime and must read the time afresh on every tick.
-    pub now_ms: fn() -> i64,
 }
 
 /// Keep `node` advertised under `tag` for as long as this future is polled. Never returns.
@@ -347,20 +387,38 @@ pub struct Advertise {
 /// maintenance-hook cadence can never announce, because a serving host has no maintenance hook.
 /// Without this the only publishers would be the only fetchers.
 ///
-/// Ticks at a QUARTER of the TTL and renews once less than [`RENEWAL_THRESHOLD`] of it remains, so
-/// a renewal lands at roughly half-life with the other half still in hand — see those constants for
-/// why the margin is the whole point. The first tick fires immediately, so a host is discoverable
-/// from startup rather than a fraction of a TTL later. Each tick is a full [`exchange`], so the
-/// fetch-before-publish skip applies and a long-running host does not stack copies of itself.
+/// Ticks at an eighth of the TTL and republishes once half of it has elapsed, so a renewal lands at
+/// half-life with four ticks in hand before expiry — see [`TICKS_PER_TTL`] and [`RENEW_AFTER_NUM`],
+/// where the fractions are a slot budget rather than a comfort margin. The first tick fires
+/// immediately, so a host is discoverable from startup rather than a fraction of a TTL later.
 ///
-/// Publish-only in effect: the fetched peers are discarded, because peers dial a serving host
-/// rather than the other way round.
+/// **Liveness is this loop's own record, not something read back from the service.** It keeps the
+/// envelope it last got accepted and the monotonic instant of that acceptance, and republishes when
+/// either the envelope changed (a roster move, which must take effect at the next tick) or half the
+/// TTL has passed. Asking the service instead is the trap [`exchange`] documents: fetch responses
+/// are a sampled subset, so a live announcement is often missing from one, and believing that
+/// stacks copies until hosts evict each other. Keeping the record locally also makes a
+/// not-yet-due tick completely free — no dial at all — which is what lets the tick be fine enough
+/// to give renewal four attempts.
+///
+/// A publish that FAILS deliberately leaves the record untouched, so the very next tick retries;
+/// only the service accepting one moves it forward.
+///
+/// Publish-only: [`DiscoveryExchange::fetch`] is off, because peers dial a serving host rather than
+/// the other way round.
 pub async fn advertise(params: Advertise) {
-    let Advertise { endpoint, service, tag, mut announcement, ttl_seconds, now_ms } = params;
-    // `.max(4)` keeps the interval positive even if a future TTL floor drops below 4s; a zero
-    // period would make `interval` panic.
-    let mut ticks =
-        tokio::time::interval(Duration::from_secs(u64::from(ttl_seconds).max(4) / TICKS_PER_TTL));
+    let Advertise { endpoint, service, tag, mut announcement, ttl_seconds } = params;
+    // Milliseconds, and `.max(1)`, so the period stays positive for any TTL the service's floor
+    // could ever permit — `interval` panics on a zero period.
+    let period = Duration::from_millis((u64::from(ttl_seconds) * 1000 / TICKS_PER_TTL).max(1));
+    let renew_after =
+        Duration::from_millis(u64::from(ttl_seconds * RENEW_AFTER_NUM / RENEW_AFTER_DEN) * 1000);
+    let mut ticks = tokio::time::interval(period);
+    // What the service last accepted from this host, and when. A MONOTONIC instant, not the wall
+    // clock and not the service's `expires_at_ms`: this is a pure "how long since we published"
+    // question, so it needs neither a clock that can step backwards nor a comparison across two
+    // machines' clocks.
+    let mut published: Option<(Vec<u8>, tokio::time::Instant)> = None;
     loop {
         ticks.tick().await;
         // Re-read per tick, not once at spawn: this is what makes a roster change take effect.
@@ -376,15 +434,25 @@ pub async fn advertise(params: Advertise) {
             tracing::debug!("nothing to advertise yet; skipping this tick");
             continue;
         };
+        if let Some((last, accepted_at)) = &published
+            && *last == envelope
+            && accepted_at.elapsed() < renew_after
+        {
+            tracing::trace!("this host's announcement is still live; not renewing yet");
+            continue;
+        }
         let outcome = exchange(DiscoveryExchange {
             endpoint: &endpoint,
             service: service.clone(),
             tag,
+            fetch: false,
             publish: Some(&envelope),
             ttl_seconds,
-            now_ms: now_ms(),
         })
         .await;
+        if outcome.publish == PublishState::Published {
+            published = Some((envelope, tokio::time::Instant::now()));
+        }
         match outcome.degraded {
             // Never fatal: a host that cannot advertise itself still serves every peer that
             // reaches it through a configured `server_peers` entry.
@@ -392,42 +460,6 @@ pub async fn advertise(params: Advertise) {
             None => tracing::debug!(state = ?outcome.publish, "advertised this host"),
         }
     }
-}
-
-/// Whether this host's own announcement is already live with comfortably more than
-/// [`RENEWAL_THRESHOLD`] of its TTL left — i.e. does not need renewing yet.
-///
-/// Compares the announcement BYTES against the envelope this host is currently publishing. That
-/// works because the envelope is sealed once per roster change and republished verbatim, not
-/// re-sealed per tick — a fresh ephemeral per publish would make every copy differ, the host would
-/// never recognise itself, and it would republish on every tick until the tag was full of its own
-/// announcements. It also earns a property: when the roster moves the envelope changes, so the old
-/// announcement stops matching and the host republishes at the NEXT tick instead of waiting out a
-/// renewal.
-///
-/// **The margin is the point, and getting it wrong is silent.** `expires_at_ms` is stamped by the
-/// SERVICE when it receives the publish, not by this client when it sends one, so an entry written
-/// at tick `t` expires at `t + round_trip + ttl`. If the threshold equalled the tick period, every
-/// tick at which renewal was due would find `round_trip` MORE than the threshold remaining, skip,
-/// and defer renewal to the following tick — by which point only `round_trip` milliseconds of life
-/// are left. A single failed renewal there (a timeout, or the `RateLimited` code the service has)
-/// would then leave the host unadvertised for a whole tick period. With a threshold of three
-/// quarters against a quarter-TTL tick, renewal happens at half-life and two further ticks remain
-/// before expiry, so one failure costs nothing.
-///
-/// The comparison also mixes clocks — client `now_ms` against service `expires_at_ms` — which is
-/// tolerable only because the margin dwarfs any plausible skew. It would not be at zero margin.
-fn is_live(
-    announcements: &[wire::WireAnnouncement],
-    envelope: &[u8],
-    ttl_seconds: u32,
-    now_ms: i64,
-) -> bool {
-    let headroom_ms = i64::from(ttl_seconds) * 1000 * RENEWAL_THRESHOLD_NUM / RENEWAL_THRESHOLD_DEN;
-    announcements.iter().any(|announcement| {
-        announcement.payload.as_slice() == envelope
-            && announcement.expires_at_ms.saturating_sub(now_ms) > headroom_ms
-    })
 }
 
 /// One request on its own bi-stream. The service reads a single frame, answers, and closes, so a

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -450,6 +450,13 @@ pub async fn advertise(params: Advertise) {
             tracing::trace!("this host's announcement is still live; not renewing yet");
             continue;
         }
+        // Started BEFORE the request, and read again only if it succeeds. The service stamps expiry
+        // when it RECEIVES the publish, so timing from the response would start this clock a round
+        // trip late and renew that much nearer expiry than intended — at the ten-second exchange
+        // deadline against the sixty-second TTL floor, half the retry margin. Erring early costs a
+        // fraction of a renewal interval; erring late costs the margin that exists to absorb a
+        // failed renewal.
+        let attempted_at = tokio::time::Instant::now();
         let outcome = exchange(DiscoveryExchange {
             endpoint: &endpoint,
             service: service.clone(),
@@ -460,7 +467,7 @@ pub async fn advertise(params: Advertise) {
         })
         .await;
         if outcome.publish == PublishState::Published {
-            published = Some((envelope, tokio::time::Instant::now()));
+            published = Some((envelope, attempted_at));
         }
         match outcome.degraded {
             // Never fatal: a host that cannot advertise itself still serves every peer that

--- a/crates/rag-rat-sync/src/discovery/stub.rs
+++ b/crates/rag-rat-sync/src/discovery/stub.rs
@@ -3,9 +3,9 @@
 //! The client half of discovery is only as trustworthy as what it was tested against, so this stub
 //! is deliberately literal: it speaks the same CBOR the counterpart does (through the test-only
 //! service-side codec in [`super::wire`], which is itself pinned to the measured golden vectors)
-//! and it reproduces the two service behaviours that shape this client's design — announcements are
-//! APPENDED under a tag and never replaced, and a tag holds at most [`PER_TAG_CAP`] live entries,
-//! REJECTING rather than evicting once full.
+//! and it reproduces the three service behaviours that shape this client's design — announcements
+//! are APPENDED under a tag and never replaced, a full tag EVICTS its oldest entry rather than
+//! refusing the newcomer, and a fetch returns only as much as fits one response frame.
 //!
 //! [`Behaviour`] covers the failure modes the client must survive. A stub that only ever answered
 //! correctly would leave every fail-open path untested, and those paths are the whole reason
@@ -24,8 +24,38 @@ use super::wire::{
     WireAnnouncement, read_frame, write_frame,
 };
 
-/// The real service's per-tag cap. Mirrored so the exhaustion behaviour under test is the real one.
-pub(crate) const PER_TAG_CAP: usize = 8;
+/// The real service's per-tag cap, mirrored so what the tests exercise is what deployments do.
+///
+/// Mirroring matters more than the number: a stub pinned to a stale value tests a service that no
+/// longer exists, and the failure is silent — every assertion still passes, against fiction.
+pub(crate) const PER_TAG_CAP: usize = 32;
+
+/// The service's response budget: as much as fits comfortably inside one frame.
+const FETCH_RESPONSE_BUDGET: usize = super::wire::MAX_FRAME_LEN / 4 * 3;
+
+/// Charged before any announcement, for the envelope around the list.
+const RESPONSE_ENVELOPE_BUDGET: usize = 64;
+
+/// The encoded size of one announcement on this wire.
+///
+/// A payload travels as a CBOR array of INTEGERS, not a byte string, so each byte costs one encoded
+/// byte below 24 and two at or above it. Estimating by payload length instead would be wrong by
+/// nearly double — and would let the stub hand back responses the real service could never send,
+/// which is the one thing a stub must not do.
+fn encoded_announcement_len(payload: &[u8], expires_at_ms: i64) -> usize {
+    let payload_bytes: usize = payload.iter().map(|byte| if *byte < 24 { 1 } else { 2 }).sum();
+    1 + cbor_head_len(payload.len() as u64) + payload_bytes + cbor_head_len(expires_at_ms as u64)
+}
+
+fn cbor_head_len(value: u64) -> usize {
+    match value {
+        0..=23 => 1,
+        24..=0xff => 2,
+        0x100..=0xffff => 3,
+        0x1_0000..=0xffff_ffff => 5,
+        _ => 9,
+    }
+}
 
 /// How the stub answers. Each variant is a failure the client must absorb without harming the
 /// configured-peer path.
@@ -160,11 +190,12 @@ fn answer(
                 return refusal(DiscoveryErrorCode::RateLimited, "slow down");
             }
             let entries = tags.entry(*tag).or_default();
-            // Reap expired, then REJECT when full — the service never evicts to make room, which is
-            // why a tag an attacker fills holds zero real peers rather than eight bad ones.
+            // Reap expired, then EVICT the oldest to make room. The service stopped refusing a
+            // publish into a full tag: refusing let whoever filled it first hold it for a whole
+            // TTL, so the tag carried no real advertisers at all.
             entries.retain(|entry| entry.expires_at_ms > now_ms);
-            if entries.len() >= PER_TAG_CAP {
-                return refusal(DiscoveryErrorCode::PerTagCapExceeded, "tag is full");
+            while entries.len() >= PER_TAG_CAP {
+                entries.remove(0);
             }
             // APPEND, never replace: republishing the same node id adds a second live copy.
             entries.push(WireAnnouncement {
@@ -174,12 +205,29 @@ fn answer(
             DiscoveryResponse::Published { withdraw_token: vec![0xaa; 8] }
         },
         DiscoveryRequest::Fetch { tag } => {
-            let mut announcements = tags
+            let live = tags
                 .get(tag)
                 .map(|entries| {
                     entries.iter().filter(|e| e.expires_at_ms > now_ms).cloned().collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            // BOUND the response to one frame, as the service does. Without this a tag holding a
+            // realistic number of sealed envelopes produces a response neither side can send, and
+            // the client's own frame handling would never be exercised against it.
+            //
+            // Deterministic here where the service samples at random: a test wants a repeatable
+            // subset, and the property random selection exists for — that no advertiser is starved
+            // over repeated fetches — belongs to the service's own suite, not to a client stub.
+            let mut used = RESPONSE_ENVELOPE_BUDGET;
+            let mut announcements = Vec::new();
+            for entry in live {
+                let cost = encoded_announcement_len(&entry.payload, entry.expires_at_ms);
+                if used + cost > FETCH_RESPONSE_BUDGET {
+                    break;
+                }
+                used += cost;
+                announcements.push(entry);
+            }
             if behaviour == Behaviour::GarbageAmongTheGood {
                 // A payload that is not 32 bytes. Anyone who can compute the tag can publish this.
                 announcements.insert(0, WireAnnouncement {

--- a/crates/rag-rat-sync/src/discovery/stub.rs
+++ b/crates/rag-rat-sync/src/discovery/stub.rs
@@ -24,6 +24,10 @@ use super::wire::{
     WireAnnouncement, read_frame, write_frame,
 };
 
+/// How long [`Behaviour::SlowPublish`] holds a publish response back. Well inside the client's
+/// exchange deadline — the point is a slow answer, not a timeout.
+pub(crate) const SLOW_PUBLISH_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// The real service's per-tag cap, mirrored so what the tests exercise is what deployments do.
 ///
 /// Mirroring matters more than the number: a stub pinned to a stale value tests a service that no
@@ -76,6 +80,12 @@ pub(crate) enum Behaviour {
     StallPublish,
     /// Answer fetches with one unusable payload alongside the real ones.
     GarbageAmongTheGood,
+    /// Store a publish immediately, then wait [`SLOW_PUBLISH_DELAY`] before answering it.
+    ///
+    /// A service under load, and the shape that separates two clocks a client could time renewal
+    /// from: the entry's TTL starts when the service STORES it, not when the client learns that it
+    /// did. Answering instantly makes the two indistinguishable.
+    SlowPublish,
     /// Store publishes normally, but answer every fetch with an EMPTY list.
     ///
     /// The real service returns a size-bounded random SAMPLE of a tag, so a live announcement —
@@ -148,6 +158,13 @@ impl StubService {
                         }
                         let response =
                             answer(&tags, &request, behaviour, now.load(Ordering::Relaxed));
+                        // AFTER `answer` has stored it: a slow service has already accepted the
+                        // announcement and started its TTL, and is merely slow to say so.
+                        if behaviour == Behaviour::SlowPublish
+                            && matches!(request, DiscoveryRequest::Publish { .. })
+                        {
+                            tokio::time::sleep(SLOW_PUBLISH_DELAY).await;
+                        }
                         if write_frame(&mut send, &response.encode()).await.is_err() {
                             return;
                         }

--- a/crates/rag-rat-sync/src/discovery/stub.rs
+++ b/crates/rag-rat-sync/src/discovery/stub.rs
@@ -80,6 +80,10 @@ pub(crate) enum Behaviour {
     StallPublish,
     /// Answer fetches with one unusable payload alongside the real ones.
     GarbageAmongTheGood,
+    /// STORE a publish, then never answer it — the client times out and sees the write as
+    /// ambiguous, though it did land. The failure #2's fix turns from unbounded slot churn into a
+    /// bounded gap: a service that accepts writes but cannot acknowledge them.
+    AckLostAfterStore,
     /// Store a publish immediately, then wait [`SLOW_PUBLISH_DELAY`] before answering it.
     ///
     /// A service under load, and the shape that separates two clocks a client could time renewal
@@ -160,6 +164,15 @@ impl StubService {
                             answer(&tags, &request, behaviour, now.load(Ordering::Relaxed));
                         // AFTER `answer` has stored it: a slow service has already accepted the
                         // announcement and started its TTL, and is merely slow to say so.
+                        if behaviour == Behaviour::AckLostAfterStore
+                            && matches!(request, DiscoveryRequest::Publish { .. })
+                        {
+                            // Stored by `answer` above; the ack is simply never sent. Parked, not
+                            // dropped: dropping the send stream would surface as a prompt error
+                            // rather than the timeout a lost ack actually produces.
+                            parked.push((send, recv));
+                            continue;
+                        }
                         if behaviour == Behaviour::SlowPublish
                             && matches!(request, DiscoveryRequest::Publish { .. })
                         {

--- a/crates/rag-rat-sync/src/discovery/stub.rs
+++ b/crates/rag-rat-sync/src/discovery/stub.rs
@@ -12,7 +12,7 @@
 //! discovery is safe to run inside the sync session lock.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use iroh::endpoint::presets;
@@ -76,6 +76,14 @@ pub(crate) enum Behaviour {
     StallPublish,
     /// Answer fetches with one unusable payload alongside the real ones.
     GarbageAmongTheGood,
+    /// Store publishes normally, but answer every fetch with an EMPTY list.
+    ///
+    /// The real service returns a size-bounded random SAMPLE of a tag, so a live announcement —
+    /// including the fetcher's own — is routinely missing from a response. This is that sample at
+    /// its most adversarial, and it exists to catch anything that infers "not present in this
+    /// response" means "not published": the inference is false, and acting on it makes a host
+    /// republish endlessly and evict the peers it was trying to join.
+    ForgetfulFetch,
 }
 
 pub(crate) struct StubService {
@@ -84,6 +92,10 @@ pub(crate) struct StubService {
     /// The stub's own clock, advanced by the test. Owned per-instance rather than read from the
     /// system so expiry and reaping are exact, and so nothing is shared between tests.
     now_ms: Arc<AtomicI64>,
+    /// Fetch requests served, so a test can assert on requests NOT made. A publish-only caller
+    /// that quietly starts fetching is invisible to every assertion about stored
+    /// announcements.
+    fetches: Arc<AtomicUsize>,
 }
 
 impl StubService {
@@ -99,12 +111,18 @@ impl StubService {
             .expect("bind the stub discovery service");
         let tags = Arc::new(Mutex::new(HashMap::new()));
         let now = Arc::new(AtomicI64::new(now_ms));
-        let service =
-            Self { endpoint: endpoint.clone(), tags: Arc::clone(&tags), now_ms: Arc::clone(&now) };
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let service = Self {
+            endpoint: endpoint.clone(),
+            tags: Arc::clone(&tags),
+            now_ms: Arc::clone(&now),
+            fetches: Arc::clone(&fetches),
+        };
         tokio::spawn(async move {
             while let Some(incoming) = endpoint.accept().await {
                 let tags = Arc::clone(&tags);
                 let now = Arc::clone(&now);
+                let fetches = Arc::clone(&fetches);
                 tokio::spawn(async move {
                     let Ok(conn) = incoming.await else { return };
                     // Swallowed streams are PARKED, not dropped: dropping a send stream closes it,
@@ -124,6 +142,9 @@ impl StubService {
                             // Accepted, never answered, held open.
                             parked.push((send, recv));
                             continue;
+                        }
+                        if matches!(request, DiscoveryRequest::Fetch { .. }) {
+                            fetches.fetch_add(1, Ordering::Relaxed);
                         }
                         let response =
                             answer(&tags, &request, behaviour, now.load(Ordering::Relaxed));
@@ -166,6 +187,11 @@ impl StubService {
             .unwrap_or_default()
     }
 
+    /// How many fetches this stub has answered.
+    pub(crate) fn fetches(&self) -> usize {
+        self.fetches.load(Ordering::Relaxed)
+    }
+
     /// Seed an announcement directly, bypassing the wire — for setting up a tag's prior state.
     pub(crate) fn seed(&self, tag: [u8; TAG_LEN], payload: Vec<u8>, expires_at_ms: i64) {
         self.tags
@@ -205,6 +231,9 @@ fn answer(
             DiscoveryResponse::Published { withdraw_token: vec![0xaa; 8] }
         },
         DiscoveryRequest::Fetch { tag } => {
+            if behaviour == Behaviour::ForgetfulFetch {
+                return DiscoveryResponse::Fetched { announcements: Vec::new() };
+            }
             let live = tags
                 .get(tag)
                 .map(|entries| {

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -124,7 +124,7 @@ async fn a_published_node_id_is_fetched_back_by_another_device() {
         tag,
         publish: Some(&published),
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert_eq!(out.publish, PublishState::Published, "degraded: {:?}", out.degraded);
@@ -136,7 +136,7 @@ async fn a_published_node_id_is_fetched_back_by_another_device() {
         tag,
         publish: None,
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert_eq!(opened(&out), vec![published], "the fetcher sees the publisher");
@@ -164,7 +164,7 @@ async fn a_device_that_does_not_advertise_itself_still_learns_its_peers() {
         tag,
         publish: None,
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert_eq!(opened(&out), vec![peer]);
@@ -187,7 +187,7 @@ async fn a_refused_publish_does_not_suppress_the_fetch() {
         tag,
         publish: Some(&local_node(&endpoint)),
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert_eq!(out.publish, PublishState::Failed);
@@ -217,7 +217,7 @@ async fn a_stalled_publish_does_not_discard_the_peers_already_fetched() {
         tag,
         publish: Some(&local_node(&endpoint)),
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
 
@@ -250,7 +250,7 @@ async fn a_malformed_announcement_is_dropped_individually() {
         tag,
         publish: None,
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert_eq!(opened(&out), vec![good], "the well-formed peer survives its malformed neighbour");
@@ -275,7 +275,7 @@ async fn a_service_that_accepts_and_never_answers_does_not_stall_the_pass() {
         tag: account_tag(&[7; 32]),
         publish: Some(&local_node(&endpoint)),
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     let elapsed = started.elapsed();
@@ -314,7 +314,7 @@ async fn an_unreachable_service_fails_open() {
         tag: account_tag(&[8; 32]),
         publish: None,
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert!(opened(&out).is_empty());
@@ -327,53 +327,6 @@ async fn an_unreachable_service_fails_open() {
 
 // ---------------------------------------------------------------- cap exhaustion
 
-/// A live announcement with room to spare means this pass spends no slot on another copy.
-#[tokio::test]
-async fn a_still_fresh_announcement_is_not_republished() {
-    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
-    let tag = account_tag(&[9; 32]);
-    let endpoint = client().await;
-    let node = local_node(&endpoint);
-    // Published a moment ago under a 600s TTL: well over half its life remains.
-    service.seed(tag, node.to_vec(), NOW_MS + 590_000);
-
-    let out = exchange(DiscoveryExchange {
-        endpoint: &endpoint,
-        service: service.addr(),
-        tag,
-        publish: Some(&node),
-        ttl_seconds: 600,
-        now_ms: NOW_MS,
-    })
-    .await;
-    assert_eq!(out.publish, PublishState::AlreadyLive);
-    assert_eq!(service.stored(&tag).len(), 1, "no second copy of ourselves was added");
-}
-
-/// Close to expiry it IS republished — skipping here would let the entry lapse between passes and
-/// silently stop advertising this device.
-#[tokio::test]
-async fn an_announcement_near_expiry_is_republished() {
-    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
-    let tag = account_tag(&[10; 32]);
-    let endpoint = client().await;
-    let node = local_node(&endpoint);
-    // Under half of a 600s TTL remains, i.e. less than one cadence of headroom.
-    service.seed(tag, node.to_vec(), NOW_MS + 200_000);
-
-    let out = exchange(DiscoveryExchange {
-        endpoint: &endpoint,
-        service: service.addr(),
-        tag,
-        publish: Some(&node),
-        ttl_seconds: 600,
-        now_ms: NOW_MS,
-    })
-    .await;
-    assert_eq!(out.publish, PublishState::Published);
-    assert_eq!(service.stored(&tag).len(), 2, "the fresh copy joins the one about to lapse");
-}
-
 /// Steady state on the default cadence: three devices, six passes, no publish ever refused.
 ///
 /// The original design — publish at the service maximum every pass, never skipping — gives each
@@ -381,12 +334,11 @@ async fn an_announcement_near_expiry_is_republished() {
 /// ninth publish is REJECTED (the service never evicts to make room), and an ordinary three-device
 /// account breaks its own discovery on default configuration.
 ///
-/// Honest about what this test can and cannot kill: at this cadence the TTL clamp and the
-/// fetch-before-publish skip are REDUNDANT — either alone keeps three devices inside the cap, so
-/// reverting one of them does not turn this red. It is a regression test on the combination. The
-/// skip has its own killing case in
-/// `rapid_passes_do_not_fill_the_tag_with_copies_of_one_device`, and the clamp's arithmetic is
-/// pinned by `the_published_ttl_is_two_cadences_clamped_to_what_the_service_accepts`.
+/// Honest about what this test can and cannot kill. It exercises the TTL clamp and the eviction
+/// policy; it cannot exercise the renewal skip, which is no longer part of an exchange at all —
+/// `advertise` owns it, and its killing case is
+/// `a_running_host_publishes_once_per_renewal_interval_however_often_it_ticks`. The clamp's
+/// arithmetic is pinned by `the_published_ttl_is_two_cadences_clamped_to_what_the_service_accepts`.
 #[tokio::test]
 async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_cap() {
     let service = StubService::start(NOW_MS, Behaviour::Serve).await;
@@ -396,7 +348,8 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
     let devices = [client().await, client().await, client().await];
     let ids: Vec<[u8; 32]> = devices.iter().map(local_node).collect();
 
-    // Six passes at the default cadence: long enough for entries to accumulate and for the first
+    // Six passes at the default cadence, each device publishing once — the cadence a host on the
+    // half-life renewal actually produces. Long enough for entries to accumulate and for the first
     // ones to age out, which is where a leak would show.
     for pass in 0..6i64 {
         let pass_now_ms = NOW_MS + pass * 300_000;
@@ -409,9 +362,9 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
                 endpoint,
                 service: service.addr(),
                 tag,
+                fetch: true,
                 publish: Some(&local_node(endpoint)),
                 ttl_seconds: ttl,
-                now_ms: pass_now_ms,
             })
             .await;
             assert_ne!(
@@ -438,9 +391,9 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
         endpoint: &observer,
         service: service.addr(),
         tag,
+        fetch: true,
         publish: None,
         ttl_seconds: ttl,
-        now_ms: NOW_MS + 1_500_000,
     })
     .await;
     for id in &ids {
@@ -448,48 +401,62 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
     }
 }
 
-/// The fetch-before-publish skip's killing case.
+/// A caller that asks for a publish gets one — the exchange does not second-guess it by fetching.
 ///
-/// `push_interval_secs = 0` runs a pass on every trigger, and several git hooks fire per action —
-/// so passes land seconds apart while the TTL floor is 60s. Publishing blind each time stacks a
-/// device's own announcements until the tag is full and EVERY device's publishes start failing.
-/// The skip is the only thing standing between that and a self-inflicted outage; delete it and this
-/// test goes red.
+/// The removed design decided liveness here, from the fetch, and that is the bug this pins shut:
+/// the service answers with a size-bounded random SAMPLE, so a host's own live announcement is
+/// often missing from a response, and reading that absence as "not live" republishes. Because the
+/// service appends rather than replaces, every spurious copy evicts another host — the tag degrades
+/// fastest exactly when it is busy enough to be sampled.
 #[tokio::test]
-async fn rapid_passes_do_not_fill_the_tag_with_copies_of_one_device() {
+async fn a_publish_is_not_conditioned_on_finding_ourselves_in_the_fetch() {
     let service = StubService::start(NOW_MS, Behaviour::Serve).await;
-    let tag = account_tag(&[12; 32]);
-    let ttl = publish_ttl_seconds(0);
-    assert_eq!(ttl, 60, "the floor is what makes rapid passes dangerous");
+    let tag = account_tag(&[9; 32]);
+    let endpoint = client().await;
+    let node = local_node(&endpoint);
+    // Already live with almost all of a 600s TTL left. Under the removed rule this was the
+    // canonical "skip it" case; the decision is no longer the exchange's to make.
+    service.seed(tag, node.to_vec(), NOW_MS + 590_000);
 
-    let devices = [client().await, client().await, client().await];
-    // Twelve passes one second apart: well inside a single TTL, so nothing expires to make room.
-    for pass in 0..12i64 {
-        let pass_now_ms = NOW_MS + pass * 1_000;
-        service.advance_to(pass_now_ms);
-        for endpoint in &devices {
-            let out = exchange(DiscoveryExchange {
-                endpoint,
-                service: service.addr(),
-                tag,
-                publish: Some(&local_node(endpoint)),
-                ttl_seconds: ttl,
-                now_ms: pass_now_ms,
-            })
-            .await;
-            assert_ne!(
-                out.publish,
-                PublishState::Failed,
-                "pass {pass}: a publish was refused — the tag filled with our own copies ({:?})",
-                out.degraded
-            );
-        }
-    }
-    assert_eq!(
-        service.stored(&tag).len(),
-        devices.len(),
-        "one live announcement per device, however many passes ran"
-    );
+    let out = exchange(DiscoveryExchange {
+        endpoint: &endpoint,
+        service: service.addr(),
+        tag,
+        fetch: true,
+        publish: Some(&node),
+        ttl_seconds: 600,
+    })
+    .await;
+    assert_eq!(out.publish, PublishState::Published);
+    assert_eq!(service.stored(&tag).len(), 2, "the publish the caller asked for was made");
+}
+
+/// `fetch: false` means no fetch request reaches the service at all.
+///
+/// Not a micro-optimisation. A serving host publishes so that peers dial IT and has no use for the
+/// list, and paying for a response frame per renewal is the smaller half; the larger half is that
+/// a fetch here invites exactly the inference the test above forbids. Asserted on the REQUEST
+/// COUNT, because an ignored response is indistinguishable from an unsent request in every
+/// assertion about stored announcements.
+#[tokio::test]
+async fn a_publish_only_exchange_never_asks_the_service_for_peers() {
+    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
+    let tag = account_tag(&[10; 32]);
+    let endpoint = client().await;
+    let node = local_node(&endpoint);
+
+    let out = exchange(DiscoveryExchange {
+        endpoint: &endpoint,
+        service: service.addr(),
+        tag,
+        fetch: false,
+        publish: Some(&node),
+        ttl_seconds: 600,
+    })
+    .await;
+    assert_eq!(out.publish, PublishState::Published);
+    assert!(out.announcements.is_empty(), "nothing was asked for, so nothing came back");
+    assert_eq!(service.fetches(), 0, "a publish-only exchange fetched anyway");
 }
 
 /// A large account is never refused, and its fetches still fit a frame.
@@ -518,7 +485,7 @@ async fn a_large_account_is_never_refused_and_its_fetches_fit_one_frame() {
             tag,
             publish: Some(&realistic_envelope(seed)),
             ttl_seconds: 600,
-            now_ms: NOW_MS,
+            fetch: true,
         })
         .await;
         assert_eq!(
@@ -535,7 +502,7 @@ async fn a_large_account_is_never_refused_and_its_fetches_fit_one_frame() {
         tag,
         publish: None,
         ttl_seconds: 600,
-        now_ms: NOW_MS,
+        fetch: true,
     })
     .await;
     assert!(!out.announcements.is_empty(), "an over-full tag must still answer");
@@ -590,7 +557,7 @@ async fn discovered_peers_join_the_configured_ones_without_this_node_or_duplicat
             tag,
             publish: Some(&me),
             ttl_seconds: 600,
-            now_ms: NOW_MS,
+            fetch: true,
         }),
         &as_node_id,
     )
@@ -629,13 +596,88 @@ async fn an_empty_discovery_result_leaves_the_configured_peers_untouched() {
             tag: account_tag(&[15; 32]),
             publish: None,
             ttl_seconds: 600,
-            now_ms: NOW_MS,
+            fetch: true,
         }),
         &as_node_id,
     )
     .await;
     assert_eq!(resolved.peers.len(), 1);
     assert_eq!(resolved.peers[0].0, configured[0]);
+}
+
+/// The peer cap counts announcements this device could OPEN, not payloads the service returned.
+///
+/// The killing case for a suppression attack that costs an attacker almost nothing. Anyone who can
+/// compute the tag may publish under it, and a removed device can compute it forever. If the cap
+/// were applied to raw payloads, `MAX_ANNOUNCEMENTS` pieces of garbage would discard every real
+/// advertiser BEFORE anything tried to open them — cheaper than filling the service's slots, and
+/// undetectable, because the good entries are dropped by the client's own bookkeeping.
+///
+/// So: a full cap's worth of unopenable payloads, then one real peer behind them.
+#[tokio::test]
+async fn unopenable_announcements_do_not_consume_the_peer_cap() {
+    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
+    let tag = account_tag(&[21; 32]);
+    let endpoint = client().await;
+
+    // Not 32 bytes, so the opener rejects them — the shape of an envelope sealed to a roster this
+    // device is not on, or simply of junk.
+    for i in 0..crate::discovery::MAX_ANNOUNCEMENTS {
+        service.seed(tag, vec![i as u8; 7], NOW_MS + 600_000);
+    }
+    let real_peer = crate::node_id_from_secret([0x44; 32]);
+    service.seed(tag, real_peer.to_vec(), NOW_MS + 600_000);
+
+    let resolved = crate::discover_peers(
+        &[],
+        "https://relay.example",
+        Some(DiscoveryExchange {
+            endpoint: &endpoint,
+            service: service.addr(),
+            tag,
+            fetch: true,
+            publish: None,
+            ttl_seconds: 600,
+        }),
+        &as_node_id,
+    )
+    .await;
+    let ids: Vec<[u8; 32]> = resolved.peers.iter().map(|(_, addr)| *addr.id.as_bytes()).collect();
+    assert_eq!(
+        ids,
+        vec![real_peer],
+        "a real advertiser was hidden behind a cap's worth of garbage"
+    );
+}
+
+/// The cap still binds — on peers that resolved.
+#[tokio::test]
+async fn the_peer_cap_bounds_how_many_discovered_peers_one_pass_admits() {
+    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
+    let tag = account_tag(&[22; 32]);
+    let endpoint = client().await;
+
+    let over = crate::discovery::MAX_ANNOUNCEMENTS + 4;
+    for i in 0..over {
+        let peer = crate::node_id_from_secret([i as u8; 32]);
+        service.seed(tag, peer.to_vec(), NOW_MS + 600_000);
+    }
+
+    let resolved = crate::discover_peers(
+        &[],
+        "https://relay.example",
+        Some(DiscoveryExchange {
+            endpoint: &endpoint,
+            service: service.addr(),
+            tag,
+            fetch: true,
+            publish: None,
+            ttl_seconds: 600,
+        }),
+        &as_node_id,
+    )
+    .await;
+    assert_eq!(resolved.peers.len(), crate::discovery::MAX_ANNOUNCEMENTS);
 }
 
 // ---------------------------------------------------------------- the serving host's advertisement
@@ -650,12 +692,12 @@ async fn an_empty_discovery_result_leaves_the_configured_peers_untouched() {
 /// The renewal half is asserted separately from the first announcement, because it is a different
 /// mechanism and the obvious test misses it entirely: waiting only for the FIRST announcement stays
 /// green with the `loop` reduced to a single iteration, with the tick period set to something
-/// absurd (an `interval`'s first tick is immediate whatever its period), and with `is_live` stubbed
-/// to return true forever. Requiring a SECOND announcement kills all three.
+/// absurd (an `interval`'s first tick is immediate whatever its period), and with the renewal
+/// check stubbed to "still live" forever. Requiring a SECOND announcement kills all three.
 ///
-/// Real clocks on both sides, unlike the frozen-instant tests above: renewal is a question about
-/// elapsed time, and a frozen clock can only ever answer it one way — which is exactly how a
-/// zero-margin renewal went unnoticed.
+/// Real elapsed time, unlike the frozen-clock tests above: renewal is a question about elapsed
+/// time, and a frozen clock can only ever answer it one way — which is exactly how a zero-margin
+/// renewal went unnoticed.
 #[tokio::test]
 async fn a_serving_host_advertises_itself_immediately_and_keeps_renewing() {
     fn wall_clock_ms() -> i64 {
@@ -665,8 +707,8 @@ async fn a_serving_host_advertises_itself_immediately_and_keeps_renewing() {
             .as_millis() as i64
     }
 
-    // A four-second TTL ticks once a second and renews once under three seconds remain, so the
-    // whole publish-then-renew cycle fits inside a test.
+    // A four-second TTL ticks twice a second and renews at two seconds, so the whole
+    // publish-then-renew cycle fits inside a test.
     const TTL: u32 = 4;
     let service = StubService::start(wall_clock_ms(), Behaviour::Serve).await;
     let tag = account_tag(&[16; 32]);
@@ -680,7 +722,6 @@ async fn a_serving_host_advertises_itself_immediately_and_keeps_renewing() {
         tag,
         announcement,
         ttl_seconds: TTL,
-        now_ms: wall_clock_ms,
     }));
 
     let announced = wait_for(|| !service.stored(&tag).is_empty()).await;
@@ -732,7 +773,6 @@ async fn a_new_envelope_reaches_a_running_advertiser_at_the_next_tick() {
         tag,
         announcement,
         ttl_seconds: TTL,
-        now_ms: wall_clock_ms,
     }));
 
     assert!(
@@ -748,4 +788,48 @@ async fn a_new_envelope_reaches_a_running_advertiser_at_the_next_tick() {
         switched,
         "the replacement was never published; the watch is being read once, not per tick"
     );
+}
+
+/// A host publishes once per renewal interval however many times it ticks — and never asks the
+/// service whether it is still live.
+///
+/// The killing case for renewal being LOCAL state. `ForgetfulFetch` answers every fetch with an
+/// empty list, which is the real service's size-bounded random sample at its most adversarial: a
+/// host's own live announcement is routinely missing from a response. Any implementation that
+/// decides "am I live?" from a fetch sees "no" on every tick here, republishes on every tick, and
+/// — because the service appends rather than replaces — evicts a real peer each time. That is a
+/// feedback loop, not a wasted request: it is worst exactly when the tag is busy enough to sample.
+///
+/// Three assertions, because they fail for different reasons. The stored count kills republishing;
+/// the fetch count kills a fetch whose answer is merely ignored, which no assertion about stored
+/// announcements can see; and requiring at least one publish kills a loop that does nothing at all.
+#[tokio::test]
+async fn a_running_host_publishes_once_per_renewal_interval_however_often_it_ticks() {
+    // Eight seconds ticks every second and renews at four, so the window below spans several ticks
+    // and stops short of the first renewal.
+    const TTL: u32 = 8;
+    let service = StubService::start(0, Behaviour::ForgetfulFetch).await;
+    let tag = account_tag(&[23; 32]);
+    let host = client().await;
+    let node = local_node(&host);
+
+    let (envelopes, announcement) = tokio::sync::watch::channel(Some(node.to_vec()));
+    let advertiser = tokio::spawn(super::advertise(super::Advertise {
+        endpoint: host.clone(),
+        service: service.addr(),
+        tag,
+        announcement,
+        ttl_seconds: TTL,
+    }));
+
+    assert!(wait_for(|| !service.stored(&tag).is_empty()).await, "the host never advertised");
+    // Well past three further ticks, still inside the four-second renewal interval.
+    tokio::time::sleep(Duration::from_millis(3_200)).await;
+    let stored = service.stored(&tag).len();
+    let fetches = service.fetches();
+    advertiser.abort();
+    drop(envelopes);
+
+    assert_eq!(stored, 1, "the host republished on ticks where its announcement was still live");
+    assert_eq!(fetches, 0, "the advertiser asked the service about its own liveness");
 }

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -190,7 +190,7 @@ async fn a_refused_publish_does_not_suppress_the_fetch() {
         fetch: true,
     })
     .await;
-    assert_eq!(out.publish, PublishState::Failed);
+    assert_eq!(out.publish, PublishState::Refused, "the service answered and declined");
     assert_eq!(opened(&out), vec![peer], "the fetched peers survive the publish failure");
     assert!(out.degraded.is_some(), "and the failure is reported for logging");
 }
@@ -222,7 +222,11 @@ async fn a_stalled_publish_does_not_discard_the_peers_already_fetched() {
     .await;
 
     assert_eq!(opened(&out), vec![peer], "the fetched peer survives the stalled publish");
-    assert_eq!(out.publish, PublishState::Failed);
+    assert_eq!(
+        out.publish,
+        PublishState::Uncertain,
+        "a timed-out publish is ambiguous, not refused"
+    );
     assert!(out.degraded.is_some_and(|d| d.contains("timed out")), "and the stall is reported");
     assert!(
         started.elapsed() >= DISCOVERY_TIMEOUT,
@@ -367,10 +371,10 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
                 ttl_seconds: ttl,
             })
             .await;
-            assert_ne!(
+            assert_eq!(
                 out.publish,
-                PublishState::Failed,
-                "pass {pass}: a publish was refused — the tag filled up ({:?})",
+                PublishState::Published,
+                "pass {pass}: a publish did not succeed — the tag filled up ({:?})",
                 out.degraded
             );
         }
@@ -885,5 +889,62 @@ async fn renewal_is_timed_from_the_publish_being_sent_not_answered() {
         renewed,
         "renewal ran late; the clock is being started when the response arrives, not when the \
          publish is sent"
+    );
+}
+
+/// A publish the service stored but never acknowledged is reported as ambiguous, not failed.
+///
+/// The distinction the renewal fix rests on. The service stamps expiry and stores on receipt,
+/// before it answers, so a lost or late ack says nothing about whether the write landed — and the
+/// stub proves exactly that by storing the announcement and then withholding the response.
+/// Reporting this as `Refused` (definitely not stored) would make a renewing host re-append it
+/// every tick.
+#[tokio::test]
+async fn a_stored_publish_with_a_lost_ack_is_uncertain_not_refused() {
+    let service = StubService::start(NOW_MS, Behaviour::AckLostAfterStore).await;
+    let tag = account_tag(&[25; 32]);
+    let endpoint = client().await;
+    let node = local_node(&endpoint);
+    let started = Instant::now();
+
+    let out = exchange(DiscoveryExchange {
+        endpoint: &endpoint,
+        service: service.addr(),
+        tag,
+        fetch: false,
+        publish: Some(&node),
+        ttl_seconds: 600,
+    })
+    .await;
+
+    assert_eq!(out.publish, PublishState::Uncertain, "a stored-but-unacked publish is ambiguous");
+    assert_eq!(service.stored(&tag).len(), 1, "and it really was stored");
+    assert!(
+        started.elapsed() >= DISCOVERY_TIMEOUT,
+        "the deadline is what ends the wait for the missing ack"
+    );
+}
+
+/// The renewal-recording rule: possibly-live outcomes are recorded, a refusal is not.
+///
+/// This is the pure core of the lost-ack fix, unit-tested because exercising it through `advertise`
+/// would cost a full `DISCOVERY_TIMEOUT` stall per tick. `Uncertain` records BECAUSE the write may
+/// have landed — re-appending it every tick is how a host whose acks are dropped fills the tag.
+/// `Refused` does not, because the service answered and stored nothing, so the next tick must
+/// retry.
+#[test]
+fn only_possibly_live_publishes_reset_the_renewal_clock() {
+    assert!(super::records_liveness(PublishState::Published), "a confirmed publish is live");
+    assert!(
+        super::records_liveness(PublishState::Uncertain),
+        "an unacknowledged publish may be live and must not be re-appended every tick"
+    );
+    assert!(
+        !super::records_liveness(PublishState::Refused),
+        "a refusal stored nothing, so the next tick should retry"
+    );
+    assert!(
+        !super::records_liveness(PublishState::NotAttempted),
+        "nothing was published, so there is nothing to renew"
     );
 }

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -833,3 +833,57 @@ async fn a_running_host_publishes_once_per_renewal_interval_however_often_it_tic
     assert_eq!(stored, 1, "the host republished on ticks where its announcement was still live");
     assert_eq!(fetches, 0, "the advertiser asked the service about its own liveness");
 }
+
+/// Renewal is timed from when the publish was SENT, not from when the answer came back.
+///
+/// The service stamps expiry on receipt, so a client that starts its clock on the response is a
+/// round trip behind the entry it is tracking, and renews that much nearer expiry. It is silent —
+/// every renewal still succeeds — until one fails, and by then the margin that was supposed to
+/// absorb it has been spent. At the exchange's ten-second deadline against the sixty-second TTL
+/// floor it halves, from four attempts to two.
+///
+/// The stub stores the announcement and only then delays its response, which is what a loaded
+/// service does. With an eight-second TTL renewal is due four seconds after the publish is sent,
+/// and six after the response is read; the assertion falls between the two, so it can only pass
+/// for a client timing from the send.
+#[tokio::test]
+async fn renewal_is_timed_from_the_publish_being_sent_not_answered() {
+    const TTL: u32 = 8;
+    let service = StubService::start(0, Behaviour::SlowPublish).await;
+    let tag = account_tag(&[24; 32]);
+    let host = client().await;
+    let node = local_node(&host);
+
+    let (envelopes, announcement) = tokio::sync::watch::channel(Some(node.to_vec()));
+    let started = tokio::time::Instant::now();
+    let advertiser = tokio::spawn(super::advertise(super::Advertise {
+        endpoint: host.clone(),
+        service: service.addr(),
+        tag,
+        announcement,
+        ttl_seconds: TTL,
+    }));
+
+    assert!(wait_for(|| !service.stored(&tag).is_empty()).await, "the host never advertised");
+    // Wait for the renewal up to a deadline that sits BETWEEN the two candidate schedules: a
+    // send-timed clock renews at four seconds, a response-timed one no earlier than six. Polling to
+    // a deadline rather than sampling at a fixed instant keeps the dial latency inside each
+    // exchange from deciding the result.
+    let deadline = started + Duration::from_millis(5_500);
+    let mut renewed = false;
+    while tokio::time::Instant::now() < deadline {
+        if service.stored(&tag).len() >= 2 {
+            renewed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    advertiser.abort();
+    drop(envelopes);
+
+    assert!(
+        renewed,
+        "renewal ran late; the clock is being started when the response arrives, not when the \
+         publish is sent"
+    );
+}

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -5,8 +5,8 @@ use iroh::{Endpoint, RelayMode};
 
 use super::stub::{Behaviour, PER_TAG_CAP, StubService};
 use super::{
-    DISCOVERY_TAG_DOMAIN, DISCOVERY_TIMEOUT, DiscoveryExchange, PEER_DISCOVERY_ALPN, PublishState,
-    account_tag, exchange, publish_ttl_seconds,
+    DISCOVERY_TAG_DOMAIN, DISCOVERY_TIMEOUT, DiscoveryExchange, DiscoveryOutcome,
+    PEER_DISCOVERY_ALPN, PublishState, account_tag, exchange, publish_ttl_seconds,
 };
 
 /// A fixed instant: the announcement arithmetic under test is about durations, and a real clock
@@ -25,6 +25,21 @@ async fn client() -> Endpoint {
 
 fn local_node(endpoint: &Endpoint) -> [u8; 32] {
     *endpoint.id().as_bytes()
+}
+
+/// These tests publish a bare node id as the announcement payload and read it straight back.
+///
+/// Real announcements are sealed envelopes, but sealing is the op-log crate's concern and is
+/// covered there; what this module tests is the transport — publish, fetch, renew, bound, fail
+/// open — and it should not have to build a roster to do so. The opener is the seam that lets the
+/// two be tested separately.
+fn as_node_id(payload: &[u8]) -> Option<[u8; 32]> {
+    <[u8; 32]>::try_from(payload).ok()
+}
+
+/// The node ids in an outcome, as the composing caller would recover them.
+fn opened(outcome: &DiscoveryOutcome) -> Vec<[u8; 32]> {
+    outcome.announcements.iter().filter_map(|payload| as_node_id(payload)).collect()
 }
 
 /// Poll `ready` until it holds, up to a few seconds. Returns whether it ever did.
@@ -107,7 +122,7 @@ async fn a_published_node_id_is_fetched_back_by_another_device() {
         endpoint: &publisher,
         service: service.addr(),
         tag,
-        publish: Some(published),
+        publish: Some(&published),
         ttl_seconds: 600,
         now_ms: NOW_MS,
     })
@@ -124,7 +139,7 @@ async fn a_published_node_id_is_fetched_back_by_another_device() {
         now_ms: NOW_MS,
     })
     .await;
-    assert_eq!(out.peers, vec![published], "the fetcher sees the publisher");
+    assert_eq!(opened(&out), vec![published], "the fetcher sees the publisher");
     assert_eq!(
         out.publish,
         PublishState::NotAttempted,
@@ -152,7 +167,7 @@ async fn a_device_that_does_not_advertise_itself_still_learns_its_peers() {
         now_ms: NOW_MS,
     })
     .await;
-    assert_eq!(out.peers, vec![peer]);
+    assert_eq!(opened(&out), vec![peer]);
     assert_eq!(service.stored(&tag).len(), 1, "nothing of ours was added");
 }
 
@@ -170,13 +185,13 @@ async fn a_refused_publish_does_not_suppress_the_fetch() {
         endpoint: &endpoint,
         service: service.addr(),
         tag,
-        publish: Some(local_node(&endpoint)),
+        publish: Some(&local_node(&endpoint)),
         ttl_seconds: 600,
         now_ms: NOW_MS,
     })
     .await;
     assert_eq!(out.publish, PublishState::Failed);
-    assert_eq!(out.peers, vec![peer], "the fetched peers survive the publish failure");
+    assert_eq!(opened(&out), vec![peer], "the fetched peers survive the publish failure");
     assert!(out.degraded.is_some(), "and the failure is reported for logging");
 }
 
@@ -200,13 +215,13 @@ async fn a_stalled_publish_does_not_discard_the_peers_already_fetched() {
         endpoint: &endpoint,
         service: service.addr(),
         tag,
-        publish: Some(local_node(&endpoint)),
+        publish: Some(&local_node(&endpoint)),
         ttl_seconds: 600,
         now_ms: NOW_MS,
     })
     .await;
 
-    assert_eq!(out.peers, vec![peer], "the fetched peer survives the stalled publish");
+    assert_eq!(opened(&out), vec![peer], "the fetched peer survives the stalled publish");
     assert_eq!(out.publish, PublishState::Failed);
     assert!(out.degraded.is_some_and(|d| d.contains("timed out")), "and the stall is reported");
     assert!(
@@ -238,7 +253,7 @@ async fn a_malformed_announcement_is_dropped_individually() {
         now_ms: NOW_MS,
     })
     .await;
-    assert_eq!(out.peers, vec![good], "the well-formed peer survives its malformed neighbour");
+    assert_eq!(opened(&out), vec![good], "the well-formed peer survives its malformed neighbour");
 }
 
 /// The timeout's whole reason for existing.
@@ -258,14 +273,14 @@ async fn a_service_that_accepts_and_never_answers_does_not_stall_the_pass() {
         endpoint: &endpoint,
         service: service.addr(),
         tag: account_tag(&[7; 32]),
-        publish: Some(local_node(&endpoint)),
+        publish: Some(&local_node(&endpoint)),
         ttl_seconds: 600,
         now_ms: NOW_MS,
     })
     .await;
     let elapsed = started.elapsed();
 
-    assert!(out.peers.is_empty(), "a stalled service yields no peers");
+    assert!(opened(&out).is_empty(), "a stalled service yields no peers");
     assert!(out.degraded.is_some_and(|d| d.contains("timed out")), "and says why");
     assert!(
         elapsed >= DISCOVERY_TIMEOUT,
@@ -302,7 +317,7 @@ async fn an_unreachable_service_fails_open() {
         now_ms: NOW_MS,
     })
     .await;
-    assert!(out.peers.is_empty());
+    assert!(opened(&out).is_empty());
     assert!(out.degraded.is_some(), "the failure is reported, never propagated as an error");
     assert!(
         started.elapsed() < DISCOVERY_TIMEOUT,
@@ -326,7 +341,7 @@ async fn a_still_fresh_announcement_is_not_republished() {
         endpoint: &endpoint,
         service: service.addr(),
         tag,
-        publish: Some(node),
+        publish: Some(&node),
         ttl_seconds: 600,
         now_ms: NOW_MS,
     })
@@ -350,7 +365,7 @@ async fn an_announcement_near_expiry_is_republished() {
         endpoint: &endpoint,
         service: service.addr(),
         tag,
-        publish: Some(node),
+        publish: Some(&node),
         ttl_seconds: 600,
         now_ms: NOW_MS,
     })
@@ -394,7 +409,7 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
                 endpoint,
                 service: service.addr(),
                 tag,
-                publish: Some(local_node(endpoint)),
+                publish: Some(&local_node(endpoint)),
                 ttl_seconds: ttl,
                 now_ms: pass_now_ms,
             })
@@ -429,7 +444,7 @@ async fn a_three_device_account_on_the_default_cadence_stays_under_the_per_tag_c
     })
     .await;
     for id in &ids {
-        assert!(out.peers.contains(id), "a device stopped being discoverable");
+        assert!(opened(&out).contains(id), "a device stopped being discoverable");
     }
 }
 
@@ -457,7 +472,7 @@ async fn rapid_passes_do_not_fill_the_tag_with_copies_of_one_device() {
                 endpoint,
                 service: service.addr(),
                 tag,
-                publish: Some(local_node(endpoint)),
+                publish: Some(&local_node(endpoint)),
                 ttl_seconds: ttl,
                 now_ms: pass_now_ms,
             })
@@ -506,7 +521,7 @@ async fn beyond_roughly_four_devices_the_service_starts_refusing_publishes() {
                 endpoint,
                 service: service.addr(),
                 tag,
-                publish: Some(local_node(endpoint)),
+                publish: Some(&local_node(endpoint)),
                 ttl_seconds: ttl,
                 now_ms: pass_now_ms,
             })
@@ -516,7 +531,7 @@ async fn beyond_roughly_four_devices_the_service_starts_refusing_publishes() {
                 // The point of the limit being survivable: a device that cannot advertise ITSELF
                 // still learns where everyone else is. (A refusal only happens once the tag is
                 // full, so there is certainly something to have fetched.)
-                assert!(!out.peers.is_empty(), "a refused publish must not cost us the fetch");
+                assert!(!opened(&out).is_empty(), "a refused publish must not cost us the fetch");
             }
         }
     }
@@ -558,10 +573,11 @@ async fn discovered_peers_join_the_configured_ones_without_this_node_or_duplicat
             endpoint: &endpoint,
             service: service.addr(),
             tag,
-            publish: Some(me),
+            publish: Some(&me),
             ttl_seconds: 600,
             now_ms: NOW_MS,
         }),
+        &as_node_id,
     )
     .await;
 
@@ -600,6 +616,7 @@ async fn an_empty_discovery_result_leaves_the_configured_peers_untouched() {
             ttl_seconds: 600,
             now_ms: NOW_MS,
         }),
+        &as_node_id,
     )
     .await;
     assert_eq!(resolved.peers.len(), 1);
@@ -641,11 +658,12 @@ async fn a_serving_host_advertises_itself_immediately_and_keeps_renewing() {
     let host = client().await;
     let node = local_node(&host);
 
+    let (_tx, announcement) = tokio::sync::watch::channel(Some(node.to_vec()));
     let advertiser = tokio::spawn(super::advertise(super::Advertise {
         endpoint: host.clone(),
         service: service.addr(),
         tag,
-        node,
+        announcement,
         ttl_seconds: TTL,
         now_ms: wall_clock_ms,
     }));

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -673,7 +673,7 @@ async fn a_serving_host_advertises_itself_immediately_and_keeps_renewing() {
     let host = client().await;
     let node = local_node(&host);
 
-    let (_tx, announcement) = tokio::sync::watch::channel(Some(node.to_vec()));
+    let (envelopes, announcement) = tokio::sync::watch::channel(Some(node.to_vec()));
     let advertiser = tokio::spawn(super::advertise(super::Advertise {
         endpoint: host.clone(),
         service: service.addr(),
@@ -699,5 +699,53 @@ async fn a_serving_host_advertises_itself_immediately_and_keeps_renewing() {
     assert!(
         stored.iter().all(|payload| payload.as_slice() == node.as_slice()),
         "every announcement under this tag is this host's own node id"
+    );
+    drop(envelopes);
+}
+
+/// The advertiser must re-read the watch on EVERY tick, not once at spawn.
+///
+/// This is what makes a roster change reach a long-running host: a device enrolled an hour after it
+/// started becomes a recipient at the next renewal rather than never. Reading once at spawn passes
+/// the renewal test above — which only ever sees one value — so the property needs its own case
+/// that actually changes the value.
+#[tokio::test]
+async fn a_new_envelope_reaches_a_running_advertiser_at_the_next_tick() {
+    fn wall_clock_ms() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("a clock after 1970")
+            .as_millis() as i64
+    }
+
+    const TTL: u32 = 4;
+    let service = StubService::start(wall_clock_ms(), Behaviour::Serve).await;
+    let tag = account_tag(&[19; 32]);
+    let host = client().await;
+
+    let before = vec![0xa1u8; 48];
+    let after = vec![0xb2u8; 48];
+    let (envelopes, announcement) = tokio::sync::watch::channel(Some(before.clone()));
+    let advertiser = tokio::spawn(super::advertise(super::Advertise {
+        endpoint: host.clone(),
+        service: service.addr(),
+        tag,
+        announcement,
+        ttl_seconds: TTL,
+        now_ms: wall_clock_ms,
+    }));
+
+    assert!(
+        wait_for(|| service.stored(&tag).contains(&before)).await,
+        "the first envelope is advertised"
+    );
+
+    // Swap it, as a roster change does.
+    envelopes.send(Some(after.clone())).unwrap();
+    let switched = wait_for(|| service.stored(&tag).contains(&after)).await;
+    advertiser.abort();
+    assert!(
+        switched,
+        "the replacement was never published; the watch is being read once, not per tick"
     );
 }

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -492,54 +492,69 @@ async fn rapid_passes_do_not_fill_the_tag_with_copies_of_one_device() {
     );
 }
 
-/// The residual, pinned so it is a known limit rather than a surprise.
+/// A large account is never refused, and its fetches still fit a frame.
 ///
-/// The service caps a tag at 8 live announcements and REJECTS rather than evicting once full, so an
-/// account large enough to need more slots than that has publishes refused no matter how carefully
-/// this client rations them. Two live copies per device is the steady state, so the ceiling is
-/// around four devices. Fetching is unaffected — a refused device simply stops being discoverable
-/// itself while still finding everyone else — and explicit `server_peers` remain first-class, which
-/// is why this is a limit and not a blocker. Lifting it needs the SERVICE to evict oldest instead
-/// of refusing.
+/// This replaces a test that asserted the opposite. The service used to refuse a publish into a
+/// full tag, so an account past roughly four advertisers lost discovery outright; it now evicts the
+/// oldest entry instead, and bounds what a fetch returns. The observable flips: publishing always
+/// succeeds, and it is the RESPONSE that is limited.
+///
+/// The payload size here is deliberate — a sealed envelope for a sixteen-device roster, about 1,281
+/// bytes. Thirty-two of those is roughly 78 KiB once the wire's integer-array encoding is counted,
+/// comfortably past the 64 KiB frame, so this exercises the bound rather than passing under it.
 #[tokio::test]
-async fn beyond_roughly_four_devices_the_service_starts_refusing_publishes() {
+async fn a_large_account_is_never_refused_and_its_fetches_fit_one_frame() {
+    use super::wire::{DiscoveryResponse, MAX_FRAME_LEN, WireAnnouncement};
+
     let service = StubService::start(NOW_MS, Behaviour::Serve).await;
     let tag = account_tag(&[13; 32]);
-    let ttl = publish_ttl_seconds(300);
+    let realistic_envelope = |seed: u8| vec![seed.wrapping_add(100); 1 + 16 * 80];
 
-    let mut devices = Vec::new();
-    for _ in 0..5 {
-        devices.push(client().await);
+    let endpoint = client().await;
+    for seed in 0..32u8 {
+        let out = exchange(DiscoveryExchange {
+            endpoint: &endpoint,
+            service: service.addr(),
+            tag,
+            publish: Some(&realistic_envelope(seed)),
+            ttl_seconds: 600,
+            now_ms: NOW_MS,
+        })
+        .await;
+        assert_eq!(
+            out.publish,
+            PublishState::Published,
+            "publish {seed} was refused; a full tag must evict, not refuse ({:?})",
+            out.degraded
+        );
     }
 
-    let mut refused = false;
-    for pass in 0..4i64 {
-        let pass_now_ms = NOW_MS + pass * 300_000;
-        service.advance_to(pass_now_ms);
-        for endpoint in &devices {
-            let out = exchange(DiscoveryExchange {
-                endpoint,
-                service: service.addr(),
-                tag,
-                publish: Some(&local_node(endpoint)),
-                ttl_seconds: ttl,
-                now_ms: pass_now_ms,
-            })
-            .await;
-            if out.publish == PublishState::Failed {
-                refused = true;
-                // The point of the limit being survivable: a device that cannot advertise ITSELF
-                // still learns where everyone else is. (A refusal only happens once the tag is
-                // full, so there is certainly something to have fetched.)
-                assert!(!opened(&out).is_empty(), "a refused publish must not cost us the fetch");
-            }
-        }
-    }
+    let out = exchange(DiscoveryExchange {
+        endpoint: &endpoint,
+        service: service.addr(),
+        tag,
+        publish: None,
+        ttl_seconds: 600,
+        now_ms: NOW_MS,
+    })
+    .await;
+    assert!(!out.announcements.is_empty(), "an over-full tag must still answer");
     assert!(
-        refused,
-        "five devices are expected to hit the per-tag cap; if this stops happening the service \
-         changed its cap or its eviction policy and the limit above should be re-measured"
+        out.announcements.len() < 32,
+        "and must answer with a SUBSET, not everything: {}",
+        out.announcements.len()
     );
+
+    // The returned set must be one the service could actually have sent.
+    let response = DiscoveryResponse::Fetched {
+        announcements: out
+            .announcements
+            .iter()
+            .map(|payload| WireAnnouncement { payload: payload.clone(), expires_at_ms: NOW_MS })
+            .collect(),
+    };
+    let encoded = response.encode().len();
+    assert!(encoded <= MAX_FRAME_LEN, "response of {encoded} bytes exceeds the frame cap");
 }
 
 // ---------------------------------------------------------------- composition

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -148,6 +148,11 @@ pub struct DiscoveredPeers {
 /// None` reduces this to the configured resolver. A configured id that does not parse is logged
 /// and counted rather than aborting the pass, so one typo cannot suppress every other peer.
 ///
+/// `open_announcement` recovers a node id from a sealed announcement, or `None` for one this
+/// device cannot read. It is a parameter rather than something this crate does itself because
+/// sealing is the op-log crate's concern; passing a closure that always returns `None` reduces this
+/// to the configured-peer resolver.
+///
 /// **Everything is compared on the raw 32 bytes, never the display string.**
 /// [`iroh::EndpointId::from_str`] accepts 64-char lowercase hex (the `Display` form) OR standard
 /// base32, and uppercases before base32-decoding, so three distinct strings can name one peer —
@@ -157,6 +162,7 @@ pub async fn discover_peers(
     configured_peers: &[String],
     relay_url: &str,
     discovery: Option<crate::discovery::DiscoveryExchange<'_>>,
+    open_announcement: &dyn Fn(&[u8]) -> Option<[u8; 32]>,
 ) -> DiscoveredPeers {
     let mut peers: Vec<(String, EndpointAddr)> = Vec::new();
     let mut seen: HashSet<[u8; 32]> = HashSet::new();
@@ -194,7 +200,14 @@ pub async fn discover_peers(
             "peer discovery degraded; continuing with the peers already resolved"
         );
     }
-    for node in outcome.peers {
+    // Announcements arrive sealed. Opening happens HERE rather than inside the exchange because it
+    // needs a database connection, which is not `Sync` and so cannot cross the await inside the
+    // spawned advertise loop that shares that code.
+    //
+    // One that will not open is dropped INDIVIDUALLY — it is sealed to a roster this device has
+    // left, malformed, or from a newer version. Failing the batch would let one bad entry, which
+    // anyone able to compute the tag may publish, hide every good one.
+    for node in outcome.announcements.iter().filter_map(|payload| open_announcement(payload)) {
         if node == local_node || !seen.insert(node) {
             continue;
         }
@@ -769,6 +782,11 @@ mod tests {
         assert_eq!(reconcile_step(&quiet, 8, 8), ReconcileStep::Stop { converged: true });
     }
 
+    /// A configured-peers-only resolve: nothing published, nothing to open.
+    fn no_announcements(_payload: &[u8]) -> Option<[u8; 32]> {
+        None
+    }
+
     #[tokio::test]
     async fn discover_peers_resolves_valid_ids_and_counts_invalid_ones() {
         let valid = node_id_to_string(&node_id_from_secret([7u8; 32])).unwrap();
@@ -776,6 +794,7 @@ mod tests {
             &[valid.clone(), "not-a-node-id".to_string()],
             "https://relay.example",
             None,
+            &no_announcements,
         )
         .await;
         assert_eq!(
@@ -838,7 +857,8 @@ mod tests {
 
         let configured =
             [hex.clone(), base32_upper.clone(), base32_lower.clone(), base32_upper.clone()];
-        let resolved = discover_peers(&configured, "https://relay.example", None).await;
+        let resolved =
+            discover_peers(&configured, "https://relay.example", None, &no_announcements).await;
         assert_eq!(resolved.peers.len(), 1, "every spelling names one peer, dialed once");
         assert_eq!(resolved.peers[0].0, hex, "the first spelling configured wins");
         assert_eq!(

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -204,16 +204,32 @@ pub async fn discover_peers(
     // needs a database connection, which is not `Sync` and so cannot cross the await inside the
     // spawned advertise loop that shares that code.
     //
-    // One that will not open is dropped INDIVIDUALLY — it is sealed to a roster this device has
-    // left, malformed, or from a newer version. Failing the batch would let one bad entry, which
-    // anyone able to compute the tag may publish, hide every good one.
-    for node in outcome.announcements.iter().filter_map(|payload| open_announcement(payload)) {
+    // Failures are INDIVIDUAL throughout the loop below. Failing the batch would let one bad
+    // entry, which anyone able to compute the tag may publish, hide every good one.
+    // The peer cap is applied HERE, to announcements that actually resolved, and not in the
+    // exchange to raw payloads. Capping payloads would let anyone able to compute the tag suppress
+    // every real advertiser with a handful of unopenable entries — see `MAX_ANNOUNCEMENTS`.
+    let mut admitted = 0usize;
+    for payload in &outcome.announcements {
+        if admitted >= crate::discovery::MAX_ANNOUNCEMENTS {
+            tracing::debug!(
+                cap = crate::discovery::MAX_ANNOUNCEMENTS,
+                "discovered the most peers one pass admits; ignoring the rest"
+            );
+            break;
+        }
+        // One that will not open is skipped without spending cap budget: it is sealed to a roster
+        // this device has left, malformed, or from a newer version.
+        let Some(node) = open_announcement(payload) else { continue };
         if node == local_node || !seen.insert(node) {
             continue;
         }
         match peer_addr_from_bytes(&node, relay_url) {
             // The label comes off the parsed id rather than a second fallible conversion.
-            Ok(addr) => peers.push((addr.id.to_string(), addr)),
+            Ok(addr) => {
+                peers.push((addr.id.to_string(), addr));
+                admitted += 1;
+            },
             // `from_bytes` rejects a non-canonical point. Dropped individually: anyone who can
             // compute the tag can publish garbage, and one bad entry must not hide the good ones.
             Err(error) =>

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -186,12 +186,20 @@ take back:
 
 - **The discovery tag**, which is derived from immutable account material already in that device's
   database. It can therefore keep watching the tag: how many hosts advertise and when they renew or
-  stop. It can also publish junk under the tag, costing whoever fetches it a wasted slot. What it
-  can no longer do is read a host's node id out of any announcement sealed after its removal.
-  Rotating the tag itself is [#1081](https://github.com/cq27-dev/rag-rat/issues/1081).
-- **Announcements sealed before the removal**, which stay openable by it until they expire — at most
-  one TTL, so 15 minutes at the default cadence. A host re-seals at its next session after a roster
-  change, so the window closes on its own.
+  stop, and — because each sealed envelope is a version byte plus a fixed 80 bytes per recipient —
+  the exact number of devices on the account, `(len - 1) / 80`, tracked across enrollments and
+  removals without opening a single wrap. It can also publish junk under the tag, costing whoever
+  fetches it a wasted slot. What it can no longer do is read a host's node id out of any
+  announcement sealed after its removal. Rotating the tag itself is
+  [#1081](https://github.com/cq27-dev/rag-rat/issues/1081); padding the envelope to hide device
+  count is [#1087](https://github.com/cq27-dev/rag-rat/issues/1087).
+- **Announcements sealed before it stops being a recipient**, which stay openable by it until they
+  expire — at most one TTL, so 15 minutes at the default cadence. The window is measured from when a
+  host **learns** of the removal, not from when it was authored: a removal authored on another
+  device does not reach a host until an authorized peer syncs it there, and until then the host
+  keeps the removed device in its own effective roster and re-seals every renewal to include it. A
+  host that no remaining device ever reaches never learns, and keeps a removed device openable
+  indefinitely — one more reason a host is only as current as its last inbound sync.
 
 Neither grants access to data. Every peer, discovered or configured, still passes full mutual roster
 authorization before a single log entry moves, and a removed device fails it. Pin your hosts in

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -73,27 +73,36 @@ becomes meaningful on any device, because a device that advertises itself will b
 ### Scale
 
 Dials grow linearly with the number of devices — each device dials the host, not every other device
-— and only the hosts advertise, so the per-tag announcement limit is a limit on **hosts**, not on
-devices. One or two hosts stay well inside it no matter how many devices sync through them.
+— and only the hosts advertise, so the per-tag *slot* limit counts **hosts**, not devices. One or
+two hosts stay well inside it no matter how many devices sync through them. Device count reaches
+discovery by a different route: it sets the size of each announcement, which is the 25-device
+ceiling above.
 
 Adding hosts is how you spread load or place one nearer a group of devices; devices that dial more
 than one host also propagate changes between those hosts.
 
-## The limit on advertised hosts
+## The limits on discovery
 
-The discovery service holds at most 8 live announcements per account and refuses further publishes
-rather than evicting. A host keeps about two live announcements of itself, so **roughly four hosts
-can advertise at once**. Devices cost nothing here — they only fetch.
+Two separate ceilings, with different symptoms. Neither binds for an ordinary account, and both
+degrade rather than breaking: discovery is routing advice, so anything it fails to find is still
+reachable through `server_peers`.
 
-Four hosts is far more than most accounts want, so this is unlikely to bind. If it does, it degrades
-rather than breaking:
+**How many hosts can advertise.** The service holds at most 32 live announcements per account and
+evicts the oldest to make room rather than refusing a newcomer. A host renews at half the TTL, so it
+keeps about two live announcements of itself — **roughly sixteen hosts advertising at once**.
+Devices cost nothing here; they only fetch. Past that, hosts evict each other and discoverability
+**flaps**: a host findable this hour may not be next hour. Pin those hosts in `server_peers` instead.
 
-- A host whose publish is refused **stops being discoverable**. It keeps serving normally, and any
-  device that reaches it through `server_peers` is unaffected.
-- Which hosts hold the free slots shifts as announcements expire, so **discoverability flaps** — a
-  host findable this hour may not be next hour.
+**How many devices an account can have.** An announcement is sealed once per recipient, so it grows
+by 80 bytes per roster-effective device against a publish limit of 2048 bytes — a ceiling of about
+**25 devices**. Past it a host logs `roster is too large to seal into one announcement` and does not
+advertise; it serves normally, and every device that reaches it through `server_peers` is
+unaffected. The announcement is never truncated to fit, because which recipients got dropped would
+silently decide who can find that host.
 
-The fix is to pin the hosts in `server_peers` rather than relying on discovery for all of them.
+A fetch is bounded the same way: the service answers with as much as fits one response frame, chosen
+at random, so a busy tag returns a **sample** rather than everything. A device therefore learns some
+of its peers per pass and the rest on later passes.
 
 ## Settings
 

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -158,13 +158,19 @@ use — including any you add later.
 ## What each service learns
 
 - **The relay** forwards opaque encrypted QUIC traffic between peers.
-- **The discovery service** is a blind key-value store keyed on a tag it cannot link to an account.
-  The tag comes from account-scoped key material only enrolled devices hold — not from the account
-  id, which every host you have ever dialed knows — so an outsider cannot compute it or find your
-  hosts. What the service itself *can* see under that pseudonym is the advertised node ids
-  themselves — in the clear, and dialable — along with how many there are and when they stop
-  renewing. Unlinkability is the guarantee; hiding which hosts advertise, how many, and when, is
-  not.
+- **The discovery service** is a key-value store keyed on a tag it cannot link to an account. The
+  tag comes from account-scoped key material only enrolled devices hold — not from the account id,
+  which every host you have ever dialed knows — so an outsider cannot compute it or find your hosts.
+  Announcements are sealed to the account's current devices, so the service reads no node id out of
+  a payload.
+
+  It learns your node ids anyway, by a different route: publishes and fetches arrive over
+  authenticated connections, so the service sees the node id at the other end of each one. Under
+  that tag it can therefore see which nodes advertise, which nodes ask, how many there are, and when
+  they stop renewing — that is, your active device set and its liveness. Sealing is aimed at whoever
+  can compute the tag *without* being the service, which is the case that actually arises: a removed
+  device, or a leaked tag. Unlinkability of tag to account is the guarantee; hiding your devices from
+  the service is not.
 - **Neither is trusted.** A discovered address is routing advice only: every peer, discovered or
   configured, passes full mutual roster authorization before a single log entry is exchanged. A
   forged announcement costs a failed dial and nothing else.
@@ -172,8 +178,21 @@ use — including any you add later.
 Discovery failing — unreachable, slow, rate-limited, or answering with nonsense — never fails a
 sync. The configured peers are dialed exactly as they would have been.
 
-One known gap: a device removed from the roster can no longer sync, but keeps the ability to compute
-the account's discovery tag, so it can still see which hosts are advertised and when. Fixing that
-needs rotatable discovery key material —
-[#1080](https://github.com/cq27-dev/rag-rat/issues/1080). Pin your hosts in `server_peers` if that
-matters to you before it lands; discovery is then not in the path at all.
+### What a removed device keeps
+
+Removing a device stops it syncing immediately, and it stops appearing as a recipient of anything
+sealed afterwards. Two things survive that, because they do not depend on anything the account can
+take back:
+
+- **The discovery tag**, which is derived from immutable account material already in that device's
+  database. It can therefore keep watching the tag: how many hosts advertise and when they renew or
+  stop. It can also publish junk under the tag, costing whoever fetches it a wasted slot. What it
+  can no longer do is read a host's node id out of any announcement sealed after its removal.
+  Rotating the tag itself is [#1081](https://github.com/cq27-dev/rag-rat/issues/1081).
+- **Announcements sealed before the removal**, which stay openable by it until they expire — at most
+  one TTL, so 15 minutes at the default cadence. A host re-seals at its next session after a roster
+  change, so the window closes on its own.
+
+Neither grants access to data. Every peer, discovered or configured, still passes full mutual roster
+authorization before a single log entry moves, and a removed device fails it. Pin your hosts in
+`server_peers` and set `discovery = false` if you would rather the tag not be in the path at all.

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -180,9 +180,13 @@ sync. The configured peers are dialed exactly as they would have been.
 
 ### What a removed device keeps
 
-Removing a device stops it syncing immediately, and it stops appearing as a recipient of anything
-sealed afterwards. Two things survive that, because they do not depend on anything the account can
-take back:
+Removing a device revokes it, but per host and not instantly: a serving host authorizes every peer
+against its own local roster projection, so it stops syncing with the removed device only once it has
+learned and folded the removal — the same per-host propagation that governs sealing below. A removal
+authored on another device reaches a host only when an authorized peer syncs it there; until then
+that host still treats the device as enrolled and syncs with it. The device also stops appearing as a
+recipient of anything sealed afterwards. Two further things survive removal even at a host that has
+folded it, because they do not depend on anything the account can take back:
 
 - **The discovery tag**, which is derived from immutable account material already in that device's
   database. It can therefore keep watching the tag: how many hosts advertise and when they renew or
@@ -202,5 +206,6 @@ take back:
   indefinitely — one more reason a host is only as current as its last inbound sync.
 
 Neither grants access to data. Every peer, discovered or configured, still passes full mutual roster
-authorization before a single log entry moves, and a removed device fails it. Pin your hosts in
-`server_peers` and set `discovery = false` if you would rather the tag not be in the path at all.
+authorization before a single log entry moves, and a removed device fails it at any host that has
+folded the removal. Pin your hosts in `server_peers` and set `discovery = false` if you would rather
+the tag not be in the path at all.


### PR DESCRIPTION
Closes #1080. The service-side half — evicting instead of refusing, a bounded fetch response, and the raised per-tag cap — is already deployed; this is the client half.

## The problem

A discovery announcement carried this node's iroh node id **in the clear**. The service is described as blind, but it is only tag-blind: the payload is a dialable identity. Anyone able to compute the account's tag — including a device removed from the roster, since the tag derives from the immutable account genesis hash — could read the account's advertised hosts straight out of it.

## Sealed per recipient, not under a shared key

The payload is now `version || wrap*`: one 80-byte wrap per roster-effective device, sealed to that device's long-term X25519 key and bound to the tag.

Per recipient rather than under one shared account secret, because of an asymmetry that decides the whole design. A device offline for a month and a device removed from the roster are **indistinguishable to the discovery service**, so anything keyed on a shared rotating secret revokes the removed device and strands the offline one in the same stroke. They are *not* indistinguishable to the publisher: the offline device is still roster-effective and its device key never rotates, while the removed one is simply absent from the roster read at seal time. The cut falls exactly on roster membership — no key epoch, no rotation, nothing to distribute.

| | can open a new announcement |
|---|---|
| Roster-effective, online | yes |
| Roster-effective, offline for a month | **yes** — its device key never changed |
| Removed | no |

**Revocation governs what is sealed next, not what is already published.** An announcement sealed while a device was effective stays readable by it until it expires. A test pins that, so nobody reads this as instant.

## What it does and does not buy

Worth stating plainly, because the intuitive reading overstates it:

- **A leaked genesis hash degrades from catastrophic to modest** — it yields a count and a liveness pattern instead of the full host list. The strongest win here.
- **A removed device cannot learn hosts that begin advertising after its removal.** Real, and narrow.
- **It does not blind the service operator.** The advertiser dials the service from the very endpoint whose node id it seals, so the operator reads that identity off the handshake regardless. Sealing protects stored and fetchable state — which is what makes the leak win real, since a leaker is not the operator.
- **It does not stop a removed device probing hosts it already knew.** Node ids never rotate.
- **It does not close the removed device's ongoing view** of counts and cadence. That needs rotating the tag, which carries a trade this does not — it strands any device that was offline across the rotation — and is tracked as #1081.

## Seal once per roster change

Sealing needs a database connection, and the advertise loop is a spawned task that cannot hold one. So the serve loop seals — it already owns the connection and already folds the WAL between sessions — and a watch channel carries the bytes; the advertiser republishes them verbatim and re-reads the watch on every tick, so a device enrolled while a host is running becomes a recipient at the next renewal rather than never.

Republishing identical bytes is safe, and two things depend on it: `is_live` recognises this host's own announcement by comparing bytes rather than opening anything, and the fetch path de-duplicates announcements by bytes before applying the peer cap. A fresh seal per publish would break both at once — the host would never recognise itself and would republish every tick until the tag was full of its own copies.

**Detecting the roster change needs care, and the obvious approach is wrong.** Sealing draws a fresh ephemeral per wrap, so two seals of an *unchanged* roster differ in every byte; comparing envelopes to decide whether to re-seal is a predicate that is always true, and acting on it produces exactly the tag exhaustion above. The comparison is therefore a stamp over the recipient set — a digest of the fingerprints and keys, computed inside the op-log crate so no roster material crosses the boundary, and reported alongside each seal so the two cannot drift. Two op-log tests pin the pair of facts that make this necessary and correct: two seals of an unchanged roster differ, and the stamp does not.

## Boundaries

- **Both halves live in `rag-rat-oplog`.** The device X25519 secret's documentation pins that it stays internal to that crate, and the effective-roster public keys are `pub(super)`. Exporting either to satisfy a caller elsewhere would have traded an invariant for convenience, so the crate gained two narrow functions instead.
- **Opening happens at the caller, not inside the exchange.** An opener needs a connection, which is not `Sync`, so one carried in `DiscoveryExchange` would cross an await inside the spawned advertise loop and make that future unspawnable. The exchange returns payloads unopened; the device-side pass opens them, and the advertise loop discards them because peers dial a host rather than the reverse.
- **Opening is silent when a wrap fails its tag.** Every announcement carries one wrap per roster device, so all but one are expected to fail. Recording those the way the content path records unwrap failures would write a security event per foreign wrap per announcement per pass.

## Also fixed here

The peer cap was applied to raw announcements, so at about two live copies per publisher a sixteen-announcement budget admitted roughly eight unique peers. De-duplication now happens before the cap.

## Testing

The in-process service stub mirrors the deployed one again — cap 32, evict-oldest, and a frame-bounded response with the same encoded-size accounting, since a payload travels as a CBOR array of integers and estimating by length would be wrong by nearly double. A stub that has drifted tests a service that no longer exists, and it fails silently.

One test asserted behaviour that no longer exists (that an account past roughly four advertisers has its publishes refused) and is replaced rather than deleted, by the case that matters at that size: thirty-two realistic sealed envelopes are all accepted, and the fetch returns a subset the service could actually have sent.

Coverage worth naming: the serve loop's stamp comparison has no test — it binds an endpoint, takes the session lock, and runs until interrupted — and replacing that condition with `true` survives the suite. The code says so at the site.