### PR TITLE
refactor: derive schema recognizers from the ladder and reuse shared helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,7 +4961,6 @@ dependencies = [
  "toon-format",
  "tracing",
  "tui-tree-widget",
- "url",
  "zeroize",
 ]
 

--- a/crates/rag-rat-base/src/hash.rs
+++ b/crates/rag-rat-base/src/hash.rs
@@ -15,6 +15,28 @@ pub fn hex_lower(bytes: &[u8]) -> String {
     out
 }
 
+/// One hex nibble's value (`0-9`, `a-f`, `A-F`), or `None` for any other byte. Shared so the
+/// fingerprint/digest parsers don't each re-derive the table.
+pub fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode an even-length hex string. `None` on an odd length or any non-hex byte; callers that
+/// need the failing position iterate [`hex_nibble`] themselves for the precise error.
+pub fn hex_decode(text: &str) -> Option<Vec<u8>> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        out.push(hex_nibble(pair[0])? << 4 | hex_nibble(pair[1])?);
+    }
+    bytes.chunks_exact(2).remainder().is_empty().then_some(out)
+}
+
 /// Hex SHA-256 of a byte slice. This is the hash space of `files.sha256` (the indexer writes
 /// `hex_sha256(fs::read(file))`), so every consumer that compares against stored file hashes —
 /// the content-integrity check, the oracle's scip-vs-disk gate (#82 TOCTOU) — MUST hash through

--- a/crates/rag-rat-base/src/language.rs
+++ b/crates/rag-rat-base/src/language.rs
@@ -26,7 +26,6 @@ struct LanguageSpec {
     aliases: &'static [&'static str],
     simple_extensions: &'static [&'static str],
     target_extensions: &'static [&'static str],
-    supports_embeddings: bool,
 }
 
 const LANGUAGE_SPECS: [LanguageSpec; 9] = [
@@ -36,7 +35,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["rs"],
         simple_extensions: &["rs"],
         target_extensions: &["rs"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::TypeScript,
@@ -44,7 +42,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["ts", "tsx"],
         simple_extensions: &["ts", "tsx"],
         target_extensions: &["ts", "tsx"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::Kotlin,
@@ -52,7 +49,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["kt"],
         simple_extensions: &["kt", "kts"],
         target_extensions: &["kt", "kts"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::C,
@@ -60,7 +56,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &[],
         simple_extensions: &["c", "h"],
         target_extensions: &["c", "h"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::Cpp,
@@ -68,7 +63,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["c++", "cc", "cxx"],
         simple_extensions: &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++"],
         target_extensions: &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++", "h"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::Python,
@@ -76,7 +70,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["py"],
         simple_extensions: &["py", "pyi"],
         target_extensions: &["py", "pyi"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::Swift,
@@ -84,7 +77,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &[],
         simple_extensions: &["swift"],
         target_extensions: &["swift"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::Go,
@@ -92,7 +84,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["golang"],
         simple_extensions: &["go"],
         target_extensions: &["go"],
-        supports_embeddings: true,
     },
     LanguageSpec {
         language: Language::Markdown,
@@ -100,7 +91,6 @@ const LANGUAGE_SPECS: [LanguageSpec; 9] = [
         aliases: &["md"],
         simple_extensions: &["md", "markdown"],
         target_extensions: &["md", "markdown"],
-        supports_embeddings: true,
     },
 ];
 
@@ -171,10 +161,6 @@ impl Language {
     /// drift.
     pub fn default_include_globs(self) -> Vec<String> {
         self.target_extensions().iter().map(|ext| format!("**/*.{ext}")).collect()
-    }
-
-    pub fn supports_embeddings(self) -> bool {
-        self.spec().supports_embeddings
     }
 
     pub fn from_path(path: &std::path::Path) -> Option<Self> {

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -39,7 +39,6 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["net", "signal"] }
 tracing.workspace = true
 rusqlite.workspace = true
-url.workspace = true
 # Minting the persisted sync node key (OS CSPRNG) and scrubbing the in-memory copy.
 getrandom.workspace = true
 zeroize.workspace = true

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -212,24 +212,7 @@ pub(crate) struct ServeArgs {
 /// path, query, or fragment. A trailing slash is normalized away; anything else that would
 /// silently never match the header is rejected at parse time.
 fn parse_lens_origin(raw: &str) -> Result<String, String> {
-    let trimmed = raw.trim();
-    let parsed = url::Url::parse(trimmed)
-        .map_err(|_| format!("origin `{raw}` must look like scheme://host[:port]"))?;
-    if !matches!(parsed.scheme(), "http" | "https") {
-        return Err(format!("origin scheme must be http or https: `{raw}`"));
-    }
-    if parsed.host().is_none()
-        || !parsed.username().is_empty()
-        || parsed.password().is_some()
-        || parsed.path() != "/"
-        || parsed.query().is_some()
-        || parsed.fragment().is_some()
-    {
-        return Err(format!(
-            "origin must not contain credentials, a path, query, or fragment: `{raw}`"
-        ));
-    }
-    Ok(parsed.origin().ascii_serialization())
+    rag_rat_mcp::lens_server::canonical_lens_origin(raw.trim()).map_err(|err| err.to_string())
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -118,7 +118,7 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     // run covering fresh state isn't falsely judged stale even after a long lock wait) yet before
     // any mid-run reindex (so a run that misses one IS judged stale). (#145 + #146 review)
     let (started_at_ms, pre_spawn_sha) = with_oracle_write_lock(config, |db| {
-        Ok((crate::now_epoch_ms(), db.oracle_pre_spawn_snapshot()?))
+        Ok((rag_rat_base::time::now_ms(), db.oracle_pre_spawn_snapshot()?))
     })?;
     let scip_output = config
         .database
@@ -300,7 +300,7 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
                 tool,
                 &scip_bytes,
                 rag_rat_core::index::OracleShaSnapshots::default(),
-                crate::now_epoch_ms(),
+                rag_rat_base::time::now_ms(),
             )
         })?
     } else {
@@ -313,7 +313,7 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
             anyhow::bail!("oracle tool for corpus `{}` unavailable: {hint}", profile.corpus_id);
         }
         let (started_at_ms, pre_spawn_sha) = with_oracle_write_lock(config, |db| {
-            Ok((crate::now_epoch_ms(), db.oracle_pre_spawn_snapshot()?))
+            Ok((rag_rat_base::time::now_ms(), db.oracle_pre_spawn_snapshot()?))
         })?;
         let scip_output = config
             .database

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -262,7 +262,7 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_base::config::Config) {
         quiet_period_ms: i64,
         min_interval_ms: i64,
     ) -> anyhow::Result<()> {
-        let now_ms = now_epoch_ms();
+        let now_ms = rag_rat_base::time::now_ms();
         // `indexed_at_ms` is the active checkout's last index-change clock; without it we can't
         // judge staleness, so skip this tick.
         let last_index_change_ms = {
@@ -330,7 +330,7 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_base::config::Config) {
         // reindex can interleave between reading the indexed state and recording the start; under
         // the lock, started_at matches the indexed state this run covers (#145 + #146 review).
         let (started_at_ms, pre_spawn_sha) = with_oracle_write_lock(config, |db| {
-            Ok((now_epoch_ms(), db.oracle_pre_spawn_snapshot()?))
+            Ok((rag_rat_base::time::now_ms(), db.oracle_pre_spawn_snapshot()?))
         })?;
         let scip_output = config
             .database
@@ -364,13 +364,6 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_base::config::Config) {
     fn saturating_secs_to_ms(secs: u64) -> i64 {
         i64::try_from(secs).unwrap_or(i64::MAX).saturating_mul(1000)
     }
-}
-
-fn now_epoch_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0)
 }
 
 /// Load the config, mapping a missing file to a friendly hint instead of a raw IO error.

--- a/crates/rag-rat-core/src/distill/output.rs
+++ b/crates/rag-rat-core/src/distill/output.rs
@@ -152,7 +152,8 @@ fn dedup_in_place<T: std::hash::Hash + Eq + Copy>(items: &mut Vec<T>) {
 }
 
 /// Stable output-ladder tokens. The names map directly to the `rung_*` run-counter columns.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
 pub(crate) enum OutputRung {
     /// A guided model call was attempted.
     Guided,
@@ -168,23 +169,12 @@ impl OutputRung {
     pub(crate) const VARIANTS: [Self; 4] =
         [Self::Guided, Self::Serde, Self::Unguided, Self::Tolerant];
 
-    pub(crate) const fn as_db_str(self) -> &'static str {
-        match self {
-            Self::Guided => "guided",
-            Self::Serde => "serde",
-            Self::Unguided => "unguided",
-            Self::Tolerant => "tolerant",
-        }
+    pub(crate) fn as_db_str(self) -> &'static str {
+        self.into()
     }
 
     pub(crate) fn from_db_str(value: &str) -> anyhow::Result<Self> {
-        match value {
-            "guided" => Ok(Self::Guided),
-            "serde" => Ok(Self::Serde),
-            "unguided" => Ok(Self::Unguided),
-            "tolerant" => Ok(Self::Tolerant),
-            _ => Err(anyhow::anyhow!("unknown output-rung token `{value}`")),
-        }
+        value.parse().map_err(|_| anyhow::anyhow!("unknown output-rung token `{value}`"))
     }
 }
 

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -138,10 +138,7 @@ pub(crate) fn cheap_skip_policy(
     if is_test_fixture_path(&path_text) {
         return Some(policy("SkipTestFixture", 9, false));
     }
-    let Ok(language_kind) = language.parse::<Language>() else {
-        return Some(policy("SkipLanguageUnsupported", 9, false));
-    };
-    if !language_kind.supports_embeddings() {
+    if language.parse::<Language>().is_err() {
         return Some(policy("SkipLanguageUnsupported", 9, false));
     }
     if trimmed.chars().count() < MIN_EMBEDDING_CHARS {

--- a/crates/rag-rat-core/src/index/anchors.rs
+++ b/crates/rag-rat-core/src/index/anchors.rs
@@ -1,4 +1,4 @@
-use sha2::{Digest, Sha256};
+use rag_rat_base::hash::hex_sha256;
 
 #[derive(Debug, Clone)]
 pub struct ChunkAnchor {
@@ -148,14 +148,4 @@ fn context_hash(lines: &[&str], line: usize, radius: usize) -> String {
     let normalized =
         lines[start..end].iter().map(|line| line.trim()).collect::<Vec<_>>().join("\n");
     hex_sha256(normalized.as_bytes())
-}
-
-fn hex_sha256(bytes: &[u8]) -> String {
-    let hash = Sha256::digest(bytes);
-    let mut out = String::with_capacity(hash.len() * 2);
-    for byte in hash {
-        use std::fmt::Write as _;
-        let _ = write!(out, "{byte:02x}");
-    }
-    out
 }

--- a/crates/rag-rat-core/src/query/clusters.rs
+++ b/crates/rag-rat-core/src/query/clusters.rs
@@ -435,7 +435,7 @@ fn cluster_for(cluster: ClusterBuild) -> RepoCluster {
     let category = cluster_category(&metrics).to_string();
     let confidence = confidence_for(&metrics, cluster.avg_edge_score).to_string();
     let why = why_for(&metrics, cluster.avg_edge_score, &name);
-    let next_tools = next_tools_for(representative_paths.first());
+    let next_tools = next_tools_for(representative_paths.first().map(String::as_str));
 
     RepoCluster {
         cluster_id: String::new(),
@@ -520,7 +520,7 @@ fn why_for(metrics: &RepoClusterMetrics, avg_edge_score: f64, name: &str) -> Vec
     why
 }
 
-fn next_tools_for(path: Option<&String>) -> Vec<RepoClusterNextTool> {
+fn next_tools_for(path: Option<&str>) -> Vec<RepoClusterNextTool> {
     let Some(path) = path else {
         return Vec::new();
     };
@@ -533,11 +533,11 @@ fn next_tools_for(path: Option<&String>) -> Vec<RepoClusterNextTool> {
         next_tool(
             "impact_surface",
             "inspect graph, git, papertrail, and memories for the representative path",
-            [("query", path.clone())],
+            [("query", path.to_string())],
         ),
         next_tool("git_history_for_path", "inspect co-touch and churn history", [(
             "path",
-            path.clone(),
+            path.to_string(),
         )]),
     ]
 }

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -120,14 +120,12 @@ fn parse_latest_response(body: &str) -> Option<String> {
 /// server's background, an explicit `version-check` command) — never on the session-start read
 /// path.
 pub fn refresh(database: &Path) -> Option<CachedVersion> {
-    let cached = CachedVersion { latest_version: fetch_latest()?, checked_at_ms: now_ms() };
+    let cached = CachedVersion {
+        latest_version: fetch_latest()?,
+        checked_at_ms: rag_rat_base::time::now_ms(),
+    };
     write_cache(database, &cached);
     Some(cached)
-}
-
-fn now_ms() -> i64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as i64).unwrap_or(0)
 }
 
 /// `(major, minor, patch)`, pre-release/build metadata stripped. `None` if it doesn't parse.

--- a/crates/rag-rat-db/src/content_digest.rs
+++ b/crates/rag-rat-db/src/content_digest.rs
@@ -106,15 +106,6 @@ pub fn encode_state(state: &DigestState) -> String {
     out
 }
 
-fn hex_digit(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
-}
-
 /// Decode a 64-hex `state` back to four LE `u64` lanes. Errs (fail-closed) on any length other than
 /// 64 or any non-hex byte — the malformed-state case the scalar fold raises.
 pub fn decode_state(hex: &str) -> Result<DigestState, MalformedDigestState> {
@@ -124,9 +115,9 @@ pub fn decode_state(hex: &str) -> Result<DigestState, MalformedDigestState> {
     }
     let mut raw = [0u8; 32];
     for (out, chunk) in raw.iter_mut().zip(bytes.chunks_exact(2)) {
-        let hi = hex_digit(chunk[0])
+        let hi = rag_rat_base::hash::hex_nibble(chunk[0])
             .ok_or_else(|| MalformedDigestState(format!("non-hex byte {:#04x}", chunk[0])))?;
-        let lo = hex_digit(chunk[1])
+        let lo = rag_rat_base::hash::hex_nibble(chunk[1])
             .ok_or_else(|| MalformedDigestState(format!("non-hex byte {:#04x}", chunk[1])))?;
         *out = (hi << 4) | lo;
     }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1296,326 +1296,35 @@ pub(crate) fn apply_logical_group_reason_by_evidence(conn: &Connection) -> rusql
 }
 
 pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
-    migrations
-        .iter()
-        .filter_map(|migration| match migration.id.as_str() {
-            MIGRATION_001_ID => Some(1),
-            MIGRATION_002_ID => Some(2),
-            MIGRATION_003_ID => Some(3),
-            MIGRATION_004_ID => Some(4),
-            MIGRATION_005_ID => Some(5),
-            MIGRATION_006_ID => Some(6),
-            MIGRATION_007_ID => Some(7),
-            MIGRATION_008_ID => Some(8),
-            MIGRATION_009_ID => Some(9),
-            MIGRATION_010_ID => Some(10),
-            MIGRATION_011_ID => Some(11),
-            MIGRATION_012_ID => Some(12),
-            MIGRATION_013_ID => Some(13),
-            MIGRATION_014_ID => Some(14),
-            MIGRATION_015_ID => Some(15),
-            MIGRATION_016_ID => Some(16),
-            MIGRATION_017_ID => Some(17),
-            MIGRATION_018_ID => Some(18),
-            MIGRATION_019_ID => Some(19),
-            MIGRATION_020_ID => Some(20),
-            MIGRATION_021_ID => Some(21),
-            MIGRATION_022_ID => Some(22),
-            MIGRATION_023_ID => Some(23),
-            MIGRATION_024_ID => Some(24),
-            MIGRATION_025_ID => Some(25),
-            MIGRATION_026_ID => Some(26),
-            MIGRATION_027_ID => Some(27),
-            MIGRATION_028_ID => Some(28),
-            MIGRATION_029_ID => Some(29),
-            MIGRATION_030_ID => Some(30),
-            MIGRATION_031_ID => Some(31),
-            MIGRATION_032_ID => Some(32),
-            MIGRATION_033_ID => Some(33),
-            MIGRATION_034_ID => Some(34),
-            MIGRATION_035_ID => Some(35),
-            MIGRATION_036_ID => Some(36),
-            MIGRATION_037_ID => Some(37),
-            MIGRATION_038_ID => Some(38),
-            MIGRATION_039_ID => Some(39),
-            MIGRATION_040_ID => Some(40),
-            MIGRATION_041_ID => Some(41),
-            MIGRATION_042_ID => Some(42),
-            MIGRATION_043_ID => Some(43),
-            MIGRATION_044_ID => Some(44),
-            MIGRATION_045_ID => Some(45),
-            MIGRATION_046_ID => Some(46),
-            MIGRATION_047_ID => Some(47),
-            MIGRATION_048_ID => Some(48),
-            MIGRATION_049_ID => Some(49),
-            MIGRATION_050_ID => Some(50),
-            MIGRATION_051_ID => Some(51),
-            MIGRATION_052_ID => Some(52),
-            MIGRATION_053_ID => Some(53),
-            MIGRATION_054_ID => Some(54),
-            MIGRATION_055_ID => Some(55),
-            MIGRATION_056_ID => Some(56),
-            MIGRATION_057_ID => Some(57),
-            MIGRATION_058_ID => Some(58),
-            MIGRATION_059_ID => Some(59),
-            MIGRATION_060_ID => Some(60),
-            MIGRATION_061_ID => Some(61),
-            MIGRATION_062_ID => Some(62),
-            MIGRATION_063_ID => Some(63),
-            MIGRATION_064_ID => Some(64),
-            MIGRATION_065_ID => Some(65),
-            MIGRATION_066_ID => Some(66),
-            MIGRATION_067_ID => Some(67),
-            MIGRATION_068_ID => Some(68),
-            MIGRATION_069_ID => Some(69),
-            MIGRATION_070_ID => Some(70),
-            MIGRATION_071_ID => Some(71),
-            MIGRATION_072_ID => Some(72),
-            MIGRATION_073_ID => Some(73),
-            MIGRATION_074_ID => Some(74),
-            MIGRATION_075_ID => Some(75),
-            MIGRATION_076_ID => Some(76),
-            MIGRATION_077_ID => Some(77),
-            MIGRATION_078_ID => Some(78),
-            MIGRATION_079_ID => Some(79),
-            MIGRATION_080_ID => Some(80),
-            MIGRATION_081_ID => Some(81),
-            MIGRATION_082_ID => Some(82),
-            MIGRATION_083_ID => Some(83),
-            MIGRATION_084_ID => Some(84),
-            MIGRATION_085_ID => Some(85),
-            MIGRATION_086_ID => Some(86),
-            MIGRATION_087_ID => Some(87),
-            MIGRATION_088_ID => Some(88),
-            MIGRATION_089_ID => Some(89),
-            MIGRATION_090_ID => Some(90),
-            MIGRATION_091_ID => Some(91),
-            MIGRATION_092_ID => Some(92),
-            MIGRATION_093_ID => Some(93),
-            MIGRATION_094_ID => Some(94),
-            MIGRATION_095_ID => Some(95),
-            MIGRATION_096_ID => Some(96),
-            MIGRATION_097_ID => Some(97),
-            MIGRATION_098_ID => Some(98),
-            MIGRATION_099_ID => Some(99),
-            MIGRATION_100_ID => Some(100),
-            _ => None,
-        })
-        .max()
-        .unwrap_or(0)
+    migrations.iter().filter_map(|migration| shipped_version(&migration.id)).max().unwrap_or(0)
 }
 
 pub(crate) fn known_migration(id: &str) -> bool {
-    matches!(
-        id,
-        MIGRATION_001_ID
-            | MIGRATION_002_ID
-            | MIGRATION_003_ID
-            | MIGRATION_004_ID
-            | MIGRATION_005_ID
-            | MIGRATION_006_ID
-            | MIGRATION_007_ID
-            | MIGRATION_008_ID
-            | MIGRATION_009_ID
-            | MIGRATION_010_ID
-            | MIGRATION_011_ID
-            | MIGRATION_012_ID
-            | MIGRATION_013_ID
-            | MIGRATION_014_ID
-            | MIGRATION_015_ID
-            | MIGRATION_016_ID
-            | MIGRATION_017_ID
-            | MIGRATION_018_ID
-            | MIGRATION_019_ID
-            | MIGRATION_020_ID
-            | MIGRATION_021_ID
-            | MIGRATION_022_ID
-            | MIGRATION_023_ID
-            | MIGRATION_024_ID
-            | MIGRATION_025_ID
-            | MIGRATION_026_ID
-            | MIGRATION_027_ID
-            | MIGRATION_028_ID
-            | MIGRATION_029_ID
-            | MIGRATION_030_ID
-            | MIGRATION_031_ID
-            | MIGRATION_032_ID
-            | MIGRATION_033_ID
-            | MIGRATION_034_ID
-            | MIGRATION_035_ID
-            | MIGRATION_036_ID
-            | MIGRATION_037_ID
-            | MIGRATION_038_ID
-            | MIGRATION_039_ID
-            | MIGRATION_040_ID
-            | MIGRATION_041_ID
-            | MIGRATION_042_ID
-            | MIGRATION_043_ID
-            | MIGRATION_044_ID
-            | MIGRATION_045_ID
-            | MIGRATION_046_ID
-            | MIGRATION_047_ID
-            | MIGRATION_048_ID
-            | MIGRATION_049_ID
-            | MIGRATION_050_ID
-            | MIGRATION_051_ID
-            | MIGRATION_052_ID
-            | MIGRATION_053_ID
-            | MIGRATION_054_ID
-            | MIGRATION_055_ID
-            | MIGRATION_056_ID
-            | MIGRATION_057_ID
-            | MIGRATION_058_ID
-            | MIGRATION_059_ID
-            | MIGRATION_060_ID
-            | MIGRATION_061_ID
-            | MIGRATION_062_ID
-            | MIGRATION_063_ID
-            | MIGRATION_064_ID
-            | MIGRATION_065_ID
-            | MIGRATION_066_ID
-            | MIGRATION_067_ID
-            | MIGRATION_068_ID
-            | MIGRATION_069_ID
-            | MIGRATION_070_ID
-            | MIGRATION_071_ID
-            | MIGRATION_072_ID
-            | MIGRATION_073_ID
-            | MIGRATION_074_ID
-            | MIGRATION_075_ID
-            | MIGRATION_076_ID
-            | MIGRATION_077_ID
-            | MIGRATION_078_ID
-            | MIGRATION_079_ID
-            | MIGRATION_080_ID
-            | MIGRATION_081_ID
-            | MIGRATION_082_ID
-            | MIGRATION_083_ID
-            | MIGRATION_084_ID
-            | MIGRATION_085_ID
-            | MIGRATION_086_ID
-            | MIGRATION_087_ID
-            | MIGRATION_088_ID
-            | MIGRATION_089_ID
-            | MIGRATION_090_ID
-            | MIGRATION_091_ID
-            | MIGRATION_092_ID
-            | MIGRATION_093_ID
-            | MIGRATION_094_ID
-            | MIGRATION_095_ID
-            | MIGRATION_096_ID
-            | MIGRATION_097_ID
-            | MIGRATION_098_ID
-            | MIGRATION_099_ID
-            | MIGRATION_100_ID
-            | DIRTY_MIGRATION_ID
-    )
+    shipped_version(id).is_some() || id == DIRTY_MIGRATION_ID
 }
 
 pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool {
-    match migration.id.as_str() {
-        MIGRATION_001_ID => migration.checksum != MIGRATION_001_CHECKSUM,
-        MIGRATION_002_ID => migration.checksum != MIGRATION_002_CHECKSUM,
-        MIGRATION_003_ID => migration.checksum != MIGRATION_003_CHECKSUM,
-        MIGRATION_004_ID => migration.checksum != MIGRATION_004_CHECKSUM,
-        MIGRATION_005_ID => migration.checksum != MIGRATION_005_CHECKSUM,
-        MIGRATION_006_ID => migration.checksum != MIGRATION_006_CHECKSUM,
-        MIGRATION_007_ID => migration.checksum != MIGRATION_007_CHECKSUM,
-        MIGRATION_008_ID => migration.checksum != MIGRATION_008_CHECKSUM,
-        MIGRATION_009_ID => migration.checksum != MIGRATION_009_CHECKSUM,
-        MIGRATION_010_ID => migration.checksum != MIGRATION_010_CHECKSUM,
-        MIGRATION_011_ID => migration.checksum != MIGRATION_011_CHECKSUM,
-        MIGRATION_012_ID => migration.checksum != MIGRATION_012_CHECKSUM,
-        MIGRATION_013_ID => migration.checksum != MIGRATION_013_CHECKSUM,
-        MIGRATION_014_ID => migration.checksum != MIGRATION_014_CHECKSUM,
-        MIGRATION_015_ID => migration.checksum != MIGRATION_015_CHECKSUM,
-        MIGRATION_016_ID => migration.checksum != MIGRATION_016_CHECKSUM,
-        MIGRATION_017_ID => migration.checksum != MIGRATION_017_CHECKSUM,
-        MIGRATION_018_ID => migration.checksum != MIGRATION_018_CHECKSUM,
-        MIGRATION_019_ID => migration.checksum != MIGRATION_019_CHECKSUM,
-        MIGRATION_020_ID => migration.checksum != MIGRATION_020_CHECKSUM,
-        MIGRATION_021_ID => migration.checksum != MIGRATION_021_CHECKSUM,
-        MIGRATION_022_ID => migration.checksum != MIGRATION_022_CHECKSUM,
-        MIGRATION_023_ID => migration.checksum != MIGRATION_023_CHECKSUM,
-        MIGRATION_024_ID => migration.checksum != MIGRATION_024_CHECKSUM,
-        MIGRATION_025_ID => migration.checksum != MIGRATION_025_CHECKSUM,
-        MIGRATION_026_ID => migration.checksum != MIGRATION_026_CHECKSUM,
-        MIGRATION_027_ID => migration.checksum != MIGRATION_027_CHECKSUM,
-        MIGRATION_028_ID => migration.checksum != MIGRATION_028_CHECKSUM,
-        MIGRATION_029_ID => migration.checksum != MIGRATION_029_CHECKSUM,
-        MIGRATION_030_ID => migration.checksum != MIGRATION_030_CHECKSUM,
-        MIGRATION_031_ID => migration.checksum != MIGRATION_031_CHECKSUM,
-        MIGRATION_032_ID => migration.checksum != MIGRATION_032_CHECKSUM,
-        MIGRATION_033_ID => migration.checksum != MIGRATION_033_CHECKSUM,
-        MIGRATION_034_ID => migration.checksum != MIGRATION_034_CHECKSUM,
-        MIGRATION_035_ID => migration.checksum != MIGRATION_035_CHECKSUM,
-        MIGRATION_036_ID => migration.checksum != MIGRATION_036_CHECKSUM,
-        MIGRATION_037_ID => migration.checksum != MIGRATION_037_CHECKSUM,
-        MIGRATION_038_ID => migration.checksum != MIGRATION_038_CHECKSUM,
-        MIGRATION_039_ID => migration.checksum != MIGRATION_039_CHECKSUM,
-        MIGRATION_040_ID => migration.checksum != MIGRATION_040_CHECKSUM,
-        MIGRATION_041_ID => migration.checksum != MIGRATION_041_CHECKSUM,
-        MIGRATION_042_ID => migration.checksum != MIGRATION_042_CHECKSUM,
-        MIGRATION_043_ID => migration.checksum != MIGRATION_043_CHECKSUM,
-        MIGRATION_044_ID => migration.checksum != MIGRATION_044_CHECKSUM,
-        MIGRATION_045_ID => migration.checksum != MIGRATION_045_CHECKSUM,
-        MIGRATION_046_ID => migration.checksum != MIGRATION_046_CHECKSUM,
-        MIGRATION_047_ID => migration.checksum != MIGRATION_047_CHECKSUM,
-        MIGRATION_048_ID => migration.checksum != MIGRATION_048_CHECKSUM,
-        MIGRATION_049_ID => migration.checksum != MIGRATION_049_CHECKSUM,
-        MIGRATION_050_ID => migration.checksum != MIGRATION_050_CHECKSUM,
-        MIGRATION_051_ID => migration.checksum != MIGRATION_051_CHECKSUM,
-        MIGRATION_052_ID => migration.checksum != MIGRATION_052_CHECKSUM,
-        MIGRATION_053_ID => migration.checksum != MIGRATION_053_CHECKSUM,
-        MIGRATION_054_ID => migration.checksum != MIGRATION_054_CHECKSUM,
-        MIGRATION_055_ID => migration.checksum != MIGRATION_055_CHECKSUM,
-        MIGRATION_056_ID => migration.checksum != MIGRATION_056_CHECKSUM,
-        MIGRATION_057_ID => migration.checksum != MIGRATION_057_CHECKSUM,
-        MIGRATION_058_ID => migration.checksum != MIGRATION_058_CHECKSUM,
-        MIGRATION_059_ID => migration.checksum != MIGRATION_059_CHECKSUM,
-        MIGRATION_060_ID => migration.checksum != MIGRATION_060_CHECKSUM,
-        MIGRATION_061_ID => migration.checksum != MIGRATION_061_CHECKSUM,
-        MIGRATION_062_ID => migration.checksum != MIGRATION_062_CHECKSUM,
-        MIGRATION_063_ID => migration.checksum != MIGRATION_063_CHECKSUM,
-        MIGRATION_064_ID => migration.checksum != MIGRATION_064_CHECKSUM,
-        MIGRATION_065_ID => migration.checksum != MIGRATION_065_CHECKSUM,
-        MIGRATION_066_ID => migration.checksum != MIGRATION_066_CHECKSUM,
-        MIGRATION_067_ID => migration.checksum != MIGRATION_067_CHECKSUM,
-        MIGRATION_068_ID => migration.checksum != MIGRATION_068_CHECKSUM,
-        MIGRATION_069_ID => migration.checksum != MIGRATION_069_CHECKSUM,
-        MIGRATION_070_ID => migration.checksum != MIGRATION_070_CHECKSUM,
-        MIGRATION_071_ID => migration.checksum != MIGRATION_071_CHECKSUM,
-        MIGRATION_072_ID => migration.checksum != MIGRATION_072_CHECKSUM,
-        MIGRATION_073_ID => migration.checksum != MIGRATION_073_CHECKSUM,
-        MIGRATION_074_ID => migration.checksum != MIGRATION_074_CHECKSUM,
-        MIGRATION_075_ID => migration.checksum != MIGRATION_075_CHECKSUM,
-        MIGRATION_076_ID => migration.checksum != MIGRATION_076_CHECKSUM,
-        MIGRATION_077_ID => migration.checksum != MIGRATION_077_CHECKSUM,
-        MIGRATION_078_ID => migration.checksum != MIGRATION_078_CHECKSUM,
-        MIGRATION_079_ID => migration.checksum != MIGRATION_079_CHECKSUM,
-        MIGRATION_080_ID => migration.checksum != MIGRATION_080_CHECKSUM,
-        MIGRATION_081_ID => migration.checksum != MIGRATION_081_CHECKSUM,
-        MIGRATION_082_ID => migration.checksum != MIGRATION_082_CHECKSUM,
-        MIGRATION_083_ID => migration.checksum != MIGRATION_083_CHECKSUM,
-        MIGRATION_084_ID => migration.checksum != MIGRATION_084_CHECKSUM,
-        MIGRATION_085_ID => migration.checksum != MIGRATION_085_CHECKSUM,
-        MIGRATION_086_ID => migration.checksum != MIGRATION_086_CHECKSUM,
-        MIGRATION_087_ID => migration.checksum != MIGRATION_087_CHECKSUM,
-        MIGRATION_088_ID => migration.checksum != MIGRATION_088_CHECKSUM,
-        MIGRATION_089_ID => migration.checksum != MIGRATION_089_CHECKSUM,
-        MIGRATION_090_ID => migration.checksum != MIGRATION_090_CHECKSUM,
-        MIGRATION_091_ID => migration.checksum != MIGRATION_091_CHECKSUM,
-        MIGRATION_092_ID => migration.checksum != MIGRATION_092_CHECKSUM,
-        MIGRATION_093_ID => migration.checksum != MIGRATION_093_CHECKSUM,
-        MIGRATION_094_ID => migration.checksum != MIGRATION_094_CHECKSUM,
-        MIGRATION_095_ID => migration.checksum != MIGRATION_095_CHECKSUM,
-        MIGRATION_096_ID => migration.checksum != MIGRATION_096_CHECKSUM,
-        MIGRATION_097_ID => migration.checksum != MIGRATION_097_CHECKSUM,
-        MIGRATION_098_ID => migration.checksum != MIGRATION_098_CHECKSUM,
-        MIGRATION_099_ID => migration.checksum != MIGRATION_099_CHECKSUM,
-        MIGRATION_100_ID => migration.checksum != MIGRATION_100_CHECKSUM,
-        _ => false,
+    shipped_checksum(&migration.id).is_some_and(|checksum| migration.checksum != checksum)
+}
+
+/// The ladder position a shipped migration id maps to: the baseline (001) is 1, and each
+/// [`ADDITIVE_MIGRATIONS`] entry is its 1-based position after it. `None` for a row written by a
+/// future binary (or the dirty marker, which has no version).
+fn shipped_version(id: &str) -> Option<u32> {
+    if id == MIGRATION_001_ID {
+        return Some(1);
     }
+    ADDITIVE_MIGRATIONS
+        .iter()
+        .position(|step| step.id == id)
+        .and_then(|index| u32::try_from(index + 2).ok())
+}
+
+fn shipped_checksum(id: &str) -> Option<&'static str> {
+    if id == MIGRATION_001_ID {
+        return Some(MIGRATION_001_CHECKSUM);
+    }
+    ADDITIVE_MIGRATIONS.iter().find(|step| step.id == id).map(|step| step.checksum)
 }
 
 pub(crate) fn record_migration(

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -570,7 +570,10 @@ fn parse_lens_origins(value: &str) -> anyhow::Result<Vec<String>> {
         .collect()
 }
 
-fn canonical_lens_origin(raw: &str) -> anyhow::Result<String> {
+/// Canonicalize one browser Origin (`scheme://host[:port]`, no path/query/fragment/credentials).
+/// Shared by the server-side `RAG_RAT_LENS_ORIGINS` env allowlist and the CLI's
+/// `--allow-origin` clap parser so both surfaces accept exactly the same spellings.
+pub fn canonical_lens_origin(raw: &str) -> anyhow::Result<String> {
     let parsed = url::Url::parse(raw)
         .with_context(|| format!("invalid origin in RAG_RAT_LENS_ORIGINS: `{raw}`"))?;
     if !matches!(parsed.scheme(), "http" | "https")

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -270,7 +270,7 @@ pub(crate) fn call_tool_with_db(
             // model-derived findings a prior `--verify` run persisted (dream_run's resolve sweep is
             // kind-scoped), so `memory_divergence` etc. still surface in this worklist.
             json!(db.dream_run(rag_rat_dream::DreamOptions {
-                now_ms: now_ms(),
+                now_ms: rag_rat_base::time::now_ms(),
                 limit: args.limit as usize,
                 verify: false,
                 include_reviewed: args.all,
@@ -278,7 +278,11 @@ pub(crate) fn call_tool_with_db(
         },
         "dream_review" => {
             let args: DreamReviewArgs = serde_json::from_value(arguments)?;
-            json!(db.review_dream_finding(&args.finding, args.verdict.core(), now_ms())?)
+            json!(db.review_dream_finding(
+                &args.finding,
+                args.verdict.core(),
+                rag_rat_base::time::now_ms(),
+            )?)
         },
         "find_clones" => {
             let args: FindClonesArgs = serde_json::from_value(arguments)?;
@@ -740,16 +744,6 @@ pub(crate) fn graph_symbol_selector(args: &SymbolGraphArgs) -> anyhow::Result<Sy
         allow_ambiguous: args.allow_ambiguous,
         limit: args.limit,
     })
-}
-
-/// Wall-clock milliseconds for the dream write tools (finding first/last-seen + review stamps).
-/// Mirrors the CLI `dream` command's inline clock — the core `now_ms` helpers are crate-private, so
-/// the MCP surface computes its own; the dream lifecycle only needs a monotonic-enough stamp.
-fn now_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0)
 }
 
 pub(crate) fn find_clones_tool(db: &IndexDatabase, args: FindClonesArgs) -> anyhow::Result<Value> {

--- a/crates/rag-rat-oplog/src/op.rs
+++ b/crates/rag-rat-oplog/src/op.rs
@@ -134,9 +134,9 @@ impl FromStr for DeviceFingerprint {
         }
         let mut bytes = [0u8; 32];
         for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
-            let high = hex_nibble(pair[0])
+            let high = rag_rat_base::hash::hex_nibble(pair[0])
                 .ok_or(ParseDeviceFingerprintError::InvalidHex { index: index * 2 })?;
-            let low = hex_nibble(pair[1])
+            let low = rag_rat_base::hash::hex_nibble(pair[1])
                 .ok_or(ParseDeviceFingerprintError::InvalidHex { index: index * 2 + 1 })?;
             bytes[index] = high << 4 | low;
         }
@@ -150,15 +150,6 @@ impl fmt::Display for DeviceFingerprint {
             write!(f, "{byte:02x}")?;
         }
         Ok(())
-    }
-}
-
-fn hex_nibble(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
     }
 }
 

--- a/crates/rag-rat-oplog/src/table_sync/row_op.rs
+++ b/crates/rag-rat-oplog/src/table_sync/row_op.rs
@@ -333,22 +333,13 @@ pub(crate) fn cells_hash(cells: &[Cell]) -> String {
 /// producer can reconstruct a deleted row's identity (present in the published-rows table, absent
 /// from the table) to emit a `Remove`.
 pub(crate) fn row_pk_values(row_pk: &str) -> anyhow::Result<Vec<TypedValue>> {
-    let bytes = hex_decode(row_pk)?;
+    let bytes = rag_rat_base::hash::hex_decode(row_pk)
+        .ok_or_else(|| anyhow::anyhow!("bad hex in row_pk"))?;
     let mut d = Decoder::new(&bytes);
     let values =
         decode_values(&mut d).map_err(|err| anyhow::anyhow!("row_pk decode failed: {err}"))?;
     anyhow::ensure!(d.position() == bytes.len(), "trailing bytes in row_pk");
     Ok(values)
-}
-
-fn hex_decode(text: &str) -> anyhow::Result<Vec<u8>> {
-    anyhow::ensure!(text.len().is_multiple_of(2), "hex string has an odd length");
-    (0..text.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&text[i..i + 2], 16).map_err(|err| anyhow::anyhow!("bad hex: {err}"))
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-query/src/memory/mod.rs
+++ b/crates/rag-rat-query/src/memory/mod.rs
@@ -18,10 +18,11 @@ pub use edges::{
 pub use edges::{EdgeRelation, EdgeTarget, NodeEdge};
 pub use hydrate::*;
 pub use moniker::*;
+use rag_rat_base::hash::hex_sha256;
+use rag_rat_base::time::now_ms;
 pub use resolve::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 pub use validate::*;
 
 /// The active `repo_id` scope for the memory tables, or `None` on the pre-A5 schema (the memory

--- a/crates/rag-rat-query/src/memory/validate.rs
+++ b/crates/rag-rat-query/src/memory/validate.rs
@@ -987,16 +987,6 @@ fn payload_cbor_element(payload_json: Option<&str>) -> (u64, Vec<u8>) {
     (0, buf)
 }
 
-pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
-    let hash = Sha256::digest(bytes);
-    hash.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-pub(crate) fn now_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| i64::try_from(duration.as_millis()).unwrap_or(i64::MAX))
-        .unwrap_or(0)
-}
 pub(crate) fn fts_query(query: &str) -> String {
     let terms = query
         .split(|ch: char| !ch.is_alphanumeric() && ch != '_')

--- a/crates/rag-rat-sync/src/discovery/wire.rs
+++ b/crates/rag-rat-sync/src/discovery/wire.rs
@@ -408,7 +408,7 @@ mod tests {
     }
 
     fn unhex(s: &str) -> Vec<u8> {
-        (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+        rag_rat_base::hash::hex_decode(s).unwrap()
     }
 
     /// The vector the SERVICE's own test suite pins. This one line is what ties this hand-written


### PR DESCRIPTION
## What changed

- **Migration recognizers** — `known_version` / `known_migration` / `migration_checksum_mismatch` each carried a hand-maintained 100-arm match; they now derive version/identity/checksum from `ADDITIVE_MIGRATIONS` (+ the baseline), so a new migration no longer needs three more arms.
- **Shared hash/time helpers** — deleted local `hex_sha256` / `now_ms` reimplementations; call sites use `rag_rat_base::hash` / `rag_rat_base::time` directly (no one-line wrapper fns).
- **Lens origin parsing** — the CLI `--allow-origin` clap parser now delegates to the MCP server's `canonical_lens_origin`; the CLI's direct `url` dependency is gone.
- **Small style items** — `OutputRung` moved to strum-backed tokens; always-true `supports_embeddings` removed from the language spec; `next_tools_for` borrows `&str`.

Net: -368 lines, -1 direct dependency.

## Verification

- 480 tests pass (`cargo nextest run -p rag-rat-db -p rag-rat-base -p rag-rat-query` = 394; targeted rag-rat-core migration/clusters/anchor/policy/lens set = 86)
- `cargo clippy --all-targets` clean on the touched crates
- `cargo +nightly fmt` applied