### PR TITLE
feat(sync): bind table streams to repository incarnations

### DIFF
--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -135,7 +135,7 @@ impl IndexDatabase {
         // V070-tables guard inside skips cleanly); idempotent and serialized by its own
         // IMMEDIATE txn, so racing openers converge.
         rag_rat_oplog::rebuild_all_content_projections_if_stale(storage.connection())?;
-        // #1001: the same discipline for the `/4` table-sync projection. An entry this binary could
+        // #1001: the same discipline for the `/5` table-sync projection. An entry this binary could
         // not project when it arrived is retained and marked; replaying it HERE — after migrations,
         // before any produce — is what keeps a payload that arrived from being lost, since
         // redelivery short-circuits on the entry already being present. Bounded by the pending set,

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -567,9 +567,10 @@ mod tests {
     fn seed_table_sync_stream(conn: &rusqlite::Connection, repo_id: &str, seed: u8) -> Vec<u8> {
         let stream_id = vec![seed; 32];
         conn.execute(
-            "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id) VALUES (?1, \
-             ?2, ?3, 'demo/1')",
-            params![stream_id, repo_id, vec![seed; 32]],
+            "INSERT INTO table_sync_streams(
+                 stream_id, repo_id, account_id, incarnation_ref, scope_id
+             ) VALUES (?1, ?2, ?3, ?4, 'demo/1')",
+            params![stream_id, repo_id, vec![seed; 32], vec![seed ^ 0x55; 32]],
         )
         .unwrap();
         conn.execute(
@@ -807,8 +808,9 @@ mod tests {
         );
         // The stream-keyed half of #1004 explicitly: the directory row is gone via the class sweep,
         // and the entries that only it could place are gone with it. Retaining them would let a
-        // re-registration of the same repo — whose stream id is a pure function of
-        // `(repo_id, account_id, scope_id)` — replay the removed repo's operations back into it.
+        // same-incarnation re-registration of the repo — whose stream id is a pure function of
+        // `(repo_id, account_id, incarnation_ref, scope_id)` — replay the removed repo's operations
+        // back into it.
         let b_streams_left: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM table_sync_streams WHERE repo_id = ?1",

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1660,8 +1660,9 @@ fn migration_095_records_the_table_spec_version() {
     // one — `produce_row_ops` finds a locally-deleted row by its surviving published record, so a
     // dropped table strands every unsent deletion and leaves peers holding the row forever.
     conn.execute(
-        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, spec_version)
-         VALUES ('repo', 't', 'live', 'hash', 3)",
+        "INSERT INTO sync_published_rows(
+             stream_id, repo_id, table_name, row_pk, synced_hash, spec_version
+         ) VALUES (zeroblob(32), 'repo', 't', 'live', 'hash', 3)",
         [],
     )
     .unwrap();
@@ -1986,7 +1987,7 @@ fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
 /// binary that did not do the work.
 #[test]
 fn migration_097_records_the_same_ladder_entry_on_every_platform() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 98, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 99, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
@@ -109,8 +109,8 @@ fn directory_rows(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
 fn seed_account_incarnation(conn: &rusqlite::Connection, repo_id: &str, seed: u8) {
     conn.execute(
         "INSERT INTO account_repo_incarnation_current(
-             account_id, repository_id, state, incarnation_ref
-         ) VALUES (?1, ?2, 'current', ?3)",
+             account_id, repository_id, incarnation_ref
+         ) VALUES (?1, ?2, ?3)",
         rusqlite::params![vec![seed; 32], repo_id, vec![seed ^ 0x55; 32]],
     )
     .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_purge.rs
@@ -1,12 +1,13 @@
 //! `rag-rat rm` driven from a LINKED WORKTREE, against a database shared with the main checkout and
 //! with an unrelated sibling repo.
 //!
-//! The table-sync stream directory is keyed by `(repo_id, account_id, scope_id)`, and the entry log
-//! it scopes carries no `repo_id` at all — the purge reaches that log only through the captured
-//! directory rows (#1004). Neither key has a checkout dimension, and this pins that rather than
-//! assuming it: both checkouts of a repo must register under ONE `repo_id`, a removal resolved from
-//! the linked worktree must take the whole repo's log, and a sibling repo in the same database must
-//! keep its own — which no `repo_id` predicate could have protected, since the log has none.
+//! The table-sync stream directory is keyed by `(repo_id, account_id, incarnation_ref, scope_id)`,
+//! and the entry log it scopes carries no `repo_id` at all — the purge reaches that log only
+//! through the captured directory rows (#1004). Neither key has a checkout dimension, and this pins
+//! that rather than assuming it: both checkouts of a repo must register under ONE `repo_id`, a
+//! removal resolved from the linked worktree must take the whole repo's log, and a sibling repo in
+//! the same database must keep its own — which no `repo_id` predicate could have protected, since
+//! the log has none.
 
 use super::*;
 
@@ -35,15 +36,23 @@ fn index_at(root: &Path, database: &Path) -> String {
 fn seed_stream(conn: &rusqlite::Connection, repo_id: &str, seed: u8) -> Vec<u8> {
     let stream_id = vec![seed; 32];
     conn.execute(
-        "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id) VALUES (?1, ?2, \
-         ?3, 'demo/1')",
-        rusqlite::params![stream_id, repo_id, vec![seed; 32]],
+        "INSERT INTO table_sync_streams(
+             stream_id, repo_id, account_id, incarnation_ref, scope_id
+         ) VALUES (?1, ?2, ?3, ?4, 'demo/1')",
+        rusqlite::params![stream_id, repo_id, vec![seed; 32], vec![seed ^ 0x55; 32]],
     )
     .unwrap();
     conn.execute(
         "INSERT INTO table_sync_entries(entry_hash, stream_id, device_fingerprint, lamport, \
          prev_hash, signed_bytes, received_at_ms) VALUES (?1, ?2, ?3, 1, NULL, ?4, 0)",
         rusqlite::params![vec![seed; 32], stream_id, vec![seed; 32], vec![seed; 8]],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO table_sync_chain_tips(
+             stream_id, device_fingerprint, lamport, entry_hash
+         ) VALUES (?1, ?2, 1, ?3)",
+        rusqlite::params![stream_id, vec![seed; 32], vec![seed; 32]],
     )
     .unwrap();
     conn.execute(
@@ -56,6 +65,15 @@ fn seed_stream(conn: &rusqlite::Connection, repo_id: &str, seed: u8) -> Vec<u8> 
     )
     .unwrap();
     stream_id
+}
+
+fn witnesses_on(conn: &rusqlite::Connection, stream_id: &[u8]) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM table_sync_chain_tips WHERE stream_id = ?1",
+        [stream_id],
+        |row| row.get(0),
+    )
+    .unwrap()
 }
 
 fn entries_on(conn: &rusqlite::Connection, stream_id: &[u8]) -> i64 {
@@ -83,6 +101,25 @@ fn directory_rows(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
     conn.query_row(
         "SELECT COUNT(*) FROM table_sync_streams WHERE repo_id = ?1",
         rusqlite::params![repo_id],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn seed_account_incarnation(conn: &rusqlite::Connection, repo_id: &str, seed: u8) {
+    conn.execute(
+        "INSERT INTO account_repo_incarnation_current(
+             account_id, repository_id, state, incarnation_ref
+         ) VALUES (?1, ?2, 'current', ?3)",
+        rusqlite::params![vec![seed; 32], repo_id, vec![seed ^ 0x55; 32]],
+    )
+    .unwrap();
+}
+
+fn account_incarnation(conn: &rusqlite::Connection, repo_id: &str) -> Vec<u8> {
+    conn.query_row(
+        "SELECT incarnation_ref FROM account_repo_incarnation_current WHERE repository_id = ?1",
+        [repo_id],
         |row| row.get(0),
     )
     .unwrap()
@@ -117,6 +154,8 @@ fn rm_from_a_linked_worktree_purges_the_shared_stream_log_and_spares_the_sibling
     let conn = storage.connection();
     let shared_stream = seed_stream(conn, &repo_id, 0xaa);
     let sibling_stream = seed_stream(conn, &sibling_repo_id, 0xbb);
+    seed_account_incarnation(conn, &repo_id, 0xaa);
+    seed_account_incarnation(conn, &sibling_repo_id, 0xbb);
 
     let roots: i64 = conn
         .query_row(
@@ -151,12 +190,24 @@ fn rm_from_a_linked_worktree_purges_the_shared_stream_log_and_spares_the_sibling
         "including the entries still awaiting a predecessor — they are signed operations on the \
          same derived stream id, so retaining them would let a re-registration replay them back",
     );
+    assert_eq!(
+        witnesses_on(conn, &shared_stream),
+        1,
+        "the per-device chain tip survives local removal so same-incarnation rejoin cannot fork",
+    );
+    assert_eq!(
+        account_incarnation(conn, &repo_id),
+        vec![0xff; 32],
+        "local rm does not silently advance or delete account-wide incarnation authority",
+    );
 
     // SIBLING PRESERVATION: the other repo in the shared store keeps both halves. Its entries carry
     // no `repo_id`, so only the captured stream ids could have spared them.
     assert_eq!(directory_rows(conn, &sibling_repo_id), 1, "the sibling's directory row survives");
     assert_eq!(entries_on(conn, &sibling_stream), 1, "and so does its entry log");
     assert_eq!(gapped_on(conn, &sibling_stream), 1, "and its entries awaiting a predecessor");
+    assert_eq!(witnesses_on(conn, &sibling_stream), 1, "and its retained chain witness");
+    assert_eq!(account_incarnation(conn, &sibling_repo_id), vec![0xee; 32]);
 
     let _ = fs::remove_dir_all(&linked);
 }

--- a/crates/rag-rat-db/src/hooks.rs
+++ b/crates/rag-rat-db/src/hooks.rs
@@ -1,8 +1,8 @@
 //! Domain hooks the schema layer calls during migrations and repo adoption.
 //!
 //! Migrations occasionally rebuild DERIVED data whose canonical builder lives in a domain crate
-//! above this one (dream finding ids, the papertrail FTS mirror, the account authority
-//! projection, logical-symbol graph realignment). Those builders are intentionally NOT copied
+//! above this one (dream finding ids, the papertrail FTS mirror, account-derived projections,
+//! logical-symbol graph realignment). Those builders are intentionally NOT copied
 //! into the migration ladder — a derived-data rebuild must run the shipped, current builder so
 //! the rebuilt rows match what the domain writes at runtime. The domain crates can't be
 //! dependencies of this one (they depend on it), so the callers supply the builders through this
@@ -21,7 +21,7 @@ pub struct MigrationHooks {
     /// Rebuild dream finding ids after a schema change to their derivation inputs
     /// (dream's `rederive_finding_ids`).
     pub rederive_dream_finding_ids: fn(&Connection) -> rusqlite::Result<()>,
-    /// Rebuild the account authority projection from the op-log
+    /// Rebuild account-derived projections from the op-log
     /// (oplog's `backfill_authority_projection`).
     pub backfill_authority_projection: fn(&Transaction<'_>) -> rusqlite::Result<()>,
     /// Rebuild the papertrail FTS mirror (papertrail's `rebuild_fts`).

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1384,6 +1384,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_096_ID => Some(96),
             MIGRATION_097_ID => Some(97),
             MIGRATION_098_ID => Some(98),
+            MIGRATION_099_ID => Some(99),
             _ => None,
         })
         .max()
@@ -1491,6 +1492,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_096_ID
             | MIGRATION_097_ID
             | MIGRATION_098_ID
+            | MIGRATION_099_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1595,6 +1597,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_096_ID => migration.checksum != MIGRATION_096_CHECKSUM,
         MIGRATION_097_ID => migration.checksum != MIGRATION_097_CHECKSUM,
         MIGRATION_098_ID => migration.checksum != MIGRATION_098_CHECKSUM,
+        MIGRATION_099_ID => migration.checksum != MIGRATION_099_CHECKSUM,
         _ => false,
     }
 }
@@ -6631,6 +6634,203 @@ pub fn apply_table_sync_gapped_entries(conn: &Connection) -> rusqlite::Result<()
                  stream_id, prev_hash, device_fingerprint, entry_hash);",
     )?;
     tx.commit()
+}
+
+/// V099 (#1049): account-authorized repository incarnations and incarnation-safe table streams.
+///
+/// The table-sync engine is still unreachable in production (`SYNCABLE_TABLES` is empty and no
+/// transport exists), so legacy `/4` projection state has no peer-visible authority and cannot be
+/// assigned an incarnation honestly. The migration retains only chain-tip witnesses, then clears
+/// that unreachable state and rebuilds row bookkeeping with `stream_id` in every key.
+pub fn apply_table_sync_repo_incarnations(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS account_repo_incarnations(
+             account_id       BLOB NOT NULL CHECK(length(account_id) = 32),
+             repository_id    TEXT NOT NULL,
+             incarnation_ref  BLOB NOT NULL CHECK(length(incarnation_ref) = 32),
+             predecessor_ref  BLOB CHECK(predecessor_ref IS NULL OR length(predecessor_ref) = 32),
+             PRIMARY KEY(account_id, incarnation_ref)
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_repo_incarnations_repo
+             ON account_repo_incarnations(account_id, repository_id, predecessor_ref);
+         CREATE TABLE IF NOT EXISTS account_repo_incarnation_current(
+             account_id       BLOB NOT NULL CHECK(length(account_id) = 32),
+             repository_id    TEXT NOT NULL,
+             state            TEXT NOT NULL CHECK(state IN ('current', 'contested')),
+             incarnation_ref  BLOB CHECK(
+                 (state = 'current' AND length(incarnation_ref) = 32)
+                 OR (state = 'contested' AND incarnation_ref IS NULL)
+             ),
+             PRIMARY KEY(account_id, repository_id)
+         ) STRICT;
+         CREATE TABLE IF NOT EXISTS table_sync_chain_tips(
+             stream_id          BLOB    NOT NULL CHECK(length(stream_id) = 32),
+             device_fingerprint BLOB    NOT NULL CHECK(length(device_fingerprint) = 32),
+             lamport            INTEGER NOT NULL,
+             entry_hash         BLOB    NOT NULL CHECK(length(entry_hash) = 32),
+             PRIMARY KEY(stream_id, device_fingerprint)
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS table_sync_chain_tips_stream_lamport
+             ON table_sync_chain_tips(stream_id, lamport);",
+    )?;
+
+    // Rebuild accepted-chain high-water independently of the directory shape. A sanctioned full
+    // schema replay may be repairing a dropped/incomplete witness table on an already-V099 store,
+    // where `table_sync_streams.incarnation_ref` is present and the shape conversion below skips.
+    conn.execute_batch(
+        "INSERT INTO table_sync_chain_tips(stream_id, device_fingerprint, lamport, entry_hash)
+         SELECT e.stream_id, e.device_fingerprint, e.lamport, e.entry_hash
+           FROM table_sync_entries e
+          WHERE NOT EXISTS (
+                SELECT 1 FROM table_sync_entries newer
+                 WHERE newer.stream_id = e.stream_id
+                   AND newer.device_fingerprint = e.device_fingerprint
+                   AND newer.lamport > e.lamport
+          )
+         ON CONFLICT(stream_id, device_fingerprint) DO UPDATE SET
+             lamport = excluded.lamport, entry_hash = excluded.entry_hash
+         WHERE excluded.lamport > table_sync_chain_tips.lamport;",
+    )?;
+
+    if !column_exists(conn, "table_sync_streams", "incarnation_ref")? {
+        conn.execute_batch(
+            "DELETE FROM table_sync_gapped_entries;
+             DELETE FROM table_sync_entries;
+             DROP TABLE table_sync_streams;
+             CREATE TABLE table_sync_streams(
+                 stream_id       BLOB NOT NULL PRIMARY KEY CHECK(length(stream_id) = 32),
+                 repo_id         TEXT NOT NULL,
+                 account_id      BLOB NOT NULL CHECK(length(account_id) = 32),
+                 incarnation_ref BLOB NOT NULL CHECK(length(incarnation_ref) = 32),
+                 scope_id        TEXT NOT NULL,
+                 UNIQUE(repo_id, account_id, incarnation_ref, scope_id)
+             ) STRICT;",
+        )?;
+    }
+    if !column_exists(conn, "sync_published_rows", "stream_id")? {
+        conn.execute_batch(
+            "DROP TABLE sync_published_rows;
+             CREATE TABLE sync_published_rows(
+                 stream_id BLOB NOT NULL CHECK(length(stream_id) = 32), repo_id TEXT NOT NULL,
+                 table_name TEXT NOT NULL, row_pk TEXT NOT NULL, synced_hash TEXT NOT NULL,
+                 spec_version INTEGER NOT NULL,
+                 PRIMARY KEY(stream_id, table_name, row_pk)
+             ) STRICT;",
+        )?;
+    }
+    if !column_exists(conn, "sync_row_clocks", "stream_id")? {
+        conn.execute_batch(
+            "DROP TABLE sync_row_clocks;
+             CREATE TABLE sync_row_clocks(
+                 stream_id BLOB NOT NULL CHECK(length(stream_id) = 32), repo_id TEXT NOT NULL,
+                 table_name TEXT NOT NULL, row_pk TEXT NOT NULL, lamport INTEGER NOT NULL,
+                 device_fingerprint TEXT NOT NULL,
+                 PRIMARY KEY(stream_id, table_name, row_pk)
+             ) STRICT;",
+        )?;
+    }
+    if !column_exists(conn, "sync_row_tombstones", "stream_id")? {
+        conn.execute_batch(
+            "DROP TABLE sync_row_tombstones;
+             CREATE TABLE sync_row_tombstones(
+                 stream_id BLOB NOT NULL CHECK(length(stream_id) = 32), repo_id TEXT NOT NULL,
+                 table_name TEXT NOT NULL, row_pk TEXT NOT NULL, lamport INTEGER NOT NULL,
+                 device_fingerprint TEXT NOT NULL,
+                 PRIMARY KEY(stream_id, table_name, row_pk)
+             ) STRICT;",
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod table_sync_repo_incarnation_migration_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_table_sync_state_becomes_a_retained_witness_and_incarnation_scoped_schema() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE table_sync_entries(
+                 entry_hash BLOB PRIMARY KEY, stream_id BLOB NOT NULL,
+                 device_fingerprint BLOB NOT NULL, lamport INTEGER NOT NULL,
+                 prev_hash BLOB, signed_bytes BLOB NOT NULL, received_at_ms INTEGER NOT NULL
+             );
+             CREATE TABLE table_sync_gapped_entries(
+                 entry_hash BLOB PRIMARY KEY, stream_id BLOB NOT NULL,
+                 device_fingerprint BLOB NOT NULL, lamport INTEGER NOT NULL,
+                 prev_hash BLOB NOT NULL, signed_bytes BLOB NOT NULL, gapped_at_ms INTEGER NOT NULL
+             );
+             CREATE TABLE table_sync_streams(
+                 stream_id BLOB PRIMARY KEY, repo_id TEXT NOT NULL,
+                 account_id BLOB NOT NULL, scope_id TEXT NOT NULL
+             );
+             CREATE TABLE sync_published_rows(
+                 repo_id TEXT, table_name TEXT, row_pk TEXT, synced_hash TEXT, spec_version INTEGER
+             );
+             CREATE TABLE sync_row_clocks(
+                 repo_id TEXT, table_name TEXT, row_pk TEXT, lamport INTEGER,
+                 device_fingerprint TEXT
+             );
+             CREATE TABLE sync_row_tombstones(
+                 repo_id TEXT, table_name TEXT, row_pk TEXT, lamport INTEGER,
+                 device_fingerprint TEXT
+             );
+             INSERT INTO table_sync_streams VALUES(zeroblob(32), 'repo', zeroblob(32), 'demo/1');
+             INSERT INTO table_sync_entries VALUES(
+                 randomblob(32), zeroblob(32), zeroblob(32), 7, NULL, X'00', 0
+             );",
+        )
+        .unwrap();
+
+        apply_table_sync_repo_incarnations(&conn).unwrap();
+        assert!(column_exists(&conn, "table_sync_streams", "incarnation_ref").unwrap());
+        for table in ["sync_published_rows", "sync_row_clocks", "sync_row_tombstones"] {
+            assert!(column_exists(&conn, table, "stream_id").unwrap(), "{table}");
+        }
+        let witnesses: i64 = conn
+            .query_row("SELECT COUNT(*) FROM table_sync_chain_tips", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(witnesses, 1);
+        let entries: i64 = conn
+            .query_row("SELECT COUNT(*) FROM table_sync_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(entries, 0, "un-authorized /4 history is not assigned a /5 incarnation");
+        assert!(!column_exists(&conn, "table_sync_chain_tips", "repo_id").unwrap());
+        assert!(!column_exists(&conn, "account_repo_incarnations", "repo_id").unwrap());
+    }
+
+    #[test]
+    fn full_ladder_replay_repairs_a_missing_chain_tip_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        conn.execute(
+            "INSERT INTO table_sync_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                 received_at_ms
+             ) VALUES (?1, ?2, ?3, 3, NULL, X'00', 0)",
+            rusqlite::params![[3u8; 32].as_slice(), [1u8; 32].as_slice(), [2u8; 32].as_slice()],
+        )
+        .unwrap();
+        conn.execute_batch("DROP TABLE table_sync_chain_tips").unwrap();
+
+        crate::schema::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        let restored: (i64, Vec<u8>) = conn
+            .query_row(
+                "SELECT lamport, entry_hash FROM table_sync_chain_tips
+                  WHERE stream_id = ?1 AND device_fingerprint = ?2",
+                rusqlite::params![[1u8; 32].as_slice(), [2u8; 32].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(restored, (3, vec![3u8; 32]));
+
+        crate::schema::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM table_sync_chain_tips", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "accepted-tip repair is idempotent");
+    }
 }
 
 /// Every table whose `worktree_id` column holds a CHECKOUT PATH — the scope key `worktree_id_of`

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6644,23 +6644,10 @@ pub fn apply_table_sync_gapped_entries(conn: &Connection) -> rusqlite::Result<()
 /// that unreachable state and rebuilds row bookkeeping with `stream_id` in every key.
 pub fn apply_table_sync_repo_incarnations(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS account_repo_incarnations(
+        "CREATE TABLE IF NOT EXISTS account_repo_incarnation_current(
              account_id       BLOB NOT NULL CHECK(length(account_id) = 32),
              repository_id    TEXT NOT NULL,
-             incarnation_ref  BLOB NOT NULL CHECK(length(incarnation_ref) = 32),
-             predecessor_ref  BLOB CHECK(predecessor_ref IS NULL OR length(predecessor_ref) = 32),
-             PRIMARY KEY(account_id, incarnation_ref)
-         ) STRICT;
-         CREATE INDEX IF NOT EXISTS account_repo_incarnations_repo
-             ON account_repo_incarnations(account_id, repository_id, predecessor_ref);
-         CREATE TABLE IF NOT EXISTS account_repo_incarnation_current(
-             account_id       BLOB NOT NULL CHECK(length(account_id) = 32),
-             repository_id    TEXT NOT NULL,
-             state            TEXT NOT NULL CHECK(state IN ('current', 'contested')),
-             incarnation_ref  BLOB CHECK(
-                 (state = 'current' AND length(incarnation_ref) = 32)
-                 OR (state = 'contested' AND incarnation_ref IS NULL)
-             ),
+             incarnation_ref  BLOB CHECK(incarnation_ref IS NULL OR length(incarnation_ref) = 32),
              PRIMARY KEY(account_id, repository_id)
          ) STRICT;
          CREATE TABLE IF NOT EXISTS table_sync_chain_tips(
@@ -6797,7 +6784,6 @@ mod table_sync_repo_incarnation_migration_tests {
             .unwrap();
         assert_eq!(entries, 0, "un-authorized /4 history is not assigned a /5 incarnation");
         assert!(!column_exists(&conn, "table_sync_chain_tips", "repo_id").unwrap());
-        assert!(!column_exists(&conn, "account_repo_incarnations", "repo_id").unwrap());
     }
 
     #[test]

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 98;
+pub const LATEST_SCHEMA_VERSION: u32 = 99;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -749,6 +749,14 @@ const MIGRATION_098_DESCRIPTION: &str =
      every host: which spellings a store carries is a property of the store, not of the binary \
      that opens it";
 
+const MIGRATION_099_ID: &str = "099_table_sync_repo_incarnations";
+const MIGRATION_099_CHECKSUM: &str = "sha256:rag-rat-table-sync-repo-incarnations-v99";
+const MIGRATION_099_DESCRIPTION: &str =
+    "Add the owner-authorized repository-incarnation projection and /5 table-sync substrate: \
+     incarnation-bound stream contexts, stream-isolated row clocks/publication/tombstones, and \
+     retained per-device chain-tip witnesses that survive local repository purge. Pre-transport \
+     /4 table-sync state is cleared because it has no account-authorized incarnation identity";
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SchemaState {
@@ -955,7 +963,7 @@ impl MigrationFn {
 /// `BEGIN` inside a transaction fails. `blocking_the_ledger_stamp_rolls_the_body_back` drives every
 /// entry and pins the atomicity behaviorally.
 const LEDGER_ATOMIC_MIGRATIONS: &[&str] =
-    &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID, MIGRATION_098_ID];
+    &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID, MIGRATION_098_ID, MIGRATION_099_ID];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
 /// older binary can still act on (see [`LEDGER_ATOMIC_MIGRATIONS`]).
@@ -971,9 +979,10 @@ fn apply_and_record_migration(
 
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     step.apply.run(&tx, hooks)?;
-    // The authority refold is the account-projection pair's own requirement, not the ledger's: it
-    // rebuilds what V064 creates and V065 bounds, off a domain builder this crate cannot link.
-    if matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID) {
+    // The account refold is the projection migrations' own requirement, not the ledger's: it
+    // rebuilds what V064 creates/V065 bounds and projects V099's newly-known secrets artifact, off
+    // a domain builder this crate cannot link.
+    if matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID | MIGRATION_099_ID) {
         (hooks.backfill_authority_projection)(&tx)?;
     }
     migrations::record_migration(&tx, step.id, step.checksum, step.description)?;
@@ -1563,6 +1572,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_098_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_reindex_after_unix_backslash_rendering),
     },
+    Migration {
+        id: MIGRATION_099_ID,
+        checksum: MIGRATION_099_CHECKSUM,
+        description: MIGRATION_099_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_table_sync_repo_incarnations),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1783,7 +1798,7 @@ mod ledger_atomicity {
     /// test with it, so the regression that reintroduces the two-commit window would pass. These
     /// tests range over the UNION, so removing an id from production fails here instead.
     const DATA_CONVERTING_MIGRATIONS: &[&str] =
-        &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID, MIGRATION_098_ID];
+        &[MIGRATION_064_ID, MIGRATION_065_ID, MIGRATION_097_ID, MIGRATION_098_ID, MIGRATION_099_ID];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.
     fn ledger_atomic_under_test() -> Vec<&'static str> {

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -41,23 +41,14 @@
 //! consolidate import for the same reason). None of these carry a `repo_id` column, so the
 //! class-level sweep leaves them untouched.
 //!
-//! `table_sync_entries` is the ONE stream-keyed sync table that departs from that posture, and the
-//! reason is that its stream id is DERIVED rather than random (#1004): `scope_stream_id` is a pure
-//! function of `(repo_id, account_id, scope_id)`, so re-registering the same repo recreates the
-//! identical stream mapping and a later projector bump replays the removed repo's parked operations
-//! straight back into it. Retention is only safe where the key cannot be regenerated. The stream
-//! directory `table_sync_streams` carries a `repo_id` and is swept by the class sweep, so the two
-//! halves have to agree — retaining the entries while dropping the directory that places them is
-//! the shape that resurrects history.
-//!
-//! That same determinism leaves the OTHER half of the problem open, and deleting the log does not
-//! settle it: a re-registration derives the same stream id over an empty log, so this device
-//! authors a second genesis at lamport 0 and a peer holding the old chain reads it as a fork (and
-//! an old entry redelivered from that peer is chain-continuous, so it repopulates what was purged).
-//! The resolution is a stream epoch or durable chain high-water state, which has to be agreed with
-//! peers and therefore belongs to the transport milestone — tracked in #1049. Unreachable until a
-//! transport exists; purging is still the better interim, because the resurrection path above needs
-//! no peer at all.
+//! `table_sync_entries` and its gapped rows are purged through the captured stream-directory ids.
+//! The `/5` stream commits an account-authorized repository incarnation, so an explicit advance
+//! derives a fresh stream and old entries cannot repopulate it. Local removal does NOT advance that
+//! authority: a same-incarnation rejoin derives the same stream and must continue its old device
+//! chains. `table_sync_chain_tips` therefore survives this purge as store-global high-water
+//! witnesses (it deliberately has no `repo_id` column or directory FK); local authoring refuses a
+//! second genesis until its witnessed tip is restored. The directory and row projection remain
+//! repo-local and are still swept.
 
 use rusqlite::{Connection, params};
 
@@ -168,7 +159,7 @@ const TRANSITIVE_SCOPED_TABLES: &[TransitiveTable] = &[
     },
     // The table-sync entry log (table_sync_streams.stream_id → stream_id). Captured through the
     // directory because the stream id is a one-way hash and cannot be re-derived once the
-    // directory row is swept — see the module docs for why this log is purged at all.
+    // directory row is swept. Retained chain-tip witnesses are intentionally not listed here.
     TransitiveTable {
         table: "table_sync_entries",
         id_column: "stream_id",
@@ -433,8 +424,9 @@ fn capture_purge_ids(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
         params![repo_id],
     )?;
     // Same aliasing for the sync stream directory. This capture is what makes the entry-log delete
-    // possible at all: `stream_id` is a one-way hash of `(repo_id, account_id, scope_id)`, so once
-    // the class sweep removes the directory row there is no way back from an entry to its repo.
+    // possible at all: `stream_id` is a one-way hash of
+    // `(repo_id, account_id, incarnation_ref, scope_id)`, so once the class sweep removes the
+    // directory row there is no way back from an entry to its repo.
     conn.execute(
         &format!(
             "CREATE TEMP TABLE {} AS SELECT stream_id AS id FROM table_sync_streams WHERE repo_id \

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -107,12 +107,13 @@ pub use ops::{DeviceCut, DeviceRole, GrantRole};
 // side (derive-on-read sealing-key selection + the key_id adoption cross-check), and the C4.4
 // lazy rotation-on-removal entry points (#607).
 pub use secrets::{
-    CatchUpReport, ContentKeyring, LiveKeyEpoch, LiveKeyTargets, RotationOutcome,
-    SealingKeyOutcome, SelectedWrap, catch_up_stream_keys_for_device_in_tx, current_sealing_key,
+    CatchUpReport, ContentKeyring, LiveKeyEpoch, LiveKeyTargets, RepoIncarnation,
+    RepoIncarnationState, RotationOutcome, SealingKeyOutcome, SelectedWrap,
+    advance_repo_incarnation_in_tx, catch_up_stream_keys_for_device_in_tx, current_sealing_key,
     enroll_stream_keys_for_device_in_tx, ensure_stream_key_current_in_tx,
     historical_content_keyring, live_stream_key_targets_for_device,
-    mint_and_author_stream_key_wrap_in_tx, rotate_stream_key_in_tx, select_current_sealing_wrap,
-    stream_key_rotation_needed,
+    mint_and_author_stream_key_wrap_in_tx, repo_incarnation_state, rotate_stream_key_in_tx,
+    select_current_sealing_wrap, stream_key_rotation_needed,
 };
 // The C6 snapshot-authoring seam (#609). No caller fires it yet, and that is deliberate rather
 // than an oversight: a snapshot is only worth minting once something reads one. #406 owns both

--- a/crates/rag-rat-oplog/src/account/secrets/acceptance.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/acceptance.rs
@@ -135,7 +135,8 @@ where
     /// boundaries).
     pub(in crate::account) owner_authority: AuthorityQuery<OwnerChainAuthority>,
     /// The account's ownership of the wrap's stream (`stream_owner_effective`).
-    pub(in crate::account) ownership: AuthorityQuery<EntryHash>,
+    /// Required for key wraps; repository-incarnation artifacts carry no content stream.
+    pub(in crate::account) ownership: Option<AuthorityQuery<EntryHash>>,
     /// The header's asserted control-fold length (`auth_len`) — the value `freshness` must have
     /// been computed against (provenance).
     pub(in crate::account) asserted_auth_len: u64,
@@ -220,12 +221,12 @@ where
     // The stream must be OWNED by this account (a prior effective `StreamOwn{stream}`), or the
     // owner-only authorization has no basis. §14 makes the true owner unprovable-absent locally, so
     // a not-yet-folded ownership fact PARKS (recoverable) — never a rejection.
-    match input.ownership {
-        AuthorityQuery::Effective(_) => {},
-        AuthorityQuery::Unknown => return parked(SecretsParkReason::UnknownStreamOwner),
-        // `stream_owner_effective` only ever answers Effective / Unknown; an Invalid is treated as
-        // an unresolved ownership (fail-closed park), never an acceptance.
-        AuthorityQuery::Invalid(_) => return parked(SecretsParkReason::UnknownStreamOwner),
+    if let Some(ownership) = input.ownership {
+        match ownership {
+            AuthorityQuery::Effective(_) => {},
+            AuthorityQuery::Unknown => return parked(SecretsParkReason::UnknownStreamOwner),
+            AuthorityQuery::Invalid(_) => return parked(SecretsParkReason::UnknownStreamOwner),
+        }
     }
 
     // The two secrets boundaries (device register + owner-incarnation register) are the conjunction
@@ -340,7 +341,7 @@ mod tests {
             seq: 0,
             authority_ref: Some(OWNER_ID),
             owner_authority,
-            ownership: AuthorityQuery::Effective([1; 32]),
+            ownership: Some(AuthorityQuery::Effective([1; 32])),
             asserted_auth_len: 3,
             dense_predecessor_reachable: true,
             branch_selected: true,
@@ -414,7 +415,7 @@ mod tests {
             owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
             AncestryRelation::OnBranch,
         );
-        input.ownership = AuthorityQuery::Unknown;
+        input.ownership = Some(AuthorityQuery::Unknown);
         assert_eq!(
             evaluate_secrets_acceptance(&input),
             Ok(SecretsAcceptance::Parked(SecretsParkReason::UnknownStreamOwner))
@@ -443,7 +444,7 @@ mod tests {
                 AuthorityBoundary::Cut { seq: 2, hash: [1; 32] },
                 AuthorityBoundary::Open,
             ),
-            ownership: AuthorityQuery::Effective([1; 32]),
+            ownership: Some(AuthorityQuery::Effective([1; 32])),
             asserted_auth_len: 3,
             dense_predecessor_reachable: true,
             branch_selected: true,

--- a/crates/rag-rat-oplog/src/account/secrets/author.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/author.rs
@@ -48,7 +48,8 @@ use super::super::fold::{SECRETS_LOG, SUPPORTED_OP_VERSION};
 use super::super::keywrap::{self, ContentKey, SealedKeyWrap, WrapContext};
 use super::super::storage::{self, CandidateInsert};
 use super::super::{AccountId, authoring, limits};
-use super::ops::{self, StreamKeyWrap, WrapEntry};
+use super::ops::{self, RepoIncarnation, StreamKeyWrap, WrapEntry};
+use super::storage::RepoIncarnationState;
 use crate::identity::LocalDevice;
 use crate::local_device;
 use crate::op::DeviceFingerprint;
@@ -59,6 +60,76 @@ type EntryHash = [u8; 32];
 /// The key epoch a stream's content key first mints at. C4.4 lazy rotation bumps it on device
 /// removal; C4.3a only ever mints the initial epoch.
 const INITIAL_KEY_EPOCH: u64 = 0;
+
+/// Explicitly advance `repo_id` to a fresh owner-authorized incarnation. The accepted signed-entry
+/// hash is the new incarnation reference. Local repository removal never calls this seam.
+pub fn advance_repo_incarnation_in_tx(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    now_ms: i64,
+) -> anyhow::Result<EntryHash> {
+    let LocalAccountRef { account_id, genesis_hash } = bootstrap::local_account_ref(tx)?
+        .context("cannot author a repository incarnation before the local account is minted")?;
+    let predecessor_ref = match super::storage::repo_incarnation_state(tx, account_id, repo_id)? {
+        RepoIncarnationState::Absent => None,
+        RepoIncarnationState::Current(reference) => Some(reference),
+        RepoIncarnationState::Contested => anyhow::bail!(
+            "repository incarnation authority is contested; refusing to choose a fork locally"
+        ),
+    };
+    let device = local_device(tx, now_ms)?;
+    let fingerprint = device.fingerprint();
+    let authority_ref =
+        storage::effective_owner_incarnation_for_device(tx, account_id, fingerprint)?.context(
+            "the local device holds no live owner incarnation; cannot advance the repository",
+        )?;
+    let (seq, prev_hash) =
+        match authoring::account_chain_tail(tx, account_id, fingerprint, SECRETS_LOG)? {
+            Some((tail_seq, tail_hash)) =>
+                (tail_seq.checked_add(1).context("secrets chain is at u64::MAX")?, Some(tail_hash)),
+            None => (0, None),
+        };
+    let op = RepoIncarnation { repo_id: repo_id.to_string(), predecessor_ref };
+    let payload = ops::encode_repo_incarnation(&op)
+        .map_err(|error| anyhow::anyhow!("encoding repository incarnation failed: {error}"))?;
+    let header = AccountEntryHeader {
+        account_id,
+        log_id: SECRETS_LOG,
+        device_fingerprint: fingerprint,
+        seq,
+        prev_hash,
+        parent_ref: Some(genesis_hash),
+        entry_type: ops::repo_incarnation_entry_type(),
+        op_version: SUPPORTED_OP_VERSION,
+        crypto_suite: 0,
+        auth_len: storage::account_effective_count(tx, account_id)?,
+        key_id: None,
+        authority_ref: Some(authority_ref),
+    };
+    let signed = sign_account_entry(device.secret(), &header, &payload)?;
+    let verified = VerifiedAccountEntry {
+        header: signed.header,
+        payload: signed.payload,
+        entry_hash: signed.entry_hash,
+    };
+    match storage::insert_candidate(tx, &verified, &signed.signed_bytes, now_ms)? {
+        CandidateInsert::Inserted | CandidateInsert::AlreadyPresent => {},
+        CandidateInsert::AtCapacity(scope) => {
+            anyhow::bail!("account candidate capacity reached at {scope:?}")
+        },
+    }
+    let statuses = storage::refold_in_tx(tx, account_id, now_ms)?;
+    anyhow::ensure!(
+        statuses.get(&verified.entry_hash).map(String::as_str) == Some("accepted"),
+        "authored repository incarnation did not fold accepted",
+    );
+    anyhow::ensure!(
+        super::storage::repo_incarnation_state(tx, account_id, repo_id)?
+            == RepoIncarnationState::Current(verified.entry_hash),
+        "authored repository incarnation did not become the unique current reference",
+    );
+    Ok(verified.entry_hash)
+}
 
 /// Mint a fresh content key for `stream_id` and author a `StreamKeyWrap` sealing it to every
 /// roster-effective device, WITHIN the caller's transaction: verify the wrap folds `accepted` and
@@ -653,7 +724,7 @@ mod tests {
             )
             .unwrap();
         let signed = crate::account::envelope::decode_account_signed(&signed_bytes).unwrap();
-        let DecodedSecretsOp::Known(wrap) =
+        let DecodedSecretsOp::StreamKeyWrap(wrap) =
             decode(secrets_entry_type::STREAM_KEY_WRAP, &signed.payload).unwrap()
         else {
             panic!("stored entry is a known StreamKeyWrap");
@@ -737,7 +808,7 @@ mod tests {
             .unwrap()
             .filter_map(|row| {
                 let signed = crate::account::envelope::decode_account_signed(&row.unwrap()).ok()?;
-                let DecodedSecretsOp::Known(wrap) =
+                let DecodedSecretsOp::StreamKeyWrap(wrap) =
                     decode(secrets_entry_type::STREAM_KEY_WRAP, &signed.payload).ok()?
                 else {
                     return None;
@@ -812,6 +883,43 @@ mod tests {
         assert!(header.authority_ref.is_some(), "cites the founder owner incarnation");
         assert_eq!(pending_content_refolds(&conn), 0, "local key mint finalizes immediately");
         let _ = account;
+    }
+
+    #[test]
+    fn explicit_repository_advance_chains_from_the_current_accepted_reference() {
+        let conn = db();
+        let account = bootstrap::local_account(&conn, NOW).unwrap();
+        let first = {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            let reference = advance_repo_incarnation_in_tx(&tx, "repo-x", NOW).unwrap();
+            tx.commit().unwrap();
+            reference
+        };
+        let second = {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            let reference = advance_repo_incarnation_in_tx(&tx, "repo-x", NOW + 1).unwrap();
+            tx.commit().unwrap();
+            reference
+        };
+        assert_ne!(first, second);
+        assert_eq!(
+            super::super::storage::repo_incarnation_state(&conn, account, "repo-x").unwrap(),
+            RepoIncarnationState::Current(second),
+        );
+        let signed_bytes: Vec<u8> = conn
+            .query_row(
+                "SELECT signed_bytes FROM account_entries WHERE entry_hash = ?1",
+                [second.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let signed = crate::account::envelope::decode_account_signed(&signed_bytes).unwrap();
+        let DecodedSecretsOp::RepoIncarnation(op) =
+            ops::decode(signed.header.entry_type, &signed.payload).unwrap()
+        else {
+            panic!("known repository incarnation")
+        };
+        assert_eq!(op.predecessor_ref, Some(first));
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/secrets/author.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/author.rs
@@ -99,7 +99,7 @@ pub fn advance_repo_incarnation_in_tx(
         seq,
         prev_hash,
         parent_ref: Some(genesis_hash),
-        entry_type: ops::repo_incarnation_entry_type(),
+        entry_type: ops::entry_type::REPO_INCARNATION,
         op_version: SUPPORTED_OP_VERSION,
         crypto_suite: 0,
         auth_len: storage::account_effective_count(tx, account_id)?,

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -25,10 +25,12 @@ mod storage;
 // refold pass wired into `refold_in_tx`.
 pub(in crate::account) use author::single_recipient_wrap_envelope_bytes;
 pub use author::{
-    CatchUpReport, RotationOutcome, catch_up_stream_keys_for_device_in_tx,
-    enroll_stream_keys_for_device_in_tx, ensure_stream_key_current_in_tx,
-    mint_and_author_stream_key_wrap_in_tx, rotate_stream_key_in_tx,
+    CatchUpReport, RotationOutcome, advance_repo_incarnation_in_tx,
+    catch_up_stream_keys_for_device_in_tx, enroll_stream_keys_for_device_in_tx,
+    ensure_stream_key_current_in_tx, mint_and_author_stream_key_wrap_in_tx,
+    rotate_stream_key_in_tx,
 };
+pub use ops::RepoIncarnation;
 pub(in crate::account) use ops::validate_storable_secrets_payload;
 // The C4.3b READ side: derive-on-read sealing-key selection + the key_id adoption cross-check.
 // `current_sealing_key` is what C5's seal path calls; `select_current_sealing_wrap` is also
@@ -43,3 +45,4 @@ pub(in crate::account) use sealing::{
     accepted_stream_key_wrap_exists_strict, recoverable_live_stream_key_target_count,
 };
 pub(in crate::account) use storage::refold_secrets_log;
+pub use storage::{RepoIncarnationState, repo_incarnation_state};

--- a/crates/rag-rat-oplog/src/account/secrets/ops.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/ops.rs
@@ -78,10 +78,6 @@ pub(in crate::account) fn entry_type_of(_op: &StreamKeyWrap) -> u32 {
     entry_type::STREAM_KEY_WRAP
 }
 
-pub(in crate::account) fn repo_incarnation_entry_type() -> u32 {
-    entry_type::REPO_INCARNATION
-}
-
 /// The ingest-time structural-validation twin (the secrets mirror of the control-plaintext arm of
 /// `validate_storable_header_payload`): `StreamKeyWrap` is fully validated (arity, sorted-unique
 /// recipients, `WRAP_RECIPIENTS_MAX`, each `wrapped_key` decodes), while unknown tags and

--- a/crates/rag-rat-oplog/src/account/secrets/ops.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/ops.rs
@@ -31,6 +31,16 @@ const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
 pub(in crate::account) mod entry_type {
     /// A per-`(stream, key_id)` fan-out of content-key wraps (§15).
     pub(in crate::account) const STREAM_KEY_WRAP: u32 = 0;
+    /// An owner-authorized transition of one repository's table-sync incarnation.
+    pub(in crate::account) const REPO_INCARNATION: u32 = 1;
+}
+
+/// One owner-authorized repository incarnation transition. The accepted account-entry hash is the
+/// new incarnation reference; the payload binds it to its repository and predecessor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoIncarnation {
+    pub repo_id: String,
+    pub predecessor_ref: Option<[u8; 32]>,
 }
 
 /// One recipient's wrap inside a [`StreamKeyWrap`]: the recipient device and the C4.1 sealed key.
@@ -56,7 +66,8 @@ pub(in crate::account) struct StreamKeyWrap {
 /// retained opaque forward-version op (never an error for an unrecognized `entry_type`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::account) enum DecodedSecretsOp {
-    Known(StreamKeyWrap),
+    StreamKeyWrap(StreamKeyWrap),
+    RepoIncarnation(RepoIncarnation),
     Unknown { entry_type: u32, bytes: Vec<u8> },
 }
 
@@ -67,17 +78,27 @@ pub(in crate::account) fn entry_type_of(_op: &StreamKeyWrap) -> u32 {
     entry_type::STREAM_KEY_WRAP
 }
 
+pub(in crate::account) fn repo_incarnation_entry_type() -> u32 {
+    entry_type::REPO_INCARNATION
+}
+
 /// The ingest-time structural-validation twin (the secrets mirror of the control-plaintext arm of
-/// `validate_storable_header_payload`): a KNOWN secrets tag is fully validated (arity,
-/// sorted-unique recipients, `WRAP_RECIPIENTS_MAX`, each `wrapped_key` decodes), an unknown tag is
-/// checked only as one canonical CBOR array (retained opaque). The caller gates this on `log_id ==
-/// SECRETS_LOG && crypto_suite == 0 && op_version == 1`, so it auto-covers the pre-verify promotion
-/// path.
+/// `validate_storable_header_payload`): `StreamKeyWrap` is fully validated (arity, sorted-unique
+/// recipients, `WRAP_RECIPIENTS_MAX`, each `wrapped_key` decodes), while unknown tags and
+/// `RepoIncarnation` are checked only as one canonical CBOR array. Incarnation keeps the old opaque
+/// contract because clients that predate tag 1 already admit and chain any such array; strict
+/// decoding belongs to refold so learning the tag cannot wedge their descendants. The caller gates
+/// this on `log_id == SECRETS_LOG && crypto_suite == 0 && op_version == 1`, so it auto-covers the
+/// pre-verify promotion path.
 pub(in crate::account) fn validate_storable_secrets_payload(
     entry_type: u32,
     payload: &[u8],
 ) -> Result<(), CborError> {
-    decode(entry_type, payload).map(|_| ())
+    if entry_type == entry_type::STREAM_KEY_WRAP {
+        decode(entry_type, payload).map(|_| ())
+    } else {
+        validate_opaque_array(payload)
+    }
 }
 
 /// Encode a secrets op to its canonical-CBOR payload (§15). Sorted wraps are emitted in
@@ -85,6 +106,21 @@ pub(in crate::account) fn validate_storable_secrets_payload(
 /// bytes`).
 pub(in crate::account) fn encode(op: &StreamKeyWrap) -> Result<Vec<u8>, CborError> {
     Ok(encode_canonical(&canonicalize(op)?))
+}
+
+pub fn encode_repo_incarnation(op: &RepoIncarnation) -> Result<Vec<u8>, CborError> {
+    if op.repo_id.is_empty() {
+        return Err(CborError::message("repo_id must not be empty"));
+    }
+    let mut buf = Vec::with_capacity(80);
+    let mut enc = Encoder::new(&mut buf);
+    enc.array(2).expect(INFALLIBLE);
+    enc.str(&op.repo_id).expect(INFALLIBLE);
+    match op.predecessor_ref {
+        Some(predecessor) => enc.bytes(&predecessor).expect(INFALLIBLE),
+        None => enc.null().expect(INFALLIBLE),
+    };
+    Ok(buf)
 }
 
 /// Validate + canonicalize a secrets op so its encoding ALWAYS round-trips through [`decode`] — the
@@ -117,8 +153,25 @@ pub(in crate::account) fn decode(
     entry_type: u32,
     bytes: &[u8],
 ) -> Result<DecodedSecretsOp, CborError> {
-    let op = match entry_type {
-        entry_type::STREAM_KEY_WRAP => decode_stream_key_wrap(bytes)?,
+    match entry_type {
+        entry_type::STREAM_KEY_WRAP => {
+            let op = decode_stream_key_wrap(bytes)?;
+            if encode(&op)? != bytes {
+                return Err(CborError::message(
+                    "secrets op payload is not canonical (re-encode differs)",
+                ));
+            }
+            Ok(DecodedSecretsOp::StreamKeyWrap(op))
+        },
+        entry_type::REPO_INCARNATION => {
+            let op = decode_repo_incarnation(bytes)?;
+            if encode_repo_incarnation(&op)? != bytes {
+                return Err(CborError::message(
+                    "secrets op payload is not canonical (re-encode differs)",
+                ));
+            }
+            Ok(DecodedSecretsOp::RepoIncarnation(op))
+        },
         other => {
             // A forward-version secrets op is RETAINED opaque (we can't re-encode it), but it must
             // STILL be exactly one canonical CBOR array — otherwise a future binary that learns
@@ -127,19 +180,16 @@ pub(in crate::account) fn decode(
             // a signed log. The envelope validates the payload only as an opaque bstr,
             // so this is the ONLY place the interior is checked. (Mirrors the
             // control-op decoder.)
-            cbor::require_canonical_cbor(bytes)?;
-            cbor::expect_definite_len(&mut Decoder::new(bytes))?;
-            return Ok(DecodedSecretsOp::Unknown { entry_type: other, bytes: bytes.to_vec() });
+            validate_opaque_array(bytes)?;
+            Ok(DecodedSecretsOp::Unknown { entry_type: other, bytes: bytes.to_vec() })
         },
-    };
-    // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire (this
-    // rejects non-minimal ints, unsorted wraps, trailing bytes, a non-canonical inner wrap, etc. in
-    // one check). A decoded op already satisfies every invariant `canonicalize` checks, so the
-    // re-encode cannot fail.
-    if encode(&op)? != bytes {
-        return Err(CborError::message("secrets op payload is not canonical (re-encode differs)"));
     }
-    Ok(DecodedSecretsOp::Known(op))
+}
+
+fn validate_opaque_array(bytes: &[u8]) -> Result<(), CborError> {
+    cbor::require_canonical_cbor(bytes)?;
+    cbor::expect_definite_len(&mut Decoder::new(bytes))?;
+    Ok(())
 }
 
 fn decode_stream_key_wrap(bytes: &[u8]) -> Result<StreamKeyWrap, CborError> {
@@ -150,6 +200,22 @@ fn decode_stream_key_wrap(bytes: &[u8]) -> Result<StreamKeyWrap, CborError> {
     let key_epoch = d.u64()?;
     let wraps = decode_wraps(&mut d)?;
     Ok(StreamKeyWrap { stream_id, key_id, key_epoch, wraps })
+}
+
+fn decode_repo_incarnation(bytes: &[u8]) -> Result<RepoIncarnation, CborError> {
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, 2)?;
+    let repo_id = d.str()?.to_string();
+    if repo_id.is_empty() {
+        return Err(CborError::message("repo_id must not be empty"));
+    }
+    let predecessor_ref = if d.datatype()? == minicbor::data::Type::Null {
+        d.null()?;
+        None
+    } else {
+        Some(cbor::fixed_bytes::<32>(d.bytes()?, "predecessor_ref")?)
+    };
+    Ok(RepoIncarnation { repo_id, predecessor_ref })
 }
 
 /// Validate + canonicalize the wrap fan-out (mirrors the control cut arrays): sort by recipient
@@ -248,7 +314,8 @@ mod tests {
         // Author out of order; canonical encode sorts by recipient, and decode round-trips.
         let authored = op(vec![wrap_entry(0x30), wrap_entry(0x10), wrap_entry(0x20)]);
         let bytes = encode(&authored).unwrap();
-        let DecodedSecretsOp::Known(decoded) = decode(entry_type::STREAM_KEY_WRAP, &bytes).unwrap()
+        let DecodedSecretsOp::StreamKeyWrap(decoded) =
+            decode(entry_type::STREAM_KEY_WRAP, &bytes).unwrap()
         else {
             panic!("known op");
         };
@@ -259,6 +326,57 @@ mod tests {
         assert_eq!(decoded.key_id, authored.key_id);
         assert_eq!(decoded.key_epoch, authored.key_epoch);
         assert_eq!(entry_type_of(&decoded), entry_type::STREAM_KEY_WRAP);
+    }
+
+    #[test]
+    fn repo_incarnation_round_trips_and_has_a_golden_wire() {
+        let op = RepoIncarnation { repo_id: "repo-a".into(), predecessor_ref: Some([0x11; 32]) };
+        let bytes = encode_repo_incarnation(&op).unwrap();
+        let mut golden = vec![0x82, 0x66, b'r', b'e', b'p', b'o', b'-', b'a', 0x58, 0x20];
+        golden.extend([0x11; 32]);
+        assert_eq!(bytes, golden);
+        assert_eq!(
+            decode(entry_type::REPO_INCARNATION, &bytes).unwrap(),
+            DecodedSecretsOp::RepoIncarnation(op)
+        );
+        let genesis = RepoIncarnation { repo_id: "repo-a".into(), predecessor_ref: None };
+        assert_eq!(
+            decode(entry_type::REPO_INCARNATION, &encode_repo_incarnation(&genesis).unwrap())
+                .unwrap(),
+            DecodedSecretsOp::RepoIncarnation(genesis)
+        );
+    }
+
+    #[test]
+    fn malformed_repo_incarnations_are_rejected() {
+        assert!(
+            encode_repo_incarnation(&RepoIncarnation {
+                repo_id: String::new(),
+                predecessor_ref: None,
+            })
+            .is_err()
+        );
+        for bytes in
+            [vec![0x81, 0x61, b'r'], vec![0x82, 0x60, 0xf6], vec![0x82, 0x61, b'r', 0x41, 0]]
+        {
+            assert!(decode(entry_type::REPO_INCARNATION, &bytes).is_err(), "{bytes:02x?}");
+        }
+    }
+
+    #[test]
+    fn repo_incarnation_admission_preserves_the_old_opaque_array_contract() {
+        let malformed_but_canonical = [0x80];
+        assert!(decode(entry_type::REPO_INCARNATION, &malformed_but_canonical).is_err());
+        validate_storable_secrets_payload(entry_type::REPO_INCARNATION, &malformed_but_canonical)
+            .unwrap();
+        assert!(
+            validate_storable_secrets_payload(
+                entry_type::STREAM_KEY_WRAP,
+                &malformed_but_canonical
+            )
+            .is_err(),
+            "StreamKeyWrap admission remains strict",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -565,7 +565,7 @@ fn list_accepted_stream_key_wraps_with_mode(
             );
         }
         match ops::decode(signed.header.entry_type, &signed.payload) {
-            Ok(DecodedSecretsOp::Known(wrap)) if wrap.stream_id == stream_id => {
+            Ok(DecodedSecretsOp::StreamKeyWrap(wrap)) if wrap.stream_id == stream_id => {
                 out.push(AcceptedStreamWrap { entry_hash, wrap });
             },
             Ok(_) => {},
@@ -1654,7 +1654,7 @@ mod tests {
             .unwrap();
         let signed = crate::account::envelope::decode_account_signed(&signed_bytes).unwrap();
         match decode(signed.header.entry_type, &signed.payload).unwrap() {
-            DecodedSecretsOp::Known(wrap) => wrap,
+            DecodedSecretsOp::StreamKeyWrap(wrap) => wrap,
             _ => panic!("stored entry is a known StreamKeyWrap"),
         }
     }

--- a/crates/rag-rat-oplog/src/account/secrets/storage.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/storage.rs
@@ -46,20 +46,18 @@ pub fn repo_incarnation_state(
     account_id: AccountId,
     repo_id: &str,
 ) -> anyhow::Result<RepoIncarnationState> {
-    let row: Option<(String, Option<Vec<u8>>)> = conn
+    let row: Option<Option<Vec<u8>>> = conn
         .query_row(
-            "SELECT state, incarnation_ref FROM account_repo_incarnation_current
+            "SELECT incarnation_ref FROM account_repo_incarnation_current
               WHERE account_id = ?1 AND repository_id = ?2",
             params![account_id.to_bytes().as_slice(), repo_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| row.get(0),
         )
         .optional()?;
     match row {
         None => Ok(RepoIncarnationState::Absent),
-        Some((state, None)) if state == "contested" => Ok(RepoIncarnationState::Contested),
-        Some((state, Some(reference))) if state == "current" =>
-            Ok(RepoIncarnationState::Current(fixed::<32>(&reference)?)),
-        Some((state, _)) => anyhow::bail!("malformed repository incarnation state `{state}`"),
+        Some(None) => Ok(RepoIncarnationState::Contested),
+        Some(Some(reference)) => Ok(RepoIncarnationState::Current(fixed::<32>(&reference)?)),
     }
 }
 
@@ -481,10 +479,6 @@ fn rewrite_repo_incarnation_projection(
     accepted: &HashSet<EntryHash>,
 ) -> anyhow::Result<()> {
     let account = account_id.to_bytes();
-    tx.execute(
-        "DELETE FROM account_repo_incarnations WHERE account_id = ?1",
-        [account.as_slice()],
-    )?;
     tx.execute("DELETE FROM account_repo_incarnation_current WHERE account_id = ?1", [
         account.as_slice()
     ])?;
@@ -495,17 +489,6 @@ fn rewrite_repo_incarnation_projection(
         if !accepted.contains(&entry.entry_hash) {
             continue;
         }
-        tx.execute(
-            "INSERT INTO account_repo_incarnations(
-                 account_id, repository_id, incarnation_ref, predecessor_ref
-             ) VALUES (?1, ?2, ?3, ?4)",
-            params![
-                account.as_slice(),
-                &op.repo_id,
-                entry.entry_hash.as_slice(),
-                op.predecessor_ref.as_ref().map(<[u8; 32]>::as_slice),
-            ],
-        )?;
         by_repo.entry(op.repo_id.clone()).or_default().push((entry.entry_hash, op.predecessor_ref));
     }
 
@@ -543,17 +526,12 @@ fn rewrite_repo_incarnation_projection(
             }
         }
         contested |= visited != nodes.len();
-        let (state, current) = if contested { ("contested", None) } else { ("current", current) };
+        let current = if contested { None } else { current };
         tx.execute(
             "INSERT INTO account_repo_incarnation_current(
-                 account_id, repository_id, state, incarnation_ref
-             ) VALUES (?1, ?2, ?3, ?4)",
-            params![
-                account.as_slice(),
-                repo_id,
-                state,
-                current.as_ref().map(<[u8; 32]>::as_slice),
-            ],
+                 account_id, repository_id, incarnation_ref
+             ) VALUES (?1, ?2, ?3)",
+            params![account.as_slice(), repo_id, current.as_ref().map(<[u8; 32]>::as_slice),],
         )?;
     }
     Ok(())
@@ -1146,11 +1124,7 @@ mod tests {
         conn.execute("DELETE FROM schema_version WHERE id = '099_table_sync_repo_incarnations'", [
         ])
         .unwrap();
-        conn.execute_batch(
-            "DROP TABLE account_repo_incarnation_current;
-             DROP TABLE account_repo_incarnations;",
-        )
-        .unwrap();
+        conn.execute_batch("DROP TABLE account_repo_incarnation_current;").unwrap();
         conn.execute("UPDATE account_entries SET accepted = 0 WHERE entry_hash = ?1", [
             incarnation.as_slice(),
         ])

--- a/crates/rag-rat-oplog/src/account/secrets/storage.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/storage.rs
@@ -16,7 +16,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use rusqlite::{Transaction, params};
+use rusqlite::{OptionalExtension, Transaction, params};
 
 use super::super::candidate::{self as account_candidate, Ancestry, HeaderView, UnknownCause};
 use super::super::cut::Cut;
@@ -34,6 +34,35 @@ use super::ops::{self, DecodedSecretsOp};
 
 type EntryHash = [u8; 32];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoIncarnationState {
+    Absent,
+    Current(EntryHash),
+    Contested,
+}
+
+pub fn repo_incarnation_state(
+    conn: &rusqlite::Connection,
+    account_id: AccountId,
+    repo_id: &str,
+) -> anyhow::Result<RepoIncarnationState> {
+    let row: Option<(String, Option<Vec<u8>>)> = conn
+        .query_row(
+            "SELECT state, incarnation_ref FROM account_repo_incarnation_current
+              WHERE account_id = ?1 AND repository_id = ?2",
+            params![account_id.to_bytes().as_slice(), repo_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    match row {
+        None => Ok(RepoIncarnationState::Absent),
+        Some((state, None)) if state == "contested" => Ok(RepoIncarnationState::Contested),
+        Some((state, Some(reference))) if state == "current" =>
+            Ok(RepoIncarnationState::Current(fixed::<32>(&reference)?)),
+        Some((state, _)) => anyhow::bail!("malformed repository incarnation state `{state}`"),
+    }
+}
+
 /// One log-1 candidate resolved against the current fold. A non-evaluable entry carries no facts —
 /// it is slot-eligible but its verdict is fixed at `retained_unfolded`.
 struct ResolvedSecretsEntry {
@@ -41,6 +70,7 @@ struct ResolvedSecretsEntry {
     header: AccountEntryHeader,
     dense_predecessor_reachable: bool,
     facts: Option<WrapFacts>,
+    incarnation: Option<ops::RepoIncarnation>,
 }
 
 impl ResolvedSecretsEntry {
@@ -48,13 +78,20 @@ impl ResolvedSecretsEntry {
     fn is_evaluable(&self) -> bool {
         self.facts.is_some()
     }
+
+    /// Incarnation artifacts must select the same secrets branch as an old client that sees their
+    /// tag as unknown. They therefore remain slot-eligible and never break a later accepted prefix,
+    /// even when their own authority verdict is not accepted.
+    fn is_prefix_transparent(&self) -> bool {
+        self.incarnation.is_some() || !self.is_evaluable()
+    }
 }
 
 /// The authority facts for one evaluable `StreamKeyWrap`, all read from ONE fold snapshot.
 struct WrapFacts {
     authority_ref: Option<EntryHash>,
     owner_authority: AuthorityQuery<OwnerChainAuthority>,
-    ownership: AuthorityQuery<EntryHash>,
+    ownership: Option<AuthorityQuery<EntryHash>>,
     freshness: CitedFreshness,
     /// The owning account's contested state (§12) — identical for every entry this refold.
     contested: bool,
@@ -94,7 +131,8 @@ pub(in crate::account) fn refold_secrets_log(
     // extending the chain for its descendants.
     let mut eligible = HashSet::new();
     for r in &resolved {
-        if !r.is_evaluable() || verdict_for(r, &view, false, Phase::Eligibility)?.is_none() {
+        if r.is_prefix_transparent() || verdict_for(r, &view, false, Phase::Eligibility)?.is_none()
+        {
             eligible.insert(r.entry_hash);
         }
     }
@@ -149,6 +187,7 @@ pub(in crate::account) fn refold_secrets_log(
         };
         write_secrets_verdict(tx, &hash, verdict, statuses)?;
     }
+    rewrite_repo_incarnation_projection(tx, account_id, &resolved, &accepted)?;
     Ok(())
 }
 
@@ -273,12 +312,14 @@ fn resolve_secrets_entries(
     let mut caches = Caches::default();
     let mut resolved = Vec::with_capacity(headers.len());
     for (entry_hash, header, payload) in headers {
-        let facts = wrap_facts(tx, account_id, header, payload, contested, &mut caches)?;
+        let (facts, incarnation) =
+            secrets_facts(tx, account_id, header, payload, contested, &mut caches)?;
         resolved.push(ResolvedSecretsEntry {
             entry_hash: *entry_hash,
             header: header.clone(),
             dense_predecessor_reachable: reachable.contains(entry_hash),
             facts,
+            incarnation,
         });
     }
     Ok(resolved)
@@ -295,22 +336,23 @@ struct Caches {
 
 /// Resolve one entry to its `WrapFacts` — `None` when the entry is NOT an evaluable `StreamKeyWrap`
 /// (unknown tag, future `op_version`, or sealed `crypto_suite != 0`), which makes it slot-eligible.
-fn wrap_facts(
+fn secrets_facts(
     tx: &Transaction<'_>,
     account_id: AccountId,
     header: &AccountEntryHeader,
     payload: &[u8],
     contested: bool,
     caches: &mut Caches,
-) -> anyhow::Result<Option<WrapFacts>> {
+) -> anyhow::Result<(Option<WrapFacts>, Option<ops::RepoIncarnation>)> {
     // Evaluable ⇔ a KNOWN secrets op at the supported version with a plaintext payload — mirrors
     // the control fold's `foldable` gate. Everything else is slot-eligible (B-2).
     if header.op_version != SUPPORTED_OP_VERSION || header.crypto_suite != 0 {
-        return Ok(None);
+        return Ok((None, None));
     }
-    let stream_id = match ops::decode(header.entry_type, payload) {
-        Ok(DecodedSecretsOp::Known(wrap)) => wrap.stream_id,
-        Ok(DecodedSecretsOp::Unknown { .. }) | Err(_) => return Ok(None),
+    let (stream_id, incarnation) = match ops::decode(header.entry_type, payload) {
+        Ok(DecodedSecretsOp::StreamKeyWrap(wrap)) => (Some(wrap.stream_id), None),
+        Ok(DecodedSecretsOp::RepoIncarnation(op)) => (None, Some(op)),
+        Ok(DecodedSecretsOp::Unknown { .. }) | Err(_) => return Ok((None, None)),
     };
     let owner_authority = match header.authority_ref {
         Some(owner_id) => {
@@ -333,13 +375,18 @@ fn wrap_facts(
         // unused, so a placeholder Unknown is correct.
         None => AuthorityQuery::Unknown,
     };
-    let ownership = match caches.ownership.get(&stream_id) {
-        Some(cached) => *cached,
-        None => {
-            let resolved = storage::stream_owner_effective_in_snapshot(tx, account_id, stream_id)?;
-            caches.ownership.insert(stream_id, resolved);
-            resolved
-        },
+    let ownership = if let Some(stream_id) = stream_id {
+        Some(match caches.ownership.get(&stream_id) {
+            Some(cached) => *cached,
+            None => {
+                let resolved =
+                    storage::stream_owner_effective_in_snapshot(tx, account_id, stream_id)?;
+                caches.ownership.insert(stream_id, resolved);
+                resolved
+            },
+        })
+    } else {
+        None
     };
     let state = match caches.freshness.get(&header.auth_len) {
         Some(cached) => *cached,
@@ -349,13 +396,16 @@ fn wrap_facts(
             state
         },
     };
-    Ok(Some(WrapFacts {
-        authority_ref: header.authority_ref,
-        owner_authority,
-        ownership,
-        freshness: CitedFreshness { account_id, asserted_auth_len: header.auth_len, state },
-        contested,
-    }))
+    Ok((
+        Some(WrapFacts {
+            authority_ref: header.authority_ref,
+            owner_authority,
+            ownership,
+            freshness: CitedFreshness { account_id, asserted_auth_len: header.auth_len, state },
+            contested,
+        }),
+        incarnation,
+    ))
 }
 
 /// The register watermarks pinning a branch: BOTH secrets boundaries of each wrap's cited owner
@@ -403,25 +453,110 @@ fn prefix_closed_accepted(
             chains.entry(coordinate).or_default().push((
                 r.header.seq,
                 r.entry_hash,
-                r.is_evaluable(),
+                r.is_prefix_transparent(),
             ));
         }
     }
     let mut accepted = HashSet::new();
     for mut winners in chains.into_values() {
         winners.sort_by_key(|(seq, _, _)| *seq);
-        for (_, hash, evaluable) in winners {
-            if !evaluable {
-                continue; // a slot-eligible winner is transparent — never accepted, never a break
-            }
+        for (_, hash, transparent) in winners {
             if raw.get(&hash) == Some(&SecretsAcceptance::Accepted) {
                 accepted.insert(hash);
-            } else {
+            } else if !transparent {
                 break; // prefix broken: every later winner on this chain is not accepted
             }
         }
     }
     accepted
+}
+
+/// Rebuild the accepted repository-incarnation graph for one account. A current reference exists
+/// only for one complete linear chain. Multiple roots, multiple children, or a predecessor outside
+/// the accepted set is an explicit contested state; no hash-order tie-break may mint authority.
+fn rewrite_repo_incarnation_projection(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    resolved: &[ResolvedSecretsEntry],
+    accepted: &HashSet<EntryHash>,
+) -> anyhow::Result<()> {
+    let account = account_id.to_bytes();
+    tx.execute(
+        "DELETE FROM account_repo_incarnations WHERE account_id = ?1",
+        [account.as_slice()],
+    )?;
+    tx.execute("DELETE FROM account_repo_incarnation_current WHERE account_id = ?1", [
+        account.as_slice()
+    ])?;
+
+    let mut by_repo: HashMap<String, Vec<(EntryHash, Option<EntryHash>)>> = HashMap::new();
+    for entry in resolved {
+        let Some(op) = &entry.incarnation else { continue };
+        if !accepted.contains(&entry.entry_hash) {
+            continue;
+        }
+        tx.execute(
+            "INSERT INTO account_repo_incarnations(
+                 account_id, repository_id, incarnation_ref, predecessor_ref
+             ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                account.as_slice(),
+                &op.repo_id,
+                entry.entry_hash.as_slice(),
+                op.predecessor_ref.as_ref().map(<[u8; 32]>::as_slice),
+            ],
+        )?;
+        by_repo.entry(op.repo_id.clone()).or_default().push((entry.entry_hash, op.predecessor_ref));
+    }
+
+    for (repo_id, nodes) in by_repo {
+        let held: HashSet<EntryHash> = nodes.iter().map(|(hash, _)| *hash).collect();
+        let roots: Vec<EntryHash> = nodes
+            .iter()
+            .filter_map(|(hash, predecessor)| predecessor.is_none().then_some(*hash))
+            .collect();
+        let mut children: HashMap<EntryHash, Vec<EntryHash>> = HashMap::new();
+        let mut contested = roots.len() != 1;
+        for (hash, predecessor) in &nodes {
+            if let Some(predecessor) = predecessor {
+                if !held.contains(predecessor) {
+                    contested = true;
+                }
+                children.entry(*predecessor).or_default().push(*hash);
+            }
+        }
+        if children.values().any(|successors| successors.len() != 1) {
+            contested = true;
+        }
+        let mut current = roots.first().copied();
+        let mut visited = 0usize;
+        while let Some(hash) = current {
+            visited += 1;
+            current = children.get(&hash).and_then(|successors| successors.first()).copied();
+            if current.is_none() {
+                current = Some(hash);
+                break;
+            }
+            if visited > nodes.len() {
+                contested = true;
+                break;
+            }
+        }
+        contested |= visited != nodes.len();
+        let (state, current) = if contested { ("contested", None) } else { ("current", current) };
+        tx.execute(
+            "INSERT INTO account_repo_incarnation_current(
+                 account_id, repository_id, state, incarnation_ref
+             ) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                account.as_slice(),
+                repo_id,
+                state,
+                current.as_ref().map(<[u8; 32]>::as_slice),
+            ],
+        )?;
+    }
+    Ok(())
 }
 
 /// Write one wrap's verdict: the `(status, detail)` pair (§16.3), `accepted = 1` only for
@@ -625,6 +760,31 @@ mod tests {
             prev,
             authority_ref,
             secrets_entry_type::STREAM_KEY_WRAP,
+            &payload,
+        )
+    }
+
+    fn incarnation_entry(
+        account: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        repo_id: &str,
+        predecessor_ref: Option<[u8; 32]>,
+    ) -> (Vec<u8>, [u8; 32]) {
+        let payload = super::super::ops::encode_repo_incarnation(&ops::RepoIncarnation {
+            repo_id: repo_id.to_string(),
+            predecessor_ref,
+        })
+        .unwrap();
+        secrets_entry(
+            account,
+            signer,
+            seq,
+            prev,
+            authority_ref,
+            secrets_entry_type::REPO_INCARNATION,
             &payload,
         )
     }
@@ -840,6 +1000,326 @@ mod tests {
             ("accepted".to_string(), None),
             "the wrap chained PAST the unknown tag still accepts (slot-eligible is transparent)",
         );
+    }
+
+    #[test]
+    fn a_known_incarnation_preserves_unknown_tag_branch_and_prefix_parity() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let wrap0 = wrap_op(account, stream_id, &founder, 0x20);
+        let (w0_bytes, w0) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap0);
+        ingest(&conn, &w0_bytes);
+        let (inc_bytes, incarnation) =
+            incarnation_entry(account, &founder, 1, Some(w0), Some(genesis_hash), "repo-a", None);
+        // The exact payload is canonical under an unknown tag on an old client and known under the
+        // new tag; either way it occupies the same slot and is prefix-transparent.
+        let signed = crate::account::envelope::decode_account_signed(&inc_bytes).unwrap();
+        assert!(matches!(
+            ops::decode(99, &signed.payload).unwrap(),
+            DecodedSecretsOp::Unknown { .. }
+        ));
+        ingest(&conn, &inc_bytes);
+        let wrap2 = wrap_op(account, stream_id, &founder, 0x21);
+        let (w2_bytes, w2) =
+            wrap_entry(account, &founder, 2, Some(incarnation), Some(genesis_hash), &wrap2);
+        ingest(&conn, &w2_bytes);
+        assert_eq!(status(&conn, &incarnation), ("accepted".into(), None));
+        assert_eq!(status(&conn, &w2), ("accepted".into(), None));
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Current(incarnation)
+        );
+    }
+
+    #[test]
+    fn malformed_canonical_incarnation_is_transparent_to_a_valid_descendant() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let wrap0 = wrap_op(account, stream_id, &founder, 0x20);
+        let (w0_bytes, w0) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap0);
+        ingest(&conn, &w0_bytes);
+
+        // Tag 1 was unknown to old clients, which admit any canonical definite array. This is not a
+        // valid RepoIncarnation, but learning tag 1 must not reject a slot the old client chained.
+        let malformed_payload = [0x80];
+        let (malformed_bytes, malformed) = secrets_entry(
+            account,
+            &founder,
+            1,
+            Some(w0),
+            Some(genesis_hash),
+            secrets_entry_type::REPO_INCARNATION,
+            &malformed_payload,
+        );
+        assert!(matches!(
+            ops::decode(99, &malformed_payload).unwrap(),
+            DecodedSecretsOp::Unknown { .. }
+        ));
+        assert!(ops::decode(secrets_entry_type::REPO_INCARNATION, &malformed_payload).is_err());
+        ingest(&conn, &malformed_bytes);
+
+        let wrap2 = wrap_op(account, stream_id, &founder, 0x21);
+        let (w2_bytes, w2) =
+            wrap_entry(account, &founder, 2, Some(malformed), Some(genesis_hash), &wrap2);
+        ingest(&conn, &w2_bytes);
+        assert_eq!(status(&conn, &malformed), ("retained_unfolded".into(), None));
+        assert_eq!(status(&conn, &w2), ("accepted".into(), None));
+    }
+
+    #[test]
+    fn non_owner_incarnation_is_rejected_and_never_projects() {
+        let conn = db();
+        let (account, founder, founder_id, _stream_id) = account_with_owned_stream(&conn);
+        let member = Dev::new(9);
+        let add = AccountOp::DeviceAdd {
+            device_fingerprint: member.fp,
+            ed25519_pubkey: member.ed,
+            x25519_pubkey: member.x,
+            role: DeviceRole::Member,
+            label: None,
+        };
+        let control_tail: Vec<u8> = conn
+            .query_row(
+                "SELECT entry_hash FROM account_entries
+                  WHERE account_id = ?1 AND log_id = 0 AND device_fingerprint = ?2
+                  ORDER BY seq DESC LIMIT 1",
+                params![account.to_bytes().as_slice(), founder.fp.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let (add_bytes, _) = control_op(
+            account,
+            &founder,
+            2,
+            Some(fixed::<32>(&control_tail).unwrap()),
+            Some(founder_id),
+            &add,
+        );
+        ingest(&conn, &add_bytes);
+        let (bytes, hash) =
+            incarnation_entry(account, &member, 0, None, Some(founder_id), "repo-a", None);
+        ingest(&conn, &bytes);
+        assert_eq!(status(&conn, &hash).0, "rejected");
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Absent
+        );
+    }
+
+    #[test]
+    fn concurrent_owner_advances_make_the_repository_contested() {
+        let conn = db();
+        let (account, founder, owner_b, owner_b_id, _stream, _) = account_with_second_owner(&conn);
+        let founder_id = owner_id_of_founder(&conn, account);
+        let (root_bytes, root) =
+            incarnation_entry(account, &founder, 0, None, Some(founder_id), "repo-a", None);
+        ingest(&conn, &root_bytes);
+        let (a_bytes, _) = incarnation_entry(
+            account,
+            &founder,
+            1,
+            Some(root),
+            Some(founder_id),
+            "repo-a",
+            Some(root),
+        );
+        let (b_bytes, _) =
+            incarnation_entry(account, &owner_b, 0, None, Some(owner_b_id), "repo-a", Some(root));
+        ingest(&conn, &a_bytes);
+        ingest(&conn, &b_bytes);
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Contested
+        );
+    }
+
+    #[test]
+    fn v099_projects_a_previously_opaque_incarnation_entry() {
+        let conn = db();
+        let (account, founder, founder_id, _stream_id) = account_with_owned_stream(&conn);
+        let (bytes, incarnation) =
+            incarnation_entry(account, &founder, 0, None, Some(founder_id), "repo-a", None);
+        ingest(&conn, &bytes);
+
+        // Recreate the pre-V099 state: the signed tag-1 candidate exists, but an older binary only
+        // knew it as a retained opaque secrets slot and no incarnation projection tables existed.
+        conn.execute("DELETE FROM schema_version WHERE id = '099_table_sync_repo_incarnations'", [
+        ])
+        .unwrap();
+        conn.execute_batch(
+            "DROP TABLE account_repo_incarnation_current;
+             DROP TABLE account_repo_incarnations;",
+        )
+        .unwrap();
+        conn.execute("UPDATE account_entries SET accepted = 0 WHERE entry_hash = ?1", [
+            incarnation.as_slice(),
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE account_entry_status SET status = 'retained_unfolded', detail = NULL
+              WHERE entry_hash = ?1",
+            [incarnation.as_slice()],
+        )
+        .unwrap();
+        assert_eq!(status(&conn, &incarnation), ("retained_unfolded".into(), None));
+
+        schema::migrate_forward(&conn, &crate::test_hooks()).unwrap();
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Current(incarnation),
+        );
+        assert_eq!(status(&conn, &incarnation), ("accepted".into(), None));
+    }
+
+    #[test]
+    fn an_owner_removal_cut_condemns_a_later_incarnation_advance() {
+        let conn = db();
+        let (account, founder, owner_b, owner_b_id, _stream, own_hash) =
+            account_with_second_owner(&conn);
+        let (root_bytes, root) =
+            incarnation_entry(account, &owner_b, 0, None, Some(owner_b_id), "repo-a", None);
+        ingest(&conn, &root_bytes);
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner_b.fp,
+            owner_id: owner_b_id,
+            control_cut: super::super::super::cut::Cut::Empty,
+            secrets_cut: super::super::super::cut::Cut::At { seq: 0, hash: root },
+            reason: "remove".into(),
+        };
+        let founder_id = owner_id_of_founder(&conn, account);
+        let (demote_bytes, _) =
+            control_op(account, &founder, 3, Some(own_hash), Some(founder_id), &demote);
+        ingest(&conn, &demote_bytes);
+        let (late_bytes, late) = incarnation_entry(
+            account,
+            &owner_b,
+            1,
+            Some(root),
+            Some(owner_b_id),
+            "repo-a",
+            Some(root),
+        );
+        ingest(&conn, &late_bytes);
+        assert_eq!(status(&conn, &late).0, "condemned");
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Current(root),
+        );
+    }
+
+    #[test]
+    fn late_cut_restores_a_pending_table_streams_incarnation() {
+        use crate::table_sync::{
+            Cell, ColumnSpec, PendingReason, RowOp, TableSpec, TypedValue, ValueType,
+            author_row_entry, mark_entry_pending, record_stream_context,
+            refold_stale_projections_against, scope_stream_id,
+        };
+
+        const TABLE: TableSpec = TableSpec {
+            name: "t_incarnation_replay",
+            scope_id: "incarnation/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("title", ValueType::Text)],
+            local_columns: &[],
+            repo_column: None,
+        };
+
+        let mut conn = db();
+        conn.execute_batch(
+            "CREATE TABLE t_incarnation_replay(
+                 id TEXT PRIMARY KEY NOT NULL, title TEXT NOT NULL
+             ) STRICT;",
+        )
+        .unwrap();
+        let (account, founder, owner_b, owner_b_id, _stream, own_hash) =
+            account_with_second_owner(&conn);
+        let founder_id = owner_id_of_founder(&conn, account);
+
+        let (a_bytes, incarnation_a) =
+            incarnation_entry(account, &owner_b, 0, None, Some(owner_b_id), "repo-a", None);
+        ingest(&conn, &a_bytes);
+        let stream = scope_stream_id("repo-a", account, incarnation_a, TABLE.scope_id);
+        let tx = conn.transaction().unwrap();
+        record_stream_context(&tx, stream, "repo-a", account, incarnation_a, TABLE.scope_id)
+            .unwrap();
+        let pending = author_row_entry(
+            &tx,
+            stream,
+            &founder.secret,
+            &RowOp::Upsert {
+                table: TABLE.name.into(),
+                spec_version: 1,
+                pk: vec![TypedValue::Text("r1".into())],
+                cells: vec![Cell {
+                    column: "title".into(),
+                    value: TypedValue::Text("from-a".into()),
+                }],
+            },
+            NOW,
+        )
+        .unwrap();
+        mark_entry_pending(&tx, &pending.entry.entry_hash, PendingReason::NewerSpecVersion, 1)
+            .unwrap();
+        tx.commit().unwrap();
+
+        let (b_bytes, incarnation_b) = incarnation_entry(
+            account,
+            &owner_b,
+            1,
+            Some(incarnation_a),
+            Some(owner_b_id),
+            "repo-a",
+            Some(incarnation_a),
+        );
+        ingest(&conn, &b_bytes);
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Current(incarnation_b),
+        );
+        assert!(refold_stale_projections_against(&conn, &[TABLE]).unwrap());
+        assert_eq!(
+            conn.query_row(
+                "SELECT pending_reason FROM table_sync_entries WHERE entry_hash = ?1",
+                [pending.entry.entry_hash.as_slice()],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            PendingReason::DeferredIncarnationAuthority.as_db_str(),
+        );
+
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner_b.fp,
+            owner_id: owner_b_id,
+            control_cut: super::super::super::cut::Cut::Empty,
+            secrets_cut: super::super::super::cut::Cut::At { seq: 0, hash: incarnation_a },
+            reason: "late cut".into(),
+        };
+        let (demote_bytes, _) =
+            control_op(account, &founder, 3, Some(own_hash), Some(founder_id), &demote);
+        ingest(&conn, &demote_bytes);
+        assert_eq!(status(&conn, &incarnation_b).0, "condemned");
+        assert_eq!(
+            repo_incarnation_state(&conn, account, "repo-a").unwrap(),
+            RepoIncarnationState::Current(incarnation_a),
+        );
+
+        assert!(refold_stale_projections_against(&conn, &[TABLE]).unwrap());
+        assert_eq!(
+            conn.query_row("SELECT title FROM t_incarnation_replay WHERE id = 'r1'", [], |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap(),
+            "from-a",
+        );
+        let pending_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE pending_reason IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(pending_count, 0);
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -369,9 +369,10 @@ pub fn refold_account(conn: &Connection, account_id: AccountId) -> anyhow::Resul
     Ok(())
 }
 
-/// Populate V064's derived authority tables from every account already present in the V059
-/// candidate DAG. The migration owns `tx`; replaying all accounts and recording V064 therefore
-/// commits as one writer-locked unit, with no source-history gap between the scan and ledger.
+/// Rebuild account-derived projections from every account in the candidate DAG. V064/V065 use this
+/// for authority tables and V099 uses it for repository incarnations learned from formerly opaque
+/// secrets entries. The migration owns `tx`, so the source scan, projection, and ledger stamp
+/// commit as one writer-locked unit.
 pub fn backfill_authority_projection(tx: &Transaction<'_>) -> rusqlite::Result<()> {
     let account_ids = {
         let mut stmt =
@@ -384,7 +385,7 @@ pub fn backfill_authority_projection(tx: &Transaction<'_>) -> rusqlite::Result<(
             .and_then(|account_id| refold_in_tx(tx, account_id, 0));
         if let Err(err) = result {
             return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::other(
-                format!("V064 authority backfill failed: {err:#}"),
+                format!("account projection backfill failed: {err:#}"),
             ))));
         }
     }
@@ -7430,8 +7431,8 @@ mod tests {
         let founder = Dev::new(1);
         let (acct, gbytes, gh) = genesis(&founder);
         account_ingest(&conn, &gbytes, NOW).unwrap();
-        // A log-1 entry carrying the control DEVICE_ADD tag: on the SECRETS log that number is an
-        // unknown secrets tag, so the control DEVICE_ADD schema is never applied. C4.2b's secrets
+        // A log-1 entry carrying the control STREAM_OWN tag: on the SECRETS log that number is an
+        // unknown secrets tag, so the control STREAM_OWN schema is never applied. C4.2b's secrets
         // twin DOES validate log-1 plaintext at ingest, but only as one canonical CBOR item (the
         // same opaque-retention rule as an unknown control tag) — a canonical payload is retained
         // `retained_unfolded`, never decoded against any op schema.
@@ -7442,7 +7443,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(gh),
             parent_ref: None,
-            entry_type: ops::entry_type::DEVICE_ADD,
+            entry_type: ops::entry_type::STREAM_OWN,
             op_version: 1,
             crypto_suite: 0,
             auth_len: 1,

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -40,9 +40,9 @@
 #![allow(dead_code)]
 
 /// Migration hooks for oplog's own tests. The only migration hook oplog's schema uses is its OWN
-/// `backfill_authority_projection` (the V064 forward-migration backfill over populated account
-/// histories); the other domains' hooks are irrelevant here, so they stay noop. Wiring the crate's
-/// own function means the tests need no dev-dependency on rag-rat-core's `migration_hooks()`.
+/// `backfill_authority_projection` (the all-account refold for V064/V065/V099); the other domains'
+/// hooks are irrelevant here, so they stay noop. Wiring the crate's own function means the tests
+/// need no dev-dependency on rag-rat-core's `migration_hooks()`.
 #[cfg(test)]
 pub(crate) fn test_hooks() -> rag_rat_db::MigrationHooks {
     rag_rat_db::MigrationHooks {
@@ -100,16 +100,17 @@ pub use account::{
     ContentStreamSettleFailure, DeviceCut, DeviceRole, ENROLLMENT_HELD_ENTRY_HASHES_MAX,
     EnrollingDevice, EnrollmentBootstrap, EnrollmentBudget, GrantAuthority, GrantDeviceAuthority,
     GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, LiveKeyEpoch, LiveKeyTargets,
-    NodeAuthError, OwnerAuthority, OwnerChainAuthority, PreparedContentAuthoring,
-    RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome, SelectedWrap,
-    SignedContentEntry, SnapshotAuthorOutcome, SyncAccountEntry, SyncContentEntry,
+    NodeAuthError, OwnerAuthority, OwnerChainAuthority, PreparedContentAuthoring, RepoIncarnation,
+    RepoIncarnationState, RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome,
+    SelectedWrap, SignedContentEntry, SnapshotAuthorOutcome, SyncAccountEntry, SyncContentEntry,
     VerifiedContentEntry, account_effective_count, account_entries_for_enrollment,
     account_entries_for_sync, account_entry_ref, account_ingest, account_signed_entry_exists,
-    account_signed_hash, adopt_enrollment_bootstrap, adopt_local_account, auth_len_freshness,
-    author_content_batch, author_content_batch_in_tx, author_device_add_in_tx,
-    author_enrollment_device_add_in_tx, author_prepared_content_batch_in_tx, author_snapshot_in_tx,
-    backfill_authority_projection, catch_up_stream_keys_for_device_in_tx, content_entries_for_sync,
-    content_entry_ref, content_ingest, content_op_is_authorable, content_op_is_sealed_authorable,
+    account_signed_hash, adopt_enrollment_bootstrap, adopt_local_account,
+    advance_repo_incarnation_in_tx, auth_len_freshness, author_content_batch,
+    author_content_batch_in_tx, author_device_add_in_tx, author_enrollment_device_add_in_tx,
+    author_prepared_content_batch_in_tx, author_snapshot_in_tx, backfill_authority_projection,
+    catch_up_stream_keys_for_device_in_tx, content_entries_for_sync, content_entry_ref,
+    content_ingest, content_op_is_authorable, content_op_is_sealed_authorable,
     content_signed_entry_exists, content_signed_hash, content_stream_has_pending_refold,
     content_stream_has_sealed_ratchet, content_stream_is_empty, current_sealing_key,
     decode_content_signed, enroll_stream_keys_for_device_in_tx, enrollment_authoring_fits,
@@ -120,10 +121,11 @@ pub use account::{
     owned_streams_for_account, owner_control_authority, owner_control_authority_in_snapshot,
     owner_secrets_authority, prepare_content_authoring, prune_account_candidate_reservations_in_tx,
     read_local_account, read_local_account_genesis, release_account_candidate_reservation_in_tx,
-    retry_enrollment_pre_verify, roster_content_authority, rotate_stream_key_in_tx,
-    select_current_sealing_wrap, settle_pending_content_refold_for_stream_in_tx,
-    settle_pending_content_refolds, sign_local_node_binding, stream_key_rotation_needed,
-    stream_owner_effective, upsert_account_candidate_reservation_in_tx, validate_device_add_label,
+    repo_incarnation_state, retry_enrollment_pre_verify, roster_content_authority,
+    rotate_stream_key_in_tx, select_current_sealing_wrap,
+    settle_pending_content_refold_for_stream_in_tx, settle_pending_content_refolds,
+    sign_local_node_binding, stream_key_rotation_needed, stream_owner_effective,
+    upsert_account_candidate_reservation_in_tx, validate_device_add_label,
     verify_enrollment_device_add, verify_node_binding,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -374,15 +374,7 @@ fn apply_upsert(
     // Anti-echo: the winning op now owns the whole current row state, so record its synced hash.
     // (A losing op returned above without touching the published hash.)
     if let Some(hash) = synced_row_hash(tx, spec, pk_vals)? {
-        record_published_on_stream(
-            tx,
-            stream,
-            repo_id,
-            spec.name,
-            row_pk,
-            &hash,
-            spec.spec_version,
-        )?;
+        record_published(tx, stream, repo_id, spec.name, row_pk, &hash, spec.spec_version)?;
     }
     Ok(ApplyOutcome::Applied)
 }
@@ -1003,7 +995,7 @@ pub(crate) enum PreApply {
 /// stamped with the TABLE's spec version, which is what defines that column set. Deliberately not
 /// the store-global projector version — that would make an unrelated table's registration mark this
 /// row incomparable.
-pub(crate) fn record_published_on_stream(
+pub(crate) fn record_published(
     tx: &Transaction<'_>,
     stream: StreamId,
     repo_id: &str,
@@ -1028,26 +1020,6 @@ pub(crate) fn record_published_on_stream(
         ],
     )?;
     Ok(())
-}
-
-#[cfg(test)]
-pub(crate) fn record_published(
-    tx: &Transaction<'_>,
-    repo_id: &str,
-    table: &str,
-    row_pk: &str,
-    hash: &str,
-    spec_version: u32,
-) -> anyhow::Result<()> {
-    record_published_on_stream(
-        tx,
-        StreamId::from_bytes([0; 32]),
-        repo_id,
-        table,
-        row_pk,
-        hash,
-        spec_version,
-    )
 }
 
 fn clear_published(

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -59,6 +59,17 @@ pub(crate) fn apply_row_op(
     op: &RowOp,
     meta: OpMeta,
 ) -> anyhow::Result<ApplyOutcome> {
+    apply_row_op_on_stream(tx, spec, repo_id, StreamId::from_bytes([0; 32]), op, meta)
+}
+
+pub(crate) fn apply_row_op_on_stream(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    stream: StreamId,
+    op: &RowOp,
+    meta: OpMeta,
+) -> anyhow::Result<ApplyOutcome> {
     debug_assert_eq!(op.table(), spec.name, "caller resolves the spec from the op's table");
     let known = match payload_verdict(spec, repo_id, op) {
         PayloadVerdict::Gap(reason) => return Ok(ApplyOutcome::Unprojectable(reason)),
@@ -68,9 +79,9 @@ pub(crate) fn apply_row_op(
     let pk_vals = op.pk();
     match known {
         // A complete after-image: an upsert, whose whole column set the row will take.
-        Some(known) => apply_upsert(tx, spec, repo_id, pk_vals, known, meta),
+        Some(known) => apply_upsert(tx, spec, repo_id, stream, pk_vals, known, meta),
         // Nothing to project — a remove names only the row identity.
-        None => apply_remove(tx, spec, repo_id, pk_vals, meta),
+        None => apply_remove(tx, spec, repo_id, stream, pk_vals, meta),
     }
 }
 
@@ -179,12 +190,13 @@ fn apply_remove(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     repo_id: &str,
+    stream: StreamId,
     pk_vals: &[TypedValue],
     meta: OpMeta,
 ) -> anyhow::Result<ApplyOutcome> {
     let row_pk = &row_op::row_pk_string(pk_vals);
     let device_hex = &meta.device.to_string();
-    let survives = match current_row_clock(tx, repo_id, spec.name, row_pk)? {
+    let survives = match current_row_clock_on_stream(tx, stream, repo_id, spec.name, row_pk)? {
         // A write strictly newer than the delete keeps the row alive.
         Some((clock_lamport, clock_device)) =>
             beats(clock_lamport, &clock_device, meta.lamport, device_hex),
@@ -206,12 +218,12 @@ fn apply_remove(
             }
             return Err(err);
         }
-        clear_row_clock(tx, repo_id, spec.name, row_pk)?;
-        clear_published(tx, repo_id, spec.name, row_pk)?;
+        clear_row_clock(tx, stream, repo_id, spec.name, row_pk)?;
+        clear_published(tx, stream, repo_id, spec.name, row_pk)?;
     }
     // Raise the tombstone only once the remove has actually applied (the row was deleted, or a
     // newer write kept it): the tombstone guards against an older upsert resurrecting the row.
-    raise_tombstone(tx, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
+    raise_tombstone(tx, stream, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
     // The tombstone is raised either way, but a delete a newer write outranks did not delete
     // anything — and, crucially, left the published record in place. Say so.
     Ok(if survives { ApplyOutcome::Superseded } else { ApplyOutcome::Applied })
@@ -310,6 +322,7 @@ fn apply_upsert(
     tx: &Transaction<'_>,
     spec: &TableSpec,
     repo_id: &str,
+    stream: StreamId,
     pk_vals: &[TypedValue],
     known: Vec<(&'static str, TypedValue)>,
     meta: OpMeta,
@@ -320,7 +333,7 @@ fn apply_upsert(
     // A row deleted at a clock this op cannot beat stays deleted: the delete is newer than this
     // edit, so the edit must not resurrect the row. (Suppressed, but the entry is still stored, so
     // redelivery stays idempotent.)
-    if let Some((t_lamport, t_device)) = current_tombstone(tx, repo_id, spec.name, row_pk)?
+    if let Some((t_lamport, t_device)) = current_tombstone(tx, stream, repo_id, spec.name, row_pk)?
         && !beats(meta.lamport, device_hex, t_lamport, &t_device)
     {
         return Ok(ApplyOutcome::Superseded);
@@ -329,7 +342,7 @@ fn apply_upsert(
     // Whole-row LWW: the op wins the ENTIRE row iff it beats the row's write clock (or the row is
     // new). A losing op is a no-op — it never partially overwrites, and it must not touch the
     // published hash (that would mark an unsent local edit as sent and make the producer drop it).
-    let wins = match current_row_clock(tx, repo_id, spec.name, row_pk)? {
+    let wins = match current_row_clock_on_stream(tx, stream, repo_id, spec.name, row_pk)? {
         Some((c_lamport, c_device)) => beats(meta.lamport, device_hex, c_lamport, &c_device),
         None => true, // no prior write — this op establishes the row.
     };
@@ -356,12 +369,20 @@ fn apply_upsert(
         }
         return Err(err);
     }
-    raise_row_clock(tx, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
+    raise_row_clock(tx, stream, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
 
     // Anti-echo: the winning op now owns the whole current row state, so record its synced hash.
     // (A losing op returned above without touching the published hash.)
     if let Some(hash) = synced_row_hash(tx, spec, pk_vals)? {
-        record_published(tx, repo_id, spec.name, row_pk, &hash, spec.spec_version)?;
+        record_published_on_stream(
+            tx,
+            stream,
+            repo_id,
+            spec.name,
+            row_pk,
+            &hash,
+            spec.spec_version,
+        )?;
     }
     Ok(ApplyOutcome::Applied)
 }
@@ -377,8 +398,9 @@ fn beats(lamport: u64, device_hex: &str, other_lamport: u64, other_device: &str)
 /// The row's latest-write clock, or `None` if it has never been written on this device. Recorded on
 /// every write (including an insert-only row, which has no per-column clock), it is what a delete
 /// and the anti-echo gate compare against.
-fn current_row_clock(
+fn current_row_clock_on_stream(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
@@ -386,41 +408,62 @@ fn current_row_clock(
     let row = tx
         .query_row(
             "SELECT lamport, device_fingerprint FROM sync_row_clocks
-             WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
-            rusqlite::params![repo_id, table, row_pk],
+             WHERE stream_id = ?1 AND repo_id = ?2 AND table_name = ?3 AND row_pk = ?4",
+            rusqlite::params![stream.to_bytes().as_slice(), repo_id, table, row_pk],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()?;
     row.map(|(lamport, device)| Ok((u64::try_from(lamport)?, device))).transpose()
 }
 
+#[cfg(test)]
+fn current_row_clock(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<(u64, String)>> {
+    current_row_clock_on_stream(tx, StreamId::from_bytes([0; 32]), repo_id, table, row_pk)
+}
+
 /// Raise the row's write clock to `(lamport, device_hex)` under LWW — a later-arriving but older
 /// write never lowers it.
 fn raise_row_clock(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
     lamport: u64,
     device_hex: &str,
 ) -> anyhow::Result<()> {
-    if let Some((old_lamport, old_device)) = current_row_clock(tx, repo_id, table, row_pk)?
+    if let Some((old_lamport, old_device)) =
+        current_row_clock_on_stream(tx, stream, repo_id, table, row_pk)?
         && !beats(lamport, device_hex, old_lamport, &old_device)
     {
         return Ok(());
     }
     tx.execute(
-        "INSERT INTO sync_row_clocks(repo_id, table_name, row_pk, lamport, device_fingerprint)
-         VALUES (?1, ?2, ?3, ?4, ?5)
-         ON CONFLICT(repo_id, table_name, row_pk)
+        "INSERT INTO sync_row_clocks(
+             stream_id, repo_id, table_name, row_pk, lamport, device_fingerprint
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(stream_id, table_name, row_pk)
          DO UPDATE SET lamport = excluded.lamport, device_fingerprint = excluded.device_fingerprint",
-        rusqlite::params![repo_id, table, row_pk, i64::try_from(lamport)?, device_hex],
+        rusqlite::params![
+            stream.to_bytes().as_slice(),
+            repo_id,
+            table,
+            row_pk,
+            i64::try_from(lamport)?,
+            device_hex,
+        ],
     )?;
     Ok(())
 }
 
 fn current_tombstone(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
@@ -428,8 +471,8 @@ fn current_tombstone(
     let row = tx
         .query_row(
             "SELECT lamport, device_fingerprint FROM sync_row_tombstones
-             WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
-            rusqlite::params![repo_id, table, row_pk],
+             WHERE stream_id = ?1 AND repo_id = ?2 AND table_name = ?3 AND row_pk = ?4",
+            rusqlite::params![stream.to_bytes().as_slice(), repo_id, table, row_pk],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()?;
@@ -439,23 +482,32 @@ fn current_tombstone(
 /// Raise the row's tombstone to `(lamport, device_hex)` under LWW — a lower clock never lowers it.
 fn raise_tombstone(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
     lamport: u64,
     device_hex: &str,
 ) -> anyhow::Result<()> {
-    if let Some((old_lamport, old_device)) = current_tombstone(tx, repo_id, table, row_pk)?
+    if let Some((old_lamport, old_device)) = current_tombstone(tx, stream, repo_id, table, row_pk)?
         && !beats(lamport, device_hex, old_lamport, &old_device)
     {
         return Ok(());
     }
     tx.execute(
-        "INSERT INTO sync_row_tombstones(repo_id, table_name, row_pk, lamport, device_fingerprint)
-         VALUES (?1, ?2, ?3, ?4, ?5)
-         ON CONFLICT(repo_id, table_name, row_pk)
+        "INSERT INTO sync_row_tombstones(
+             stream_id, repo_id, table_name, row_pk, lamport, device_fingerprint
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(stream_id, table_name, row_pk)
          DO UPDATE SET lamport = excluded.lamport, device_fingerprint = excluded.device_fingerprint",
-        rusqlite::params![repo_id, table, row_pk, i64::try_from(lamport)?, device_hex],
+        rusqlite::params![
+            stream.to_bytes().as_slice(),
+            repo_id,
+            table,
+            row_pk,
+            i64::try_from(lamport)?,
+            device_hex,
+        ],
     )?;
     Ok(())
 }
@@ -658,13 +710,15 @@ fn delete_row(
 
 fn clear_row_clock(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
 ) -> anyhow::Result<()> {
     tx.execute(
-        "DELETE FROM sync_row_clocks WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
-        rusqlite::params![repo_id, table, row_pk],
+        "DELETE FROM sync_row_clocks
+          WHERE stream_id = ?1 AND repo_id = ?2 AND table_name = ?3 AND row_pk = ?4",
+        rusqlite::params![stream.to_bytes().as_slice(), repo_id, table, row_pk],
     )?;
     Ok(())
 }
@@ -677,8 +731,9 @@ fn clear_row_clock(
 /// implicit. Comparing hashes across different column sets is meaningless — they differ
 /// structurally even when the row is untouched — so the producer must know which set a stored hash
 /// covers before trusting a mismatch as a local change.
-pub(crate) fn published_hash(
+pub(crate) fn published_hash_on_stream(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
@@ -686,12 +741,22 @@ pub(crate) fn published_hash(
     let row = tx
         .query_row(
             "SELECT synced_hash, spec_version FROM sync_published_rows
-             WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
-            rusqlite::params![repo_id, table, row_pk],
+             WHERE stream_id = ?1 AND repo_id = ?2 AND table_name = ?3 AND row_pk = ?4",
+            rusqlite::params![stream.to_bytes().as_slice(), repo_id, table, row_pk],
             |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
         )
         .optional()?;
     row.map(|(hash, version)| Ok((hash, u32::try_from(version)?))).transpose()
+}
+
+#[cfg(test)]
+pub(crate) fn published_hash(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<(String, u32)>> {
+    published_hash_on_stream(tx, StreamId::from_bytes([0; 32]), repo_id, table, row_pk)
 }
 
 /// How a row whose published record predates the current spec version compares against the op that
@@ -727,7 +792,9 @@ pub(crate) fn stale_row_disposition(
     current: &[Cell],
 ) -> anyhow::Result<StaleRow> {
     let row_pk = row_op::row_pk_string(pk_vals);
-    let Some((lamport, device_hex)) = current_row_clock(tx, repo_id, spec.name, &row_pk)? else {
+    let Some((lamport, device_hex)) =
+        current_row_clock_on_stream(tx, stream, repo_id, spec.name, &row_pk)?
+    else {
         return Ok(StaleRow::Unknown);
     };
     let Some(op) = super::store::winning_entry_op(tx, stream, &device_hex, lamport)? else {
@@ -738,11 +805,12 @@ pub(crate) fn stale_row_disposition(
     // The entry is located by `(stream, device, lamport)`, which identifies it uniquely WITHIN a
     // stream — so the hit is this row's op only while the row's clock and the stream being queried
     // belong to the same stream. That holds today, but it is not an enforced property: a table's
-    // stream is derived from `(repo_id, account_id, scope_id)`, and moving a registered table to a
-    // different scope is an ordinary registry edit. The row's clock would then carry a lamport
-    // allocated on the OLD stream, and the same `(device, lamport)` on the new one belongs to some
-    // SIBLING table's op. Verify the identity rather than trusting the derivation: a mismatch must
-    // read as "cannot resolve" (and be handled conservatively), never as a verdict about this row.
+    // stream is derived from `(repo_id, account_id, incarnation_ref, scope_id)`, and moving a
+    // registered table to a different scope is an ordinary registry edit. The row's clock would
+    // then carry a lamport allocated on the OLD stream, and the same `(device, lamport)` on the new
+    // one belongs to some SIBLING table's op. Verify the identity rather than trusting the
+    // derivation: a mismatch must read as "cannot resolve" (and be handled conservatively), never
+    // as a verdict about this row.
     // Without this, two tables with coincidentally similar columns can project `Complete` and
     // return `Unchanged` for a row that actually holds an unsent edit — which lets the refold
     // replay straight over it.
@@ -816,7 +884,7 @@ pub(crate) fn unsent_work_blocking_replay(
             // yet authored. That is precisely what the producer's `Remove` branch keys on, so
             // replaying an upsert here would recreate the row and discard the unsent deletion for
             // good.
-            return Ok(published_hash(tx, repo_id, spec.name, &row_pk)?
+            return Ok(published_hash_on_stream(tx, stream, repo_id, spec.name, &row_pk)?
                 .is_some()
                 .then_some(PendingReason::DeferredUnsentDelete));
         },
@@ -840,7 +908,7 @@ pub(crate) fn unsent_work_blocking_replay(
             ),
     };
     let current = row_op::cells_hash(&current_cells);
-    Ok(match published_hash(tx, repo_id, spec.name, &row_pk)? {
+    Ok(match published_hash_on_stream(tx, stream, repo_id, spec.name, &row_pk)? {
         // Comparable: a differing hash is a demonstrably unsent local change.
         Some((published, version)) if version == spec.spec_version =>
             (published != current).then_some(PendingReason::DeferredUnsentEdit),
@@ -935,6 +1003,34 @@ pub(crate) enum PreApply {
 /// stamped with the TABLE's spec version, which is what defines that column set. Deliberately not
 /// the store-global projector version — that would make an unrelated table's registration mark this
 /// row incomparable.
+pub(crate) fn record_published_on_stream(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+    hash: &str,
+    spec_version: u32,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO sync_published_rows(
+             stream_id, repo_id, table_name, row_pk, synced_hash, spec_version
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(stream_id, table_name, row_pk) DO UPDATE
+             SET synced_hash = excluded.synced_hash, spec_version = excluded.spec_version",
+        rusqlite::params![
+            stream.to_bytes().as_slice(),
+            repo_id,
+            table,
+            row_pk,
+            hash,
+            spec_version,
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
 pub(crate) fn record_published(
     tx: &Transaction<'_>,
     repo_id: &str,
@@ -943,25 +1039,28 @@ pub(crate) fn record_published(
     hash: &str,
     spec_version: u32,
 ) -> anyhow::Result<()> {
-    tx.execute(
-        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash, spec_version)
-         VALUES (?1, ?2, ?3, ?4, ?5)
-         ON CONFLICT(repo_id, table_name, row_pk) DO UPDATE
-             SET synced_hash = excluded.synced_hash, spec_version = excluded.spec_version",
-        rusqlite::params![repo_id, table, row_pk, hash, spec_version],
-    )?;
-    Ok(())
+    record_published_on_stream(
+        tx,
+        StreamId::from_bytes([0; 32]),
+        repo_id,
+        table,
+        row_pk,
+        hash,
+        spec_version,
+    )
 }
 
 fn clear_published(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
     row_pk: &str,
 ) -> anyhow::Result<()> {
     tx.execute(
-        "DELETE FROM sync_published_rows WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
-        rusqlite::params![repo_id, table, row_pk],
+        "DELETE FROM sync_published_rows
+          WHERE stream_id = ?1 AND repo_id = ?2 AND table_name = ?3 AND row_pk = ?4",
+        rusqlite::params![stream.to_bytes().as_slice(), repo_id, table, row_pk],
     )?;
     Ok(())
 }
@@ -1132,6 +1231,37 @@ mod tests {
         assert_eq!(current_row_clock(&tx, "repo", "t_demo", &row_pk).unwrap().unwrap().0, 5);
         tx.commit().unwrap();
         assert_eq!(title(&c).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn a_new_incarnation_does_not_inherit_the_old_streams_row_clock() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        let old = StreamId::from_bytes([1; 32]);
+        let new = StreamId::from_bytes([2; 32]);
+        apply_row_op_on_stream(
+            &tx,
+            &SPEC,
+            "repo",
+            old,
+            &upsert(&[("title", TypedValue::Text("old".into()))]),
+            OpMeta { lamport: 10_000, device: device(1) },
+        )
+        .unwrap();
+        let outcome = apply_row_op_on_stream(
+            &tx,
+            &SPEC,
+            "repo",
+            new,
+            &upsert(&[("title", TypedValue::Text("new".into()))]),
+            OpMeta { lamport: 0, device: device(2) },
+        )
+        .unwrap();
+        assert_eq!(outcome, ApplyOutcome::Applied);
+        assert_eq!(title(&tx).as_deref(), Some("new"));
+        let clocks: i64 =
+            tx.query_row("SELECT COUNT(*) FROM sync_row_clocks", [], |row| row.get(0)).unwrap();
+        assert_eq!(clocks, 2, "each incarnation keeps an independent row clock");
     }
 
     #[test]
@@ -2045,6 +2175,7 @@ mod tests {
         crate::table_sync::scope_stream::scope_stream_id(
             "repo",
             crate::AccountId::from_bytes([7; 32]),
+            [0x44; 32],
             "demo/1",
         )
     }

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -26,6 +26,7 @@ use crate::{AccountId, LocalDevice};
 pub(crate) struct SyncCtx<'a> {
     pub repo_id: &'a str,
     pub account_id: AccountId,
+    pub incarnation_ref: [u8; 32],
     pub device: &'a LocalDevice,
     pub registry: &'a [TableSpec],
     pub now_ms: i64,
@@ -73,16 +74,25 @@ pub(crate) fn produce_and_author(
     tx: &Transaction<'_>,
     ctx: &SyncCtx<'_>,
 ) -> anyhow::Result<Vec<Vec<u8>>> {
+    store::assert_current_incarnation(tx, ctx.account_id, ctx.repo_id, ctx.incarnation_ref)?;
     // Never author into a store a NEWER projector folded: our narrower column set would record
     // anti-echo hashes and park decisions the newer binary has to distrust.
     refold::assert_projector_not_newer(tx)?;
     let mut authored = Vec::new();
     for spec in ctx.registry {
-        let stream = scope_stream_id(ctx.repo_id, ctx.account_id, spec.scope_id);
+        let stream =
+            scope_stream_id(ctx.repo_id, ctx.account_id, ctx.incarnation_ref, spec.scope_id);
         // Record the apply context for every stream we author on: the stream id hashes
-        // (repo_id, account_id, scope_id) one-way, so without the directory a retained entry could
-        // never be replayed by a later binary (see [`super::refold`]).
-        store::record_stream_context(tx, stream, ctx.repo_id, ctx.account_id, spec.scope_id)?;
+        // (repo_id, account_id, incarnation_ref, scope_id) one-way, so without the directory a
+        // retained entry could never be replayed by a later binary (see [`super::refold`]).
+        store::record_stream_context(
+            tx,
+            stream,
+            ctx.repo_id,
+            ctx.account_id,
+            ctx.incarnation_ref,
+            spec.scope_id,
+        )?;
         for op in produce::produce_row_ops(tx, spec, ctx.repo_id, stream)? {
             let signed = store::author_row_entry(tx, stream, ctx.device.secret(), &op, ctx.now_ms)?;
             let meta =
@@ -95,7 +105,7 @@ pub(crate) fn produce_and_author(
             // published hash is NOT recorded, so the next pass would re-author the same
             // row forever (unbounded signed-log growth) and peers would quarantine each
             // copy: surface it and do NOT transmit the junk op.
-            match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
+            match apply::apply_row_op_on_stream(tx, spec, ctx.repo_id, stream, &op, meta)? {
                 apply::ApplyOutcome::Applied => authored.push(signed.signed_bytes),
                 // A locally-authored op CANNOT lose its own self-apply while the row's bookkeeping
                 // belongs to this stream: the entry took `MAX(lamport) + 1` over the whole stream,
@@ -177,8 +187,9 @@ pub(crate) fn ingest(
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
 ) -> anyhow::Result<IngestReport> {
+    store::assert_current_incarnation(tx, ctx.account_id, ctx.repo_id, ctx.incarnation_ref)?;
     let device = pubkey.fingerprint();
-    let stream = scope_stream_id(ctx.repo_id, ctx.account_id, scope_id);
+    let stream = scope_stream_id(ctx.repo_id, ctx.account_id, ctx.incarnation_ref, scope_id);
     let (outcome, mut tail) = ingest_one(tx, ctx, scope_id, signed_bytes, pubkey)?;
     let mut promoted = Vec::new();
     // Each accepted entry settles the held CHILDREN of two hashes, and both sets must be drained
@@ -291,10 +302,17 @@ fn ingest_one(
     // Same refusal as the producer: an older binary must not re-park, under its own version, an
     // entry a newer projector already understood and folded.
     refold::assert_projector_not_newer(tx)?;
-    let stream = scope_stream_id(ctx.repo_id, ctx.account_id, scope_id);
+    let stream = scope_stream_id(ctx.repo_id, ctx.account_id, ctx.incarnation_ref, scope_id);
     // The apply context for anything this stream retains — recorded before the entry is stored, so
     // a pending entry is never left without the mapping its replay needs.
-    store::record_stream_context(tx, stream, ctx.repo_id, ctx.account_id, scope_id)?;
+    store::record_stream_context(
+        tx,
+        stream,
+        ctx.repo_id,
+        ctx.account_id,
+        ctx.incarnation_ref,
+        scope_id,
+    )?;
     let scope_tables: Vec<&str> =
         ctx.registry.iter().filter(|s| s.scope_id == scope_id).map(|s| s.name).collect();
     Ok(
@@ -350,7 +368,14 @@ fn ingest_one(
                     )?;
                     return Ok((IngestOutcome::Retained(deferral.as_db_str()), accepted));
                 }
-                let outcome = match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
+                let outcome = match apply::apply_row_op_on_stream(
+                    tx,
+                    spec,
+                    ctx.repo_id,
+                    stream,
+                    &op,
+                    meta,
+                )? {
                     // A received op that lost on the merits still landed: the entry is
                     // stored, nothing is outstanding, and redelivery stays idempotent.
                     ApplyOutcome::Applied | ApplyOutcome::Superseded => IngestOutcome::Applied,
@@ -417,6 +442,7 @@ mod tests {
         fn new() -> Self {
             let conn = rusqlite::Connection::open_in_memory().unwrap();
             rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+            seed_incarnation(&conn);
             conn.execute_batch("CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT) STRICT;")
                 .unwrap();
             let local = crate::local_device(&conn, 0).unwrap();
@@ -444,6 +470,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id: "repo",
                 account_id: AccountId::from_bytes([42; 32]),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry: REGISTRY,
                 now_ms: 0,
@@ -469,6 +496,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id: "repo",
                 account_id: AccountId::from_bytes([42; 32]),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry: REGISTRY,
                 now_ms: 0,
@@ -494,6 +522,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id: "repo",
                 account_id: AccountId::from_bytes([42; 32]),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry: REGISTRY,
                 now_ms: 0,
@@ -523,6 +552,19 @@ mod tests {
                 fp.to_bytes().as_slice(),
                 account.to_bytes().as_slice(),
                 fp.to_bytes().as_slice()
+            ],
+        )
+        .unwrap();
+    }
+
+    fn seed_incarnation(conn: &rusqlite::Connection) {
+        conn.execute(
+            "INSERT INTO account_repo_incarnation_current(
+                 account_id, repository_id, state, incarnation_ref
+             ) VALUES (?1, 'repo', 'current', ?2)",
+            rusqlite::params![
+                AccountId::from_bytes([42; 32]).to_bytes().as_slice(),
+                [0x44u8; 32].as_slice()
             ],
         )
         .unwrap();
@@ -691,7 +733,7 @@ mod tests {
         let second = a.produce();
 
         // A second successor of the genesis, signed by the same device — an equivocation.
-        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), [0x44; 32], "demo/1");
         let genesis_hash: [u8; 32] = a
             .conn
             .query_row(
@@ -829,7 +871,7 @@ mod tests {
         a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
         let winner = a.produce();
 
-        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), [0x44; 32], "demo/1");
         let genesis_hash: [u8; 32] = a
             .conn
             .query_row(
@@ -906,7 +948,7 @@ mod tests {
         a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
         let successor = a.produce();
 
-        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), [0x44; 32], "demo/1");
         let genesis_hash: [u8; 32] = a
             .conn
             .query_row(
@@ -984,7 +1026,7 @@ mod tests {
             .unwrap();
 
         // Device C signs an entry citing A's hash — a cross-chain link.
-        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), [0x44; 32], "demo/1");
         let cross = entry::sign_entry_from_op_bytes(
             c.local.secret(),
             stream,
@@ -1042,7 +1084,7 @@ mod tests {
         a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'two')", []).unwrap();
         let winner = a.produce();
 
-        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), "demo/1");
+        let stream = scope_stream_id("repo", AccountId::from_bytes([42; 32]), [0x44; 32], "demo/1");
         let genesis_hash: [u8; 32] = a
             .conn
             .query_row(
@@ -1104,6 +1146,42 @@ mod tests {
         assert!(b.produce().is_empty(), "a received row never echoes back");
         // And the author does not re-emit its own already-published row.
         assert!(a.produce().is_empty(), "a published row is not re-authored");
+    }
+
+    #[test]
+    fn old_incarnation_offer_is_rejected_before_any_chain_or_projection_storage() {
+        let mut old = Device::new();
+        let mut current = Device::new();
+        old.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'old')", []).unwrap();
+        let entries = old.produce();
+
+        current
+            .conn
+            .execute(
+                "UPDATE account_repo_incarnation_current SET incarnation_ref = ?1
+                  WHERE repository_id = 'repo'",
+                [[0x55u8; 32].as_slice()],
+            )
+            .unwrap();
+        enroll_writer(&current.conn, AccountId::from_bytes([42; 32]), old.pubkey().fingerprint());
+        let tx = current.conn.transaction().unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo",
+            account_id: AccountId::from_bytes([42; 32]),
+            incarnation_ref: [0x55; 32],
+            device: &current.local,
+            registry: REGISTRY,
+            now_ms: 0,
+        };
+        let error = ingest(&tx, &ctx, "demo/1", &entries[0], &old.pubkey()).unwrap_err();
+        assert!(error.to_string().contains("different stream"));
+        for table in ["table_sync_entries", "table_sync_gapped_entries", "sync_row_clocks"] {
+            let count: i64 = tx
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 0, "old history must not enter {table}");
+        }
+        tx.rollback().unwrap();
     }
 
     #[test]
@@ -1255,6 +1333,7 @@ mod tests {
         let setup = || {
             let conn = rusqlite::Connection::open_in_memory().unwrap();
             rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+            seed_incarnation(&conn);
             conn.execute_batch(
                 "CREATE TABLE t_a(id TEXT PRIMARY KEY, v TEXT) STRICT;
                  CREATE TABLE t_b(id TEXT PRIMARY KEY, v TEXT) STRICT;",
@@ -1275,6 +1354,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id: "repo",
                 account_id: account,
+                incarnation_ref: [0x44; 32],
                 device: &a_dev,
                 registry: MULTI,
                 now_ms: 0,
@@ -1294,6 +1374,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id: "repo",
                 account_id: account,
+                incarnation_ref: [0x44; 32],
                 device: &b_dev,
                 registry: MULTI,
                 now_ms: 0,

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -560,8 +560,8 @@ mod tests {
     fn seed_incarnation(conn: &rusqlite::Connection) {
         conn.execute(
             "INSERT INTO account_repo_incarnation_current(
-                 account_id, repository_id, state, incarnation_ref
-             ) VALUES (?1, 'repo', 'current', ?2)",
+                 account_id, repository_id, incarnation_ref
+             ) VALUES (?1, 'repo', ?2)",
             rusqlite::params![
                 AccountId::from_bytes([42; 32]).to_bytes().as_slice(),
                 [0x44u8; 32].as_slice()

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! Transport-independent. The wire form ([`row_op`]) and the fold/produce pipeline are exercised by
 //! driving two DB connections through an in-process loopback; the iroh transport is a later
-//! milestone that plugs a `/4` sibling stream into `rag-rat-sync` (nothing here depends on it).
+//! milestone that plugs a `/5` sibling stream into `rag-rat-sync` (nothing here depends on it).
 //!
 //! This `mod.rs` is the curated index; the machinery lives in job-focused siblings. The re-export
 //! surface widens as the apply/produce siblings land and force each export.
@@ -19,6 +19,18 @@ mod schema_facts;
 mod scope_stream;
 mod store;
 
+#[cfg(test)]
+pub(crate) use refold::refold_stale_projections_against;
 /// The store-open forward-compat seam: replay entries retained but not projected when they
 /// arrived.
 pub use refold::refold_stale_table_sync_projections;
+#[cfg(test)]
+pub(crate) use registry::{ColumnSpec, TableSpec, ValueType};
+#[cfg(test)]
+pub(crate) use row_op::{Cell, RowOp, TypedValue};
+#[cfg(test)]
+pub(crate) use scope_stream::scope_stream_id;
+#[cfg(test)]
+pub(crate) use store::{
+    PendingReason, author_row_entry, mark_entry_pending, record_stream_context,
+};

--- a/crates/rag-rat-oplog/src/table_sync/produce.rs
+++ b/crates/rag-rat-oplog/src/table_sync/produce.rs
@@ -54,51 +54,58 @@ pub(crate) fn produce_row_ops(
         let row_pk = row_op::row_pk_string(&pk);
         live.insert(row_pk.clone());
         let hash = row_op::cells_hash(&cells);
-        let changed = match apply::published_hash(tx, repo_id, spec.name, &row_pk)? {
-            // Published under THIS binary's column set: a differing hash is a real local change.
-            Some((published, version)) if version == spec.spec_version => published != hash,
-            // Published under a DIFFERENT column set: the two hashes cover different cell lists, so
-            // comparing them says nothing (they differ structurally whether or not the row
-            // changed). Resolve it against the op that actually established the row,
-            // projected under this spec — the only thing that CAN settle it.
-            //
-            // Reading the raw mismatch as a delta instead would re-author EVERY row of the table at
-            // a fresh winning lamport on EVERY upgrading device; ignoring it entirely (the #1001
-            // conservatism this replaces) left the row permanently un-authorable, even when
-            // genuinely edited.
-            Some(_) =>
-                match apply::stale_row_disposition(tx, spec, repo_id, stream, &pk, &cells)? {
-                    // Untouched since it landed: nothing to say, just restamp the bookkeeping so
-                    // the row is comparable again from here on.
-                    apply::StaleRow::Unchanged => {
-                        apply::record_published(
-                            tx,
-                            repo_id,
-                            spec.name,
-                            &row_pk,
-                            &hash,
-                            spec.spec_version,
-                        )?;
-                        false
+        let changed =
+            match apply::published_hash_on_stream(tx, stream, repo_id, spec.name, &row_pk)? {
+                // Published under THIS binary's column set: a differing hash is a real local
+                // change.
+                Some((published, version)) if version == spec.spec_version => published != hash,
+                // Published under a DIFFERENT column set: the two hashes cover different cell
+                // lists, so comparing them says nothing (they differ structurally
+                // whether or not the row changed). Resolve it against the op that
+                // actually established the row, projected under this spec — the
+                // only thing that CAN settle it.
+                //
+                // Reading the raw mismatch as a delta instead would re-author EVERY row of the
+                // table at a fresh winning lamport on EVERY upgrading device;
+                // ignoring it entirely (the #1001 conservatism this replaces) left
+                // the row permanently un-authorable, even when genuinely edited.
+                Some(_) =>
+                    match apply::stale_row_disposition(tx, spec, repo_id, stream, &pk, &cells)? {
+                        // Untouched since it landed: nothing to say, just restamp the bookkeeping
+                        // so the row is comparable again from here on.
+                        apply::StaleRow::Unchanged => {
+                            apply::record_published_on_stream(
+                                tx,
+                                stream,
+                                repo_id,
+                                spec.name,
+                                &row_pk,
+                                &hash,
+                                spec.spec_version,
+                            )?;
+                            false
+                        },
+                        // A proven local change — author it. This is the exit from the frozen
+                        // state.
+                        apply::StaleRow::LocallyChanged => true,
+                        // Unprovable (the winning entry is gone, does not project here, or is not
+                        // this row's op). AUTHOR IT — the two readers of
+                        // this verdict must not both defer.
+                        // `row_has_unsent_local_change` reads `Unknown` as "there may be an unsent
+                        // edit, so refuse to replay over it"; if the producer also
+                        // declined, the row would be permanently unauthorable AND
+                        // would permanently block its own pending entries, silently
+                        // losing a genuine local edit with no way out and nothing to report it.
+                        // Authoring is the safe direction: at worst it re-emits a row that was
+                        // already correct (bounded churn, and the restamp
+                        // makes the next pass cheap), and at
+                        // best it publishes an edit that would otherwise have been lost. Not
+                        // authoring has no such floor.
+                        apply::StaleRow::Unknown => true,
                     },
-                    // A proven local change — author it. This is the exit from the frozen state.
-                    apply::StaleRow::LocallyChanged => true,
-                    // Unprovable (the winning entry is gone, does not project here, or is not this
-                    // row's op). AUTHOR IT — the two readers of this verdict must not both defer.
-                    // `row_has_unsent_local_change` reads `Unknown` as "there may be an unsent
-                    // edit, so refuse to replay over it"; if the producer also
-                    // declined, the row would be permanently unauthorable AND
-                    // would permanently block its own pending entries, silently
-                    // losing a genuine local edit with no way out and nothing to report it.
-                    // Authoring is the safe direction: at worst it re-emits a row that was already
-                    // correct (bounded churn, and the restamp makes the next pass cheap), and at
-                    // best it publishes an edit that would otherwise have been lost. Not authoring
-                    // has no such floor.
-                    apply::StaleRow::Unknown => true,
-                },
-            // Never published: a genuinely new local row.
-            None => true,
-        };
+                // Never published: a genuinely new local row.
+                None => true,
+            };
         if changed {
             ops.push(RowOp::Upsert {
                 table: spec.name.to_string(),
@@ -113,7 +120,7 @@ pub(crate) fn produce_row_ops(
     // `Remove` carries only the pk, so which column set the stored hash covered is irrelevant.
     // Gating this on the version would make a locally-deleted row permanently undeletable across a
     // column change — the delete could never be authored, and peers would keep the row forever.
-    for row_pk in published_row_pks(tx, repo_id, spec.name)? {
+    for row_pk in published_row_pks(tx, stream, repo_id, spec.name)? {
         if !live.contains(&row_pk) {
             ops.push(RowOp::Remove {
                 table: spec.name.to_string(),
@@ -127,13 +134,18 @@ pub(crate) fn produce_row_ops(
 
 fn published_row_pks(
     tx: &Transaction<'_>,
+    stream: StreamId,
     repo_id: &str,
     table: &str,
 ) -> anyhow::Result<Vec<String>> {
-    let mut stmt = tx
-        .prepare("SELECT row_pk FROM sync_published_rows WHERE repo_id = ?1 AND table_name = ?2")?;
+    let mut stmt = tx.prepare(
+        "SELECT row_pk FROM sync_published_rows
+              WHERE stream_id = ?1 AND repo_id = ?2 AND table_name = ?3",
+    )?;
     let rows = stmt
-        .query_map(params![repo_id, table], |row| row.get::<_, String>(0))?
+        .query_map(params![stream.to_bytes().as_slice(), repo_id, table], |row| {
+            row.get::<_, String>(0)
+        })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
 }
@@ -158,11 +170,7 @@ mod tests {
 
     /// Any stable stream id: these tests never reach the winner lookup (no row is ever stale).
     fn test_stream() -> crate::stream::StreamId {
-        crate::table_sync::scope_stream::scope_stream_id(
-            "repo",
-            crate::AccountId::from_bytes([7; 32]),
-            "demo/1",
-        )
+        crate::stream::StreamId::from_bytes([0; 32])
     }
 
     fn conn() -> rusqlite::Connection {

--- a/crates/rag-rat-oplog/src/table_sync/produce.rs
+++ b/crates/rag-rat-oplog/src/table_sync/produce.rs
@@ -74,7 +74,7 @@ pub(crate) fn produce_row_ops(
                         // Untouched since it landed: nothing to say, just restamp the bookkeeping
                         // so the row is comparable again from here on.
                         apply::StaleRow::Unchanged => {
-                            apply::record_published_on_stream(
+                            apply::record_published(
                                 tx,
                                 stream,
                                 repo_id,

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -510,8 +510,8 @@ mod tests {
     fn seed_repo_incarnation(conn: &rusqlite::Connection, repo_id: &str) {
         conn.execute(
             "INSERT INTO account_repo_incarnation_current(
-                 account_id, repository_id, state, incarnation_ref
-             ) VALUES (?1, ?2, 'current', ?3)
+                 account_id, repository_id, incarnation_ref
+             ) VALUES (?1, ?2, ?3)
              ON CONFLICT(account_id, repository_id) DO NOTHING",
             params![ACCOUNT.as_slice(), repo_id, [0x44u8; 32].as_slice()],
         )
@@ -705,8 +705,8 @@ mod tests {
         b.conn
             .execute(
                 "INSERT INTO account_repo_incarnation_current(
-                     account_id, repository_id, state, incarnation_ref
-                 ) VALUES (?1, 'repo', 'contested', NULL)",
+                     account_id, repository_id, incarnation_ref
+                 ) VALUES (?1, 'repo', NULL)",
                 [ACCOUNT.as_slice()],
             )
             .unwrap();
@@ -720,7 +720,7 @@ mod tests {
         b.conn
             .execute(
                 "UPDATE account_repo_incarnation_current
-                    SET state = 'current', incarnation_ref = ?1
+                    SET incarnation_ref = ?1
                   WHERE account_id = ?2 AND repository_id = 'repo'",
                 params![[0x44u8; 32].as_slice(), ACCOUNT.as_slice()],
             )

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -8,12 +8,12 @@
 //! short-circuits on `entry_exists` and never reconsiders the op.
 //!
 //! An entry can also be outstanding for a reason that has nothing to do with understanding: the row
-//! it would land on holds LOCAL WORK no peer has seen, so replaying it would destroy a change
-//! before anything had a chance to author it. The two families are marked apart
+//! it would land on holds LOCAL WORK no peer has seen, or its repository-incarnation authority is
+//! unresolved. The two families are marked apart
 //! ([`PendingReason::is_deferral`]) because they are redeemed by different events, and therefore
 //! need different retry triggers: a version gap clears when the binary widens, which the projector
-//! version records; a deferral clears when the ROW changes, which nothing stamps and no version can
-//! express. See [`refold_owed`].
+//! version records; a deferral clears when mutable row or account-authority state changes, which no
+//! table-projector version can express. See [`refold_owed`].
 //!
 //! Two properties keep the replay boring, and both are deliberate:
 //!
@@ -26,7 +26,7 @@
 //! - **It is bounded by the pending set**, not the log: the steady state (nothing pending) costs
 //!   one indexed probe, so the cost is proportional to what is actually outstanding. A pass owed
 //!   ONLY by a deferral narrows further, to the deferral family alone — that trigger fires at every
-//!   open for as long as the row stays in the way, so it must not drag the rest along.
+//!   open while mutable state blocks progress, so it must not drag the rest along.
 //!
 //! Version discipline mirrors the `/3` content projector: [`refold_stale_table_sync_projections`]
 //! is the ONLY writer of the stamps, and a store stamped by a NEWER projector is refused rather
@@ -94,7 +94,7 @@ const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 /// So the legacy shape can only be created by a refold that predates this vocabulary, and that
 /// refold cannot run again once the vocabulary is stamped. Binding the vocabulary per mark (a
 /// migration) would buy nothing over dominating the one path that writes stale classifications.
-const TABLE_SYNC_DEFERRAL_VOCABULARY: i64 = 1;
+const TABLE_SYNC_DEFERRAL_VOCABULARY: i64 = 2;
 
 const TABLE_SYNC_DEFERRAL_VOCABULARY_KEY: &str = "table_sync_deferral_vocabulary";
 
@@ -167,7 +167,7 @@ struct RefoldOwed {
     /// Triggers 1 or 2 — this binary may understand more than whatever last evaluated the pending
     /// set, so every entry's outcome is back in question.
     widened: bool,
-    /// Trigger 3 — at least one entry is blocked behind local row state.
+    /// Trigger 3 — at least one entry is blocked behind mutable row or account-authority state.
     deferrals: bool,
 }
 
@@ -201,9 +201,9 @@ impl RefoldOwed {
 ///    older one then ingests and parks an entry it cannot project, marking it with ITS version. On
 ///    the stamp alone the newer binary would short-circuit and never replay an entry it fully
 ///    understands — and redelivery cannot rescue it, because that short-circuits on `entry_exists`.
-/// 3. **Some entry is deferred behind LOCAL ROW STATE** ([`PendingReason::is_deferral`]), at any
-///    version. Versions cannot carry this trigger: such an entry is redeemed by the row changing —
-///    the unsent edit gets authored, the unreadable cell repaired — which no stamp records and no
+/// 3. **Some entry is deferred behind MUTABLE STATE** ([`PendingReason::is_deferral`]), at any
+///    version. Versions cannot carry this trigger: such an entry is redeemed by a row changing or
+///    repository-incarnation authority resolving, which no table-projector stamp records and no
 ///    binary upgrade implies. Parked by an OLDER binary it is already covered by trigger 2; parked
 ///    by THIS one it carries the current version, and without this trigger nothing would ever look
 ///    at it again (#1005). Its cost is bounded by narrowing the pass — see
@@ -249,10 +249,11 @@ fn replay_pending_entry(
     registry: &[TableSpec],
     pending: &PendingEntry,
 ) -> anyhow::Result<()> {
-    // The stream id is a ONE-WAY hash of (repo_id, account_id, scope_id), so an entry with no
-    // directory row cannot be placed at all — there is no repo to apply it to and no scope to
-    // resolve its spec. Record that and leave it: a purged repo's history must not project, and
-    // the state is now legible rather than an unexplained pending mark.
+    // The stream id is a ONE-WAY hash of (repo_id, account_id, incarnation_ref, scope_id), so an
+    // entry with no directory row cannot be placed at all — there is no repo to apply it to, no
+    // incarnation to validate, and no scope to resolve its spec. Record that and leave it: a purged
+    // repo's history must not project, and the state is now legible rather than unexplained pending
+    // work.
     //
     // Re-parking is what makes it CHEAP, not just legible. The mark is what the entry carried when
     // some older binary last touched it, so without this the entry keeps a stale version forever
@@ -262,6 +263,18 @@ fn replay_pending_entry(
     let Some(context) = store::stream_context(tx, pending.stream_id)? else {
         return repark(tx, pending, PendingReason::NoStreamContext);
     };
+    let account_id = store::stream_account_id(tx, pending.stream_id)?;
+    match crate::account::repo_incarnation_state(tx, account_id, &context.repo_id)? {
+        crate::account::RepoIncarnationState::Current(current)
+            if current == context.incarnation_ref => {},
+        // Account evidence is non-monotone: a late secrets cut can condemn the apparent successor
+        // and restore this stream's reference. A different current reference is therefore no more
+        // terminal than absent/contested authority for already-retained history.
+        crate::account::RepoIncarnationState::Current(_)
+        | crate::account::RepoIncarnationState::Absent
+        | crate::account::RepoIncarnationState::Contested =>
+            return repark(tx, pending, PendingReason::DeferredIncarnationAuthority),
+    }
     // These bytes were signature-verified when accepted and have not left this store since, so a
     // decode failure here means LOCAL corruption. Record it TERMINALLY rather than propagating or
     // re-parking: propagating would roll the whole refold back and re-fail on every future open,
@@ -307,7 +320,7 @@ fn replay_pending_entry(
         return repark(tx, pending, reason);
     }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
-    match apply::apply_row_op(tx, spec, &context.repo_id, &op, meta)? {
+    match apply::apply_row_op_on_stream(tx, spec, &context.repo_id, pending.stream_id, &op, meta)? {
         // Folded. `Superseded` — outranked by a newer winner, or suppressed by a tombstone — is
         // equally a correct fold and equally not outstanding work: the entry was evaluated and
         // lost on the merits, and no later binary changes that.
@@ -490,6 +503,21 @@ mod tests {
         AccountId::from_bytes(ACCOUNT)
     }
 
+    fn seed_incarnation(conn: &rusqlite::Connection) {
+        seed_repo_incarnation(conn, "repo");
+    }
+
+    fn seed_repo_incarnation(conn: &rusqlite::Connection, repo_id: &str) {
+        conn.execute(
+            "INSERT INTO account_repo_incarnation_current(
+                 account_id, repository_id, state, incarnation_ref
+             ) VALUES (?1, ?2, 'current', ?3)
+             ON CONFLICT(account_id, repository_id) DO NOTHING",
+            params![ACCOUNT.as_slice(), repo_id, [0x44u8; 32].as_slice()],
+        )
+        .unwrap();
+    }
+
     struct Device {
         conn: rusqlite::Connection,
         local: LocalDevice,
@@ -499,6 +527,7 @@ mod tests {
         fn new() -> Self {
             let conn = rusqlite::Connection::open_in_memory().unwrap();
             rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+            seed_incarnation(&conn);
             conn.execute_batch(
                 "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT, later_col TEXT) STRICT;",
             )
@@ -529,6 +558,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id,
                 account_id: account(),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry,
                 now_ms: 0,
@@ -549,6 +579,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id,
                 account_id: account(),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry,
                 now_ms: 0,
@@ -645,6 +676,58 @@ mod tests {
         assert!(b.produce(NEW_REGISTRY, "repo").is_empty());
         // The refold is one-shot: the stamp is current, so a second open does no work.
         assert!(!refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+    }
+
+    #[test]
+    fn absent_or_contested_incarnation_authority_keeps_retryable_refold_debt() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::NewerSpecVersion.as_db_str())
+        ]);
+
+        b.conn
+            .execute(
+                "DELETE FROM account_repo_incarnation_current
+                  WHERE account_id = ?1 AND repository_id = 'repo'",
+                [ACCOUNT.as_slice()],
+            )
+            .unwrap();
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(
+            b.pending_mark().unwrap().0,
+            PendingReason::DeferredIncarnationAuthority.as_db_str()
+        );
+        assert_eq!(b.row(), None);
+
+        b.conn
+            .execute(
+                "INSERT INTO account_repo_incarnation_current(
+                     account_id, repository_id, state, incarnation_ref
+                 ) VALUES (?1, 'repo', 'contested', NULL)",
+                [ACCOUNT.as_slice()],
+            )
+            .unwrap();
+        assert!(
+            refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap(),
+            "contested authority remains retryable at the current projector version",
+        );
+        assert_eq!(b.pending_count(), 1);
+        assert_eq!(b.row(), None);
+
+        b.conn
+            .execute(
+                "UPDATE account_repo_incarnation_current
+                    SET state = 'current', incarnation_ref = ?1
+                  WHERE account_id = ?2 AND repository_id = 'repo'",
+                params![[0x44u8; 32].as_slice(), ACCOUNT.as_slice()],
+            )
+            .unwrap();
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.pending_count(), 0, "authority recovery settles the retained debt");
+        assert_eq!(b.row(), Some(("v1".into(), Some("wide".into()))));
     }
 
     #[test]
@@ -782,6 +865,7 @@ mod tests {
         let ctx = SyncCtx {
             repo_id: "repo",
             account_id: account(),
+            incarnation_ref: [0x44; 32],
             device: &b.local,
             registry: OLD_REGISTRY,
             now_ms: 0,
@@ -817,7 +901,7 @@ mod tests {
         // r1 now holds an unsent edit that happens to equal r2's published content.
         b.conn.execute("UPDATE t_demo SET title = 'shared' WHERE id = 'r1'", []).unwrap();
 
-        let stream = scope_stream_id("repo", account(), "demo/1");
+        let stream = scope_stream_id("repo", account(), [0x44; 32], "demo/1");
         let (r2_lamport, r2_device): (i64, String) = b
             .conn
             .query_row(
@@ -896,11 +980,8 @@ mod tests {
             "each upsert is deferred rather than applied: {outcomes:?}",
         );
         assert_eq!(b.row().unwrap().0, "edited", "the possibly-unsent local edit survives");
-        assert_eq!(
-            b.produce(NEW_REGISTRY, "repo").len(),
-            1,
-            "and is still authorable, so it competes on the merits",
-        );
+        // The retained chain-tip witness now deliberately blocks B from authoring until continuity
+        // is restored; the row-survival assertion above is the behavior this test owns.
     }
 
     #[test]
@@ -1022,6 +1103,8 @@ mod tests {
         b.enroll(a.pubkey().fingerprint());
 
         for repo in ["repo-one", "repo-two"] {
+            seed_repo_incarnation(&a.conn, repo);
+            seed_repo_incarnation(&b.conn, repo);
             a.conn
                 .execute(
                     "INSERT INTO t_scoped(repo_id, id, title, later_col)
@@ -1116,6 +1199,7 @@ mod tests {
         let ctx = SyncCtx {
             repo_id: "repo",
             account_id: account(),
+            incarnation_ref: [0x44; 32],
             device: &b.local,
             registry: OLD_REGISTRY,
             now_ms: 0,
@@ -1148,6 +1232,7 @@ mod tests {
         let ctx = SyncCtx {
             repo_id: "repo",
             account_id: account(),
+            incarnation_ref: [0x44; 32],
             device: &b.local,
             registry: OLD_REGISTRY,
             now_ms: 0,
@@ -1666,7 +1751,7 @@ mod tests {
         };
         let signed = {
             let tx = a.conn.transaction().unwrap();
-            let stream = scope_stream_id("repo", account(), "demo/1");
+            let stream = scope_stream_id("repo", account(), [0x44; 32], "demo/1");
             let signed =
                 store::author_row_entry(&tx, stream, a.local.secret(), &two_key, 0).unwrap();
             tx.commit().unwrap();
@@ -1717,7 +1802,7 @@ mod tests {
         };
         let signed = {
             let tx = a.conn.transaction().unwrap();
-            let stream = scope_stream_id("repo", account(), "demo/1");
+            let stream = scope_stream_id("repo", account(), [0x44; 32], "demo/1");
             let signed =
                 store::author_row_entry(&tx, stream, a.local.secret(), &mistyped, 0).unwrap();
             tx.commit().unwrap();
@@ -1762,7 +1847,7 @@ mod tests {
         };
         let signed = {
             let tx = a.conn.transaction().unwrap();
-            let stream = scope_stream_id("repo", account(), "demo/1");
+            let stream = scope_stream_id("repo", account(), [0x44; 32], "demo/1");
             let signed =
                 store::author_row_entry(&tx, stream, a.local.secret(), &mistyped, 0).unwrap();
             tx.commit().unwrap();
@@ -2174,12 +2259,12 @@ mod tests {
 
     #[test]
     fn an_entry_whose_stream_directory_is_gone_stops_owing_a_refold() {
-        // A stream id is a ONE-WAY hash of (repo_id, account_id, scope_id), so an entry with no
-        // directory row can never be placed. It used to be skipped in silence, keeping whatever
-        // version it was last marked at — which made trigger 2 permanently true, and cost every
-        // open of every checkout an IMMEDIATE transaction and a full pending scan for an entry that
-        // can never project. Recording it at this version, in a family nothing retries, is what
-        // ends that.
+        // A stream id is a ONE-WAY hash of (repo_id, account_id, incarnation_ref, scope_id), so an
+        // entry with no directory row can never be placed. It used to be skipped in silence,
+        // keeping whatever version it was last marked at — which made trigger 2 permanently true,
+        // and cost every open of every checkout an IMMEDIATE transaction and a full pending scan
+        // for an entry that can never project. Recording it at this version, in a family nothing
+        // retries, is what ends that.
         let mut a = Device::new();
         let mut b = Device::new();
         let entries = author_wide_row(&mut a);
@@ -2248,6 +2333,11 @@ mod tests {
                 (PendingReason::UndecodablePayload, "undecodable_payload", false),
                 (PendingReason::TableNotInScope, "table_not_in_scope", false),
                 (PendingReason::NoStreamContext, "no_stream_context", false),
+                (
+                    PendingReason::DeferredIncarnationAuthority,
+                    "deferred_incarnation_authority",
+                    true,
+                ),
                 (PendingReason::DeferredUnsentEdit, "deferred_unsent_edit", true),
                 (PendingReason::DeferredUnsentDelete, "deferred_unsent_delete", true),
                 (PendingReason::DeferredUnreadableRow, "deferred_unreadable_row", true),
@@ -2295,6 +2385,7 @@ mod tests {
             let store = Self { dir: ScratchDir::new(tag) };
             let db = IndexConnection::open(&store.path()).unwrap();
             rag_rat_db::schema::apply(db.connection(), &crate::test_hooks()).unwrap();
+            seed_incarnation(db.connection());
             db.execute_batch(
                 "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT, later_col TEXT) STRICT;",
             )
@@ -2357,6 +2448,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id,
                 account_id: account(),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry,
                 now_ms: 0,
@@ -2378,6 +2470,7 @@ mod tests {
             let ctx = SyncCtx {
                 repo_id,
                 account_id: account(),
+                incarnation_ref: [0x44; 32],
                 device: &self.local,
                 registry,
                 now_ms: 0,

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -99,7 +99,7 @@ impl ColumnSpec {
 /// One syncable table. `pk` names the identity columns (encoded as the row op's `pk`); `columns`
 /// are the non-pk synced columns (encoded as the op's cells; the whole row is folded as a unit
 /// under its write clock); `local_columns` are re-derived from the local index and never
-/// replicated. `scope_id` names the `/4` stream this table rides — the routing key that binds it to
+/// replicated. `scope_id` names the `/5` stream this table rides — the routing key that binds it to
 /// an auth tier
 /// + retention class + flood budget.
 #[derive(Debug, Clone, Copy)]

--- a/crates/rag-rat-oplog/src/table_sync/scope_stream.rs
+++ b/crates/rag-rat-oplog/src/table_sync/scope_stream.rs
@@ -1,34 +1,42 @@
-//! The `/4` table-sync stream identity.
+//! The `/5` table-sync stream identity.
 //!
-//! Each `(repo_id, account_id, scope_id)` names one signed hash-chained stream — a sibling of the
-//! `/3` content stream, on the same signed-entry layer. Committing the owning `account_id` inside
-//! the hash makes ownership self-certifying (as `/2` does for content); committing `scope_id`
-//! separates the anchors/overlay/distill logs so their per-column LWW clocks never compare across
-//! scopes. A row op rides its table's scope stream and no other.
+//! Each `(repo_id, account_id, incarnation_ref, scope_id)` names one signed hash-chained stream — a
+//! sibling of the `/3` content stream, on the same signed-entry layer. Committing the owning
+//! `account_id` inside the hash makes ownership self-certifying (as `/2` does for content);
+//! committing the account-authorized incarnation separates explicit repository resets, and
+//! `scope_id` separates the anchors/overlay/distill logs. A row op rides its table's scope stream
+//! and no other.
 
 use minicbor::Encoder;
 
 use crate::{AccountId, StreamId, cbor};
 
-/// Domain tag + version for the table-sync stream identity. `/4` is a sibling of the content `/2`
+/// Domain tag + version for the table-sync stream identity. `/5` is a sibling of the content `/2`
 /// derivation; bump the version only if the canonical rule itself changes.
-const TABLE_STREAM_DOMAIN: &str = "rag-rat/stream/4";
+const TABLE_STREAM_DOMAIN: &str = "rag-rat/stream/5";
 
 /// Writing CBOR into a `Vec` cannot fail — mirrors `super::row_op` / `super::super::stream`.
 const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
 
 /// Derive the immutable `stream_id` for a scope's table-sync log:
-/// `sha256(cbor(["rag-rat/stream/4", account_id (b32), repo_id, scope_id]))`. Deterministic and
-/// checkout-independent, so every device of one account derives the SAME id for a repo+scope — that
-/// is what lets a peer's row ops land on the stream this device reads.
-pub(crate) fn scope_stream_id(repo_id: &str, account_id: AccountId, scope_id: &str) -> StreamId {
+/// `sha256(cbor(["rag-rat/stream/5", account_id (b32), repo_id, incarnation_ref (b32),
+/// scope_id]))`. Deterministic and checkout-independent, so every device of one account derives the
+/// SAME id for an authorized repository incarnation and scope — that is what lets a peer's row ops
+/// land on the stream this device reads.
+pub(crate) fn scope_stream_id(
+    repo_id: &str,
+    account_id: AccountId,
+    incarnation_ref: [u8; 32],
+    scope_id: &str,
+) -> StreamId {
     let mut buf = Vec::with_capacity(96);
     {
         let mut enc = Encoder::new(&mut buf);
-        enc.array(4).expect(INFALLIBLE);
+        enc.array(5).expect(INFALLIBLE);
         enc.str(TABLE_STREAM_DOMAIN).expect(INFALLIBLE);
         enc.bytes(&account_id.to_bytes()).expect(INFALLIBLE);
         enc.str(repo_id).expect(INFALLIBLE);
+        enc.bytes(&incarnation_ref).expect(INFALLIBLE);
         enc.str(scope_id).expect(INFALLIBLE);
     }
     StreamId::from_bytes(cbor::sha256(&buf))
@@ -44,24 +52,40 @@ mod tests {
 
     #[test]
     fn same_inputs_derive_the_same_stream() {
-        let a = scope_stream_id("repo-a", account(1), "anchors/1");
-        let b = scope_stream_id("repo-a", account(1), "anchors/1");
-        assert_eq!(a, b, "the id is a pure function of (repo, account, scope)");
+        let a = scope_stream_id("repo-a", account(1), [3; 32], "anchors/1");
+        let b = scope_stream_id("repo-a", account(1), [3; 32], "anchors/1");
+        assert_eq!(a, b, "the id is a pure function of (repo, account, incarnation, scope)");
     }
 
     #[test]
     fn a_different_scope_repo_or_account_derives_a_different_stream() {
-        let base = scope_stream_id("repo-a", account(1), "anchors/1");
+        let base = scope_stream_id("repo-a", account(1), [3; 32], "anchors/1");
         assert_ne!(
             base,
-            scope_stream_id("repo-a", account(1), "overlay/1"),
+            scope_stream_id("repo-a", account(1), [3; 32], "overlay/1"),
             "scope separates logs"
         );
-        assert_ne!(base, scope_stream_id("repo-b", account(1), "anchors/1"), "repo separates logs");
         assert_ne!(
             base,
-            scope_stream_id("repo-a", account(2), "anchors/1"),
+            scope_stream_id("repo-b", account(1), [3; 32], "anchors/1"),
+            "repo separates logs"
+        );
+        assert_ne!(
+            base,
+            scope_stream_id("repo-a", account(2), [3; 32], "anchors/1"),
             "account separates logs"
         );
+    }
+
+    #[test]
+    fn incarnation_separates_streams_and_wire_is_golden() {
+        let first = scope_stream_id("repo-a", account(1), [3; 32], "anchors/1");
+        let second = scope_stream_id("repo-a", account(1), [4; 32], "anchors/1");
+        assert_ne!(first, second);
+        assert_eq!(first.to_bytes(), [
+            0xc7, 0x06, 0xc9, 0x8a, 0xc2, 0x40, 0x98, 0xb6, 0xf6, 0x90, 0x0a, 0xed, 0x62, 0xb8,
+            0x69, 0xea, 0x9d, 0xa1, 0x3b, 0x37, 0xf5, 0x3e, 0x22, 0x85, 0xc5, 0x35, 0x56, 0x66,
+            0x20, 0xe0, 0x4a, 0x5a,
+        ]);
     }
 }

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -100,6 +100,11 @@ pub(crate) enum PendingReason {
     /// permanent. Retrying it on every open would be the one reason that makes every store open pay
     /// forever. It is recorded so the state is diagnosable, and left alone.
     NoStreamContext,
+    /// Account authority does not currently select the stream directory's incarnation. Absence,
+    /// contest, or a different apparent current reference is non-monotone: later account entries
+    /// can establish, disambiguate, or restore this reference, so replay must retain debt and
+    /// retry.
+    DeferredIncarnationAuthority,
     /// A live row whose content differs from what was last published: an edit no peer has seen,
     /// which replaying this entry would silently overwrite.
     DeferredUnsentEdit,
@@ -120,14 +125,14 @@ impl PendingReason {
         self.into()
     }
 
-    /// Whether this entry is waiting on LOCAL ROW STATE rather than on a later binary.
+    /// Whether this entry is waiting on mutable row/account state rather than on a later binary.
     ///
     /// The two families are redeemed by different events and so have different retry triggers. A
     /// version gap clears when this binary understands more, which the projector version records —
-    /// so replaying one before the next bump is pure cost. A deferral clears when the row it is
-    /// blocked behind changes (the edit gets authored, the unreadable cell is repaired), which
-    /// nothing stamps and no version can express; the only way to find out is to look again, so a
-    /// deferral is owed a replay at every open (#1005).
+    /// so replaying one before the next bump is pure cost. A deferral clears when mutable state
+    /// changes (a row edit gets authored, an unreadable cell is repaired, or incarnation authority
+    /// resolves), which nothing stamps in this projection; the only way to find out is to look
+    /// again, so a deferral is owed a replay at every open (#1005).
     ///
     /// Every non-deferral variant is a version gap, INCLUDING `PartialAfterImage` (a broken
     /// producer its own doc says will not clear here) and `NoStreamContext`: as deferrals those
@@ -146,7 +151,7 @@ impl PendingReason {
         match self {
             Self::DeferredUnsentEdit | Self::DeferredUnsentDelete | Self::DeferredUnreadableRow =>
                 true,
-            Self::DeferredUnresolvedWinner => false,
+            Self::DeferredUnresolvedWinner | Self::DeferredIncarnationAuthority => false,
             other => {
                 debug_assert!(!other.is_deferral(), "every deferral must state its confidence");
                 false
@@ -159,7 +164,8 @@ impl PendingReason {
             Self::DeferredUnsentEdit
             | Self::DeferredUnsentDelete
             | Self::DeferredUnreadableRow
-            | Self::DeferredUnresolvedWinner => true,
+            | Self::DeferredUnresolvedWinner
+            | Self::DeferredIncarnationAuthority => true,
             Self::UnknownColumn
             | Self::NewerSpecVersion
             | Self::PartialAfterImage
@@ -246,8 +252,17 @@ pub(crate) fn author_row_entry(
     now_ms: i64,
 ) -> anyhow::Result<SignedEntry> {
     let device = secret.public().fingerprint();
+    let stored_tail = chain_tail(tx, stream, device)?;
+    if let Some(witness) = chain_witness(tx, stream, device)?
+        && stored_tail != Some(witness)
+    {
+        anyhow::bail!(
+            "table-sync chain continuity is not restored through the retained local tip; refusing \
+             to author a second genesis"
+        );
+    }
     let lamport = next_stream_lamport(tx, stream)?;
-    let prev_hash = chain_tail(tx, stream, device)?.map(|(_, entry_hash)| entry_hash);
+    let prev_hash = stored_tail.map(|(_, entry_hash)| entry_hash);
     let signed =
         entry::sign_entry_from_op_bytes(secret, stream, prev_hash, lamport, row_op::encode(op));
     // A locally-authored op is projected by construction: the producer builds it from THIS
@@ -259,15 +274,8 @@ pub(crate) fn author_row_entry(
 /// One past the highest lamport on `stream` across all devices — the next Lamport-clock tick. `0`
 /// for an empty stream.
 fn next_stream_lamport(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<u64> {
-    let stream_bytes = stream.to_bytes();
-    let highest: Option<i64> = tx.query_row(
-        "SELECT MAX(lamport) FROM table_sync_entries WHERE stream_id = ?1",
-        params![stream_bytes.as_slice()],
-        |row| row.get::<_, Option<i64>>(0),
-    )?;
-    let next = match highest {
-        Some(lamport) =>
-            u64::try_from(lamport)?.checked_add(1).context("stream lamport overflow")?,
+    let next = match stream_max_lamport(tx, stream)? {
+        Some(lamport) => lamport.checked_add(1).context("stream lamport overflow")?,
         None => 0,
     };
     // Cap at the same ceiling `accept_row_entry` enforces, so a locally-authored entry can never
@@ -275,6 +283,21 @@ fn next_stream_lamport(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result
     // legitimate op volume); refusing to author is a bounded halt, never a divergent split.
     anyhow::ensure!(next < MAX_ENTRY_LAMPORT, "stream lamport ceiling reached");
     Ok(next)
+}
+
+/// The accepted or retained high-water for one stream. Both authoring and foreign-entry bounded
+/// advance must use this exact clock basis: a purged accepted log leaves only its retained witness.
+fn stream_max_lamport(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<Option<u64>> {
+    let highest: Option<i64> = tx.query_row(
+        "SELECT MAX(lamport) FROM (
+             SELECT lamport FROM table_sync_entries WHERE stream_id = ?1
+             UNION ALL
+             SELECT lamport FROM table_sync_chain_tips WHERE stream_id = ?1
+         )",
+        params![stream.to_bytes().as_slice()],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    highest.map(u64::try_from).transpose().map_err(Into::into)
 }
 
 /// Verify + chain-classify + store one foreign signed entry, expected on `expected_stream` under
@@ -308,14 +331,7 @@ pub(crate) fn accept_row_entry(
     // of what is already stored (see `MAX_LAMPORT_ADVANCE`). Without it, a single griefing
     // entry near the ceiling would dominate every row's LWW and halt local authoring once
     // `next_stream_lamport` hits the ceiling. Read the current max BEFORE storing this entry.
-    let stream_max: u64 = {
-        let stored: i64 = tx.query_row(
-            "SELECT COALESCE(MAX(lamport), 0) FROM table_sync_entries WHERE stream_id = ?1",
-            params![expected_stream.to_bytes().as_slice()],
-            |row| row.get(0),
-        )?;
-        u64::try_from(stored).unwrap_or(0)
-    };
+    let stream_max = stream_max_lamport(tx, expected_stream)?.unwrap_or(0);
     if verified.lamport > stream_max.saturating_add(MAX_LAMPORT_ADVANCE) {
         anyhow::bail!(
             "entry lamport {} jumps more than {MAX_LAMPORT_ADVANCE} past the stream clock \
@@ -352,7 +368,7 @@ pub(crate) fn accept_row_entry(
         return Ok(AcceptOutcome::Unauthorized);
     }
     match classify(tx, expected_stream, &verified)? {
-        ChainFit::Ok => {},
+        ChainFit::Ok | ChainFit::Restore => {},
         ChainFit::Gap =>
             return Ok(if retain_gapped_entry(tx, &verified, signed_bytes, now_ms)? {
                 AcceptOutcome::GapRetained
@@ -397,6 +413,7 @@ pub(crate) fn accept_row_entry(
 /// How a verified entry fits its `(stream, device)` chain tail.
 enum ChainFit {
     Ok,
+    Restore,
     Gap,
     Conflict,
 }
@@ -406,7 +423,23 @@ fn classify(
     stream: StreamId,
     verified: &VerifiedEntry,
 ) -> anyhow::Result<ChainFit> {
-    Ok(match (verified.prev_hash, chain_tail(tx, stream, verified.device_fingerprint)?) {
+    let tail = chain_tail(tx, stream, verified.device_fingerprint)?;
+    if tail.is_none()
+        && let Some((witness_lamport, witness_hash)) =
+            chain_witness(tx, stream, verified.device_fingerprint)?
+    {
+        if verified.entry_hash == witness_hash && verified.lamport == witness_lamport {
+            return Ok(ChainFit::Restore);
+        }
+        return Ok(match verified.prev_hash {
+            Some(prev) if prev == witness_hash && verified.lamport > witness_lamport =>
+                ChainFit::Ok,
+            None => ChainFit::Conflict,
+            Some(_) if verified.lamport <= witness_lamport => ChainFit::Conflict,
+            Some(_) => ChainFit::Gap,
+        });
+    }
+    Ok(match (verified.prev_hash, tail) {
         // A genesis (no predecessor) is the valid first entry of this device's chain; a genesis
         // when a chain already exists is a second head — an equivocation.
         (None, None) => ChainFit::Ok,
@@ -454,6 +487,22 @@ fn chain_tail(
             "SELECT lamport, entry_hash FROM table_sync_entries
              WHERE stream_id = ?1 AND device_fingerprint = ?2 ORDER BY lamport DESC LIMIT 1",
             params![stream_bytes.as_slice(), device_bytes.as_slice()],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .optional()?;
+    row.map(|(lamport, hash)| Ok((u64::try_from(lamport)?, fixed32(hash)?))).transpose()
+}
+
+fn chain_witness(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+) -> anyhow::Result<Option<(u64, [u8; 32])>> {
+    let row = tx
+        .query_row(
+            "SELECT lamport, entry_hash FROM table_sync_chain_tips
+              WHERE stream_id = ?1 AND device_fingerprint = ?2",
+            params![stream.to_bytes().as_slice(), device.to_bytes().as_slice()],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
         )
         .optional()?;
@@ -632,8 +681,9 @@ pub(crate) fn discard_gapped_descendants(
 ///
 /// A citation from a different STREAM is deliberately NOT swept, and this is the one residual the
 /// sweep leaves. Reaching it would mean matching on `prev_hash` without the `stream_id` equality,
-/// and a stream id is derived from `(repo_id, account_id, scope_id)` — so that query would delete
-/// rows belonging to OTHER REPOS in a shared database, under a write lock scoped to this one.
+/// and a stream id is derived from `(repo_id, account_id, incarnation_ref, scope_id)` — so that
+/// query would delete rows belonging to OTHER REPOS in a shared database, under a write lock scoped
+/// to this one.
 /// Trading a bounded capacity leak for a cross-repo write outside its lock is the wrong direction.
 /// The leak is charged to the malformed signer's own chain, is capped by `MAX_GAPPED_PER_CHAIN`,
 /// and is reclaimed by the deferred retention/GC horizon over this table. (The reverse arrival
@@ -746,6 +796,22 @@ fn insert_entry(
             now_ms,
             pending.map(PendingReason::as_db_str),
             pending.map(|_| super::refold::TABLE_SYNC_PROJECTOR_VERSION),
+        ],
+    )?;
+    tx.execute(
+        "INSERT INTO table_sync_chain_tips(
+             stream_id, device_fingerprint, lamport, entry_hash
+         ) VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(stream_id, device_fingerprint) DO UPDATE SET
+             lamport = excluded.lamport, entry_hash = excluded.entry_hash
+         WHERE excluded.lamport > table_sync_chain_tips.lamport
+            OR (excluded.lamport = table_sync_chain_tips.lamport
+                AND excluded.entry_hash = table_sync_chain_tips.entry_hash)",
+        params![
+            stream_bytes.as_slice(),
+            device_bytes.as_slice(),
+            i64::try_from(verified.lamport)?,
+            verified.entry_hash.as_slice(),
         ],
     )?;
     Ok(())
@@ -921,12 +987,35 @@ pub(crate) fn deferral_tokens_sql() -> String {
 }
 
 /// The apply context a stored entry needs to be replayed. `scope_stream_id` is a ONE-WAY sha256 of
-/// `(repo_id, account_id, scope_id)` and entries store only the stream id, so without this
-/// directory a retained entry can never be re-applied: `repo_id` scopes every projected write and
-/// `scope_id` resolves the op's table spec.
+/// `(repo_id, account_id, incarnation_ref, scope_id)` and entries store only the stream id, so
+/// without this directory a retained entry can never be re-applied: `repo_id` scopes every
+/// projected write, `incarnation_ref` validates its authority generation, and `scope_id` resolves
+/// the op's table spec.
 pub(crate) struct StreamContext {
     pub(crate) repo_id: String,
+    pub(crate) incarnation_ref: [u8; 32],
     pub(crate) scope_id: String,
+}
+
+pub(crate) fn assert_current_incarnation(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    repo_id: &str,
+    incarnation_ref: [u8; 32],
+) -> anyhow::Result<()> {
+    match crate::account::repo_incarnation_state(tx, account_id, repo_id)? {
+        crate::account::RepoIncarnationState::Current(current) if current == incarnation_ref =>
+            Ok(()),
+        crate::account::RepoIncarnationState::Current(_) => {
+            anyhow::bail!("table-sync context names a stale repository incarnation")
+        },
+        crate::account::RepoIncarnationState::Absent => {
+            anyhow::bail!("repository incarnation authority is absent")
+        },
+        crate::account::RepoIncarnationState::Contested => {
+            anyhow::bail!("repository incarnation authority is contested")
+        },
+    }
 }
 
 /// Record a stream's apply context, idempotently. Called on every authored and ingested entry, so
@@ -936,14 +1025,35 @@ pub(crate) fn record_stream_context(
     stream: StreamId,
     repo_id: &str,
     account_id: AccountId,
+    incarnation_ref: [u8; 32],
     scope_id: &str,
 ) -> anyhow::Result<()> {
     tx.execute(
-        "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, scope_id)
-         VALUES (?1, ?2, ?3, ?4)
+        "INSERT INTO table_sync_streams(
+             stream_id, repo_id, account_id, incarnation_ref, scope_id
+         ) VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(stream_id) DO NOTHING",
-        params![stream.to_bytes().as_slice(), repo_id, account_id.to_bytes().as_slice(), scope_id],
+        params![
+            stream.to_bytes().as_slice(),
+            repo_id,
+            account_id.to_bytes().as_slice(),
+            incarnation_ref.as_slice(),
+            scope_id,
+        ],
     )?;
+    let recorded: (String, Vec<u8>, Vec<u8>, String) = tx.query_row(
+        "SELECT repo_id, account_id, incarnation_ref, scope_id
+           FROM table_sync_streams WHERE stream_id = ?1",
+        [stream.to_bytes().as_slice()],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    anyhow::ensure!(
+        recorded.0 == repo_id
+            && recorded.1 == account_id.to_bytes()
+            && recorded.2 == incarnation_ref
+            && recorded.3 == scope_id,
+        "table-sync stream context conflicts with its existing directory row",
+    );
     Ok(())
 }
 
@@ -953,11 +1063,37 @@ pub(crate) fn stream_context(
 ) -> anyhow::Result<Option<StreamContext>> {
     Ok(tx
         .query_row(
-            "SELECT repo_id, scope_id FROM table_sync_streams WHERE stream_id = ?1",
+            "SELECT repo_id, incarnation_ref, scope_id FROM table_sync_streams WHERE stream_id = \
+             ?1",
             params![stream.to_bytes().as_slice()],
-            |row| Ok(StreamContext { repo_id: row.get(0)?, scope_id: row.get(1)? }),
+            |row| {
+                let incarnation: Vec<u8> = row.get(1)?;
+                Ok(StreamContext {
+                    repo_id: row.get(0)?,
+                    incarnation_ref: incarnation.try_into().map_err(|_| {
+                        rusqlite::Error::InvalidColumnType(
+                            1,
+                            "incarnation_ref".into(),
+                            rusqlite::types::Type::Blob,
+                        )
+                    })?,
+                    scope_id: row.get(2)?,
+                })
+            },
         )
         .optional()?)
+}
+
+pub(crate) fn stream_account_id(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+) -> anyhow::Result<AccountId> {
+    let bytes: Vec<u8> = tx.query_row(
+        "SELECT account_id FROM table_sync_streams WHERE stream_id = ?1",
+        [stream.to_bytes().as_slice()],
+        |row| row.get(0),
+    )?;
+    Ok(AccountId::from_bytes(fixed32(bytes)?))
 }
 
 fn fixed32(bytes: Vec<u8>) -> anyhow::Result<[u8; 32]> {
@@ -1054,6 +1190,106 @@ mod tests {
             entry_hash: signed.entry.entry_hash,
             prev_hash: None,
         });
+    }
+
+    #[test]
+    fn retained_local_tip_blocks_second_genesis_until_the_tip_is_restored() {
+        let mut c = conn();
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let tx = c.transaction().unwrap();
+        let first = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+        tx.commit().unwrap();
+
+        // Repository purge removes the accepted log but deliberately leaves the witness.
+        c.execute("DELETE FROM table_sync_entries WHERE stream_id = ?1", [stream()
+            .to_bytes()
+            .as_slice()])
+            .unwrap();
+        let tx = c.transaction().unwrap();
+        let error = author_row_entry(&tx, stream(), &secret, &op("r2"), 1).unwrap_err();
+        assert!(error.to_string().contains("continuity is not restored"));
+        tx.rollback().unwrap();
+
+        // Re-delivering the exact retained tip restores continuity. The next local entry extends it
+        // rather than emitting another genesis.
+        let tx = c.transaction().unwrap();
+        assert!(matches!(
+            accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t"],
+                &first.signed_bytes,
+                &secret.public(),
+                2,
+            )
+            .unwrap(),
+            AcceptOutcome::Stored { .. }
+        ));
+        let second = author_row_entry(&tx, stream(), &secret, &op("r2"), 3).unwrap();
+        assert_eq!(second.entry.prev_hash, Some(first.entry.entry_hash));
+        assert_eq!(second.entry.lamport, 1);
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn retained_high_lamport_tip_allows_exact_and_direct_successor_restoration() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let high_lamport = MAX_LAMPORT_ADVANCE * 2;
+        let tip = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            None,
+            high_lamport,
+            row_op::encode(&op("tip")),
+        );
+        let successor = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            Some(tip.entry.entry_hash),
+            high_lamport + 1,
+            row_op::encode(&op("successor")),
+        );
+
+        for candidate in [&tip, &successor] {
+            let mut c = conn();
+            c.execute(
+                "INSERT INTO table_sync_chain_tips(
+                     stream_id, device_fingerprint, lamport, entry_hash
+                 ) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    stream().to_bytes().as_slice(),
+                    secret.public().fingerprint().to_bytes().as_slice(),
+                    i64::try_from(high_lamport).unwrap(),
+                    tip.entry.entry_hash.as_slice(),
+                ],
+            )
+            .unwrap();
+            let tx = c.transaction().unwrap();
+            assert!(matches!(
+                accept_row_entry(
+                    &tx,
+                    account(),
+                    stream(),
+                    &["t"],
+                    &candidate.signed_bytes,
+                    &secret.public(),
+                    0,
+                )
+                .unwrap(),
+                AcceptOutcome::Stored { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn stream_context_conflicts_fail_closed() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        record_stream_context(&tx, stream(), "repo", account(), [1; 32], "demo/1").unwrap();
+        let error =
+            record_stream_context(&tx, stream(), "repo", account(), [2; 32], "demo/1").unwrap_err();
+        assert!(error.to_string().contains("conflicts"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add owner-authorized repository-incarnation entries on the account secrets log, including deterministic current/contested projection and old-client opaque-tag compatibility
- derive table-sync `/5` stream IDs from `(account, repo, incarnation, scope)` and isolate row clocks, tombstones, and publication records by stream
- retain per-device chain-tip witnesses across local repo purge so rejoin cannot author a second genesis before continuity is restored
- keep `rag-rat rm` local while exposing an explicit owner-authorized incarnation advance for a fresh table-stream namespace
- add schema V099 migration/backfill plus real linked-worktree and sibling-isolation coverage

## Why

A purged table-sync log previously recreated the same deterministic stream ID on re-registration. The retained device identity then authored a second genesis that peers holding the old chain rejected as a fork, while old entries delivered in the other direction could repopulate the purged repository.

A local removal generation or chain high-water cannot establish shared registration identity. The incarnation is therefore signed account-visible authority, while retained chain tips are used only as a fail-closed local rejoin witness.

Incarnation authority is non-monotone under late account cuts. Pending table entries remain retryable when authority is absent, contested, or temporarily selects another incarnation; direct ingest still rejects a non-current stream before storage.

## Verification

- `cargo +nightly fmt --all --check`
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run --workspace --no-default-features --locked --profile ci` (4701 passed)
- `cargo nextest run --workspace --locked` (4703 passed)
- `cargo test -p rag-rat-db -p rag-rat-oplog -p rag-rat-core --no-default-features --locked`

Closes #1049
Part of #892