### PR TITLE
feat(sync): add bounded table-stream transport

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -110,10 +110,11 @@ struct InviteMint {
 }
 
 /// Run a headless store-and-forward peer for this account's op log: bind the sync endpoint over the
-/// configured relay and replicate with peers the roster authorizes. Serves BOTH streams a peer may
-/// negotiate — the account log (`SYNC_ALPN`) and `/3` content (`CONTENT_SYNC_ALPN`) — routing
+/// configured relay and replicate with peers the roster authorizes. Serves every stream a peer may
+/// negotiate — the account log (`SYNC_ALPN`), `/3` content (`CONTENT_SYNC_ALPN`), and repo-scoped
+/// `/5` tables (`TABLE_SYNC_ALPN`) — routing
 /// each connection by its ALPN. Runs until interrupted; `once` serves a single connection (one
-/// stream), so a full account+content sync a device drives needs two connections.
+/// stream), so a full sync requires one connection per supported ALPN.
 fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
     serve_with(config, once, None)
 }
@@ -524,11 +525,12 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
             Err(error) => return Err(anyhow!("enrollment failed: {error}")),
         }
 
-        // 2) Restore-from-zero — pull the account log then `/3` content from the inviter, now that
-        //    this device is roster-effective. Content rides on the account log's authority, so the
-        //    account log runs first. Each stream reconciles to a fixpoint (#878): a single session
-        //    can report `Done` while the store is still incomplete, so re-run until dry (or the
-        //    round cap). The inviter must still be serving (its `sync init` / `serve`).
+        // 2) Restore-from-zero — pull the account log, `/3` content, then supported `/5` table
+        //    streams from the inviter, now that this device is roster-effective. Content rides on
+        //    the account log's authority, so the account log runs first. Each stream reconciles to
+        //    a fixpoint (#878): a single session can report `Done` while the store is still
+        //    incomplete, so re-run until dry (or the round cap). The inviter must still be serving
+        //    (its `sync init` / `serve`).
         let account_report = {
             let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
             rag_rat_sync::connect_and_reconcile(
@@ -547,7 +549,7 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
             let mut store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
             rag_rat_sync::connect_and_reconcile(
                 &endpoint,
-                peer,
+                peer.clone(),
                 rag_rat_sync::CONTENT_SYNC_ALPN,
                 &mut store,
                 AuthPolicy::Closed,
@@ -556,6 +558,23 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
             )
             .await
             .map_err(|e| anyhow!("restoring content from the inviter failed: {e}"))?
+        };
+        let tables_converged = {
+            let mut store = rag_rat_sync::OplogTableSyncStore::new(conn, account_id, time::now_ms);
+            if store.has_streams()? {
+                rag_rat_sync::connect_and_table_reconcile(
+                    &endpoint,
+                    peer,
+                    &mut store,
+                    time::now_ms,
+                    rag_rat_sync::MAX_RECONCILE_ROUNDS,
+                )
+                .await
+                .map_err(|e| anyhow!("restoring table streams from the inviter failed: {e}"))?
+                .converged
+            } else {
+                true
+            }
         };
         db.fold_wal();
 
@@ -573,7 +592,9 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
             "content_entries_restored": content_report.entries_newly_stored,
             // `converged=false` means the restore hit the reconciliation round cap and a later
             // device-side sync should continue — the account/content stores may not be complete yet.
-            "converged": account_report.converged && content_report.converged,
+            "converged": account_report.converged
+                && content_report.converged
+                && tables_converged,
             "inviter_node_id": inviter,
             "inviter_relay": ticket.relay_url,
             "note": "to keep syncing, add inviter_node_id to [sync] server_peers and set [sync] \
@@ -728,7 +749,8 @@ pub(crate) fn device_sync_run(
         let peers = resolved.peers;
         let mut reached = Vec::with_capacity(peers.len());
         for (peer, addr) in &peers {
-            // Own a copy of the resolved address: it is dialed twice (account log, then content),
+            // Own a copy of the resolved address: it is dialed in dependency order (account log,
+            // content, then any supported table streams),
             // and `addr` is a borrow into `peers`.
             let addr = (*addr).clone();
             // Account log FIRST — it carries the roster + stream ownership that AUTHORIZE content,
@@ -775,7 +797,7 @@ pub(crate) fn device_sync_run(
                 let mut store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
                 match rag_rat_sync::connect_and_reconcile(
                     &endpoint,
-                    addr,
+                    addr.clone(),
                     rag_rat_sync::CONTENT_SYNC_ALPN,
                     &mut store,
                     AuthPolicy::Closed,
@@ -793,6 +815,33 @@ pub(crate) fn device_sync_run(
                         "device sync (content) complete"
                     ),
                     Err(e) => tracing::warn!(peer, error = %e, "device sync (content) failed"),
+                }
+                let mut table_store =
+                    rag_rat_sync::OplogTableSyncStore::new(conn, account_id, time::now_ms);
+                if table_store.has_streams()? {
+                    match rag_rat_sync::connect_and_table_reconcile(
+                        &endpoint,
+                        addr,
+                        &mut table_store,
+                        time::now_ms,
+                        rag_rat_sync::MAX_RECONCILE_ROUNDS,
+                    )
+                    .await
+                    {
+                        Ok(report) => tracing::info!(
+                            peer,
+                            rounds = report.rounds,
+                            converged = report.converged,
+                            sent = report.entries_sent,
+                            stored = report.entries_newly_stored,
+                            "device sync (table streams) complete"
+                        ),
+                        Err(e) => tracing::warn!(
+                            peer,
+                            error = %e,
+                            "device sync (table streams) failed"
+                        ),
+                    }
                 }
             }
             reached.push(account_ok);

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -131,4 +131,4 @@ pub use storage::{
     owner_control_authority, owner_control_authority_in_snapshot, owner_secrets_authority,
     roster_content_authority, stream_owner_effective, verify_enrollment_device_add,
 };
-pub(crate) use storage::{device_is_effective_writer, stream_owner_account};
+pub(crate) use storage::{device_is_effective_writer, stored_device_pubkeys, stream_owner_account};

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -2202,7 +2202,7 @@ pub(in crate::account) fn refresh_enrollment_reservations_for_stream_in_tx(
 /// The `(fingerprint → ed25519_pubkey)` map from every stored genesis / DeviceAdd for the account —
 /// the only ops that carry a device's key. Fold-status-independent (§16.2): a key resolves from ANY
 /// stored candidate carrying it, whether or not it is currently accepted.
-pub(super) fn stored_device_pubkeys(
+pub(crate) fn stored_device_pubkeys(
     conn: &Connection,
     account_id: AccountId,
 ) -> anyhow::Result<HashMap<DeviceFingerprint, [u8; 32]>> {

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -167,4 +167,8 @@ pub use store::{author_batch, author_op, load_projection};
 pub use stream::StreamId;
 // The table-sync forward-compat seam (#1001): replay entries retained but not projected when
 // they arrived. Belongs at store open, before producing — see the module docs.
-pub use table_sync::refold_stale_table_sync_projections;
+pub use table_sync::{
+    TableSyncIngestOutcome, TableSyncStream, refold_stale_table_sync_projections,
+    table_sync_entries_for_stream, table_sync_ingest, table_sync_signed_hash,
+    table_sync_supported_streams, table_sync_validate_stream,
+};

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -168,7 +168,7 @@ pub use stream::StreamId;
 // The table-sync forward-compat seam (#1001): replay entries retained but not projected when
 // they arrived. Belongs at store open, before producing — see the module docs.
 pub use table_sync::{
-    TableSyncIngestOutcome, TableSyncStream, refold_stale_table_sync_projections,
-    table_sync_entries_for_stream, table_sync_ingest, table_sync_signed_hash,
-    table_sync_supported_streams, table_sync_validate_stream,
+    TABLE_SYNC_ENTRY_MAX_BYTES, TableSyncIngestOutcome, TableSyncStream,
+    refold_stale_table_sync_projections, table_sync_entries_for_stream, table_sync_ingest,
+    table_sync_signed_hash, table_sync_supported_streams, table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -20,6 +20,9 @@ mod scope_stream;
 mod store;
 mod transport;
 
+/// Largest signed table-entry envelope accepted by storage and the `/5` transport.
+pub const TABLE_SYNC_ENTRY_MAX_BYTES: usize = 64 * 1024;
+
 #[cfg(test)]
 pub(crate) use refold::refold_stale_projections_against;
 /// The store-open forward-compat seam: replay entries retained but not projected when they

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -18,6 +18,7 @@ mod row_op;
 mod schema_facts;
 mod scope_stream;
 mod store;
+mod transport;
 
 #[cfg(test)]
 pub(crate) use refold::refold_stale_projections_against;
@@ -33,4 +34,8 @@ pub(crate) use scope_stream::scope_stream_id;
 #[cfg(test)]
 pub(crate) use store::{
     PendingReason, author_row_entry, mark_entry_pending, record_stream_context,
+};
+pub use transport::{
+    TableSyncIngestOutcome, TableSyncStream, table_sync_entries_for_stream, table_sync_ingest,
+    table_sync_signed_hash, table_sync_supported_streams, table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -265,6 +265,12 @@ pub(crate) fn author_row_entry(
     let prev_hash = stored_tail.map(|(_, entry_hash)| entry_hash);
     let signed =
         entry::sign_entry_from_op_bytes(secret, stream, prev_hash, lamport, row_op::encode(op));
+    anyhow::ensure!(
+        signed.signed_bytes.len() <= super::TABLE_SYNC_ENTRY_MAX_BYTES,
+        "table-sync signed entry is {} bytes, over the {}-byte transport limit",
+        signed.signed_bytes.len(),
+        super::TABLE_SYNC_ENTRY_MAX_BYTES,
+    );
     // A locally-authored op is projected by construction: the producer builds it from THIS
     // registry, so it can never carry a column or op-kind this binary does not understand.
     insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms, None)?;
@@ -315,6 +321,12 @@ pub(crate) fn accept_row_entry(
     pubkey: &DevicePublic,
     now_ms: i64,
 ) -> anyhow::Result<AcceptOutcome> {
+    anyhow::ensure!(
+        signed_bytes.len() <= super::TABLE_SYNC_ENTRY_MAX_BYTES,
+        "table-sync signed entry is {} bytes, over the {}-byte transport limit",
+        signed_bytes.len(),
+        super::TABLE_SYNC_ENTRY_MAX_BYTES,
+    );
     let verified = entry::verify_signed(signed_bytes, pubkey)?;
     if verified.stream_id != expected_stream {
         anyhow::bail!("entry names a different stream than the one being synced");
@@ -1190,6 +1202,45 @@ mod tests {
             entry_hash: signed.entry.entry_hash,
             prev_hash: None,
         });
+    }
+
+    #[test]
+    fn oversized_entries_are_refused_before_storage_and_authoring_recovers() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let mut local = conn();
+        let tx = local.transaction().unwrap();
+        let oversized = op(&"x".repeat(crate::table_sync::TABLE_SYNC_ENTRY_MAX_BYTES));
+        let error = author_row_entry(&tx, stream(), &secret, &oversized, 0).unwrap_err();
+        assert!(error.to_string().contains("over the 65536-byte transport limit"));
+        let accepted: i64 =
+            tx.query_row("SELECT COUNT(*) FROM table_sync_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(accepted, 0, "an oversized local entry never reaches accepted history");
+        author_row_entry(&tx, stream(), &secret, &op("repaired"), 1).unwrap();
+        tx.commit().unwrap();
+
+        let forged = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            None,
+            0,
+            vec![0; crate::table_sync::TABLE_SYNC_ENTRY_MAX_BYTES],
+        );
+        let mut remote = conn();
+        let tx = remote.transaction().unwrap();
+        let error = accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t"],
+            &forged.signed_bytes,
+            &secret.public(),
+            0,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("over the 65536-byte transport limit"));
+        let accepted: i64 =
+            tx.query_row("SELECT COUNT(*) FROM table_sync_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(accepted, 0, "an oversized received entry never reaches accepted history");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -1,0 +1,441 @@
+//! Production transport seams for the `/5` table-sync engine.
+//!
+//! The transport sees only current repo-scoped streams and accepted history. Gapped rows remain a
+//! local chain-repair detail and are never advertised or transferred.
+
+use std::collections::BTreeSet;
+
+use anyhow::Context;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
+
+use super::engine::{self, IngestOutcome, SyncCtx};
+use super::registry::{SYNCABLE_TABLES, TableSpec};
+use super::scope_stream::scope_stream_id;
+use crate::AccountId;
+use crate::account::{self, RepoIncarnationState};
+use crate::device::DevicePublic;
+
+/// One locally-supported repo-scoped table stream.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TableSyncStream {
+    pub repo_id: String,
+    pub incarnation_ref: [u8; 32],
+    pub scope_id: String,
+    pub stream_id: [u8; 32],
+}
+
+/// Whether one untrusted table entry added durable state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableSyncIngestOutcome {
+    Stored,
+    NoChange,
+}
+
+/// Current repo-scoped streams supported by the production registry.
+pub fn table_sync_supported_streams(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<TableSyncStream>> {
+    supported_streams_against(conn, account_id, SYNCABLE_TABLES)
+}
+
+/// Recompute an advertised route from local current-incarnation authority and the production
+/// registry. The advertised stream id is routing advice only; it never creates authority.
+pub fn table_sync_validate_stream(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+) -> anyhow::Result<bool> {
+    validate_stream_against(conn, account_id, stream, SYNCABLE_TABLES)
+}
+
+/// Accepted signed history for one validated current stream. This reads only
+/// `table_sync_entries`; `table_sync_gapped_entries` is deliberately absent.
+pub fn table_sync_entries_for_stream(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+) -> anyhow::Result<Vec<Vec<u8>>> {
+    if !table_sync_validate_stream(conn, account_id, stream)? {
+        return Ok(Vec::new());
+    }
+    accepted_entries(conn, stream.stream_id)
+}
+
+/// Feed one untrusted signed envelope through the existing table-sync authority, chain and payload
+/// gates. Invalid/stale routes are skipped before a transaction can write any table-sync state.
+pub fn table_sync_ingest(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> anyhow::Result<TableSyncIngestOutcome> {
+    ingest_against(conn, account_id, stream, signed_bytes, now_ms, SYNCABLE_TABLES)
+}
+
+/// Inventory key for an exact signed envelope.
+pub fn table_sync_signed_hash(signed_bytes: &[u8]) -> [u8; 32] {
+    crate::cbor::sha256(signed_bytes)
+}
+
+fn repo_registry(registry: &[TableSpec]) -> Vec<TableSpec> {
+    registry.iter().copied().filter(|spec| spec.repo_column.is_some()).collect()
+}
+
+fn supported_streams_against(
+    conn: &Connection,
+    account_id: AccountId,
+    registry: &[TableSpec],
+) -> anyhow::Result<Vec<TableSyncStream>> {
+    let scopes: BTreeSet<&str> = registry
+        .iter()
+        .filter(|spec| spec.repo_column.is_some())
+        .map(|spec| spec.scope_id)
+        .collect();
+    if scopes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT repository_id, incarnation_ref
+           FROM account_repo_incarnation_current
+          WHERE account_id = ?1 AND incarnation_ref IS NOT NULL
+          ORDER BY repository_id",
+    )?;
+    let rows = stmt
+        .query_map([account_id.to_bytes().as_slice()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut streams = Vec::with_capacity(rows.len().saturating_mul(scopes.len()));
+    for (repo_id, incarnation) in rows {
+        let incarnation_ref: [u8; 32] = incarnation.try_into().map_err(|got: Vec<u8>| {
+            anyhow::anyhow!("stored repository incarnation must be 32 bytes, got {}", got.len())
+        })?;
+        for scope_id in &scopes {
+            streams.push(TableSyncStream {
+                stream_id: scope_stream_id(&repo_id, account_id, incarnation_ref, scope_id)
+                    .to_bytes(),
+                repo_id: repo_id.clone(),
+                incarnation_ref,
+                scope_id: (*scope_id).to_string(),
+            });
+        }
+    }
+    Ok(streams)
+}
+
+fn validate_stream_against(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+    registry: &[TableSpec],
+) -> anyhow::Result<bool> {
+    if !registry.iter().any(|spec| spec.repo_column.is_some() && spec.scope_id == stream.scope_id) {
+        return Ok(false);
+    }
+    let current = account::repo_incarnation_state(conn, account_id, &stream.repo_id)?;
+    if current != RepoIncarnationState::Current(stream.incarnation_ref) {
+        return Ok(false);
+    }
+    Ok(scope_stream_id(&stream.repo_id, account_id, stream.incarnation_ref, &stream.scope_id)
+        .to_bytes()
+        == stream.stream_id)
+}
+
+fn accepted_entries(conn: &Connection, stream_id: [u8; 32]) -> anyhow::Result<Vec<Vec<u8>>> {
+    let mut stmt = conn.prepare(
+        "SELECT signed_bytes FROM table_sync_entries
+          WHERE stream_id = ?1
+          ORDER BY lamport, device_fingerprint, entry_hash",
+    )?;
+    Ok(stmt
+        .query_map([stream_id.as_slice()], |row| row.get(0))?
+        .collect::<rusqlite::Result<_>>()?)
+}
+
+fn ingest_against(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+    signed_bytes: &[u8],
+    now_ms: i64,
+    registry: &[TableSpec],
+) -> anyhow::Result<TableSyncIngestOutcome> {
+    if !validate_stream_against(conn, account_id, stream, registry)? {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    }
+    let Ok(signed) = crate::entry::decode_signed(signed_bytes) else {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    };
+    if signed.entry.stream_id.to_bytes() != stream.stream_id {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    }
+    let signer = signed.entry.device_fingerprint;
+    let Some(pubkey_bytes) =
+        account::stored_device_pubkeys(conn, account_id)?.get(&signer).copied()
+    else {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    };
+    let Ok(pubkey) = DevicePublic::from_bytes(&pubkey_bytes) else {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    };
+    if crate::entry::verify_signed(signed_bytes, &pubkey).is_err() {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    }
+    let local = crate::load_local_device(conn)?
+        .context("table sync requires an existing local device identity")?;
+    let registry = repo_registry(registry);
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let ctx = SyncCtx {
+        repo_id: &stream.repo_id,
+        account_id,
+        incarnation_ref: stream.incarnation_ref,
+        device: &local,
+        registry: &registry,
+        now_ms,
+    };
+    let report = engine::ingest(&tx, &ctx, &stream.scope_id, signed_bytes, &pubkey)?;
+    tx.commit()?;
+    Ok(match report.outcome {
+        IngestOutcome::Applied
+        | IngestOutcome::Retained(_)
+        | IngestOutcome::AwaitingPredecessor
+        | IngestOutcome::Quarantined(_) => TableSyncIngestOutcome::Stored,
+        IngestOutcome::AlreadyPresent
+        | IngestOutcome::AlreadyAwaiting
+        | IngestOutcome::HeldChainFull
+        | IngestOutcome::Forked
+        | IngestOutcome::AbandonedBehindFork
+        | IngestOutcome::Unauthorized => TableSyncIngestOutcome::NoChange,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::*;
+    use crate::table_sync::registry::{ColumnSpec, ValueType};
+
+    const INCARNATION: [u8; 32] = [0x24; 32];
+
+    fn account() -> AccountId {
+        AccountId::from_bytes([0x42; 32])
+    }
+
+    const REPO_SPEC: TableSpec = TableSpec {
+        name: "t_transport",
+        scope_id: "anchors/1",
+        spec_version: 1,
+        pk: &[
+            ColumnSpec::required("repo_id", ValueType::Text),
+            ColumnSpec::required("id", ValueType::Text),
+        ],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
+        local_columns: &[],
+        repo_column: Some("repo_id"),
+    };
+    const GLOBAL_SPEC: TableSpec = TableSpec {
+        name: "t_global",
+        scope_id: "global/1",
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
+        local_columns: &[],
+        repo_column: None,
+    };
+
+    fn database() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        crate::local_device(&conn, 0).unwrap();
+        conn.execute(
+            "INSERT INTO account_repo_incarnation_current(account_id, repository_id, \
+             incarnation_ref)
+             VALUES (?1, 'repo-a', ?2), (?1, 'repo-b', ?2)",
+            params![account().to_bytes().as_slice(), INCARNATION.as_slice()],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn supported_streams_are_current_repo_scoped_and_account_global_specs_are_ignored() {
+        let conn = database();
+        let streams =
+            supported_streams_against(&conn, account(), &[REPO_SPEC, GLOBAL_SPEC]).unwrap();
+        assert_eq!(streams.len(), 2);
+        assert_eq!(streams[0].repo_id, "repo-a");
+        assert_eq!(streams[1].repo_id, "repo-b");
+        assert!(streams.iter().all(|stream| stream.scope_id == "anchors/1"));
+        assert!(streams.iter().all(|stream| {
+            validate_stream_against(&conn, account(), stream, &[REPO_SPEC, GLOBAL_SPEC]).unwrap()
+        }));
+        assert!(supported_streams_against(&conn, account(), &[GLOBAL_SPEC]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn local_authority_rejects_stale_unknown_and_forged_routes_without_writes() {
+        let conn = database();
+        let current = supported_streams_against(&conn, account(), &[REPO_SPEC]).unwrap().remove(0);
+        let mut stale = current.clone();
+        stale.incarnation_ref = [9; 32];
+        let mut unknown = current.clone();
+        unknown.scope_id = "unknown/1".into();
+        let mut forged = current.clone();
+        forged.stream_id = [8; 32];
+        for route in [&stale, &unknown, &forged] {
+            assert!(!validate_stream_against(&conn, account(), route, &[REPO_SPEC]).unwrap());
+            assert_eq!(
+                ingest_against(&conn, account(), route, &[0], 0, &[REPO_SPEC]).unwrap(),
+                TableSyncIngestOutcome::NoChange,
+            );
+        }
+        assert!(
+            !validate_stream_against(&conn, AccountId::from_bytes([0x43; 32]), &current, &[
+                REPO_SPEC
+            ],)
+            .unwrap(),
+            "a sibling account cannot adopt this account's repo stream",
+        );
+        for table in [
+            "table_sync_entries",
+            "table_sync_gapped_entries",
+            "sync_row_clocks",
+            "table_sync_streams",
+        ] {
+            let count: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 0, "invalid routes write no rows to {table}");
+        }
+    }
+
+    #[test]
+    fn accepted_snapshot_excludes_gapped_rows() {
+        let conn = database();
+        let stream = supported_streams_against(&conn, account(), &[REPO_SPEC]).unwrap().remove(0);
+        conn.execute(
+            "INSERT INTO table_sync_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, signed_bytes, received_at_ms)
+             VALUES (?1, ?2, ?3, 0, x'01', 0)",
+            params![[1u8; 32].as_slice(), stream.stream_id.as_slice(), [2u8; 32].as_slice()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO table_sync_gapped_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                 gapped_at_ms)
+             VALUES (?1, ?2, ?3, 1, ?4, x'02', 0)",
+            params![
+                [3u8; 32].as_slice(),
+                stream.stream_id.as_slice(),
+                [2u8; 32].as_slice(),
+                [1u8; 32].as_slice(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(accepted_entries(&conn, stream.stream_id).unwrap(), vec![vec![1]]);
+    }
+
+    #[test]
+    fn empty_production_registry_has_no_streams() {
+        let conn = database();
+        assert!(table_sync_supported_streams(&conn, account()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn accepted_transfer_is_idempotent_and_obeys_the_current_roster_write_gate() {
+        fn add_repo_state(conn: &Connection, account: AccountId) {
+            conn.execute_batch(
+                "CREATE TABLE t_transport(
+                     repo_id TEXT NOT NULL,
+                     id TEXT NOT NULL,
+                     title TEXT NOT NULL,
+                     PRIMARY KEY(repo_id, id)
+                 ) STRICT;",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO account_repo_incarnation_current(
+                     account_id, repository_id, incarnation_ref
+                 ) VALUES (?1, 'repo-a', ?2)",
+                params![account.to_bytes().as_slice(), INCARNATION.as_slice()],
+            )
+            .unwrap();
+        }
+
+        let mut source = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&source, &crate::test_hooks()).unwrap();
+        let account = crate::local_account(&source, 0).unwrap();
+        add_repo_state(&source, account);
+        source
+            .execute(
+                "INSERT INTO t_transport(repo_id, id, title) VALUES ('repo-a', 'r1', 'one')",
+                [],
+            )
+            .unwrap();
+        let local = crate::load_local_device(&source).unwrap().unwrap();
+        let tx = source.transaction().unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo-a",
+            account_id: account,
+            incarnation_ref: INCARNATION,
+            device: &local,
+            registry: &[REPO_SPEC],
+            now_ms: 0,
+        };
+        let authored = engine::produce_and_author(&tx, &ctx).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(authored.len(), 1);
+        let route = supported_streams_against(&source, account, &[REPO_SPEC]).unwrap().remove(0);
+
+        let restore = |remove_writer: bool| {
+            let dest = Connection::open_in_memory().unwrap();
+            rag_rat_db::schema::apply(&dest, &crate::test_hooks()).unwrap();
+            crate::local_device(&dest, 0).unwrap();
+            for entry in crate::account_entries_for_sync(&source, account).unwrap() {
+                crate::account_ingest(&dest, &entry.signed_bytes, 0).unwrap();
+            }
+            add_repo_state(&dest, account);
+            if remove_writer {
+                dest.execute(
+                    "UPDATE account_roster_history SET closed_at = 1 WHERE account_id = ?1",
+                    [account.to_bytes().as_slice()],
+                )
+                .unwrap();
+            }
+            dest
+        };
+
+        let destination = restore(false);
+        assert_eq!(
+            ingest_against(&destination, account, &route, &authored[0], 1, &[REPO_SPEC]).unwrap(),
+            TableSyncIngestOutcome::Stored,
+        );
+        assert_eq!(
+            ingest_against(&destination, account, &route, &authored[0], 2, &[REPO_SPEC]).unwrap(),
+            TableSyncIngestOutcome::NoChange,
+        );
+        let title: String = destination
+            .query_row(
+                "SELECT title FROM t_transport WHERE repo_id = 'repo-a' AND id = 'r1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(title, "one");
+
+        let removed = restore(true);
+        assert_eq!(
+            ingest_against(&removed, account, &route, &authored[0], 1, &[REPO_SPEC]).unwrap(),
+            TableSyncIngestOutcome::NoChange,
+        );
+        let accepted: i64 = removed
+            .query_row("SELECT COUNT(*) FROM table_sync_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(accepted, 0, "a removed writer reaches no accepted table history");
+    }
+}

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -41,6 +41,10 @@ use crate::enrollment::{
 };
 use crate::session::{DEFAULT_IDLE_TIMEOUT, SessionError, SessionReport, SyncStore, run_session};
 use crate::store::OplogSyncStore;
+use crate::table_session::{
+    TableSessionError, TableSessionReport, TableSyncStore, run_table_session,
+};
+use crate::table_wire::TABLE_SYNC_ALPN;
 use crate::wire::{CONTENT_SYNC_ALPN, SYNC_ALPN};
 
 /// Endpoint construction or connection setup failed, before a session could run.
@@ -85,7 +89,12 @@ pub async fn build_endpoint(
     let relay_url =
         RelayUrl::from_str(relay_url.trim()).map_err(|e| EndpointError::RelayUrl(e.to_string()))?;
     Endpoint::builder(presets::Minimal)
-        .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec(), ENROLL_ALPN.to_vec()])
+        .alpns(vec![
+            SYNC_ALPN.to_vec(),
+            CONTENT_SYNC_ALPN.to_vec(),
+            TABLE_SYNC_ALPN.to_vec(),
+            ENROLL_ALPN.to_vec(),
+        ])
         .relay_mode(RelayMode::custom([relay_url]))
         .secret_key(SecretKey::from_bytes(&secret_key))
         .bind()
@@ -157,7 +166,7 @@ pub struct DiscoveredPeers {
 /// [`iroh::EndpointId::from_str`] accepts 64-char lowercase hex (the `Display` form) OR standard
 /// base32, and uppercases before base32-decoding, so three distinct strings can name one peer —
 /// while the config layer only trims and de-duplicates literally. Comparing strings would dial such
-/// a peer twice per pass (two full two-ALPN reconciles) and double-count it in `ok`/`errors`.
+/// a peer twice per pass (two full multi-ALPN reconciles) and double-count it in `ok`/`errors`.
 pub async fn discover_peers(
     configured_peers: &[String],
     relay_url: &str,
@@ -462,6 +471,48 @@ pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     Ok(report)
 }
 
+/// Dial the dedicated table-sync ALPN, run the existing mutual account auth under closed-roster
+/// policy, then reconcile the bounded manifest intersection.
+pub async fn connect_and_table_sync<S: TableSyncStore + NodeAuth>(
+    endpoint: &Endpoint,
+    peer: impl Into<EndpointAddr>,
+    store: &mut S,
+    now_ms: i64,
+) -> Result<TableSessionReport, SyncFailure> {
+    let local_node = *endpoint.id().as_bytes();
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, endpoint.connect(peer, TABLE_SYNC_ALPN))
+        .await
+        .map_err(|_| {
+            SyncFailure::Endpoint(EndpointError::Connect("table-sync dial timed out".into()))
+        })?
+        .map_err(|error| SyncFailure::Endpoint(EndpointError::Connect(error.to_string())))?;
+    let remote_node = *conn.remote_id().as_bytes();
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.open_bi())
+        .await
+        .map_err(|_| {
+            SyncFailure::Endpoint(EndpointError::Connect(
+                "opening a table-sync stream timed out".into(),
+            ))
+        })?
+        .map_err(|error| SyncFailure::Endpoint(EndpointError::Connect(error.to_string())))?;
+    let capabilities = run_auth_phase(&mut send, &mut recv, &*store, AuthConfig {
+        role: AuthRole::Dialer,
+        account_id: store.account_id(),
+        local_node,
+        remote_node,
+        policy: AuthPolicy::Closed,
+        now_ms,
+        pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
+    })
+    .await
+    .map_err(SyncFailure::Auth)?;
+    let report = run_table_session(store, send, recv, AuthRole::Dialer, capabilities)
+        .await
+        .map_err(SyncFailure::TableSession)?;
+    conn.close(0u32.into(), b"done");
+    Ok(report)
+}
+
 /// The most times a dialer re-runs a sync session against ONE peer before giving up on convergence
 /// for this pass. A cooperative account reaches a fixpoint in a handful of rounds; a peer still not
 /// dry after this many re-syncs is withholding an authorizer or is pathologically active, so stop
@@ -548,6 +599,33 @@ pub async fn connect_and_reconcile<S: SyncStore + NodeAuth>(
     }
 }
 
+/// Re-run table sessions until the same fully-quiet fixpoint used by account/content sync.
+pub async fn connect_and_table_reconcile<S: TableSyncStore + NodeAuth>(
+    endpoint: &Endpoint,
+    peer: EndpointAddr,
+    store: &mut S,
+    now_ms: impl Fn() -> i64,
+    max_rounds: usize,
+) -> Result<ReconcileReport, SyncFailure> {
+    let mut entries_newly_stored = 0;
+    let mut entries_sent = 0;
+    let mut rounds = 0;
+    loop {
+        let report = connect_and_table_sync(endpoint, peer.clone(), store, now_ms()).await?;
+        rounds += 1;
+        entries_newly_stored += report.entries_newly_stored;
+        entries_sent += report.entries_sent;
+        let session = SessionReport {
+            entries_sent: report.entries_sent,
+            entries_received: report.entries_received,
+            entries_newly_stored: report.entries_newly_stored,
+        };
+        if let ReconcileStep::Stop { converged } = reconcile_step(&session, rounds, max_rounds) {
+            return Ok(ReconcileReport { rounds, entries_newly_stored, entries_sent, converged });
+        }
+    }
+}
+
 /// Accept ONE inbound connection and run a session against it. D4's `sync serve` loops this;
 /// keeping it single-shot here keeps the store's `!Send` connection on one task (no spawn).
 ///
@@ -618,7 +696,8 @@ pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
 
 /// Accept ONE inbound connection and run the session for the STREAM the peer negotiated: the
 /// account log ([`SYNC_ALPN`] → `account_store`), `/3` content ([`CONTENT_SYNC_ALPN`] →
-/// `content_store`), or owner-side enrollment ([`ENROLL_ALPN`] → the account store's database).
+/// `content_store`), repo-scoped `/5` tables ([`TABLE_SYNC_ALPN`]), or owner-side enrollment
+/// ([`ENROLL_ALPN`] → the account store's database).
 /// The auth phase is account-level for normal sync; enrollment instead authenticates the requested
 /// node by the QUIC transport identity and atomically adds it to the roster before normal auth can
 /// admit it.
@@ -654,11 +733,12 @@ where
     let alpn = conn.alpn().to_vec();
     // Reject an unroutable ALPN BEFORE opening a stream or running auth — there is no reason to
     // complete a mutual handshake for a stream we can't serve. Unreachable today (iroh's TLS
-    // refuses any ALPN `build_endpoint` didn't bind, and it binds exactly the two routed ones),
-    // but keeping the check ahead of auth means adding a third bound ALPN without a route here
+    // refuses any ALPN `build_endpoint` didn't bind, and it binds exactly the routed ones), but
+    // keeping the check ahead of auth means adding another bound ALPN without a route here
     // fails cleanly here instead of after the peer has completed authorization.
     if alpn.as_slice() != SYNC_ALPN
         && alpn.as_slice() != CONTENT_SYNC_ALPN
+        && alpn.as_slice() != TABLE_SYNC_ALPN
         && alpn.as_slice() != ENROLL_ALPN
     {
         conn.close(0u32.into(), b"unknown-alpn");
@@ -697,7 +777,7 @@ where
         };
     }
     // Read the clock only now that a peer has connected (see `accept_and_sync`).
-    let now_ms = now_ms();
+    let auth_now_ms = now_ms();
     // The auth phase is store-agnostic (the binding is account-level), so authorize with the
     // account store BEFORE any inventory — no stream leaves this peer until it passes the policy.
     let capabilities = run_auth_phase(&mut send, &mut recv, &*account_store, AuthConfig {
@@ -705,20 +785,40 @@ where
         account_id: account_store.account_id(),
         local_node,
         remote_node,
-        policy,
-        now_ms,
+        // Table streams are private account data. Open/bootstrap admission is only for restoring
+        // the account log; it can never reveal a table manifest.
+        policy: if alpn.as_slice() == TABLE_SYNC_ALPN { AuthPolicy::Closed } else { policy },
+        now_ms: auth_now_ms,
         pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
     })
     .await
     .map_err(SyncFailure::Auth)?;
-    // Route the session to the store the negotiated ALPN names (validated to be one of the two
-    // routed ALPNs above, so the `else` is the content stream, not an unknown-ALPN fallthrough).
+    // Route the session to the store the negotiated ALPN names (validated above, so the final
+    // `else` is the table stream, not an unknown-ALPN fallthrough).
     let report = if alpn.as_slice() == SYNC_ALPN {
-        run_session(account_store, send, recv, AuthRole::Acceptor, capabilities).await
+        run_session(account_store, send, recv, AuthRole::Acceptor, capabilities)
+            .await
+            .map_err(SyncFailure::Session)?
+    } else if alpn.as_slice() == CONTENT_SYNC_ALPN {
+        run_session(content_store, send, recv, AuthRole::Acceptor, capabilities)
+            .await
+            .map_err(SyncFailure::Session)?
     } else {
-        run_session(content_store, send, recv, AuthRole::Acceptor, capabilities).await
-    }
-    .map_err(SyncFailure::Session)?;
+        let mut table_store = crate::store::OplogTableSyncStore::new(
+            account_store.connection(),
+            AccountId::from_bytes(account_store.account_id()),
+            now_ms,
+        );
+        let table =
+            run_table_session(&mut table_store, send, recv, AuthRole::Acceptor, capabilities)
+                .await
+                .map_err(SyncFailure::TableSession)?;
+        SessionReport {
+            entries_sent: table.entries_sent,
+            entries_received: table.entries_received,
+            entries_newly_stored: table.entries_newly_stored,
+        }
+    };
     // Keep the acceptor alive until the dialer reads its final acknowledgement and closes.
     let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
     conn.close(0u32.into(), b"done");
@@ -746,6 +846,7 @@ pub enum SyncFailure {
     /// The node-authorization handshake refused the peer (or we could not authorize to it).
     Auth(crate::auth::AuthError),
     Session(SessionError),
+    TableSession(TableSessionError),
 }
 
 impl std::fmt::Display for SyncFailure {
@@ -755,6 +856,7 @@ impl std::fmt::Display for SyncFailure {
             SyncFailure::Enrollment(e) => write!(f, "{e}"),
             SyncFailure::Auth(e) => write!(f, "{e}"),
             SyncFailure::Session(e) => write!(f, "{e}"),
+            SyncFailure::TableSession(e) => write!(f, "{e}"),
         }
     }
 }
@@ -851,7 +953,7 @@ mod tests {
     /// `EndpointId::from_str` takes 64-char lowercase hex OR standard base32, and uppercases before
     /// base32-decoding — so three strings name one node, while `[sync] server_peers` only
     /// de-duplicates literally. Comparing display strings would dial this peer three times per pass
-    /// (each a full two-ALPN reconcile) and triple-count it in `ok`/`errors`.
+    /// (each a full multi-ALPN reconcile) and triple-count it in `ok`/`errors`.
     #[tokio::test]
     async fn discover_peers_dedupes_configured_spellings_of_one_node() {
         let bytes = node_id_from_secret([11u8; 32]);
@@ -953,8 +1055,107 @@ mod tests {
         }
     }
 
+    struct TableTestStore {
+        auth: TestStore,
+        supported: Vec<crate::table_wire::ManifestItem>,
+        entries: HashMap<[u8; 32], HashMap<[u8; 32], Vec<u8>>>,
+    }
+
+    impl TableTestStore {
+        fn new(
+            account: [u8; 32],
+            supported: Vec<crate::table_wire::ManifestItem>,
+            entries: impl IntoIterator<Item = ([u8; 32], ([u8; 32], Vec<u8>))>,
+        ) -> Self {
+            let mut by_stream: HashMap<_, HashMap<_, _>> = HashMap::new();
+            for (stream, (hash, bytes)) in entries {
+                by_stream.entry(stream).or_default().insert(hash, bytes);
+            }
+            Self {
+                auth: TestStore::new(
+                    account,
+                    [],
+                    PeerCapability::ReadWrite,
+                    PeerCapability::ReadWrite,
+                ),
+                supported,
+                entries: by_stream,
+            }
+        }
+    }
+
+    impl TableSyncStore for TableTestStore {
+        fn account_id(&self) -> [u8; 32] {
+            self.auth.account
+        }
+
+        fn supported_streams(&self) -> anyhow::Result<Vec<crate::table_wire::ManifestItem>> {
+            Ok(self.supported.clone())
+        }
+
+        fn validates(&self, item: &crate::table_wire::ManifestItem) -> anyhow::Result<bool> {
+            Ok(self.supported.contains(item))
+        }
+
+        fn snapshot(
+            &self,
+            item: &crate::table_wire::ManifestItem,
+        ) -> anyhow::Result<Vec<([u8; 32], Vec<u8>)>> {
+            Ok(self
+                .entries
+                .get(&item.stream_id)
+                .into_iter()
+                .flatten()
+                .map(|(hash, bytes)| (*hash, bytes.clone()))
+                .collect())
+        }
+
+        fn ingest(
+            &mut self,
+            item: &crate::table_wire::ManifestItem,
+            signed_bytes: &[u8],
+        ) -> anyhow::Result<crate::session::Ingested> {
+            if !self.supported.contains(item) {
+                return Ok(crate::session::Ingested::NoChange);
+            }
+            let hash: [u8; 32] = signed_bytes[..32].try_into()?;
+            Ok(match self.entries.entry(item.stream_id).or_default().entry(hash) {
+                std::collections::hash_map::Entry::Occupied(_) =>
+                    crate::session::Ingested::NoChange,
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(signed_bytes.to_vec());
+                    crate::session::Ingested::Stored
+                },
+            })
+        }
+    }
+
+    impl NodeAuth for TableTestStore {
+        fn local_auth(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<LocalAuth> {
+            self.auth.local_auth(local_node, now_ms)
+        }
+
+        fn authorize(
+            &self,
+            binding: &[u8],
+            remote_node: &[u8; 32],
+            now_ms: i64,
+        ) -> anyhow::Result<PeerAuthorization> {
+            self.auth.authorize(binding, remote_node, now_ms)
+        }
+    }
+
     fn test_entry(seed: u8) -> ([u8; 32], Vec<u8>) {
         ([seed; 32], vec![seed; 40])
+    }
+
+    fn table_item(repo: &str, stream: u8) -> crate::table_wire::ManifestItem {
+        crate::table_wire::ManifestItem {
+            repo_id: repo.into(),
+            incarnation_ref: [1; 32],
+            scope_id: "anchors/1".into(),
+            stream_id: [stream; 32],
+        }
     }
 
     fn local_request(database: &Connection) -> EnrollmentRequest {
@@ -1033,7 +1234,12 @@ mod tests {
     async fn loopback_endpoints() -> (Endpoint, Endpoint) {
         let bind = |seed: [u8; 32]| async move {
             Endpoint::builder(presets::Minimal)
-                .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec(), ENROLL_ALPN.to_vec()])
+                .alpns(vec![
+                    SYNC_ALPN.to_vec(),
+                    CONTENT_SYNC_ALPN.to_vec(),
+                    TABLE_SYNC_ALPN.to_vec(),
+                    ENROLL_ALPN.to_vec(),
+                ])
                 .relay_mode(RelayMode::Disabled)
                 .secret_key(SecretKey::from_bytes(&seed))
                 .bind()
@@ -1052,6 +1258,98 @@ mod tests {
             .port();
         EndpointAddr::new(endpoint.id())
             .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+    }
+
+    async fn accept_test_table_sync(
+        endpoint: &Endpoint,
+        store: &mut TableTestStore,
+    ) -> TableSessionReport {
+        let incoming = endpoint.accept().await.unwrap();
+        let conn = incoming.await.unwrap();
+        assert_eq!(conn.alpn(), TABLE_SYNC_ALPN);
+        let local_node = *endpoint.id().as_bytes();
+        let remote_node = *conn.remote_id().as_bytes();
+        let (mut send, mut recv) = conn.accept_bi().await.unwrap();
+        let capabilities = run_auth_phase(&mut send, &mut recv, &*store, AuthConfig {
+            role: AuthRole::Acceptor,
+            account_id: store.account_id(),
+            local_node,
+            remote_node,
+            policy: AuthPolicy::Closed,
+            now_ms: NOW,
+            pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
+        })
+        .await
+        .unwrap();
+        let report =
+            run_table_session(store, send, recv, AuthRole::Acceptor, capabilities).await.unwrap();
+        let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
+        conn.close(0u32.into(), b"done");
+        report
+    }
+
+    async fn reconcile_test_tables(
+        listener: &Endpoint,
+        dialer: &Endpoint,
+        source: &mut TableTestStore,
+        destination: &mut TableTestStore,
+    ) -> ReconcileReport {
+        let client = connect_and_table_reconcile(
+            dialer,
+            direct_addr(listener),
+            destination,
+            || NOW,
+            MAX_RECONCILE_ROUNDS,
+        );
+        tokio::pin!(client);
+        loop {
+            tokio::select! {
+                report = &mut client => break report.unwrap(),
+                _ = accept_test_table_sync(listener, source) => {},
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn table_reconcile_transfers_only_the_scoped_intersection_over_iroh() {
+        let account = [0xa3; 32];
+        let shared = table_item("repo-shared", 1);
+        let source_only = table_item("repo-source", 2);
+        let destination_only = table_item("repo-destination", 3);
+        let shared_entry = test_entry(11);
+        let private_entry = test_entry(12);
+        let dialer_entry = test_entry(13);
+        let mut source = TableTestStore::new(account, vec![source_only.clone(), shared.clone()], [
+            (shared.stream_id, shared_entry.clone()),
+            (source_only.stream_id, private_entry),
+        ]);
+        let mut destination = TableTestStore::new(
+            account,
+            vec![shared.clone(), destination_only],
+            [(shared.stream_id, dialer_entry.clone())],
+        );
+        let (listener, dialer) = loopback_endpoints().await;
+
+        let report = reconcile_test_tables(&listener, &dialer, &mut source, &mut destination).await;
+        assert_eq!(report.rounds, 2, "one round transfers, one confirms the fixpoint");
+        assert!(report.converged);
+        assert_eq!(report.entries_newly_stored, 1);
+        assert_eq!(report.entries_sent, 1);
+        assert_eq!(destination.entries[&shared.stream_id][&shared_entry.0], shared_entry.1);
+        assert_eq!(
+            source.entries[&shared.stream_id][&dialer_entry.0], dialer_entry.1,
+            "the acceptor stores the dialer's push before the dialer closes",
+        );
+        assert!(
+            !destination.entries.contains_key(&source_only.stream_id),
+            "a repo outside the manifest intersection never crosses the connection",
+        );
+
+        let again = reconcile_test_tables(&listener, &dialer, &mut source, &mut destination).await;
+        assert_eq!(again.rounds, 1, "an idempotent replay is immediately quiet");
+        assert!(again.converged);
+        assert_eq!(again.entries_newly_stored, 0);
+        assert_eq!(again.entries_sent, 0);
     }
 
     #[tokio::test]

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -22,6 +22,9 @@ pub mod endpoint;
 pub mod enrollment;
 pub mod session;
 pub mod store;
+pub mod table_codec;
+pub mod table_session;
+pub mod table_wire;
 pub mod wire;
 
 pub use auth::{
@@ -31,8 +34,9 @@ pub use auth::{
 pub use endpoint::{
     DiscoveredPeers, EndpointError, MAX_RECONCILE_ROUNDS, ReconcileReport, SyncFailure,
     accept_and_dispatch, accept_and_sync, accept_enrollment, build_endpoint, connect_and_enroll,
-    connect_and_reconcile, connect_and_sync, discover_peers, endpoint_addr, node_id_from_secret,
-    node_id_to_string, peer_addr, peer_addr_from_bytes,
+    connect_and_reconcile, connect_and_sync, connect_and_table_reconcile, connect_and_table_sync,
+    discover_peers, endpoint_addr, node_id_from_secret, node_id_to_string, peer_addr,
+    peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,
@@ -48,5 +52,7 @@ pub use session::{
     DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES, SessionError, SessionReport, SyncStore,
     run_session, run_session_with_idle_timeout,
 };
-pub use store::{OplogContentSyncStore, OplogSyncStore};
+pub use store::{OplogContentSyncStore, OplogSyncStore, OplogTableSyncStore};
+pub use table_session::{TableSessionError, TableSessionReport, TableSyncStore, run_table_session};
+pub use table_wire::{Manifest, ManifestItem, TABLE_SYNC_ALPN, TableFrame, TableWireError};
 pub use wire::{CONTENT_SYNC_ALPN, Frame, SYNC_ALPN, WireError};

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -385,4 +385,26 @@ mod tests {
         assert_eq!(capability_for_role(DeviceRole::Member), PeerCapability::ReadWrite);
         assert_eq!(capability_for_role(DeviceRole::Owner), PeerCapability::ReadWrite);
     }
+
+    #[test]
+    fn table_store_maps_routes_and_skips_them_while_the_registry_is_empty() {
+        let conn = Connection::open_in_memory().unwrap();
+        let account_id = AccountId::from_bytes([1; 32]);
+        let stream = rag_rat_oplog::TableSyncStream {
+            repo_id: "repo-a".into(),
+            incarnation_ref: [2; 32],
+            scope_id: "anchors/1".into(),
+            stream_id: [3; 32],
+        };
+        let item = to_manifest_item(stream.clone());
+        assert_eq!(to_oplog_stream(&item), stream);
+
+        let mut store = OplogTableSyncStore::new(&conn, account_id, || 7);
+        assert_eq!(store.account_id(), account_id.to_bytes());
+        assert!(!store.has_streams().unwrap());
+        assert!(store.supported_streams().unwrap().is_empty());
+        assert!(!store.validates(&item).unwrap());
+        assert!(store.snapshot(&item).unwrap().is_empty());
+        assert_eq!(store.ingest(&item, &[0]).unwrap(), Ingested::NoChange);
+    }
 }

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -16,6 +16,8 @@ use rusqlite::Connection;
 
 use crate::auth::{LocalAuth, NodeAuth, PeerAuthorization, PeerCapability};
 use crate::session::{Ingested, SyncStore};
+use crate::table_session::TableSyncStore;
+use crate::table_wire::ManifestItem;
 
 /// Mint this account's signed node binding for `local_node`. A store with no local device yet (a
 /// fresh peer being onboarded) has nothing to prove, so it returns an EMPTY binding rather than
@@ -261,6 +263,104 @@ impl NodeAuth for OplogSyncStore<'_> {
 }
 
 impl NodeAuth for OplogContentSyncStore<'_> {
+    fn local_auth(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<LocalAuth> {
+        local_auth(self.conn, self.account_id, local_node, now_ms)
+    }
+
+    fn authorize(
+        &self,
+        binding: &[u8],
+        remote_node: &[u8; 32],
+        now_ms: i64,
+    ) -> anyhow::Result<PeerAuthorization> {
+        authorize_binding(self.conn, self.account_id, binding, remote_node, now_ms)
+    }
+}
+
+/// Production adapter for current repo-scoped `/5` table streams.
+pub struct OplogTableSyncStore<'a, F = fn() -> i64> {
+    conn: &'a Connection,
+    account_id: AccountId,
+    now_fn: F,
+}
+
+impl<'a, F: Fn() -> i64> OplogTableSyncStore<'a, F> {
+    pub fn new(conn: &'a Connection, account_id: AccountId, now_fn: F) -> Self {
+        Self { conn, account_id, now_fn }
+    }
+
+    /// Whether this binary currently supports any table stream for this account.
+    pub fn has_streams(&self) -> anyhow::Result<bool> {
+        Ok(!rag_rat_oplog::table_sync_supported_streams(self.conn, self.account_id)?.is_empty())
+    }
+}
+
+fn to_manifest_item(stream: rag_rat_oplog::TableSyncStream) -> ManifestItem {
+    ManifestItem {
+        repo_id: stream.repo_id,
+        incarnation_ref: stream.incarnation_ref,
+        scope_id: stream.scope_id,
+        stream_id: stream.stream_id,
+    }
+}
+
+fn to_oplog_stream(item: &ManifestItem) -> rag_rat_oplog::TableSyncStream {
+    rag_rat_oplog::TableSyncStream {
+        repo_id: item.repo_id.clone(),
+        incarnation_ref: item.incarnation_ref,
+        scope_id: item.scope_id.clone(),
+        stream_id: item.stream_id,
+    }
+}
+
+impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
+    fn account_id(&self) -> [u8; 32] {
+        self.account_id.to_bytes()
+    }
+
+    fn supported_streams(&self) -> anyhow::Result<Vec<ManifestItem>> {
+        Ok(rag_rat_oplog::table_sync_supported_streams(self.conn, self.account_id)?
+            .into_iter()
+            .map(to_manifest_item)
+            .collect())
+    }
+
+    fn validates(&self, item: &ManifestItem) -> anyhow::Result<bool> {
+        rag_rat_oplog::table_sync_validate_stream(
+            self.conn,
+            self.account_id,
+            &to_oplog_stream(item),
+        )
+    }
+
+    fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<([u8; 32], Vec<u8>)>> {
+        Ok(rag_rat_oplog::table_sync_entries_for_stream(
+            self.conn,
+            self.account_id,
+            &to_oplog_stream(item),
+        )?
+        .into_iter()
+        .map(|bytes| (rag_rat_oplog::table_sync_signed_hash(&bytes), bytes))
+        .collect())
+    }
+
+    fn ingest(&mut self, item: &ManifestItem, signed_bytes: &[u8]) -> anyhow::Result<Ingested> {
+        Ok(
+            match rag_rat_oplog::table_sync_ingest(
+                self.conn,
+                self.account_id,
+                &to_oplog_stream(item),
+                signed_bytes,
+                (self.now_fn)(),
+            )? {
+                rag_rat_oplog::TableSyncIngestOutcome::Stored => Ingested::Stored,
+                rag_rat_oplog::TableSyncIngestOutcome::NoChange => Ingested::NoChange,
+            },
+        )
+    }
+}
+
+impl<F> NodeAuth for OplogTableSyncStore<'_, F> {
     fn local_auth(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<LocalAuth> {
         local_auth(self.conn, self.account_id, local_node, now_ms)
     }

--- a/crates/rag-rat-sync/src/table_codec.rs
+++ b/crates/rag-rat-sync/src/table_codec.rs
@@ -1,0 +1,75 @@
+//! Length-prefixed framing for the dedicated table-sync protocol.
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::table_wire::{TableFrame, TableWireError};
+
+/// Hard frame cap, checked from the length prefix before allocating the body.
+pub const MAX_TABLE_FRAME_BYTES: u32 = 4 * 1024 * 1024;
+
+#[derive(Debug)]
+pub enum TableCodecError {
+    Io(std::io::Error),
+    FrameTooLarge(u32),
+    Wire(TableWireError),
+    Eof,
+}
+
+impl std::fmt::Display for TableCodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "table-sync stream io: {error}"),
+            Self::FrameTooLarge(bytes) =>
+                write!(f, "table-sync frame declared {bytes} bytes, over {MAX_TABLE_FRAME_BYTES}"),
+            Self::Wire(error) => write!(f, "{error}"),
+            Self::Eof => write!(f, "table-sync stream closed at a frame boundary"),
+        }
+    }
+}
+
+impl std::error::Error for TableCodecError {}
+
+pub async fn write_frame<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    frame: &TableFrame,
+) -> Result<(), TableCodecError> {
+    let body = frame.encode();
+    let len = u32::try_from(body.len()).map_err(|_| TableCodecError::FrameTooLarge(u32::MAX))?;
+    if len > MAX_TABLE_FRAME_BYTES {
+        return Err(TableCodecError::FrameTooLarge(len));
+    }
+    writer.write_all(&len.to_be_bytes()).await.map_err(TableCodecError::Io)?;
+    writer.write_all(&body).await.map_err(TableCodecError::Io)
+}
+
+pub async fn read_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<TableFrame, TableCodecError> {
+    let mut len_bytes = [0; 4];
+    match reader.read_exact(&mut len_bytes).await {
+        Ok(_) => {},
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+            return Err(TableCodecError::Eof);
+        },
+        Err(error) => return Err(TableCodecError::Io(error)),
+    }
+    let len = u32::from_be_bytes(len_bytes);
+    if len > MAX_TABLE_FRAME_BYTES {
+        return Err(TableCodecError::FrameTooLarge(len));
+    }
+    let mut body = vec![0; len as usize];
+    reader.read_exact(&mut body).await.map_err(TableCodecError::Io)?;
+    TableFrame::decode(&body).map_err(TableCodecError::Wire)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn total_frame_bound_is_checked_before_allocation() {
+        let (mut sender, mut receiver) = tokio::io::duplex(16);
+        sender.write_all(&(MAX_TABLE_FRAME_BYTES + 1).to_be_bytes()).await.unwrap();
+        assert!(matches!(read_frame(&mut receiver).await, Err(TableCodecError::FrameTooLarge(_))));
+    }
+}

--- a/crates/rag-rat-sync/src/table_codec.rs
+++ b/crates/rag-rat-sync/src/table_codec.rs
@@ -66,10 +66,36 @@ pub async fn read_frame<R: AsyncRead + Unpin>(
 mod tests {
     use super::*;
 
+    #[test]
+    fn codec_errors_render_their_cause() {
+        assert!(TableCodecError::Io(std::io::Error::other("boom")).to_string().contains("boom"));
+        assert!(TableCodecError::FrameTooLarge(7).to_string().contains("7 bytes"));
+        assert!(
+            TableCodecError::Wire(TableWireError::Malformed("bad".into()))
+                .to_string()
+                .contains("bad")
+        );
+        assert!(TableCodecError::Eof.to_string().contains("closed"));
+    }
+
     #[tokio::test]
     async fn total_frame_bound_is_checked_before_allocation() {
         let (mut sender, mut receiver) = tokio::io::duplex(16);
         sender.write_all(&(MAX_TABLE_FRAME_BYTES + 1).to_be_bytes()).await.unwrap();
         assert!(matches!(read_frame(&mut receiver).await, Err(TableCodecError::FrameTooLarge(_))));
+
+        let mut empty = tokio::io::empty();
+        assert!(matches!(read_frame(&mut empty).await, Err(TableCodecError::Eof)));
+
+        let mut sink = tokio::io::sink();
+        let oversized = TableFrame::Entries {
+            stream_id: [0; 32],
+            entries: vec![vec![0; MAX_TABLE_FRAME_BYTES as usize]],
+            more: false,
+        };
+        assert!(matches!(
+            write_frame(&mut sink, &oversized).await,
+            Err(TableCodecError::FrameTooLarge(_))
+        ));
     }
 }

--- a/crates/rag-rat-sync/src/table_session.rs
+++ b/crates/rag-rat-sync/src/table_session.rs
@@ -1,0 +1,495 @@
+//! Authenticated multi-stream table reconciliation over one bidirectional stream.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+
+use crate::auth::{AuthRole, SessionCapabilities};
+use crate::session::{DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES};
+use crate::table_codec::{self, TableCodecError};
+use crate::table_wire::{
+    MAX_TABLE_ENTRIES_PER_PAGE, MAX_TABLE_ENTRY_BYTES, MAX_TABLE_INVENTORY_HASHES, Manifest,
+    ManifestItem, TableFrame,
+};
+
+type Hash = [u8; 32];
+
+/// Store operations needed by the stream-qualified table session.
+pub trait TableSyncStore {
+    fn account_id(&self) -> Hash;
+    fn supported_streams(&self) -> anyhow::Result<Vec<ManifestItem>>;
+    fn validates(&self, item: &ManifestItem) -> anyhow::Result<bool>;
+    fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<(Hash, Vec<u8>)>>;
+    fn ingest(&mut self, item: &ManifestItem, signed_bytes: &[u8]) -> anyhow::Result<Ingested>;
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TableSessionReport {
+    pub streams: usize,
+    pub entries_sent: usize,
+    pub entries_received: usize,
+    pub entries_newly_stored: usize,
+}
+
+#[derive(Debug)]
+pub enum TableSessionError {
+    Codec(TableCodecError),
+    Protocol(String),
+    UnauthorizedPush,
+    Store(anyhow::Error),
+}
+
+impl std::fmt::Display for TableSessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Codec(error) => write!(f, "table-sync session transport: {error}"),
+            Self::Protocol(message) => write!(f, "table-sync protocol violation: {message}"),
+            Self::UnauthorizedPush => write!(f, "read-only peer attempted to push table entries"),
+            Self::Store(error) => write!(f, "table-sync session store: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for TableSessionError {}
+
+pub async fn run_table_session<S, R, W>(
+    store: &mut S,
+    send: W,
+    recv: R,
+    role: AuthRole,
+    capabilities: SessionCapabilities,
+) -> Result<TableSessionReport, TableSessionError>
+where
+    S: TableSyncStore,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    run_table_session_with_idle_timeout(store, send, recv, role, capabilities, DEFAULT_IDLE_TIMEOUT)
+        .await
+}
+
+async fn run_table_session_with_idle_timeout<S, R, W>(
+    store: &mut S,
+    mut send: W,
+    mut recv: R,
+    role: AuthRole,
+    capabilities: SessionCapabilities,
+    idle_timeout: Duration,
+) -> Result<TableSessionReport, TableSessionError>
+where
+    S: TableSyncStore,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let local_manifest =
+        Manifest::new(store.supported_streams().map_err(TableSessionError::Store)?)
+            .map_err(|error| TableSessionError::Store(error.into()))?;
+    let local_routes: HashSet<ManifestItem> = local_manifest.items().iter().cloned().collect();
+    let mut snapshots = HashMap::with_capacity(local_manifest.items().len());
+    for item in local_manifest.items() {
+        let snapshot = store.snapshot(item).map_err(TableSessionError::Store)?;
+        if snapshot.iter().any(|(_, bytes)| bytes.len() > MAX_TABLE_ENTRY_BYTES) {
+            return Err(TableSessionError::Store(anyhow::anyhow!(
+                "local table-sync entry exceeds {MAX_TABLE_ENTRY_BYTES} bytes"
+            )));
+        }
+        snapshots.insert(item.stream_id, snapshot);
+    }
+
+    let (intersection_tx, intersection_rx) = tokio::sync::oneshot::channel::<Vec<ManifestItem>>();
+    let (inventory_tx, mut inventory_rx) =
+        tokio::sync::mpsc::channel::<(Hash, HashSet<Hash>)>(local_manifest.items().len().max(1));
+
+    let sender = async move {
+        write_before(&mut send, &TableFrame::Manifest(local_manifest), idle_timeout).await?;
+        let Ok(intersection) = intersection_rx.await else {
+            return Ok((send, 0usize));
+        };
+        for item in &intersection {
+            let snapshot = snapshots.get(&item.stream_id).ok_or_else(|| {
+                TableSessionError::Protocol("intersection names an unsupported local stream".into())
+            })?;
+            let have =
+                snapshot.iter().map(|(hash, _)| *hash).take(MAX_TABLE_INVENTORY_HASHES).collect();
+            write_before(
+                &mut send,
+                &TableFrame::Inventory { stream_id: item.stream_id, have },
+                idle_timeout,
+            )
+            .await?;
+        }
+
+        let mut sent = 0;
+        for item in &intersection {
+            let Some((stream_id, peer_have)) = inventory_rx.recv().await else {
+                return Ok((send, sent));
+            };
+            if stream_id != item.stream_id {
+                return Err(TableSessionError::Protocol(
+                    "peer inventories arrived out of canonical stream order".into(),
+                ));
+            }
+            let remaining = MAX_SESSION_ENTRIES.saturating_sub(sent);
+            let mut entries: Vec<Vec<u8>> = if capabilities.local.can_push() {
+                snapshots[&item.stream_id]
+                    .iter()
+                    .filter(|(hash, _)| !peer_have.contains(hash))
+                    .take(remaining)
+                    .map(|(_, bytes)| bytes.clone())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            sent += entries.len();
+            while !entries.is_empty() {
+                let tail = entries.split_off(entries.len().min(MAX_TABLE_ENTRIES_PER_PAGE));
+                let page = std::mem::replace(&mut entries, tail);
+                let more = !entries.is_empty();
+                write_before(
+                    &mut send,
+                    &TableFrame::Entries { stream_id: item.stream_id, entries: page, more },
+                    idle_timeout,
+                )
+                .await?;
+            }
+            write_before(
+                &mut send,
+                &TableFrame::StreamDone { stream_id: item.stream_id },
+                idle_timeout,
+            )
+            .await?;
+        }
+        write_before(&mut send, &TableFrame::Done, idle_timeout).await?;
+        Ok::<_, TableSessionError>((send, sent))
+    };
+
+    let receiver = async {
+        let TableFrame::Manifest(peer_manifest) = read_before(&mut recv, idle_timeout).await?
+        else {
+            return Err(TableSessionError::Protocol("peer did not open with a manifest".into()));
+        };
+        let mut intersection = Vec::new();
+        for item in peer_manifest.items() {
+            if local_routes.contains(item)
+                && store.validates(item).map_err(TableSessionError::Store)?
+            {
+                intersection.push(item.clone());
+            }
+        }
+        let streams = intersection.len();
+        intersection_tx.send(intersection.clone()).map_err(|_| {
+            TableSessionError::Protocol("local sender stopped before manifest exchange".into())
+        })?;
+
+        for item in &intersection {
+            let TableFrame::Inventory { stream_id, have } =
+                read_before(&mut recv, idle_timeout).await?
+            else {
+                return Err(TableSessionError::Protocol(
+                    "peer did not send the expected stream inventory".into(),
+                ));
+            };
+            if stream_id != item.stream_id {
+                return Err(TableSessionError::Protocol(
+                    "peer inventory names the wrong stream".into(),
+                ));
+            }
+            inventory_tx.send((stream_id, have.into_iter().collect())).await.map_err(|_| {
+                TableSessionError::Protocol("local sender stopped during inventory exchange".into())
+            })?;
+        }
+
+        let mut received = 0;
+        let mut newly_stored = 0;
+        for item in &intersection {
+            let mut saw_page = false;
+            let mut saw_final = false;
+            loop {
+                match read_before(&mut recv, idle_timeout).await? {
+                    TableFrame::Entries { stream_id, entries, more } => {
+                        if !capabilities.peer.can_push() {
+                            return Err(TableSessionError::UnauthorizedPush);
+                        }
+                        if stream_id != item.stream_id {
+                            return Err(TableSessionError::Protocol(
+                                "peer entry page names the wrong stream".into(),
+                            ));
+                        }
+                        if entries.is_empty() || saw_final {
+                            return Err(TableSessionError::Protocol(
+                                "peer sent an empty or after-final table entry page".into(),
+                            ));
+                        }
+                        for bytes in entries {
+                            received += 1;
+                            if received > MAX_SESSION_ENTRIES {
+                                return Err(TableSessionError::Protocol(format!(
+                                    "peer streamed more than {MAX_SESSION_ENTRIES} table entries"
+                                )));
+                            }
+                            if store.ingest(item, &bytes).map_err(TableSessionError::Store)?
+                                == Ingested::Stored
+                            {
+                                newly_stored += 1;
+                            }
+                        }
+                        saw_page = true;
+                        saw_final = !more;
+                    },
+                    TableFrame::StreamDone { stream_id } => {
+                        if stream_id != item.stream_id || (saw_page && !saw_final) {
+                            return Err(TableSessionError::Protocol(
+                                "peer ended the wrong or incomplete table stream".into(),
+                            ));
+                        }
+                        break;
+                    },
+                    _ => {
+                        return Err(TableSessionError::Protocol(
+                            "peer sent an out-of-sequence table frame".into(),
+                        ));
+                    },
+                }
+            }
+        }
+        if read_before(&mut recv, idle_timeout).await? != TableFrame::Done {
+            return Err(TableSessionError::Protocol(
+                "peer did not finish after its streams".into(),
+            ));
+        }
+        Ok::<_, TableSessionError>((recv, streams, received, newly_stored))
+    };
+
+    let ((mut send, entries_sent), (mut recv, streams, entries_received, entries_newly_stored)) =
+        tokio::try_join!(sender, receiver)?;
+    complete(&mut send, &mut recv, role, idle_timeout).await?;
+    Ok(TableSessionReport { streams, entries_sent, entries_received, entries_newly_stored })
+}
+
+async fn complete<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
+    send: &mut W,
+    recv: &mut R,
+    role: AuthRole,
+    idle_timeout: Duration,
+) -> Result<(), TableSessionError> {
+    match role {
+        AuthRole::Dialer => {
+            send_ack(send, idle_timeout).await?;
+            read_ack(recv, idle_timeout).await
+        },
+        AuthRole::Acceptor => {
+            read_ack(recv, idle_timeout).await?;
+            send_ack(send, idle_timeout).await
+        },
+    }
+}
+
+async fn send_ack<W: AsyncWrite + Unpin>(
+    send: &mut W,
+    idle_timeout: Duration,
+) -> Result<(), TableSessionError> {
+    write_before(send, &TableFrame::Ack, idle_timeout).await?;
+    match tokio::time::timeout(idle_timeout, send.shutdown()).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(TableSessionError::Codec(TableCodecError::Io(error))),
+        Err(_) => Err(TableSessionError::Protocol("table session timed out while closing".into())),
+    }
+}
+
+async fn write_before<W: AsyncWrite + Unpin>(
+    send: &mut W,
+    frame: &TableFrame,
+    idle_timeout: Duration,
+) -> Result<(), TableSessionError> {
+    match tokio::time::timeout(idle_timeout, table_codec::write_frame(send, frame)).await {
+        Ok(result) => result.map_err(TableSessionError::Codec),
+        Err(_) => Err(TableSessionError::Protocol("table session timed out while writing".into())),
+    }
+}
+
+async fn read_ack<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    idle_timeout: Duration,
+) -> Result<(), TableSessionError> {
+    if read_before(recv, idle_timeout).await? == TableFrame::Ack {
+        Ok(())
+    } else {
+        Err(TableSessionError::Protocol(
+            "peer did not send the table-session acknowledgement".into(),
+        ))
+    }
+}
+
+async fn read_before<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    idle_timeout: Duration,
+) -> Result<TableFrame, TableSessionError> {
+    match tokio::time::timeout(idle_timeout, table_codec::read_frame(recv)).await {
+        Ok(Ok(frame)) => Ok(frame),
+        Ok(Err(TableCodecError::Eof)) =>
+            Err(TableSessionError::Protocol("peer closed before table-session completion".into())),
+        Ok(Err(error)) => Err(TableSessionError::Codec(error)),
+        Err(_) => Err(TableSessionError::Protocol("table session timed out as idle".into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct MemStore {
+        account: Hash,
+        supported: Vec<ManifestItem>,
+        entries: HashMap<Hash, HashMap<Hash, Vec<u8>>>,
+    }
+
+    impl MemStore {
+        fn new(items: Vec<ManifestItem>) -> Self {
+            Self { account: [7; 32], supported: items, entries: HashMap::new() }
+        }
+
+        fn insert(&mut self, stream: Hash, seed: u8) {
+            let mut bytes = vec![seed; 40];
+            bytes[..32].copy_from_slice(&[seed; 32]);
+            self.entries.entry(stream).or_default().insert([seed; 32], bytes);
+        }
+    }
+
+    impl TableSyncStore for MemStore {
+        fn account_id(&self) -> Hash {
+            self.account
+        }
+
+        fn supported_streams(&self) -> anyhow::Result<Vec<ManifestItem>> {
+            Ok(self.supported.clone())
+        }
+
+        fn validates(&self, item: &ManifestItem) -> anyhow::Result<bool> {
+            Ok(self.supported.contains(item))
+        }
+
+        fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<(Hash, Vec<u8>)>> {
+            Ok(self
+                .entries
+                .get(&item.stream_id)
+                .into_iter()
+                .flatten()
+                .map(|(hash, bytes)| (*hash, bytes.clone()))
+                .collect())
+        }
+
+        fn ingest(&mut self, item: &ManifestItem, bytes: &[u8]) -> anyhow::Result<Ingested> {
+            if !self.supported.contains(item) {
+                return Ok(Ingested::NoChange);
+            }
+            let hash: Hash = bytes[..32].try_into()?;
+            Ok(match self.entries.entry(item.stream_id).or_default().entry(hash) {
+                std::collections::hash_map::Entry::Occupied(_) => Ingested::NoChange,
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(bytes.to_vec());
+                    Ingested::Stored
+                },
+            })
+        }
+    }
+
+    fn item(repo: &str, stream: u8) -> ManifestItem {
+        ManifestItem {
+            repo_id: repo.into(),
+            incarnation_ref: [1; 32],
+            scope_id: "anchors/1".into(),
+            stream_id: [stream; 32],
+        }
+    }
+
+    async fn pair(a: &mut MemStore, b: &mut MemStore) -> (TableSessionReport, TableSessionReport) {
+        let (a_send, b_recv) = tokio::io::duplex(1 << 20);
+        let (b_send, a_recv) = tokio::io::duplex(1 << 20);
+        let (a, b) = tokio::join!(
+            run_table_session(
+                a,
+                a_send,
+                a_recv,
+                AuthRole::Dialer,
+                SessionCapabilities::bidirectional(),
+            ),
+            run_table_session(
+                b,
+                b_send,
+                b_recv,
+                AuthRole::Acceptor,
+                SessionCapabilities::bidirectional(),
+            ),
+        );
+        (a.unwrap(), b.unwrap())
+    }
+
+    #[tokio::test]
+    async fn only_the_multi_repo_manifest_intersection_reconciles() {
+        let shared = item("repo-b", 2);
+        let mut a = MemStore::new(vec![item("repo-a", 1), shared.clone()]);
+        let mut b = MemStore::new(vec![shared.clone(), item("repo-c", 3)]);
+        a.insert([1; 32], 10);
+        a.insert(shared.stream_id, 20);
+        b.insert([3; 32], 30);
+
+        let (a_report, b_report) = pair(&mut a, &mut b).await;
+        assert_eq!(a_report.streams, 1);
+        assert_eq!(b_report.entries_newly_stored, 1);
+        assert_eq!(b.entries[&shared.stream_id].len(), 1);
+        assert!(!b.entries.contains_key(&[1; 32]), "repo-a never crosses into repo-c's peer");
+        assert!(!a.entries.contains_key(&[3; 32]), "repo-c never crosses into repo-a's peer");
+
+        let (again_a, again_b) = pair(&mut a, &mut b).await;
+        assert_eq!(again_a.entries_sent + again_b.entries_sent, 0);
+        assert_eq!(again_a.entries_newly_stored + again_b.entries_newly_stored, 0);
+    }
+
+    #[tokio::test]
+    async fn empty_manifests_are_a_clean_no_op() {
+        let mut a = MemStore::new(Vec::new());
+        let mut b = MemStore::new(Vec::new());
+        let (a, b) = pair(&mut a, &mut b).await;
+        assert_eq!(a, TableSessionReport::default());
+        assert_eq!(b, TableSessionReport::default());
+    }
+
+    #[tokio::test]
+    async fn a_peer_that_stops_reading_cannot_block_writes_forever() {
+        let shared = item("repo-a", 1);
+        let mut store = MemStore::new(vec![shared.clone()]);
+        for seed in 1..=32 {
+            store.insert(shared.stream_id, seed);
+        }
+        let (send, _peer_recv) = tokio::io::duplex(64);
+        let (mut peer_send, recv) = tokio::io::duplex(4096);
+        let peer = async move {
+            for frame in [
+                TableFrame::Manifest(Manifest::new(vec![shared.clone()]).unwrap()),
+                TableFrame::Inventory { stream_id: shared.stream_id, have: Vec::new() },
+                TableFrame::StreamDone { stream_id: shared.stream_id },
+                TableFrame::Done,
+            ] {
+                table_codec::write_frame(&mut peer_send, &frame).await.unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
+        let (result, ()) = tokio::join!(
+            run_table_session_with_idle_timeout(
+                &mut store,
+                send,
+                recv,
+                AuthRole::Dialer,
+                SessionCapabilities::bidirectional(),
+                Duration::from_millis(20),
+            ),
+            peer,
+        );
+        assert!(matches!(
+            result,
+            Err(TableSessionError::Protocol(message)) if message.contains("timed out while writing")
+        ));
+    }
+}

--- a/crates/rag-rat-sync/src/table_session.rs
+++ b/crates/rag-rat-sync/src/table_session.rs
@@ -86,8 +86,25 @@ where
         Manifest::new(store.supported_streams().map_err(TableSessionError::Store)?)
             .map_err(|error| TableSessionError::Store(error.into()))?;
     let local_routes: HashSet<ManifestItem> = local_manifest.items().iter().cloned().collect();
-    let mut snapshots = HashMap::with_capacity(local_manifest.items().len());
-    for item in local_manifest.items() {
+    let manifest_frame = TableFrame::Manifest(local_manifest);
+    let send_manifest = write_before(&mut send, &manifest_frame, idle_timeout);
+    let receive_manifest = async {
+        let TableFrame::Manifest(manifest) = read_before(&mut recv, idle_timeout).await? else {
+            return Err(TableSessionError::Protocol("peer did not open with a manifest".into()));
+        };
+        Ok::<_, TableSessionError>(manifest)
+    };
+    let ((), peer_manifest) = tokio::try_join!(send_manifest, receive_manifest)?;
+
+    let mut intersection = Vec::new();
+    for item in peer_manifest.items() {
+        if local_routes.contains(item) && store.validates(item).map_err(TableSessionError::Store)? {
+            intersection.push(item.clone());
+        }
+    }
+    let streams = intersection.len();
+    let mut snapshots = HashMap::with_capacity(streams);
+    for item in &intersection {
         let snapshot = store.snapshot(item).map_err(TableSessionError::Store)?;
         if snapshot.iter().any(|(_, bytes)| bytes.len() > MAX_TABLE_ENTRY_BYTES) {
             return Err(TableSessionError::Store(anyhow::anyhow!(
@@ -97,16 +114,12 @@ where
         snapshots.insert(item.stream_id, snapshot);
     }
 
-    let (intersection_tx, intersection_rx) = tokio::sync::oneshot::channel::<Vec<ManifestItem>>();
     let (inventory_tx, mut inventory_rx) =
-        tokio::sync::mpsc::channel::<(Hash, HashSet<Hash>)>(local_manifest.items().len().max(1));
+        tokio::sync::mpsc::channel::<(Hash, HashSet<Hash>)>(streams.max(1));
+    let send_intersection = intersection.clone();
 
     let sender = async move {
-        write_before(&mut send, &TableFrame::Manifest(local_manifest), idle_timeout).await?;
-        let Ok(intersection) = intersection_rx.await else {
-            return Ok((send, 0usize));
-        };
-        for item in &intersection {
+        for item in &send_intersection {
             let snapshot = snapshots.get(&item.stream_id).ok_or_else(|| {
                 TableSessionError::Protocol("intersection names an unsupported local stream".into())
             })?;
@@ -121,7 +134,7 @@ where
         }
 
         let mut sent = 0;
-        for item in &intersection {
+        for item in &send_intersection {
             let Some((stream_id, peer_have)) = inventory_rx.recv().await else {
                 return Ok((send, sent));
             };
@@ -165,23 +178,6 @@ where
     };
 
     let receiver = async {
-        let TableFrame::Manifest(peer_manifest) = read_before(&mut recv, idle_timeout).await?
-        else {
-            return Err(TableSessionError::Protocol("peer did not open with a manifest".into()));
-        };
-        let mut intersection = Vec::new();
-        for item in peer_manifest.items() {
-            if local_routes.contains(item)
-                && store.validates(item).map_err(TableSessionError::Store)?
-            {
-                intersection.push(item.clone());
-            }
-        }
-        let streams = intersection.len();
-        intersection_tx.send(intersection.clone()).map_err(|_| {
-            TableSessionError::Protocol("local sender stopped before manifest exchange".into())
-        })?;
-
         for item in &intersection {
             let TableFrame::Inventory { stream_id, have } =
                 read_before(&mut recv, idle_timeout).await?
@@ -343,17 +339,27 @@ mod tests {
         account: Hash,
         supported: Vec<ManifestItem>,
         entries: HashMap<Hash, HashMap<Hash, Vec<u8>>>,
+        forbidden_snapshots: HashSet<Hash>,
     }
 
     impl MemStore {
         fn new(items: Vec<ManifestItem>) -> Self {
-            Self { account: [7; 32], supported: items, entries: HashMap::new() }
+            Self {
+                account: [7; 32],
+                supported: items,
+                entries: HashMap::new(),
+                forbidden_snapshots: HashSet::new(),
+            }
         }
 
         fn insert(&mut self, stream: Hash, seed: u8) {
             let mut bytes = vec![seed; 40];
             bytes[..32].copy_from_slice(&[seed; 32]);
             self.entries.entry(stream).or_default().insert([seed; 32], bytes);
+        }
+
+        fn forbid_snapshot(&mut self, stream: Hash) {
+            self.forbidden_snapshots.insert(stream);
         }
     }
 
@@ -371,6 +377,10 @@ mod tests {
         }
 
         fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<(Hash, Vec<u8>)>> {
+            anyhow::ensure!(
+                !self.forbidden_snapshots.contains(&item.stream_id),
+                "non-intersecting stream was snapshotted"
+            );
             Ok(self
                 .entries
                 .get(&item.stream_id)
@@ -434,6 +444,8 @@ mod tests {
         a.insert([1; 32], 10);
         a.insert(shared.stream_id, 20);
         b.insert([3; 32], 30);
+        a.forbid_snapshot([1; 32]);
+        b.forbid_snapshot([3; 32]);
 
         let (a_report, b_report) = pair(&mut a, &mut b).await;
         assert_eq!(a_report.streams, 1);

--- a/crates/rag-rat-sync/src/table_wire.rs
+++ b/crates/rag-rat-sync/src/table_wire.rs
@@ -13,7 +13,7 @@ pub const MAX_REPO_ID_BYTES: usize = 1024;
 pub const MAX_SCOPE_ID_BYTES: usize = 128;
 pub const MAX_TABLE_INVENTORY_HASHES: usize = 65_536;
 pub const MAX_TABLE_ENTRIES_PER_PAGE: usize = 32;
-pub const MAX_TABLE_ENTRY_BYTES: usize = 64 * 1024;
+pub const MAX_TABLE_ENTRY_BYTES: usize = rag_rat_oplog::TABLE_SYNC_ENTRY_MAX_BYTES;
 
 type Hash = [u8; 32];
 

--- a/crates/rag-rat-sync/src/table_wire.rs
+++ b/crates/rag-rat-sync/src/table_wire.rs
@@ -449,4 +449,41 @@ mod tests {
         let bytes = TableFrame::Manifest(Manifest(reversed)).encode();
         assert!(matches!(TableFrame::decode(&bytes), Err(TableWireError::Malformed(_))));
     }
+
+    #[test]
+    fn remaining_manifest_and_decoder_bounds_are_rejected() {
+        let items = (0..=MAX_MANIFEST_ITEMS)
+            .map(|index| {
+                let mut stream_id = [0; 32];
+                stream_id[..8].copy_from_slice(&(index as u64).to_be_bytes());
+                ManifestItem {
+                    repo_id: format!("repo-{index}"),
+                    incarnation_ref: [1; 32],
+                    scope_id: "anchors/1".into(),
+                    stream_id,
+                }
+            })
+            .collect();
+        let over_cap = Manifest::new(items).unwrap_err();
+        assert!(over_cap.to_string().contains("over cap"));
+        assert!(Manifest::new(vec![item("", 1, "s", 2)]).is_err());
+
+        let malformed = TableFrame::decode(&[0xff]).unwrap_err();
+        assert!(malformed.to_string().contains("malformed"));
+
+        let mut unknown_tag = Vec::new();
+        let mut enc = Encoder::new(&mut unknown_tag);
+        enc.array(2).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(99).unwrap();
+        assert!(TableFrame::decode(&unknown_tag).is_err());
+
+        let mut short_stream = Vec::new();
+        let mut enc = Encoder::new(&mut short_stream);
+        enc.array(3).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(tag::STREAM_DONE).unwrap();
+        enc.bytes(&[0]).unwrap();
+        assert!(TableFrame::decode(&short_stream).is_err());
+    }
 }

--- a/crates/rag-rat-sync/src/table_wire.rs
+++ b/crates/rag-rat-sync/src/table_wire.rs
@@ -1,0 +1,452 @@
+//! Frozen wire shapes for the repo-scoped `/5` table-sync transport.
+
+use std::collections::BTreeMap;
+
+use minicbor::{Decoder, Encoder};
+
+/// Dedicated ALPN for table-stream sync. Existing account/content/enrollment ALPNs do not move.
+pub const TABLE_SYNC_ALPN: &[u8] = b"rag-rat/table-sync/1";
+
+const FRAME_DOMAIN: &str = "rag-rat/table-sync-frame/1";
+pub const MAX_MANIFEST_ITEMS: usize = 1024;
+pub const MAX_REPO_ID_BYTES: usize = 1024;
+pub const MAX_SCOPE_ID_BYTES: usize = 128;
+pub const MAX_TABLE_INVENTORY_HASHES: usize = 65_536;
+pub const MAX_TABLE_ENTRIES_PER_PAGE: usize = 32;
+pub const MAX_TABLE_ENTRY_BYTES: usize = 64 * 1024;
+
+type Hash = [u8; 32];
+
+/// One stream route advertised after mutual account authorization.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ManifestItem {
+    pub repo_id: String,
+    pub incarnation_ref: Hash,
+    pub scope_id: String,
+    pub stream_id: Hash,
+}
+
+/// Canonical manifest: sorted, exactly deduplicated, and conflict-free.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest(Vec<ManifestItem>);
+
+impl Manifest {
+    pub fn new(mut items: Vec<ManifestItem>) -> Result<Self, TableWireError> {
+        let mut routes = BTreeMap::new();
+        let mut identities = BTreeMap::new();
+        for item in &items {
+            validate_text("repo_id", &item.repo_id, MAX_REPO_ID_BYTES)?;
+            validate_text("scope_id", &item.scope_id, MAX_SCOPE_ID_BYTES)?;
+            if routes
+                .insert((item.repo_id.as_str(), item.scope_id.as_str()), item)
+                .is_some_and(|existing| existing != item)
+                || identities.insert(item.stream_id, item).is_some_and(|existing| existing != item)
+            {
+                return Err(TableWireError::Malformed(
+                    "manifest contains conflicting routes for one stream".into(),
+                ));
+            }
+        }
+        drop((routes, identities));
+        items.sort();
+        items.dedup();
+        if items.len() > MAX_MANIFEST_ITEMS {
+            return Err(TableWireError::OverCap(format!(
+                "manifest items {} > {MAX_MANIFEST_ITEMS}",
+                items.len()
+            )));
+        }
+        Ok(Self(items))
+    }
+
+    pub fn items(&self) -> &[ManifestItem] {
+        &self.0
+    }
+}
+
+/// Table-session frames. Every inventory and entry page is explicitly stream-qualified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TableFrame {
+    Manifest(Manifest),
+    Inventory { stream_id: Hash, have: Vec<Hash> },
+    Entries { stream_id: Hash, entries: Vec<Vec<u8>>, more: bool },
+    StreamDone { stream_id: Hash },
+    Done,
+    Ack,
+}
+
+mod tag {
+    pub const MANIFEST: u8 = 0;
+    pub const INVENTORY: u8 = 1;
+    pub const ENTRIES: u8 = 2;
+    pub const STREAM_DONE: u8 = 3;
+    pub const DONE: u8 = 4;
+    pub const ACK: u8 = 5;
+}
+
+#[derive(Debug)]
+pub enum TableWireError {
+    Malformed(String),
+    OverCap(String),
+}
+
+impl std::fmt::Display for TableWireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(message) => write!(f, "malformed table-sync frame: {message}"),
+            Self::OverCap(message) => write!(f, "table-sync frame over cap: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for TableWireError {}
+
+impl TableFrame {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut enc = Encoder::new(&mut bytes);
+        match self {
+            Self::Manifest(manifest) => {
+                enc.array(3).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::MANIFEST).expect(INFALLIBLE);
+                enc.array(manifest.items().len() as u64).expect(INFALLIBLE);
+                for item in manifest.items() {
+                    enc.array(4).expect(INFALLIBLE);
+                    enc.str(&item.repo_id).expect(INFALLIBLE);
+                    enc.bytes(&item.incarnation_ref).expect(INFALLIBLE);
+                    enc.str(&item.scope_id).expect(INFALLIBLE);
+                    enc.bytes(&item.stream_id).expect(INFALLIBLE);
+                }
+            },
+            Self::Inventory { stream_id, have } => {
+                enc.array(4).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::INVENTORY).expect(INFALLIBLE);
+                enc.bytes(stream_id).expect(INFALLIBLE);
+                enc.array(have.len() as u64).expect(INFALLIBLE);
+                for hash in have {
+                    enc.bytes(hash).expect(INFALLIBLE);
+                }
+            },
+            Self::Entries { stream_id, entries, more } => {
+                enc.array(5).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::ENTRIES).expect(INFALLIBLE);
+                enc.bytes(stream_id).expect(INFALLIBLE);
+                enc.array(entries.len() as u64).expect(INFALLIBLE);
+                for entry in entries {
+                    enc.bytes(entry).expect(INFALLIBLE);
+                }
+                enc.bool(*more).expect(INFALLIBLE);
+            },
+            Self::StreamDone { stream_id } => {
+                enc.array(3).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::STREAM_DONE).expect(INFALLIBLE);
+                enc.bytes(stream_id).expect(INFALLIBLE);
+            },
+            Self::Done => {
+                enc.array(2).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::DONE).expect(INFALLIBLE);
+            },
+            Self::Ack => {
+                enc.array(2).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::ACK).expect(INFALLIBLE);
+            },
+        }
+        bytes
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, TableWireError> {
+        let mut dec = Decoder::new(bytes);
+        let outer = expect_len(dec.array().map_err(m)?, "frame")?;
+        let domain = dec.str().map_err(m)?;
+        if domain != FRAME_DOMAIN {
+            return Err(TableWireError::Malformed(format!("unknown frame domain {domain:?}")));
+        }
+        let tag = dec.u8().map_err(m)?;
+        let expected = match tag {
+            tag::MANIFEST => 3,
+            tag::INVENTORY => 4,
+            tag::ENTRIES => 5,
+            tag::STREAM_DONE => 3,
+            tag::DONE | tag::ACK => 2,
+            other => return Err(TableWireError::Malformed(format!("unknown frame tag {other}"))),
+        };
+        if outer != expected {
+            return Err(TableWireError::Malformed(format!(
+                "frame tag {tag} arity {outer}, expected {expected}"
+            )));
+        }
+        let frame = match tag {
+            tag::MANIFEST => Self::Manifest(decode_manifest(&mut dec)?),
+            tag::INVENTORY => {
+                let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
+                let count = bounded_count(
+                    dec.array().map_err(m)?,
+                    "inventory hashes",
+                    MAX_TABLE_INVENTORY_HASHES,
+                )?;
+                let mut have = Vec::with_capacity(count);
+                for _ in 0..count {
+                    have.push(fixed32(dec.bytes().map_err(m)?, "inventory hash")?);
+                }
+                Self::Inventory { stream_id, have }
+            },
+            tag::ENTRIES => {
+                let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
+                let count =
+                    bounded_count(dec.array().map_err(m)?, "entries", MAX_TABLE_ENTRIES_PER_PAGE)?;
+                let mut entries = Vec::with_capacity(count);
+                for _ in 0..count {
+                    let entry = dec.bytes().map_err(m)?;
+                    if entry.len() > MAX_TABLE_ENTRY_BYTES {
+                        return Err(TableWireError::OverCap(format!(
+                            "entry bytes {} > {MAX_TABLE_ENTRY_BYTES}",
+                            entry.len()
+                        )));
+                    }
+                    entries.push(entry.to_vec());
+                }
+                Self::Entries { stream_id, entries, more: dec.bool().map_err(m)? }
+            },
+            tag::STREAM_DONE =>
+                Self::StreamDone { stream_id: fixed32(dec.bytes().map_err(m)?, "stream_id")? },
+            tag::DONE => Self::Done,
+            tag::ACK => Self::Ack,
+            _ => unreachable!(),
+        };
+        if dec.position() != bytes.len() {
+            return Err(TableWireError::Malformed("trailing bytes after frame".into()));
+        }
+        Ok(frame)
+    }
+}
+
+fn decode_manifest(dec: &mut Decoder<'_>) -> Result<Manifest, TableWireError> {
+    let count = bounded_count(dec.array().map_err(m)?, "manifest items", MAX_MANIFEST_ITEMS)?;
+    let mut raw = Vec::with_capacity(count);
+    for _ in 0..count {
+        if dec.array().map_err(m)? != Some(4) {
+            return Err(TableWireError::Malformed("manifest item arity".into()));
+        }
+        let repo_id = dec.str().map_err(m)?;
+        validate_text("repo_id", repo_id, MAX_REPO_ID_BYTES)?;
+        let incarnation_ref = fixed32(dec.bytes().map_err(m)?, "incarnation_ref")?;
+        let scope_id = dec.str().map_err(m)?;
+        validate_text("scope_id", scope_id, MAX_SCOPE_ID_BYTES)?;
+        let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
+        raw.push(ManifestItem {
+            repo_id: repo_id.to_owned(),
+            incarnation_ref,
+            scope_id: scope_id.to_owned(),
+            stream_id,
+        });
+    }
+    let canonical = Manifest::new(raw.clone())?;
+    if canonical.items() != raw {
+        return Err(TableWireError::Malformed(
+            "manifest items are not in canonical sorted/deduplicated order".into(),
+        ));
+    }
+    Ok(canonical)
+}
+
+fn validate_text(field: &str, value: &str, max: usize) -> Result<(), TableWireError> {
+    if value.is_empty() {
+        return Err(TableWireError::Malformed(format!("empty {field}")));
+    }
+    if value.len() > max {
+        return Err(TableWireError::OverCap(format!("{field} bytes {} > {max}", value.len())));
+    }
+    Ok(())
+}
+
+fn bounded_count(count: Option<u64>, field: &str, max: usize) -> Result<usize, TableWireError> {
+    let count = expect_len(count, field)?;
+    if count > max as u64 {
+        return Err(TableWireError::OverCap(format!("{field} {count} > {max}")));
+    }
+    Ok(count as usize)
+}
+
+fn expect_len(count: Option<u64>, field: &str) -> Result<u64, TableWireError> {
+    count.ok_or_else(|| TableWireError::Malformed(format!("indefinite-length {field} array")))
+}
+
+fn fixed32(bytes: &[u8], field: &str) -> Result<Hash, TableWireError> {
+    bytes.try_into().map_err(|_| {
+        TableWireError::Malformed(format!("{field} must be 32 bytes, got {}", bytes.len()))
+    })
+}
+
+fn m(error: minicbor::decode::Error) -> TableWireError {
+    TableWireError::Malformed(error.to_string())
+}
+
+const INFALLIBLE: &str = "encoding into an owned Vec cannot fail";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(repo: &str, incarnation: u8, scope: &str, stream: u8) -> ManifestItem {
+        ManifestItem {
+            repo_id: repo.into(),
+            incarnation_ref: [incarnation; 32],
+            scope_id: scope.into(),
+            stream_id: [stream; 32],
+        }
+    }
+
+    #[test]
+    fn manifest_sorts_and_collapses_exact_duplicates_but_rejects_conflicts() {
+        let a = item("repo-a", 1, "anchors/1", 2);
+        let b = item("repo-b", 3, "anchors/1", 4);
+        let manifest = Manifest::new(vec![b.clone(), a.clone(), a.clone()]).unwrap();
+        assert_eq!(manifest.items(), &[a.clone(), b]);
+
+        let mut conflict = a.clone();
+        conflict.stream_id = [9; 32];
+        assert!(matches!(Manifest::new(vec![a, conflict]), Err(TableWireError::Malformed(_))));
+    }
+
+    #[test]
+    fn all_frames_roundtrip_and_new_wire_bytes_are_frozen() {
+        let manifest = Manifest::new(vec![item("r", 1, "s", 2)]).unwrap();
+        let frames = [
+            TableFrame::Manifest(manifest.clone()),
+            TableFrame::Inventory { stream_id: [2; 32], have: vec![[3; 32]] },
+            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]], more: false },
+            TableFrame::StreamDone { stream_id: [2; 32] },
+            TableFrame::Done,
+            TableFrame::Ack,
+        ];
+        for frame in frames {
+            assert_eq!(TableFrame::decode(&frame.encode()).unwrap(), frame);
+        }
+        assert_eq!(TableFrame::Done.encode(), [
+            0x82, 0x78, 0x1a, b'r', b'a', b'g', b'-', b'r', b'a', b't', b'/', b't', b'a', b'b',
+            b'l', b'e', b'-', b's', b'y', b'n', b'c', b'-', b'f', b'r', b'a', b'm', b'e', b'/',
+            b'1', 0x04,
+        ]);
+        assert_eq!(TABLE_SYNC_ALPN, b"rag-rat/table-sync/1");
+    }
+
+    #[test]
+    fn every_new_frame_layout_has_one_combined_golden_digest() {
+        use sha2::{Digest, Sha256};
+
+        let frames = [
+            TableFrame::Manifest(Manifest::new(vec![item("r", 1, "s", 2)]).unwrap()),
+            TableFrame::Inventory { stream_id: [2; 32], have: vec![[3; 32]] },
+            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]], more: false },
+            TableFrame::StreamDone { stream_id: [2; 32] },
+            TableFrame::Done,
+            TableFrame::Ack,
+        ];
+        let mut golden = Vec::new();
+        for frame in frames {
+            let bytes = frame.encode();
+            golden.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+            golden.extend_from_slice(&bytes);
+        }
+        assert_eq!(Sha256::digest(golden).as_slice(), &[
+            127, 65, 177, 170, 94, 248, 249, 42, 4, 84, 175, 14, 138, 115, 103, 182, 228, 64, 61,
+            105, 158, 189, 214, 59, 224, 146, 228, 176, 152, 213, 72, 222,
+        ]);
+    }
+
+    #[test]
+    fn malformed_domain_arity_and_trailing_bytes_are_rejected() {
+        let mut wrong_domain = TableFrame::Done.encode();
+        wrong_domain[3] = b'x';
+        assert!(matches!(TableFrame::decode(&wrong_domain), Err(TableWireError::Malformed(_))));
+
+        let mut wrong_arity = Vec::new();
+        let mut enc = Encoder::new(&mut wrong_arity);
+        enc.array(3).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(tag::DONE).unwrap();
+        enc.u8(0).unwrap();
+        assert!(matches!(TableFrame::decode(&wrong_arity), Err(TableWireError::Malformed(_))));
+
+        let mut trailing = TableFrame::Done.encode();
+        trailing.push(0);
+        assert!(matches!(TableFrame::decode(&trailing), Err(TableWireError::Malformed(_))));
+    }
+
+    #[test]
+    fn manifest_item_count_and_string_widths_are_bounded_before_body_allocation() {
+        let mut over_count = Vec::new();
+        let mut enc = Encoder::new(&mut over_count);
+        enc.array(3).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(tag::MANIFEST).unwrap();
+        enc.array((MAX_MANIFEST_ITEMS + 1) as u64).unwrap();
+        assert!(matches!(TableFrame::decode(&over_count), Err(TableWireError::OverCap(_))));
+
+        let over_repo = item(&"r".repeat(MAX_REPO_ID_BYTES + 1), 1, "s", 2);
+        assert!(matches!(Manifest::new(vec![over_repo]), Err(TableWireError::OverCap(_))));
+        let over_scope = item("r", 1, &"s".repeat(MAX_SCOPE_ID_BYTES + 1), 2);
+        assert!(matches!(Manifest::new(vec![over_scope]), Err(TableWireError::OverCap(_))));
+    }
+
+    #[test]
+    fn inventory_entry_count_and_entry_width_are_bounded_from_declared_lengths() {
+        let mut inventory = Vec::new();
+        let mut enc = Encoder::new(&mut inventory);
+        enc.array(4).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(tag::INVENTORY).unwrap();
+        enc.bytes(&[1; 32]).unwrap();
+        enc.array((MAX_TABLE_INVENTORY_HASHES + 1) as u64).unwrap();
+        assert!(matches!(TableFrame::decode(&inventory), Err(TableWireError::OverCap(_))));
+
+        let mut entries = Vec::new();
+        let mut enc = Encoder::new(&mut entries);
+        enc.array(5).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(tag::ENTRIES).unwrap();
+        enc.bytes(&[1; 32]).unwrap();
+        enc.array((MAX_TABLE_ENTRIES_PER_PAGE + 1) as u64).unwrap();
+        assert!(matches!(TableFrame::decode(&entries), Err(TableWireError::OverCap(_))));
+
+        let oversized = TableFrame::Entries {
+            stream_id: [1; 32],
+            entries: vec![vec![0; MAX_TABLE_ENTRY_BYTES + 1]],
+            more: false,
+        }
+        .encode();
+        assert!(matches!(TableFrame::decode(&oversized), Err(TableWireError::OverCap(_))));
+    }
+
+    #[test]
+    fn malformed_manifest_item_arity_is_rejected() {
+        let mut bytes = Vec::new();
+        let mut enc = Encoder::new(&mut bytes);
+        enc.array(3).unwrap();
+        enc.str(FRAME_DOMAIN).unwrap();
+        enc.u8(tag::MANIFEST).unwrap();
+        enc.array(1).unwrap();
+        enc.array(3).unwrap();
+        assert!(matches!(TableFrame::decode(&bytes), Err(TableWireError::Malformed(_))));
+    }
+
+    #[test]
+    fn noncanonical_wire_manifest_is_rejected() {
+        let manifest = Manifest::new(vec![
+            item("repo-a", 1, "anchors/1", 2),
+            item("repo-b", 3, "anchors/1", 4),
+        ])
+        .unwrap();
+        let mut reversed = manifest.items().to_vec();
+        reversed.reverse();
+        // Bypass `Manifest::new` only inside this module to handcraft noncanonical wire.
+        let bytes = TableFrame::Manifest(Manifest(reversed)).encode();
+        assert!(matches!(TableFrame::decode(&bytes), Err(TableWireError::Malformed(_))));
+    }
+}

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -284,10 +284,14 @@ mod tests {
     fn alpn_identifiers_are_frozen() {
         assert_eq!(SYNC_ALPN, b"rag-rat/sync/4");
         assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/3");
+        assert_eq!(crate::table_wire::TABLE_SYNC_ALPN, b"rag-rat/table-sync/1");
         assert_eq!(crate::enrollment::ENROLL_ALPN, b"rag-rat/enroll/1");
         assert_ne!(SYNC_ALPN, CONTENT_SYNC_ALPN);
         assert_ne!(SYNC_ALPN, crate::enrollment::ENROLL_ALPN);
         assert_ne!(CONTENT_SYNC_ALPN, crate::enrollment::ENROLL_ALPN);
+        assert_ne!(SYNC_ALPN, crate::table_wire::TABLE_SYNC_ALPN);
+        assert_ne!(CONTENT_SYNC_ALPN, crate::table_wire::TABLE_SYNC_ALPN);
+        assert_ne!(crate::enrollment::ENROLL_ALPN, crate::table_wire::TABLE_SYNC_ALPN);
     }
 
     #[test]

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -651,10 +651,15 @@ async fn a_real_iroh_round_trip_restores_content_via_alpn_dispatch() {
 /// 127.0.0.1 socket address — a relay-free transport so the pairing drill runs in CI, unlike the
 /// `#[ignore]` live tests that dial over a real relay.
 async fn loopback_endpoints() -> (iroh::Endpoint, iroh::Endpoint) {
-    use rag_rat_sync::{CONTENT_SYNC_ALPN, ENROLL_ALPN, SYNC_ALPN};
+    use rag_rat_sync::{CONTENT_SYNC_ALPN, ENROLL_ALPN, SYNC_ALPN, TABLE_SYNC_ALPN};
     let bind = |seed: [u8; 32]| async move {
         iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
-            .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec(), ENROLL_ALPN.to_vec()])
+            .alpns(vec![
+                SYNC_ALPN.to_vec(),
+                CONTENT_SYNC_ALPN.to_vec(),
+                TABLE_SYNC_ALPN.to_vec(),
+                ENROLL_ALPN.to_vec(),
+            ])
             .relay_mode(iroh::RelayMode::Disabled)
             .secret_key(iroh::SecretKey::from_bytes(&seed))
             .bind()
@@ -674,6 +679,92 @@ fn direct_addr(endpoint: &iroh::Endpoint) -> iroh::EndpointAddr {
         .port();
     iroh::EndpointAddr::new(endpoint.id())
         .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+}
+
+#[tokio::test]
+async fn empty_production_table_registry_negotiates_zero_streams_through_dispatch() {
+    use rag_rat_sync::{
+        AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, TABLE_SYNC_ALPN,
+        accept_and_dispatch, connect_and_table_sync,
+    };
+
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let joiner = fresh_db();
+    let (owner_endpoint, joiner_endpoint) = loopback_endpoints().await;
+    enroll_member_over_endpoint(
+        &owner_endpoint,
+        &joiner_endpoint,
+        &owner,
+        &joiner,
+        account,
+        "https://relay.example",
+    )
+    .await;
+
+    let mut account_store = OplogSyncStore::new(&owner, account, || NOW);
+    let mut content_store = OplogContentSyncStore::new(&owner, account, || NOW);
+    let mut table_store = OplogTableSyncStore::new(&joiner, account, || NOW);
+    assert!(!table_store.has_streams().unwrap(), "the production registry stays empty");
+    let server = accept_and_dispatch(
+        &owner_endpoint,
+        &mut account_store,
+        &mut content_store,
+        AuthPolicy::Closed,
+        || NOW,
+    );
+    let client = connect_and_table_sync(
+        &joiner_endpoint,
+        direct_addr(&owner_endpoint),
+        &mut table_store,
+        NOW,
+    );
+    let (server, client) = tokio::join!(server, client);
+    let (alpn, server_report) = server.unwrap();
+    let client_report = client.unwrap();
+    assert_eq!(alpn, TABLE_SYNC_ALPN);
+    assert_eq!(server_report, rag_rat_sync::SessionReport::default());
+    assert_eq!(client_report, rag_rat_sync::TableSessionReport::default());
+}
+
+#[tokio::test]
+async fn closed_table_auth_refusal_reveals_no_manifest() {
+    use rag_rat_sync::{AuthPolicy, Frame, OplogContentSyncStore, TABLE_SYNC_ALPN};
+    use tokio::io::AsyncReadExt;
+
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let (owner_endpoint, stranger_endpoint) = loopback_endpoints().await;
+    let mut account_store = OplogSyncStore::new(&owner, account, || NOW);
+    let mut content_store = OplogContentSyncStore::new(&owner, account, || NOW);
+
+    let server = rag_rat_sync::accept_and_dispatch(
+        &owner_endpoint,
+        &mut account_store,
+        &mut content_store,
+        // Even an Open account-log endpoint must force Closed semantics for table streams.
+        AuthPolicy::Open,
+        || NOW,
+    );
+    let client = async {
+        let conn =
+            stranger_endpoint.connect(direct_addr(&owner_endpoint), TABLE_SYNC_ALPN).await.unwrap();
+        let (mut send, mut recv) = conn.open_bi().await.unwrap();
+        rag_rat_sync::codec::write_frame(&mut send, &Frame::Auth {
+            account_id: account.to_bytes(),
+            binding: Vec::new(),
+        })
+        .await
+        .unwrap();
+        let revealed =
+            tokio::time::timeout(std::time::Duration::from_secs(1), recv.read_u8()).await;
+        assert!(
+            !matches!(revealed, Ok(Ok(_))),
+            "an unauthorized peer must receive no application bytes"
+        );
+    };
+    let (server, ()) = tokio::join!(server, client);
+    assert!(matches!(server, Err(rag_rat_sync::SyncFailure::Auth(_))));
 }
 
 /// Multi-round reconciliation (#878): `connect_and_reconcile` re-dials until a round is dry, so a


### PR DESCRIPTION
## Summary

- add the dedicated `rag-rat/table-sync/1` ALPN with closed-roster authorization before any bounded canonical manifest is revealed
- reconcile only locally validated current-incarnation repo streams and snapshot accepted history only after the exact manifest intersection is known
- enforce one 64 KiB signed-entry limit before local authoring or remote storage, then move accepted `/5` entries through the existing authority, chain, and payload gates
- run account, content, then table reconciliation while keeping the empty production registry a clean no-op
- bound frames, session entry counts, reads, writes, and shutdowns; cover scoped bidirectional transfer and idempotence over real iroh loopback

`SYNCABLE_TABLES` remains empty. This does not register a production table, compact accepted history, transfer gapped rows, or add account-global streams. Progress-bearing inventory continuation for retained streams above the exact-inventory cap is tracked in #1099.

## Verification

- `cargo nextest run -p rag-rat-oplog -p rag-rat-sync -p rag-rat` (1,470 passed, 2 skipped)
- `cargo clippy -p rag-rat-oplog -p rag-rat-sync -p rag-rat --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #1096
Part of #892