### PR TITLE
fix(index): make graph upgrades resumable per file

### DIFF
--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -204,8 +204,9 @@ impl IndexDatabase {
             .prepare_cached(
                 "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
                  indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, \
-                 repo_id, generation)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                 repo_id, generation, graph_version, scope_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, CAST(?14 AS \
+                 INTEGER), CAST(?15 AS INTEGER))
                  RETURNING id",
             )?
             .query_row(
@@ -226,6 +227,8 @@ impl IndexDatabase {
                     // alongside the live generation, made live by the flip), the live generation
                     // for incremental (written in place).
                     self.active_generation,
+                    GRAPH_INDEX_VERSION,
+                    LOGICAL_KEY_VERSION,
                 ],
                 |row| row.get::<_, i64>(0),
             )?;

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -83,16 +83,16 @@ impl IndexDatabase {
     }
 
     /// #827: stage the SOURCE FILES of the in-edges pointing at the changed PATH's symbols (set (b)).
-    /// Called from [`Self::remove_file_in_scope`] BEFORE the NULLing UPDATE, so the in-edges are
-    /// still bound. Keyed on `path` (+ repo + generation), NOT the removed `(commit_sha,
-    /// worktree_id)` scope: a FIRST dirty edit of a committed file removes only the (empty)
-    /// overlay scope, yet the in-edge `caller → committed target` must still be re-pointed onto
-    /// the new overlay target that now WINS the active view (a full re-resolve does exactly
-    /// this). Path-keying captures the in-edge whichever scope of the path it currently binds.
+    /// Called before a removal NULLs in-edges and after a graph heal refreshes symbol scopes.
+    /// Keyed on `path` (+ repo + generation), NOT one `(commit_sha, worktree_id)` scope: a FIRST
+    /// dirty edit of a committed file removes only the (empty) overlay scope, yet the in-edge
+    /// `caller → committed target` must still be re-pointed onto the new overlay target that now
+    /// WINS the active view (a full re-resolve does exactly this). Path-keying captures the in-edge
+    /// whichever scope of the path it currently binds.
     /// Over-capturing an in-edge from a sibling worktree is harmless — the scoped resolve's
     /// `files` view excludes non-active rows, so only the active checkout's captured sources
     /// are actually rewritten. No-op unless capture is armed.
-    fn stage_edge_rewrite_inedge_sources(
+    pub(super) fn stage_edge_rewrite_inedge_sources(
         &self,
         path: &str,
         repo_id: &str,

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -1668,12 +1668,17 @@ impl IndexDatabase {
     pub(super) fn ensure_graph_index_current(&self) -> anyhow::Result<()> {
         let graph_current =
             self.repo_meta("graph_index_version")?.as_deref() == Some(GRAPH_INDEX_VERSION);
-        let logical_current =
-            self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() == Some(LOGICAL_KEY_VERSION);
-        // A logical-key mismatch by itself is handled by the normal full-rederive gate. This
-        // on-open path owns the graph-version migration only; when both versions lag together it
-        // must refresh symbol extraction before that full regroup.
-        if graph_current {
+        let active_derivation_owed = self.active_derivation_rows_owed()?;
+        let scope_rows_newer = self.scope_rows_newer()?;
+        if scope_rows_newer && !self.active_graph_rows_owed()? {
+            return Ok(());
+        }
+        if !active_derivation_owed {
+            // A sibling checkout may still owe rows this scope cannot read. The active graph is
+            // safe to serve; once the final sibling heals, that opener advances the repo summary.
+            if !graph_current && !self.graph_rows_owed()? {
+                self.mark_graph_index_current()?;
+            }
             return Ok(());
         }
         let Some(root) = self.storage.source_root().map(Path::to_path_buf) else {
@@ -1681,6 +1686,15 @@ impl IndexDatabase {
         };
         self.storage.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
         let result = (|| -> anyhow::Result<()> {
+            self.begin_scoped_edge_rewrite()?;
+            self.storage.connection().execute(
+                "INSERT OR IGNORE INTO temp.edge_rewrite_files(file_id)
+                 SELECT id FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND graph_version <= CAST(?3 AS INTEGER)
+                   AND id IN (SELECT id FROM files)",
+                params![self.active_repo_id, self.active_generation, GRAPH_INDEX_VERSION],
+            )?;
             // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
             // version-bump re-resolve would re-derive `import_scope_*` on the new edges
             // but read an empty `packages` table (V022 only ADDED the column; it did not
@@ -1702,15 +1716,8 @@ impl IndexDatabase {
             // would stamp this checkout's graph onto another scope's rows; failing the open over
             // them would brick every later open, since this runs ON the open path.
             //
-            // A skipped row is then STALE, and stays stale: `graph_index_version` is per-repo and
-            // is stamped below regardless, so this heal never revisits it, and no later pass
-            // re-extracts a file whose content did not change. For a sibling worktree row that
-            // diverges from the active checkout, that can be indefinite. Accepted here because
-            // the alternative on this code path is worse — pre-digest-gate, such a row was wiped
-            // and rebuilt from the WRONG checkout's bytes — and because a lagging row degrades
-            // (it carries the older extractor's facts) rather than answering wrongly. Making the
-            // heal resumable per row, so a later pass can finish what this one could not vouch
-            // for, is #1014.
+            // A skipped row keeps its old per-file versions, so the checkout that owns those bytes
+            // can resume both derivations later without forcing this scope to parse them again.
             // Rows the row reader could not name are uncovered exactly like an unreadable file.
             let mut unverified = unreadable;
             let mut unrefreshed = 0usize;
@@ -1733,26 +1740,34 @@ impl IndexDatabase {
                 // fresh index hashes a real enclosing scope. Left alone, those rows would take the
                 // new stamp holding a key no fresh index produces, and nested same-named symbols
                 // would stay collapsed with no later pass owing them a re-derivation.
-                let scope_is_owed = !logical_current
+                let scope_needs_refresh = file.scope_owed
                     && file.kind != TargetKind::Generated
                     && file.language != Language::Markdown
                     && text.len() <= edges::MAX_GRAPH_PARSE_BYTES
                     && (file.language == Language::Rust
                         || self.file_has_unscoped_symbols(file.id)?);
-                if scope_is_owed
-                    && !self.refresh_symbol_scopes(
-                        file.id,
-                        Path::new(&file.path),
-                        &text,
-                        file.language,
-                    )?
-                {
-                    unrefreshed += 1;
+                if file.scope_owed && !scope_rows_newer {
+                    if !scope_needs_refresh
+                        || self.refresh_symbol_scopes(
+                            file.id,
+                            Path::new(&file.path),
+                            &text,
+                            file.language,
+                        )?
+                    {
+                        self.mark_file_scope_current(file.id)?;
+                    } else {
+                        unrefreshed += 1;
+                    }
+                }
+                if !file.graph_owed {
+                    continue;
                 }
                 if file.kind == TargetKind::Generated
                     || file.language == Language::Markdown
                     || text.len() > edges::MAX_GRAPH_PARSE_BYTES
                 {
+                    self.mark_file_graph_current(file.id)?;
                     continue;
                 }
                 // Wipe exactly the row being re-derived, immediately before re-deriving it.
@@ -1773,83 +1788,37 @@ impl IndexDatabase {
                     file.language,
                     &text,
                 )?;
+                self.mark_file_graph_current(file.id)?;
             }
-            // Rows this connection's view does not admit are never walked above, so their scope
-            // shape is untouched — and `regroup_logical_symbols` reads raw `main.files` across
-            // EVERY scope, so one stale row is enough to change logical identity. Count them for
-            // the stamp decision even though the edge pass deliberately leaves them alone.
-            let out_of_scope: i64 = self.storage.connection().query_row(
-                "SELECT COUNT(*) FROM main.files
-                  WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
-                    AND id NOT IN (SELECT id FROM files)",
-                params![self.active_repo_id, self.active_generation],
-                |row| row.get(0),
-            )?;
-            if unverified > 0 || unrefreshed > 0 || out_of_scope > 0 {
+            if unverified > 0 || unrefreshed > 0 {
                 tracing::warn!(
                     unverified,
                     unrefreshed,
-                    out_of_scope,
-                    "graph heal skipped file rows this checkout could not vouch for; their graph \
-                     stays on the previous extraction, and the logical-key stamp is deferred so \
-                     later passes keep trying (#1014)"
+                    "graph heal skipped file rows this checkout could not vouch for; their \
+                     per-file provenance remains owed for a later checkout (#1014)"
                 );
             }
             // `resolve_edges` and `rebuild_logical_symbols` are SIBLINGS, not a chain: both
             // consume `symbols.scope_path`, and neither consumes the other's output
             // (`same_logical_symbol` compares in-memory `IndexedSymbol` fields, not
             // `logical_symbols` rows — edge resolution never reads that table). What is
-            // load-bearing is that the refresh loop above completed for the whole corpus first;
-            // their relative order here is free.
-            self.resolve_edges()?;
-            // A lagging `logical_key_version` must not survive an on-open graph heal: without
-            // this, an index upgraded across a key-derivation change (e.g. scope_path joining
-            // the key) keeps its OLD merged/split logical ids until some unrelated source
-            // mutation triggers a rebuilding pass — memory bindings and symbol surfaces keep
-            // leaking across owners indefinitely on an otherwise idle repo.
-            //
-            // Stamp the new key version only when this pass actually refreshed EVERY row. The
-            // regroup reads raw `main.files` across every scope, so a row whose scope stayed on
-            // the old shape does not merely lag — it changes IDENTITY: a cross-scope group that
-            // was one logical symbol splits, the stale row keeps the original `stable_id`, and
-            // the refreshed row gets a new one. Stamping that as current would also disarm the
-            // two mechanisms built to recover from it — `logical_key_drift_snapshot` goes quiet
-            // and `can_scope_logical_rederive` starts allowing the scoped re-derive, which by
-            // construction never revisits the untouched rows. Deferring keeps both armed, at the
-            // cost of a whole-corpus regroup on later passes until coverage completes (#1014).
-            if self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() != Some(LOGICAL_KEY_VERSION) {
-                let stamp = if unverified == 0 && unrefreshed == 0 && out_of_scope == 0 {
-                    KeyVersionStamp::FullRederive
-                } else {
+            // load-bearing is that the refresh loop above completed for every row this checkout
+            // can advance first; their relative order here is free.
+            self.resolve_changed_edges()?;
+            if !scope_rows_newer
+                && self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() != Some(LOGICAL_KEY_VERSION)
+            {
+                let stamp = if self.scope_rows_owed()? {
                     KeyVersionStamp::Defer
+                } else {
+                    KeyVersionStamp::FullRederive
                 };
                 self.rebuild_logical_symbols(stamp)?;
             }
-            // The GRAPH stamp advances even when rows were skipped, unlike the key stamp above.
-            // That is deliberate, and the symmetry is tempting enough to be worth writing down.
-            //
-            // `out_of_scope` counts rows this connection's view does not admit — it is blind to
-            // whether those rows are FRESH. In a repo with two checkouts, each one always sees the
-            // other's rows as out of scope, however recently the other re-derived them. So gating
-            // this stamp on full coverage would not defer it until coverage completed; it would
-            // defer it forever, and every open of a multi-checkout repo would re-read and
-            // re-extract the entire corpus. That trades a bounded staleness for an unbounded cost.
-            //
-            // The key stamp can afford the same gate because deferring it only repeats a regroup,
-            // and because leaving it deferred keeps the drift-recovery mechanisms armed.
-            //
-            // The deferred KEY stamp is not free either, and the cost is worth naming: because
-            // `out_of_scope` is permanent in a multi-checkout repo, that stamp never becomes
-            // current there, so `can_scope_logical_rederive` stays false and every mutating pass
-            // takes the full rebuild instead of the scoped re-derive. Correct, but it gives up the
-            // write-amplification win indefinitely rather than for one pass.
-            //
-            // The real fix for both is per-row provenance — a version on the row, so the repo
-            // stamp can advance while individual rows stay owed and a checkout that CAN read those
-            // bytes finishes them later. That needs a migration and its own review (#1082).
             self.mark_graph_index_current()?;
             Ok(())
         })();
+        self.finish_scoped_edge_rewrite();
         if result.is_err() {
             let _ = self.storage.execute_batch("ROLLBACK");
         }
@@ -1859,7 +1828,101 @@ impl IndexDatabase {
     }
 
     pub(super) fn mark_graph_index_current(&self) -> anyhow::Result<()> {
-        self.set_repo_meta("graph_index_version", GRAPH_INDEX_VERSION)
+        if self.graph_rows_owed()? {
+            self.storage.connection().execute(
+                "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = 'graph_index_version'",
+                [&self.active_repo_id],
+            )?;
+            Ok(())
+        } else {
+            self.set_repo_meta("graph_index_version", GRAPH_INDEX_VERSION)
+        }
+    }
+
+    pub(super) fn active_derivation_rows_owed(&self) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND (graph_version < CAST(?3 AS INTEGER)
+                        OR scope_version < CAST(?4 AS INTEGER))
+                   AND id IN (SELECT id FROM files)
+             )",
+            params![
+                self.active_repo_id,
+                self.active_generation,
+                GRAPH_INDEX_VERSION,
+                LOGICAL_KEY_VERSION
+            ],
+            |row| row.get::<_, i64>(0),
+        )? == 1)
+    }
+
+    fn active_graph_rows_owed(&self) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND graph_version < CAST(?3 AS INTEGER)
+                   AND id IN (SELECT id FROM files)
+             )",
+            params![self.active_repo_id, self.active_generation, GRAPH_INDEX_VERSION],
+            |row| row.get::<_, i64>(0),
+        )? == 1)
+    }
+
+    fn graph_rows_owed(&self) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND graph_version < CAST(?3 AS INTEGER)
+             )",
+            params![self.active_repo_id, self.active_generation, GRAPH_INDEX_VERSION],
+            |row| row.get::<_, i64>(0),
+        )? == 1)
+    }
+
+    fn scope_rows_owed(&self) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND scope_version < CAST(?3 AS INTEGER)
+             )",
+            params![self.active_repo_id, self.active_generation, LOGICAL_KEY_VERSION],
+            |row| row.get::<_, i64>(0),
+        )? == 1)
+    }
+
+    fn scope_rows_newer(&self) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND scope_version > CAST(?3 AS INTEGER)
+             )",
+            params![self.active_repo_id, self.active_generation, LOGICAL_KEY_VERSION],
+            |row| row.get::<_, i64>(0),
+        )? == 1)
+    }
+
+    fn mark_file_graph_current(&self, file_id: i64) -> anyhow::Result<()> {
+        self.storage.connection().execute(
+            "UPDATE main.files SET graph_version = MAX(graph_version, CAST(?1 AS INTEGER))
+             WHERE id = ?2",
+            params![GRAPH_INDEX_VERSION, file_id],
+        )?;
+        Ok(())
+    }
+
+    fn mark_file_scope_current(&self, file_id: i64) -> anyhow::Result<()> {
+        self.storage.connection().execute(
+            "UPDATE main.files SET scope_version = MAX(scope_version, CAST(?1 AS INTEGER))
+             WHERE id = ?2",
+            params![LOGICAL_KEY_VERSION, file_id],
+        )?;
+        Ok(())
     }
 
     /// Refresh symbol fields whose extraction semantics changed without rewriting chunks or
@@ -1996,30 +2059,44 @@ impl IndexDatabase {
         // `mark_file_deleted` leaves `language='unknown', kind='deleted'`, and neither parses, so
         // letting one through would turn every open into a hard error.
         let mut stmt = self.storage.connection().prepare(
-            "SELECT id, path, language, kind, sha256
+            "SELECT id, path, language, kind, sha256,
+                    graph_version < CAST(?3 AS INTEGER),
+                    scope_version < CAST(?4 AS INTEGER)
                  FROM main.files
                  WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
                    AND id IN (SELECT id FROM files)
+                   AND (graph_version < CAST(?3 AS INTEGER)
+                        OR scope_version < CAST(?4 AS INTEGER))
                  ORDER BY path",
         )?;
-        let rows = stmt.query_map(params![self.active_repo_id, self.active_generation], |row| {
-            let language: String = row.get(2)?;
-            let kind: String = row.get(3)?;
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                language,
-                kind,
-                row.get::<_, String>(4)?,
-            ))
-        })?;
+        let rows = stmt.query_map(
+            params![
+                self.active_repo_id,
+                self.active_generation,
+                GRAPH_INDEX_VERSION,
+                LOGICAL_KEY_VERSION
+            ],
+            |row| {
+                let language: String = row.get(2)?;
+                let kind: String = row.get(3)?;
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    language,
+                    kind,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, bool>(5)?,
+                    row.get::<_, bool>(6)?,
+                ))
+            },
+        )?;
         let mut files = Vec::new();
         // A row this build cannot name is still a row the heal did not cover, so the caller has to
         // hear about it: with the count lost, a repo whose every OTHER row refreshed would take the
         // new key stamp, and once the stamp matches nothing ever owes this row a re-derivation.
         let mut unreadable = 0usize;
         for row in rows {
-            let (id, path, language, kind, sha256) = row?;
+            let (id, path, language, kind, sha256, graph_owed, scope_owed) = row?;
             // A marker row this build cannot name is a row to LEAVE ALONE, not a reason to fail
             // the open. `ensure_graph_index_current` is on the open path, so an unparseable
             // language/kind here would wedge the database for every later open too.
@@ -2030,7 +2107,15 @@ impl IndexDatabase {
                 unreadable += 1;
                 continue;
             };
-            files.push(GraphReindexFile { id, path, language, kind, sha256 });
+            files.push(GraphReindexFile {
+                id,
+                path,
+                language,
+                kind,
+                sha256,
+                graph_owed,
+                scope_owed,
+            });
         }
         Ok((files, unreadable))
     }

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -1687,14 +1687,6 @@ impl IndexDatabase {
         self.storage.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
         let result = (|| -> anyhow::Result<()> {
             self.begin_scoped_edge_rewrite()?;
-            self.storage.connection().execute(
-                "INSERT OR IGNORE INTO temp.edge_rewrite_files(file_id)
-                 SELECT id FROM main.files
-                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
-                   AND graph_version <= CAST(?3 AS INTEGER)
-                   AND id IN (SELECT id FROM files)",
-                params![self.active_repo_id, self.active_generation, GRAPH_INDEX_VERSION],
-            )?;
             // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
             // version-bump re-resolve would re-derive `import_scope_*` on the new edges
             // but read an empty `packages` table (V022 only ADDED the column; it did not
@@ -1721,6 +1713,7 @@ impl IndexDatabase {
             // Rows the row reader could not name are uncovered exactly like an unreadable file.
             let mut unverified = unreadable;
             let mut unrefreshed = 0usize;
+            let mut edge_rewrite_staged = false;
             for file in files {
                 let full_path = root.join(&file.path);
                 let Ok(text) = fs::read_to_string(full_path) else {
@@ -1747,14 +1740,21 @@ impl IndexDatabase {
                     && (file.language == Language::Rust
                         || self.file_has_unscoped_symbols(file.id)?);
                 if file.scope_owed && !scope_rows_newer {
-                    if !scope_needs_refresh
-                        || self.refresh_symbol_scopes(
-                            file.id,
-                            Path::new(&file.path),
-                            &text,
-                            file.language,
-                        )?
-                    {
+                    if !scope_needs_refresh {
+                        self.mark_file_scope_current(file.id)?;
+                    } else if self.refresh_symbol_scopes(
+                        file.id,
+                        Path::new(&file.path),
+                        &text,
+                        file.language,
+                    )? {
+                        self.stage_edge_rewrite_inedge_sources(
+                            &file.path,
+                            &self.active_repo_id,
+                            self.active_generation,
+                        )?;
+                        self.stage_edge_rewrite_file(file.id)?;
+                        edge_rewrite_staged = true;
                         self.mark_file_scope_current(file.id)?;
                     } else {
                         unrefreshed += 1;
@@ -1788,6 +1788,8 @@ impl IndexDatabase {
                     file.language,
                     &text,
                 )?;
+                self.stage_edge_rewrite_file(file.id)?;
+                edge_rewrite_staged = true;
                 self.mark_file_graph_current(file.id)?;
             }
             if unverified > 0 || unrefreshed > 0 {
@@ -1804,7 +1806,9 @@ impl IndexDatabase {
             // `logical_symbols` rows — edge resolution never reads that table). What is
             // load-bearing is that the refresh loop above completed for every row this checkout
             // can advance first; their relative order here is free.
-            self.resolve_changed_edges()?;
+            if edge_rewrite_staged {
+                self.resolve_changed_edges()?;
+            }
             if !scope_rows_newer
                 && self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() != Some(LOGICAL_KEY_VERSION)
             {
@@ -1844,8 +1848,12 @@ impl IndexDatabase {
             "SELECT EXISTS(
                  SELECT 1 FROM main.files
                  WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
-                   AND (graph_version < CAST(?3 AS INTEGER)
-                        OR scope_version < CAST(?4 AS INTEGER))
+                   AND graph_version < CAST(?3 AS INTEGER)
+                   AND id IN (SELECT id FROM files)
+             ) OR EXISTS(
+                 SELECT 1 FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'
+                   AND scope_version < CAST(?4 AS INTEGER)
                    AND id IN (SELECT id FROM files)
              )",
             params![

--- a/crates/rag-rat-core/src/index/languages/rust/binders.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/binders.rs
@@ -22,9 +22,8 @@ use crate::index::edges::{child_name_text, node_text};
 ///
 /// Walks outward to the file root: every item that can carry `type_parameters` contributes —
 /// `impl`, `fn`, `trait`, and the type items — so a binder introduced two levels up is still in
-/// force. Lifetimes and const parameters are collected too; neither survives
-/// [`super::edges::clean_rust_type_name`] as a type name today, so they are here for honesty
-/// rather than reach.
+/// force. Lifetimes and const parameters are collected too; neither is a nameable receiver type,
+/// so they are here for honesty rather than reach.
 pub(super) fn binds_name(at: Node<'_>, name: &str, text: &str) -> bool {
     if name.is_empty() {
         return false;
@@ -53,7 +52,7 @@ fn parameter_list_binds(parameters: Node<'_>, name: &str, text: &str) -> bool {
         // matching — so this has to strip it too, or a raw-spelled binder is substituted by the
         // owner renderer and missed by this membership test.
         "type_parameter" | "const_parameter" => child_name_text(parameter, text)
-            .is_some_and(|declared| declared.strip_prefix("r#").unwrap_or(&declared) == name),
+            .is_some_and(|declared| super::identifiers_equal(&declared, name)),
         "lifetime_parameter" | "lifetime" => {
             let lifetime = node_text(parameter, text);
             lifetime.split(':').next().unwrap_or_default().trim() == name

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -321,8 +321,7 @@ fn infer_self_type_hint(node: Node<'_>, text: &str) -> Option<String> {
         if ancestor.kind() == "impl_item"
             && let Some(type_node) = ancestor.child_by_field_name("type")
         {
-            let cleaned =
-                clean_rust_type_name(&super::render_owner(type_node, text, &[]), type_node, text)?;
+            let cleaned = clean_rust_type_name(type_node, type_node, text)?;
             // Canonical against the IMPL's own module — `mod inner { impl Worker { … } }`
             // yields `inner::Worker`, matching the method's container-based scope path.
             return module_qualified_type_path(ancestor, &cleaned, text);
@@ -350,11 +349,7 @@ fn infer_explicit_self_type_hint(node: Node<'_>, text: &str) -> Option<String> {
                     continue;
                 }
                 let type_node = parameter.child_by_field_name("type")?;
-                let type_name = clean_rust_type_name(
-                    &super::render_owner(type_node, text, &[]),
-                    type_node,
-                    text,
-                )?;
+                let type_name = clean_rust_type_name(type_node, type_node, text)?;
                 return canonical_receiver_type(type_name, type_node, text);
             }
             return infer_self_type_hint(node, text);
@@ -395,130 +390,161 @@ enum WrapperSpelling {
 /// type with its own methods, so peeling it would send `value.run()` to `Worker::run` when rustc
 /// sends it to `custom::Box::run`. A qualified spelling names the standard pointer only when it is
 /// rooted where the standard pointers live.
-fn wrapper_spelling(head: &str) -> WrapperSpelling {
-    let path: Vec<&str> = head.trim().trim_start_matches("::").split("::").map(str::trim).collect();
-    let Some(tail) = path.last() else { return WrapperSpelling::NotAWrapper };
-    if !DEREF_WRAPPERS.contains(tail) {
+fn wrapper_spelling(head: Node<'_>, text: &str) -> WrapperSpelling {
+    let Some(tail) = path_tail_node(head) else { return WrapperSpelling::NotAWrapper };
+    let tail = canonical_identifier(tail, text);
+    if !DEREF_WRAPPERS.contains(&tail) {
         return WrapperSpelling::NotAWrapper;
     }
-    match path.as_slice() {
-        [_] => WrapperSpelling::Bare,
-        [root, ..] if matches!(*root, "std" | "core" | "alloc") => WrapperSpelling::Rooted,
+    match head.kind() {
+        "identifier" | "type_identifier" => WrapperSpelling::Bare,
+        "scoped_identifier" | "scoped_type_identifier" => {
+            let Some(path) = head.child_by_field_name("path") else {
+                // Preserve the prior treatment of a leading `::Box`: the spelling has one named
+                // segment even though tree-sitter represents it as a scoped path with no `path`.
+                return WrapperSpelling::Bare;
+            };
+            let Some(root) = path_root_node(path) else { return WrapperSpelling::NotAWrapper };
+            match canonical_identifier(root, text) {
+                "std" | "core" | "alloc" => WrapperSpelling::Rooted,
+                _ => WrapperSpelling::NotAWrapper,
+            }
+        },
         _ => WrapperSpelling::NotAWrapper,
     }
 }
 
-/// Return the deref target solely to detect a standard wrapper. The single-string receiver model
-/// cannot preserve Rust's ordered `Box<Worker> -> Worker` lookup, so callers decline inference when
-/// this changes the type rather than confidently naming the inner owner.
-fn peel_deref_wrapper<'a>(type_str: &'a str, context: Node<'_>, text: &str) -> &'a str {
-    let mut current = type_str.trim();
-    loop {
-        let Some(open) = current.find('<') else { return current };
-        let head = current[..open].trim_end();
-        if !current.trim_end().ends_with('>') {
-            return current;
-        }
-        match wrapper_spelling(head) {
-            // A bare name is the standard pointer only while nothing nearer declares it. A crate
-            // with its own `struct Box<T>` gets its methods on the WRAPPER, so peeling would name
-            // the wrong owner. Only a local DECLARATION blocks it: an import does not, because
-            // `use std::sync::Arc;` is how the real one usually arrives.
-            WrapperSpelling::Bare if declares_type_item(context, qn_tail(head), text) => {
-                return current;
-            },
-            WrapperSpelling::NotAWrapper => return current,
-            WrapperSpelling::Bare | WrapperSpelling::Rooted => {},
-        }
-        let inner = current.trim_end();
-        let inner = inner[open + 1..inner.len() - 1].trim();
-        // `Cow<'a, T>` leads with a lifetime, so the LAST argument is the type. A wrapper with more
-        // than one type argument is not one of these by construction.
-        let last = match top_level_arguments(inner).pop() {
-            Some(argument) if !argument.is_empty() => argument,
-            _ => return current,
-        };
-        current = last;
+/// Whether the written type starts at a standard deref wrapper. The single-string receiver model
+/// cannot preserve Rust's ordered `Box<Worker> -> Worker` lookup, so inference declines the whole
+/// receiver rather than choosing either owner.
+fn is_deref_wrapper(type_node: Node<'_>, context: Node<'_>, text: &str) -> bool {
+    if type_node.kind() != "generic_type" {
+        return false;
+    }
+    let Some(head) = type_node.child_by_field_name("type") else { return false };
+    match wrapper_spelling(head, text) {
+        // A bare name is the standard pointer only while nothing nearer declares it. A crate with
+        // its own `struct Box<T>` gets its methods on the WRAPPER. An import does not block this:
+        // `use std::sync::Arc;` is how the standard pointer usually arrives.
+        WrapperSpelling::Bare => {
+            let Some(tail) = path_tail_node(head) else { return false };
+            let written_tail = text.get(tail.byte_range()).unwrap_or_default().trim();
+            !declares_type_item(context, written_tail, text)
+        },
+        WrapperSpelling::Rooted => true,
+        WrapperSpelling::NotAWrapper => false,
     }
 }
 
-/// Split a generic argument list on its own top-level commas.
-fn top_level_arguments(inner: &str) -> Vec<&str> {
-    let mut out = Vec::new();
-    let mut start = 0usize;
-    crate::index::edges::scope_grammar::scan(inner, |at, ch, depth, span| {
-        if span.is_code() && depth.is_top() && ch == ',' {
-            out.push(inner[start..at].trim());
-            start = at + 1;
+/// Peel only syntax that does not change the receiver owner: references and redundant parentheses.
+fn nameable_type_node(mut node: Node<'_>) -> Option<Node<'_>> {
+    loop {
+        match node.kind() {
+            "reference_type" => node = node.child_by_field_name("type")?,
+            "tuple_type" if redundant_parenthesized_type(node) => {
+                let mut cursor = node.walk();
+                node = node.named_children(&mut cursor).next()?;
+            },
+            "identifier"
+            | "type_identifier"
+            | "scoped_identifier"
+            | "scoped_type_identifier"
+            | "generic_type" => return Some(node),
+            _ => return None,
         }
-    });
-    out.push(inner[start..].trim());
-    out
+    }
 }
 
-/// Drop the whitespace around a path separator, which Rust allows and which changes nothing about
-/// the type: `Self ::Assoc` and `Self::Assoc` name one associated item.
-///
-/// Literals stay untouched — the scanner already knows where they are, and a `::` inside one is
-/// text, not a separator.
-fn normalize_separators(raw: &str) -> String {
-    let mut out = String::with_capacity(raw.len());
-    let mut skip = 0usize;
-    crate::index::edges::scope_grammar::scan(raw, |at, ch, _, span| {
-        if at < skip {
-            return;
-        }
-        if span.is_code() && ch == ':' && raw[at..].starts_with("::") {
-            while out.ends_with(char::is_whitespace) {
-                out.pop();
+fn redundant_parenthesized_type(node: Node<'_>) -> bool {
+    let mut named = node.walk();
+    if node.named_children(&mut named).count() != 1 {
+        return false;
+    }
+    let mut all = node.walk();
+    !node.children(&mut all).any(|child| child.kind() == ",")
+}
+
+fn canonical_identifier<'a>(node: Node<'_>, text: &'a str) -> &'a str {
+    let written = text.get(node.byte_range()).unwrap_or_default().trim();
+    written.strip_prefix("r#").unwrap_or(written)
+}
+
+/// Preserve the prior receiver-hint boundary without reparsing a rendered string. Parentheses,
+/// arrays, bounds, pointers and function arrows inside a generic argument made the old canonical
+/// output decline; inspect their syntax tokens directly so this refactor does not silently widen
+/// persisted hints.
+fn has_unsupported_receiver_token(node: Node<'_>, text: &str) -> bool {
+    let source = text.get(node.byte_range()).unwrap_or_default();
+    if crate::index::edges::scope_grammar::strip_comments(source).contains("for<") {
+        return true;
+    }
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        let mut cursor = current.walk();
+        for child in current.children(&mut cursor) {
+            if matches!(child.kind(), "block_comment" | "line_comment") {
+                continue;
             }
-            out.push_str("::");
-            skip = at + 2;
-            // Whitespace AFTER the separator is dropped by the same rule on the next token, so
-            // consume it here rather than leaving `Self:: Assoc`.
-            let rest = &raw[skip..];
-            skip += rest.len() - rest.trim_start().len();
-            return;
+            if matches!(child.kind(), "(" | ")" | "[" | "]" | "+" | "*" | "->" | "as") {
+                return true;
+            }
+            if child.child_count() == 0 {
+                let token = text.get(child.byte_range()).unwrap_or_default();
+                if token.contains(['(', ')', '[', ']', '+', '*'])
+                    || token.contains("->")
+                    || token.contains(" as ")
+                {
+                    return true;
+                }
+            }
+            stack.push(child);
         }
-        out.push(ch);
-    });
-    out
+    }
+    false
+}
+
+fn path_root_node(mut node: Node<'_>) -> Option<Node<'_>> {
+    loop {
+        match node.kind() {
+            "generic_type" => node = node.child_by_field_name("type")?,
+            "scoped_identifier" | "scoped_type_identifier" => {
+                node = node
+                    .child_by_field_name("path")
+                    .or_else(|| node.child_by_field_name("name"))?;
+            },
+            _ => return Some(node),
+        }
+    }
+}
+
+fn path_tail_node(mut node: Node<'_>) -> Option<Node<'_>> {
+    loop {
+        match node.kind() {
+            "generic_type" => node = node.child_by_field_name("type")?,
+            "scoped_identifier" | "scoped_type_identifier" => {
+                node = node.child_by_field_name("name")?;
+            },
+            _ => return Some(node),
+        }
+    }
 }
 
 /// The receiver type a declaration names, or `None` when this pass cannot name it.
 ///
-/// Callers hand in a string the canonical printer produced, not raw source. Rust lets whitespace
-/// sit anywhere a token boundary is legal, so `Self ::Assoc` and `Self::Assoc` are one type spelled
-/// two ways — and the checks below are string predicates. Reading raw text made every one of them
-/// sensitive to spelling: the `Self::` check missed the spaced form and handed back a qualified
-/// hint whose tail could bind an unrelated concrete type. Canonicalizing once, here, is what keeps
-/// each predicate from having to re-derive it.
-fn clean_rust_type_name(raw: &str, at: Node<'_>, text: &str) -> Option<String> {
-    let normalized = normalize_separators(raw);
-    let s = normalized.trim();
-    // A raw-pointer TYPE is not a dereferenced expression: `*mut Worker` must decline here,
-    // before the expression cleaner strips the `*` and the pointer masquerades as `Worker`.
-    if s.starts_with('*') {
+/// `type_node` supplies the type's structure; `context` supplies lexical binders and declarations.
+/// Keeping those roles separate makes unsupported syntax decline by node kind instead of letting a
+/// spelling accidentally pass a string predicate.
+fn clean_rust_type_name(type_node: Node<'_>, context: Node<'_>, text: &str) -> Option<String> {
+    let type_node = nameable_type_node(type_node)?;
+    if is_deref_wrapper(type_node, context, text) {
         return None;
     }
-    let cleaned = clean_receiver_expr(s).unwrap_or(s);
-    if cleaned.starts_with('<') || cleaned.contains(" as ") {
+    if has_unsupported_receiver_token(type_node, text) {
         return None;
     }
-    if peel_deref_wrapper(cleaned, at, text) != cleaned {
-        return None;
-    }
-    let type_str = cleaned.trim();
+    let rendered = super::render_owner(type_node, text, &[]);
+    let type_str = rendered.trim();
     if type_str.is_empty() {
-        return None;
-    }
-    if type_str.starts_with("dyn ") || type_str.starts_with("impl ") {
-        return None;
-    }
-    if type_str.contains(['(', ')', '[', ']', '+', '*'])
-        || type_str.contains("for<")
-        || type_str.contains("->")
-    {
         return None;
     }
     let identity_path = degeneric_path(type_str);
@@ -533,12 +559,12 @@ fn clean_rust_type_name(raw: &str, at: Node<'_>, text: &str) -> Option<String> {
     // The binder question is asked of the POSITION, never of a list the caller assembled: an
     // enclosing `impl`/`trait` binder is invisible from the node a caller happens to hold, and
     // every list-passing caller guessed too narrowly.
-    if binders::binds_name(at, tail, text) {
+    if binders::binds_name(context, tail, text) {
         return None;
     }
     if let Some((prefix, _)) = identity_path.rsplit_once("::") {
         let root = prefix.split("::").next().unwrap_or(prefix);
-        if binders::binds_name(at, root, text) {
+        if binders::binds_name(context, root, text) {
             return None;
         }
     }
@@ -605,8 +631,7 @@ fn infer_local_var_type_hint(call_node: Node<'_>, text: &str, recv: &str) -> Opt
                 return None;
             }
             let type_node = param.child_by_field_name("type")?;
-            let type_name =
-                clean_rust_type_name(&super::render_owner(type_node, text, &[]), type_node, text)?;
+            let type_name = clean_rust_type_name(type_node, type_node, text)?;
             let type_name = canonical_receiver_type(type_name, type_node, text)?;
             return Some(type_name);
         }
@@ -681,7 +706,7 @@ fn visible_let_binding(
             return VisibleBinding::Shadowed;
         }
         let type_name = if let Some(type_node) = child.child_by_field_name("type") {
-            clean_rust_type_name(&super::render_owner(type_node, text, &[]), type_node, text)
+            clean_rust_type_name(type_node, type_node, text)
                 .and_then(|type_name| canonical_receiver_type(type_name, type_node, text))
         } else {
             constructor_owner(child.child_by_field_name("value"), text)
@@ -739,7 +764,9 @@ fn scope_declares_item(
 ) -> bool {
     let mut cursor = scope.walk();
     scope.named_children(&mut cursor).any(|item| {
-        occupies(item) && child_name_text(item, text).is_some_and(|declared| declared == name)
+        occupies(item)
+            && child_name_text(item, text)
+                .is_some_and(|declared| super::identifiers_equal(&declared, name))
     })
 }
 
@@ -752,9 +779,8 @@ fn constructor_owner(value: Option<Node<'_>>, text: &str) -> Option<String> {
     if function.kind() != "scoped_identifier" {
         return None;
     }
-    let function_text = node_text(function, text);
-    let (type_part, method_part) = function_text.rsplit_once("::")?;
-    let method_name = method_part.trim();
+    let owner_node = function.child_by_field_name("path")?;
+    let method_name = text.get(function.child_by_field_name("name")?.byte_range())?.trim();
     // Only the two strongest conventions survive: Rust does not force ANY method to return
     // `Self`, so `from`/`with_*` (routinely builder- or conversion-shaped) are declined
     // outright, and `new`/`default` are verified against the constructor's DECLARED return type
@@ -765,7 +791,7 @@ fn constructor_owner(value: Option<Node<'_>>, text: &str) -> Option<String> {
     if !matches!(method_name, "new" | "default") {
         return None;
     }
-    let owner = clean_rust_type_name(type_part, function, text)?;
+    let owner = clean_rust_type_name(owner_node, function, text)?;
     let owner_canonical = canonical_receiver_type(owner.clone(), value, text)?;
     match same_file_constructor_return(value, text, &owner_canonical, method_name) {
         CtorReturn::SelfLike => Some(owner_canonical),
@@ -810,7 +836,7 @@ fn same_file_constructor_return(node: Node<'_>, text: &str, owner: &str, ctor: &
             match child.kind() {
                 "impl_item" => {
                     let Some(type_node) = child.child_by_field_name("type") else { continue };
-                    let impl_type = node_text(type_node, text);
+                    let impl_type = super::render_owner(type_node, text, &[]);
                     let impl_tail = qn_tail(degeneric_path(&impl_type).trim()).to_string();
                     if impl_tail != owner_tail {
                         continue;
@@ -867,19 +893,17 @@ fn classify_constructor_return(
             // A "constructor" declared to return `()` constructs nothing.
             return Some(CtorReturn::Opaque);
         };
-        let declared = node_text(return_node, text);
-        let trimmed = declared.trim();
-        if trimmed == "Self" {
-            return Some(CtorReturn::SelfLike);
-        }
         // Anchored at the RETURN node, so the binders in force are the constructor's own impl
         // and fn — `impl<T> Factory<T> { fn new<U>() -> U }` returns whatever the call site
         // instantiates. The caller's binders are not in scope here and are not consulted, so
         // `fn test<Worker>(..)` calling a constructor that genuinely returns the concrete
         // `Worker` still gets its hint.
-        let Some(declared) = clean_rust_type_name(trimmed, return_node, text) else {
+        let Some(declared) = clean_rust_type_name(return_node, return_node, text) else {
             return Some(CtorReturn::Opaque);
         };
+        if declared == "Self" {
+            return Some(CtorReturn::SelfLike);
+        }
         let Some(declared_canonical) = module_qualified_type_path(item, &declared, text) else {
             return Some(CtorReturn::Opaque);
         };
@@ -1014,10 +1038,12 @@ fn scope_binds_name(scope: Node<'_>, name: &str, text: &str) -> bool {
         if crate::index::edges::use_has_glob(declaration) {
             return true;
         }
+        let declaration = rag_rat_base::canonical::nfc(&declaration.replace("r#", ""));
+        let name = rag_rat_base::canonical::nfc(name);
         // Most scopes have no relevant import. Avoid the full use-tree walk unless the
         // declaration can contain this exact identifier.
         declaration.split(|ch: char| !ch.is_alphanumeric() && ch != '_').any(|part| part == name)
-            && crate::index::edges::use_binds_name(declaration, name)
+            && crate::index::edges::use_binds_name(&declaration, &name)
     })
 }
 
@@ -1138,6 +1164,41 @@ mod receiver_type_hint_tests {
             );
         }
     }
+
+    #[test]
+    fn receiver_type_nameability_follows_the_ast_shape() {
+        assert_eq!(extract_call_hints("fn f(w: &mut (((Worker)))) { w.run(); }"), vec![Some(
+            "Worker".to_string()
+        )]);
+        for type_name in [
+            "*mut Worker",
+            "(Worker, Other)",
+            "[Worker; 2]",
+            "dyn Service",
+            "impl Service",
+            "fn() -> Worker",
+            "<Worker as Service>::Assoc",
+            "Receiver!()",
+        ] {
+            let code = format!("fn f(w: {type_name}) {{ w.run(); }}");
+            assert_eq!(extract_call_hints(&code), vec![None], "{type_name} is not one owner path");
+        }
+    }
+
+    #[test]
+    fn constructor_owner_comes_from_the_scoped_path_node() {
+        let code = r#"
+            mod factory {
+                impl Factory { fn new() -> Worker { Worker } }
+            }
+            fn f() {
+                let worker = factory :: Factory :: new();
+                worker.run();
+            }
+        "#;
+        assert_eq!(extract_call_hints(code), vec![None, Some("factory::Worker".to_string())]);
+    }
+
     fn extract_call_hints(code: &str) -> Vec<Option<String>> {
         let mut parser = Parser::new();
         let language = tree_sitter_rust::LANGUAGE;
@@ -1712,6 +1773,17 @@ mod receiver_type_hint_tests {
             fn test(w: Arc<Worker>) { w.run(); }
         "#;
         assert_eq!(extract_call_hints(imported), vec![None]);
+        for (declaration, receiver) in [("Box", "r#Box"), ("r#Box", "Box")] {
+            let code = format!(
+                "struct {declaration}<T>(T); impl<T> {declaration}<T> {{ fn run(&self) {{}} }} fn \
+                 test(w: {receiver}<Worker>) {{ w.run(); }}"
+            );
+            assert_eq!(
+                extract_call_hints(&code),
+                vec![Some("Box<Worker>".to_string())],
+                "raw and ordinary spellings name the same local wrapper"
+            );
+        }
     }
 
     /// A QUALIFIED head is judged by its whole path, not its tail. `custom::Box<Worker>` ends in a
@@ -1732,6 +1804,10 @@ mod receiver_type_hint_tests {
                 vec![None],
                 "{rooted} has more than one possible receiver layer"
             );
+        }
+        for raw in ["r#Box<Worker>", "r#std::boxed::Box<Worker>"] {
+            let code = format!("fn test(w: {raw}) {{ w.run(); }}");
+            assert_eq!(extract_call_hints(&code), vec![None], "raw spelling is the same wrapper");
         }
     }
 
@@ -2145,6 +2221,77 @@ mod receiver_type_hint_tests {
             Some("Foo<u8>".to_string()),
             Some("Foo<u16>".to_string()),
         ]);
+    }
+
+    #[test]
+    fn generic_arguments_keep_the_existing_nameability_boundary() {
+        for type_name in [
+            "Envelope<(Worker, Other)>",
+            "Matrix<[u8; 4]>",
+            "Callback<fn() -> Worker>",
+            "Marker<'*'>",
+            "Envelope<Ty!{\"for<\"}>",
+            "Envelope<Ty!{for<}>",
+        ] {
+            let code = format!("fn f(value: {type_name}) {{ value.run(); }}");
+            assert_eq!(
+                extract_call_hints(&code),
+                vec![None],
+                "the structural refactor must not widen persisted hints"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_constructor_returns_still_decline_aliases_and_binders() {
+        let raw_alias = r#"
+            struct Worker;
+            type r#Alias = Worker;
+            struct Factory;
+            impl Factory { fn new() -> r#Alias { Worker } }
+            fn f() { let worker = Factory::new(); worker.run(); }
+        "#;
+        assert_eq!(extract_call_hints(raw_alias), vec![None, None]);
+
+        let decomposed = "Cafe\u{301}";
+        let generic = format!(
+            "struct Worker; struct Factory; impl Factory {{ fn new<{decomposed}>(value: \
+             {decomposed}) -> {decomposed} {{ value }} }} fn f() {{ let worker = \
+             Factory::new(Worker); worker.run(); }}"
+        );
+        assert_eq!(extract_call_hints(&generic), vec![None, None]);
+    }
+
+    #[test]
+    fn canonical_constructor_returns_recognize_raw_and_nfc_imports() {
+        let raw = r#"
+            mod dep { pub struct Worker; }
+            mod inner {
+                use crate::dep::r#Worker;
+                struct Factory;
+                impl Factory { fn new() -> r#Worker { todo!() } }
+                fn f() { let worker = Factory::new(); worker.run(); }
+            }
+        "#;
+        assert_eq!(extract_call_hints(raw), vec![None, Some("Worker".to_string())]);
+
+        let decomposed = "Cafe\u{301}";
+        let imported = format!(
+            "mod dep {{ pub struct Café; }} mod inner {{ use crate::dep::{decomposed}; struct \
+             Factory; impl Factory {{ fn new() -> {decomposed} {{ todo!() }} }} fn f() {{ let \
+             value = Factory::new(); value.run(); }} }}"
+        );
+        assert_eq!(extract_call_hints(&imported), vec![None, Some("Café".to_string())]);
+    }
+
+    #[test]
+    fn comments_do_not_make_a_receiver_type_unnameable() {
+        assert_eq!(extract_call_hints("fn f(w: Foo</* note */ Worker>) { w.run(); }"), vec![Some(
+            "Foo<Worker>".to_string()
+        )]);
+        assert_eq!(extract_call_hints("fn f(w: &/* note */ Worker) { w.run(); }"), vec![Some(
+            "Worker".to_string()
+        )]);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -1055,7 +1055,7 @@ fn enclosing_module_path(node: Node<'_>, text: &str) -> Vec<String> {
         if ancestor.kind() == "mod_item"
             && let Some(name) = child_name_text(ancestor, text)
         {
-            modules.push(name);
+            modules.push(super::canonical_identifier(&name).into_owned());
         }
         current = ancestor.parent();
     }
@@ -2282,6 +2282,27 @@ mod receiver_type_hint_tests {
              value = Factory::new(); value.run(); }} }}"
         );
         assert_eq!(extract_call_hints(&imported), vec![None, Some("Café".to_string())]);
+    }
+
+    #[test]
+    fn qualified_constructor_modules_use_canonical_identifiers() {
+        let raw = r#"
+            mod r#type {
+                pub struct Worker;
+                pub struct Factory;
+                impl Factory { pub fn new() -> Worker { Worker } }
+            }
+            fn f() { let worker = r#type::Factory::new(); worker.run(); }
+        "#;
+        assert_eq!(extract_call_hints(raw), vec![None, Some("type::Worker".to_string())]);
+
+        let decomposed = "Cafe\u{301}";
+        let unicode = format!(
+            "mod {decomposed} {{ pub struct Worker; pub struct Factory; impl Factory {{ pub fn \
+             new() -> Worker {{ Worker }} }} }} fn f() {{ let worker = \
+             {decomposed}::Factory::new(); worker.run(); }}"
+        );
+        assert_eq!(extract_call_hints(&unicode), vec![None, Some("Café::Worker".to_string())]);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -259,6 +259,12 @@ fn nfc_ident(token: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+pub(super) fn identifiers_equal(left: &str, right: &str) -> bool {
+    let left = left.strip_prefix("r#").unwrap_or(left);
+    let right = right.strip_prefix("r#").unwrap_or(right);
+    nfc_ident(left) == nfc_ident(right)
+}
+
 /// Types the std prelude brings into every module without a `use`. A const parameter named after
 /// one of these is shadowed by the type in argument position, exactly as a locally declared or
 /// imported type shadows it — so the same coexisting impls (`impl<const Vec: usize> Tr<{ Vec }> for

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -259,10 +259,12 @@ fn nfc_ident(token: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+pub(super) fn canonical_identifier(token: &str) -> std::borrow::Cow<'_, str> {
+    nfc_ident(token.strip_prefix("r#").unwrap_or(token))
+}
+
 pub(super) fn identifiers_equal(left: &str, right: &str) -> bool {
-    let left = left.strip_prefix("r#").unwrap_or(left);
-    let right = right.strip_prefix("r#").unwrap_or(right);
-    nfc_ident(left) == nfc_ident(right)
+    canonical_identifier(left) == canonical_identifier(right)
 }
 
 /// Types the std prelude brings into every module without a `use`. A const parameter named after

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -434,9 +434,7 @@ impl IndexDatabase {
         // empty scope. The graph / generated-flags gates read `repo_id` explicitly.
         db.set_context(&commit_sha, &worktree_id)?;
         let conn = db.storage.connection();
-        if repo_meta(conn, &db.active_repo_id, "graph_index_version")?.as_deref()
-            != Some(GRAPH_INDEX_VERSION)
-        {
+        if db.active_derivation_rows_owed()? {
             return Ok(None);
         }
         // A stale generated-flags version owes a re-derive (a write); fall back to read-write so it
@@ -879,7 +877,7 @@ fn write_scope_view_inner(conn: &rusqlite::Connection, ctx: &ScopeContext) -> ru
             DROP VIEW IF EXISTS temp.files;
             CREATE TEMP VIEW temp.files AS
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id, has_test_code
+         indexed_revision, commit_sha, worktree_id, has_test_code, graph_version, scope_version
             FROM main.files
             WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
               AND generation = (SELECT value FROM temp.connection_context WHERE key = \
@@ -888,7 +886,7 @@ fn write_scope_view_inner(conn: &rusqlite::Connection, ctx: &ScopeContext) -> ru
          'worktree_id') AND worktree_id != '' AND kind != 'deleted'
             UNION ALL
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id, has_test_code
+         indexed_revision, commit_sha, worktree_id, has_test_code, graph_version, scope_version
             FROM main.files
             WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
               AND generation = (SELECT value FROM temp.connection_context WHERE key = \
@@ -940,7 +938,7 @@ fn write_repo_generation_view(
             DROP VIEW IF EXISTS temp.files;
             CREATE TEMP VIEW temp.files AS
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id, has_test_code
+         indexed_revision, commit_sha, worktree_id, has_test_code, graph_version, scope_version
             FROM main.files
             WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
               AND generation = (SELECT value FROM temp.connection_context WHERE key = \

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -383,7 +383,9 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // Same reasoning as 13: an index stamped 13 by an interim build would never re-resolve.
 // 15: Generic Rust method calls retain receiver inference through the turbofish wrapper; re-extract
 // `receiver_type_hint_id` so deployed indexes do not keep those calls untyped.
-const GRAPH_INDEX_VERSION: &str = "15";
+// 16: Rust receiver type naming reads AST structure instead of reparsing rendered strings; raw
+// identifiers and constructor paths now share the canonical owner printer, so re-extract hints.
+const GRAPH_INDEX_VERSION: &str = "16";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag
 // on next open. Incremental discovery only rewrites a file row when its sha/language/kind changes —
@@ -436,6 +438,8 @@ struct GraphReindexFile {
     /// Digest of the text that produced this row — the graph heal's proof that the bytes it read
     /// from the active checkout are this row's own (rows span every commit/worktree scope).
     sha256: String,
+    graph_owed: bool,
+    scope_owed: bool,
 }
 
 #[derive(Debug)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -532,6 +532,47 @@ fn a_file_edited_since_indexing_does_not_wedge_the_graph_heal() {
     let _ = fs::remove_dir_all(&root);
 }
 
+#[test]
+fn retrying_an_unverified_row_does_not_reresolve_current_rows() {
+    let (root, config) = indexed_root(&[
+        ("edited.rs", "pub fn edited_helper() {}\npub fn edited_entry() { edited_helper(); }\n"),
+        ("stable.rs", "pub fn stable_helper() {}\npub fn stable_entry() { stable_helper(); }\n"),
+    ]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let edited_id = scoped_file_id(&db, "src/edited.rs", &db.active_worktree_id);
+    let stable_id = scoped_file_id(&db, "src/stable.rs", &db.active_worktree_id);
+    fs::write(
+        root.join("src/edited.rs"),
+        "pub fn unindexed() {}\npub fn edited_helper() {}\npub fn edited_entry() { \
+         edited_helper(); }\n",
+    )
+    .unwrap();
+
+    owe_both_heals(&db);
+    db.ensure_graph_index_current().unwrap();
+    assert_eq!(file_graph_version(&db, edited_id), 0);
+    assert_eq!(file_graph_version(&db, stable_id), GRAPH_INDEX_VERSION.parse::<i64>().unwrap());
+
+    let sentinel = edges::intern_edge_string(db.storage.connection(), "sentinel").unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.edges_data SET resolution_id = ?1 WHERE source_file_id = ?2",
+            params![sentinel, stable_id],
+        )
+        .unwrap();
+    let stable_before_retry = edge_targets_with_resolution(&db, stable_id);
+
+    db.ensure_graph_index_current().unwrap();
+
+    assert_eq!(
+        edge_targets_with_resolution(&db, stable_id),
+        stable_before_retry,
+        "retrying the unverified row must not rewrite an already-current sibling"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// `refresh_symbol_scopes` reports a shortfall when it cannot reach every persisted symbol of a
 /// file — the `unrefreshed` half of the heal's bookkeeping. The digest gate now short-circuits the
 /// obvious way in (an edited file), so this reaches it the only remaining way: a persisted symbol

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -14,6 +14,14 @@ fn owe_both_heals(db: &IndexDatabase) {
     db.set_repo_meta("graph_index_version", "0").unwrap();
     db.storage
         .connection()
+        .execute(
+            "UPDATE main.files SET graph_version = 0, scope_version = 0
+             WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'",
+            params![&db.active_repo_id, db.active_generation],
+        )
+        .unwrap();
+    db.storage
+        .connection()
         .execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", [])
         .unwrap();
     // These tests rewind the version meta behind a connection that has already run passes, so a
@@ -164,6 +172,87 @@ fn edge_target_names(db: &IndexDatabase, file_id: i64) -> Vec<String> {
     names.map(Result::unwrap).collect()
 }
 
+fn edge_ids(db: &IndexDatabase, file_id: i64) -> Vec<i64> {
+    let mut stmt = db
+        .storage
+        .connection()
+        .prepare("SELECT id FROM main.edges_data WHERE source_file_id = ?1 ORDER BY id")
+        .unwrap();
+    let ids = stmt.query_map([file_id], |row| row.get::<_, i64>(0)).unwrap();
+    ids.map(Result::unwrap).collect()
+}
+
+fn file_graph_version(db: &IndexDatabase, file_id: i64) -> i64 {
+    db.storage
+        .connection()
+        .query_row("SELECT graph_version FROM main.files WHERE id = ?1", [file_id], |row| {
+            row.get(0)
+        })
+        .unwrap()
+}
+
+fn file_scope_version(db: &IndexDatabase, file_id: i64) -> i64 {
+    db.storage
+        .connection()
+        .query_row("SELECT scope_version FROM main.files WHERE id = ?1", [file_id], |row| {
+            row.get(0)
+        })
+        .unwrap()
+}
+
+#[test]
+fn an_older_binary_does_not_downgrade_future_row_provenance() {
+    let (root, config) = indexed_root(&[
+        ("future.rs", "pub fn future_helper() {}\npub fn future_entry() { future_helper(); }\n"),
+        ("owed.rs", "pub fn owed_helper() {}\npub fn owed_entry() { owed_helper(); }\n"),
+    ]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let future_id = scoped_file_id(&db, "src/future.rs", &db.active_worktree_id);
+    let owed_id = scoped_file_id(&db, "src/owed.rs", &db.active_worktree_id);
+    let future_resolution =
+        edges::intern_edge_string(db.storage.connection(), "future_resolution").unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.edges_data SET resolution_id = ?1 WHERE source_file_id = ?2",
+            params![future_resolution, future_id],
+        )
+        .unwrap();
+    let future_edges = edge_targets_with_resolution(&db, future_id);
+    db.storage
+        .connection()
+        .execute("UPDATE main.files SET graph_version = 17, scope_version = 4 WHERE id = ?1", [
+            future_id,
+        ])
+        .unwrap();
+    db.storage
+        .connection()
+        .execute("UPDATE main.files SET graph_version = 0, scope_version = 0 WHERE id = ?1", [
+            owed_id,
+        ])
+        .unwrap();
+    db.set_repo_meta("graph_index_version", "0").unwrap();
+    db.set_repo_meta(LOGICAL_KEY_VERSION_KEY, "4").unwrap();
+
+    db.ensure_graph_index_current().unwrap();
+
+    assert_eq!(file_graph_version(&db, future_id), 17);
+    assert_eq!(file_scope_version(&db, future_id), 4);
+    assert_eq!(
+        edge_targets_with_resolution(&db, future_id),
+        future_edges,
+        "resolving an owed sibling must not rewrite future-derived edges"
+    );
+    assert_eq!(file_graph_version(&db, owed_id), GRAPH_INDEX_VERSION.parse::<i64>().unwrap());
+    assert_eq!(file_scope_version(&db, owed_id), 0, "scope healing waits for the newer binary");
+    assert_eq!(
+        db.repo_meta(LOGICAL_KEY_VERSION_KEY).unwrap().as_deref(),
+        Some("4"),
+        "the older binary preserves the future global grouping stamp"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// The `main.files` row id for `path` in the scope identified by `worktree_id` (`''` = base).
 fn scoped_file_id(db: &IndexDatabase, path: &str, worktree_id: &str) -> i64 {
     db.storage
@@ -219,6 +308,8 @@ fn a_graph_heal_does_not_rewrite_a_sibling_worktrees_edges() {
     assert_ne!(base_id, overlay_id, "base and overlay must hold separate rows for the path");
     let overlay_before = edge_target_names(&db, overlay_id);
     let overlay_resolved_before = edge_targets_with_resolution(&db, overlay_id);
+    let base_edge_ids_before = edge_ids(&db, base_id);
+    let overlay_edge_ids_before = edge_ids(&db, overlay_id);
     assert!(
         overlay_before.iter().any(|name| name == "overlay_helper"),
         "the overlay row's graph is derived from the BRANCH body: {overlay_before:?}"
@@ -226,6 +317,14 @@ fn a_graph_heal_does_not_rewrite_a_sibling_worktrees_edges() {
 
     owe_both_heals(&db);
     db.ensure_graph_index_current().expect("the heal runs from the base checkout");
+
+    assert_eq!(file_graph_version(&db, base_id), GRAPH_INDEX_VERSION.parse::<i64>().unwrap());
+    assert_eq!(file_scope_version(&db, base_id), LOGICAL_KEY_VERSION.parse::<i64>().unwrap());
+    assert_eq!(file_graph_version(&db, overlay_id), 0);
+    assert_eq!(file_scope_version(&db, overlay_id), 0);
+    let base_edge_ids_after = edge_ids(&db, base_id);
+    assert_ne!(base_edge_ids_after, base_edge_ids_before, "the active row was re-extracted");
+    assert_eq!(edge_ids(&db, overlay_id), overlay_edge_ids_before, "the sibling row was untouched");
 
     assert_eq!(
         edge_target_names(&db, overlay_id),
@@ -242,6 +341,54 @@ fn a_graph_heal_does_not_rewrite_a_sibling_worktrees_edges() {
     assert!(
         base_after.iter().any(|name| name == "base_helper"),
         "the active checkout's own row IS re-derived: {base_after:?}"
+    );
+
+    assert_ne!(
+        db.repo_meta("graph_index_version").unwrap().as_deref(),
+        Some(GRAPH_INDEX_VERSION),
+        "the repo summary stays pending while a sibling row is owed"
+    );
+
+    let mut linked_config = source_config(linked.to_path_buf(), Language::Rust);
+    linked_config.database = config.database.clone();
+    drop(db);
+    assert!(
+        IndexDatabase::try_open_config_read_only(&linked_config).unwrap().is_none(),
+        "a read-only sibling open must notice its visible lagging row"
+    );
+    let linked_db = IndexDatabase::open_config(&linked_config).unwrap();
+    assert_eq!(
+        edge_ids(&linked_db, base_id),
+        base_edge_ids_after,
+        "the sibling open leaves the base graph untouched"
+    );
+    assert_ne!(
+        edge_ids(&linked_db, overlay_id),
+        overlay_edge_ids_before,
+        "the sibling later re-extracts its own unchanged row"
+    );
+    assert_eq!(
+        edge_targets_with_resolution(&linked_db, overlay_id),
+        overlay_resolved_before,
+        "the refreshed sibling graph still describes the branch body"
+    );
+    assert_eq!(
+        file_graph_version(&linked_db, overlay_id),
+        GRAPH_INDEX_VERSION.parse::<i64>().unwrap()
+    );
+    assert_eq!(
+        file_scope_version(&linked_db, overlay_id),
+        LOGICAL_KEY_VERSION.parse::<i64>().unwrap()
+    );
+    assert_eq!(
+        linked_db.repo_meta("graph_index_version").unwrap().as_deref(),
+        Some(GRAPH_INDEX_VERSION),
+        "the repo summary converges after every live row is current"
+    );
+    assert_eq!(
+        linked_db.repo_meta(LOGICAL_KEY_VERSION_KEY).unwrap().as_deref(),
+        Some(LOGICAL_KEY_VERSION),
+        "the logical-key summary converges after every scope row is current"
     );
 
     let _ = fs::remove_dir_all(&main);
@@ -287,10 +434,10 @@ fn partial_coverage_defers_the_logical_key_stamp() {
     owe_both_heals(&db);
     db.ensure_graph_index_current().unwrap();
 
-    assert_eq!(
+    assert_ne!(
         db.repo_meta("graph_index_version").unwrap().as_deref(),
         Some(GRAPH_INDEX_VERSION),
-        "the graph pass itself ran to completion"
+        "an unrefreshed sibling row keeps the graph summary pending"
     );
     assert_ne!(
         db.repo_meta("logical_key_version").unwrap().as_deref(),
@@ -423,6 +570,14 @@ fn a_symbol_row_the_parser_cannot_match_does_not_wedge_the_graph_heal() {
     assert!(
         !edge_target_names(&db, file_id).is_empty(),
         "the file's edges are still re-derived — the shortfall is reported, not fatal"
+    );
+    assert_eq!(file_scope_version(&db, file_id), 0, "the failed scope refresh remains owed");
+    drop(db);
+    let reopened = IndexDatabase::open_config(&config).unwrap();
+    assert_eq!(
+        file_scope_version(&reopened, file_id),
+        0,
+        "a later open retries rather than certifying the failed refresh"
     );
 
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -626,10 +626,13 @@ fn read_only_open_serves_current_index_and_declines_when_heal_is_owed() {
     );
     drop(ro);
 
-    // Mark the graph index stale (a heal write is now owed). open() already ran and left it
-    // current, so set it afterward; the read-only path does not heal, so it must decline.
+    // Mark a file's graph derivation stale (a heal write is now owed). The read-only path does not
+    // heal, so it must decline even if the derived repo summary has not changed yet.
     let db = IndexDatabase::open(&config.database).unwrap();
-    db.set_repo_meta("graph_index_version", "0").unwrap();
+    db.storage
+        .connection()
+        .execute("UPDATE main.files SET graph_version = 0 WHERE kind != 'deleted'", [])
+        .unwrap();
     drop(db);
     assert!(
         IndexDatabase::try_open_config_read_only(&config).unwrap().is_none(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
@@ -1654,6 +1654,7 @@ fn a_legacy_row_in_any_language_has_its_scope_re_derived() {
         let conn = rusqlite::Connection::open(&config.database).unwrap();
         conn.execute("UPDATE symbols SET scope_path = NULL WHERE name = 'inner'", []).unwrap();
         conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+        conn.execute("UPDATE files SET scope_version = 0", []).unwrap();
         conn.execute("UPDATE repo_meta SET value = '0' WHERE key = 'graph_index_version'", [])
             .unwrap();
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1824,16 +1824,18 @@ fn migration_101_file_graph_version_provenance() {
         })
         .unwrap();
     assert_eq!(versions, (16, 3), "replay preserves per-row progress");
-    let index_exists: i64 = conn
-        .query_row(
-            "SELECT EXISTS(SELECT 1 FROM sqlite_master
-                            WHERE type = 'index'
-                              AND name = 'idx_files_repo_generation_graph_version')",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap();
-    assert_eq!(index_exists, 1);
+    for index in
+        ["idx_files_repo_generation_graph_version", "idx_files_repo_generation_scope_version"]
+    {
+        let exists: i64 = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?1)",
+                [index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1, "{index} exists");
+    }
 
     let latest = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&latest, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1765,8 +1765,6 @@ fn migration_093_adds_table_sync_projection_state() {
 /// V100 (#976) adds receiver_type_hint_id to edges_data and updates the edges view.
 #[test]
 fn migration_100_receiver_type_hint_interning() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 100, "move this pin with the next schema migration");
-
     let bare = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&bare, &crate::index::migration_hooks()).unwrap();
     schema::migrations::apply_receiver_type_hint_interning(&bare).unwrap();
@@ -1781,7 +1779,7 @@ fn migration_100_receiver_type_hint_interning() {
             .unwrap()
     );
 
-    assert_eq!(schema::status(&bare).unwrap().current_version, 100);
+    assert_eq!(schema::status(&bare).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     let recorded: i64 = bare
         .query_row(
             "SELECT COUNT(*) FROM schema_version
@@ -1790,7 +1788,56 @@ fn migration_100_receiver_type_hint_interning() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(recorded, 1, "the forward migration records V099");
+    assert_eq!(recorded, 1, "the forward migration records V100");
+}
+
+/// V101 (#1014) makes graph and scope healing resumable per file row.
+#[test]
+fn migration_101_file_graph_version_provenance() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 101, "move this pin with the next schema migration");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE files(path TEXT, repo_id TEXT, generation INTEGER);
+         CREATE TABLE repo_meta(repo_id TEXT, key TEXT, value TEXT);
+         INSERT INTO repo_meta VALUES ('repo', 'graph_index_version', '15');
+         INSERT INTO repo_meta VALUES ('repo', 'logical_key_version', '2');
+         INSERT INTO files VALUES ('src/lib.rs', 'repo', 1);",
+    )
+    .unwrap();
+
+    schema::migrations::apply_file_graph_version_provenance(&conn).unwrap();
+    let versions: (i64, i64) = conn
+        .query_row(
+            "SELECT graph_version, scope_version FROM files WHERE path = 'src/lib.rs'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(versions, (15, 2), "existing rows inherit both prior repo stamps");
+
+    conn.execute("UPDATE files SET graph_version = 16, scope_version = 3", []).unwrap();
+    schema::migrations::apply_file_graph_version_provenance(&conn).expect("replay is a no-op");
+    let versions: (i64, i64) = conn
+        .query_row("SELECT graph_version, scope_version FROM files", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(versions, (16, 3), "replay preserves per-row progress");
+    let index_exists: i64 = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                            WHERE type = 'index'
+                              AND name = 'idx_files_repo_generation_graph_version')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(index_exists, 1);
+
+    let latest = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&latest, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&latest).unwrap().current_version, 101);
 }
 
 /// V091 (#949) tracks the live key-target count each invite reservation covers, so fold-time
@@ -2018,7 +2065,6 @@ fn migration_094_tracks_lens_enrichment_changes_in_constant_time() {
 /// binary that did not do the work.
 #[test]
 fn migration_097_records_the_same_ladder_entry_on_every_platform() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 100, "move this pin with the next schema migration");
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     let status = schema::status(&conn).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/bootstrap.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/bootstrap.rs
@@ -56,6 +56,8 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
     assert_eq!(table_count(&db, "reconcile_meta"), 1);
     assert_eq!(table_count(&db, "reconcile_attempts"), 1);
     assert!(file_columns(&db).contains(&"indexed_revision".to_string()));
+    assert!(file_columns(&db).contains(&"graph_version".to_string()));
+    assert!(file_columns(&db).contains(&"scope_version".to_string()));
     assert_eq!(indexed_revision_count(&db), 0);
     assert!(chunk_columns(&db).contains(&"anchor_version".to_string()));
     assert!(chunk_columns(&db).contains(&"normalized_hash".to_string()));

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -987,6 +987,10 @@ fn execute_one() {
         .unwrap();
     db.storage
         .connection()
+        .execute("UPDATE main.files SET graph_version = 0 WHERE kind != 'deleted'", [])
+        .unwrap();
+    db.storage
+        .connection()
         .execute(
             "
                 UPDATE edges

--- a/crates/rag-rat-db/src/schema/baseline.rs
+++ b/crates/rag-rat-db/src/schema/baseline.rs
@@ -23,6 +23,8 @@ pub fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             indexed_revision TEXT NOT NULL DEFAULT '',
             commit_sha TEXT NOT NULL DEFAULT '',
             worktree_id TEXT NOT NULL DEFAULT '',
+            graph_version INTEGER NOT NULL DEFAULT 0,
+            scope_version INTEGER NOT NULL DEFAULT 0,
             -- 1 when the file text contains a test marker (cfg(test) / describe( / it( / test();
             -- precomputed at index time so impact_surface test detection filters on an indexed \
          flag

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -7181,7 +7181,9 @@ pub fn apply_file_graph_version_provenance(conn: &Connection) -> rusqlite::Resul
     if column_exists(conn, "files", "repo_id")? && column_exists(conn, "files", "generation")? {
         conn.execute_batch(
             "CREATE INDEX IF NOT EXISTS idx_files_repo_generation_graph_version
-             ON files(repo_id, generation, graph_version, scope_version);",
+                 ON files(repo_id, generation, graph_version);
+             CREATE INDEX IF NOT EXISTS idx_files_repo_generation_scope_version
+                 ON files(repo_id, generation, scope_version);",
         )?;
     }
     Ok(())

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -7139,6 +7139,54 @@ pub fn apply_receiver_type_hint_interning(conn: &Connection) -> rusqlite::Result
     Ok(())
 }
 
+/// V101 (#1014): record which graph extractor version produced each file row.
+///
+/// Existing rows inherit the repository stamp they previously relied on. A later extractor bump
+/// can then mark only rows whose exact bytes are readable from the active checkout, leaving a
+/// divergent linked-worktree row owed until that checkout opens the shared database itself.
+pub fn apply_file_graph_version_provenance(conn: &Connection) -> rusqlite::Result<()> {
+    let had_graph_version = column_exists(conn, "files", "graph_version")?;
+    let had_scope_version = column_exists(conn, "files", "scope_version")?;
+    add_column_if_missing(conn, "files", "graph_version", "INTEGER NOT NULL DEFAULT 0")?;
+    add_column_if_missing(conn, "files", "scope_version", "INTEGER NOT NULL DEFAULT 0")?;
+    let has_repo_meta = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'repo_meta')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if !had_graph_version && column_exists(conn, "files", "repo_id")? && has_repo_meta {
+        conn.execute(
+            "UPDATE files
+             SET graph_version = COALESCE((
+                 SELECT CAST(value AS INTEGER)
+                 FROM repo_meta
+                 WHERE repo_meta.repo_id = files.repo_id
+                   AND repo_meta.key = 'graph_index_version'
+             ), 0)",
+            [],
+        )?;
+    }
+    if !had_scope_version && column_exists(conn, "files", "repo_id")? && has_repo_meta {
+        conn.execute(
+            "UPDATE files
+             SET scope_version = COALESCE((
+                 SELECT CAST(value AS INTEGER)
+                 FROM repo_meta
+                 WHERE repo_meta.repo_id = files.repo_id
+                   AND repo_meta.key = 'logical_key_version'
+             ), 0)",
+            [],
+        )?;
+    }
+    if column_exists(conn, "files", "repo_id")? && column_exists(conn, "files", "generation")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_files_repo_generation_graph_version
+             ON files(repo_id, generation, graph_version, scope_version);",
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod memory_model_failure_migration_tests {
     use super::*;

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 100;
+pub const LATEST_SCHEMA_VERSION: u32 = 101;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -763,6 +763,12 @@ const MIGRATION_100_CHECKSUM: &str =
 const MIGRATION_100_DESCRIPTION: &str = "Add edges_data.receiver_type_hint_id for conservative \
                                          Rust receiver-type resolution and persist stable callee \
                                          identity for call-path validation";
+const MIGRATION_101_ID: &str = "101_file_graph_version_provenance";
+const MIGRATION_101_CHECKSUM: &str = "sha256:rag-rat-file-graph-version-provenance-v101";
+const MIGRATION_101_DESCRIPTION: &str = "Add per-file graph and scope derivation provenance so an \
+                                         active checkout can refresh only rows whose bytes it can \
+                                         verify, while linked worktrees retain and later complete \
+                                         their own upgrade";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1590,6 +1596,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_100_CHECKSUM,
         description: MIGRATION_100_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_receiver_type_hint_interning),
+    },
+    Migration {
+        id: MIGRATION_101_ID,
+        checksum: MIGRATION_101_CHECKSUM,
+        description: MIGRATION_101_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_file_graph_version_provenance),
     },
 ];
 


### PR DESCRIPTION
## Summary

- persist graph and scope derivation versions per file so linked worktrees heal only rows whose source bytes they can verify
- preserve future-derived rows, retry skipped work per checkout, and narrow edge resolution to successfully refreshed rows and their existing inbound callers
- keep read-only provenance checks index-backed without treating repository summary stamps as work authority
- make Rust receiver-type naming structural by consuming tree-sitter nodes directly, including canonical raw/NFC identifiers, module segments, and constructor paths

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core` (1,938 passed, 2 skipped)
- `cargo nextest run --workspace` (4,864 passed, 7 skipped)

Closes #1014
Closes #1090