### PR TITLE
feat(sync): paginate table reconciliation by chain frontier

### DIFF
--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -168,7 +168,9 @@ pub use stream::StreamId;
 // The table-sync forward-compat seam (#1001): replay entries retained but not projected when
 // they arrived. Belongs at store open, before producing — see the module docs.
 pub use table_sync::{
-    TABLE_SYNC_ENTRY_MAX_BYTES, TableSyncIngestOutcome, TableSyncStream,
-    refold_stale_table_sync_projections, table_sync_entries_for_stream, table_sync_ingest,
-    table_sync_signed_hash, table_sync_supported_streams, table_sync_validate_stream,
+    TABLE_SYNC_ENTRY_MAX_BYTES, TableSyncChainEntry, TableSyncChainHead, TableSyncEntryStart,
+    TableSyncFrontier, TableSyncIngestOutcome, TableSyncStream,
+    refold_stale_table_sync_projections, table_sync_chain_entries, table_sync_chain_frontier,
+    table_sync_chain_page_after, table_sync_ingest, table_sync_supported_streams,
+    table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -39,6 +39,8 @@ pub(crate) use store::{
     PendingReason, author_row_entry, mark_entry_pending, record_stream_context,
 };
 pub use transport::{
-    TableSyncIngestOutcome, TableSyncStream, table_sync_entries_for_stream, table_sync_ingest,
-    table_sync_signed_hash, table_sync_supported_streams, table_sync_validate_stream,
+    TableSyncChainEntry, TableSyncChainHead, TableSyncEntryStart, TableSyncFrontier,
+    TableSyncIngestOutcome, TableSyncStream, table_sync_chain_entries, table_sync_chain_frontier,
+    table_sync_chain_page_after, table_sync_ingest, table_sync_supported_streams,
+    table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::Context;
-use rusqlite::{Connection, Transaction, TransactionBehavior};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::engine::{self, IngestOutcome, SyncCtx};
 use super::registry::{SYNCABLE_TABLES, TableSpec};
@@ -31,6 +31,47 @@ pub enum TableSyncIngestOutcome {
     NoChange,
 }
 
+/// The accepted tip of one device chain in a table stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TableSyncChainHead {
+    pub device_fingerprint: [u8; 32],
+    pub lamport: u64,
+    pub entry_hash: [u8; 32],
+}
+
+/// Durable receiver progress for one offered device chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableSyncFrontier {
+    Empty,
+    /// Entries strictly after this accepted tail are missing.
+    Accepted {
+        lamport: u64,
+        entry_hash: [u8; 32],
+    },
+    /// Repository purge retained this witness but removed the accepted tip itself. The witnessed
+    /// entry must be offered inclusively to restore local authoring continuity.
+    Restore {
+        lamport: u64,
+        entry_hash: [u8; 32],
+    },
+}
+
+/// Where a causal page of one device chain starts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableSyncEntryStart {
+    Beginning,
+    After { lamport: u64, entry_hash: [u8; 32] },
+    At { lamport: u64, entry_hash: [u8; 32] },
+}
+
+/// One accepted entry plus the cursor needed to request the next page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableSyncChainEntry {
+    pub lamport: u64,
+    pub entry_hash: [u8; 32],
+    pub signed_bytes: Vec<u8>,
+}
+
 /// Current repo-scoped streams supported by the production registry.
 pub fn table_sync_supported_streams(
     conn: &Connection,
@@ -49,17 +90,46 @@ pub fn table_sync_validate_stream(
     validate_stream_against(conn, account_id, stream, SYNCABLE_TABLES)
 }
 
-/// Accepted signed history for one validated current stream. This reads only
-/// `table_sync_entries`; `table_sync_gapped_entries` is deliberately absent.
-pub fn table_sync_entries_for_stream(
+/// A bounded canonical page of device chains after `after_device`.
+pub fn table_sync_chain_page_after(
     conn: &Connection,
     account_id: AccountId,
     stream: &TableSyncStream,
-) -> anyhow::Result<Vec<Vec<u8>>> {
-    if !table_sync_validate_stream(conn, account_id, stream)? {
+    after_device: Option<[u8; 32]>,
+    limit: usize,
+) -> anyhow::Result<Vec<TableSyncChainHead>> {
+    if limit == 0 || !table_sync_validate_stream(conn, account_id, stream)? {
         return Ok(Vec::new());
     }
-    accepted_entries(conn, stream.stream_id)
+    accepted_chain_page(conn, stream.stream_id, after_device, limit)
+}
+
+/// Durable progress for one device chain in a validated current stream.
+pub fn table_sync_chain_frontier(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+    device_fingerprint: [u8; 32],
+) -> anyhow::Result<TableSyncFrontier> {
+    if !table_sync_validate_stream(conn, account_id, stream)? {
+        return Ok(TableSyncFrontier::Empty);
+    }
+    chain_frontier(conn, stream.stream_id, device_fingerprint)
+}
+
+/// A bounded causal page from one accepted device chain. Gapped rows are never transferred.
+pub fn table_sync_chain_entries(
+    conn: &Connection,
+    account_id: AccountId,
+    stream: &TableSyncStream,
+    device_fingerprint: [u8; 32],
+    start: TableSyncEntryStart,
+    limit: usize,
+) -> anyhow::Result<Vec<TableSyncChainEntry>> {
+    if limit == 0 || !table_sync_validate_stream(conn, account_id, stream)? {
+        return Ok(Vec::new());
+    }
+    accepted_chain_entries(conn, stream.stream_id, device_fingerprint, start, limit)
 }
 
 /// Feed one untrusted signed envelope through the existing table-sync authority, chain and payload
@@ -72,11 +142,6 @@ pub fn table_sync_ingest(
     now_ms: i64,
 ) -> anyhow::Result<TableSyncIngestOutcome> {
     ingest_against(conn, account_id, stream, signed_bytes, now_ms, SYNCABLE_TABLES)
-}
-
-/// Inventory key for an exact signed envelope.
-pub fn table_sync_signed_hash(signed_bytes: &[u8]) -> [u8; 32] {
-    crate::cbor::sha256(signed_bytes)
 }
 
 fn repo_registry(registry: &[TableSpec]) -> Vec<TableSpec> {
@@ -144,15 +209,212 @@ fn validate_stream_against(
         == stream.stream_id)
 }
 
-fn accepted_entries(conn: &Connection, stream_id: [u8; 32]) -> anyhow::Result<Vec<Vec<u8>>> {
+fn accepted_chain_page(
+    conn: &Connection,
+    stream_id: [u8; 32],
+    after_device: Option<[u8; 32]>,
+    limit: usize,
+) -> anyhow::Result<Vec<TableSyncChainHead>> {
     let mut stmt = conn.prepare(
-        "SELECT signed_bytes FROM table_sync_entries
-          WHERE stream_id = ?1
-          ORDER BY lamport, device_fingerprint, entry_hash",
+        "SELECT e.device_fingerprint, e.lamport, e.entry_hash
+           FROM table_sync_entries e
+          WHERE e.stream_id = ?1
+            AND (?2 IS NULL OR e.device_fingerprint > ?2)
+            AND NOT EXISTS (
+                SELECT 1 FROM table_sync_entries newer
+                 WHERE newer.stream_id = e.stream_id
+                   AND newer.device_fingerprint = e.device_fingerprint
+                   AND newer.lamport > e.lamport
+            )
+          ORDER BY e.device_fingerprint
+          LIMIT ?3",
     )?;
-    Ok(stmt
-        .query_map([stream_id.as_slice()], |row| row.get(0))?
-        .collect::<rusqlite::Result<_>>()?)
+    stmt.query_map(
+        params![
+            stream_id.as_slice(),
+            after_device.map(|device| device.to_vec()),
+            i64::try_from(limit)?,
+        ],
+        |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?, row.get::<_, Vec<u8>>(2)?)),
+    )?
+    .map(|row| {
+        let (device, lamport, hash) = row?;
+        Ok(TableSyncChainHead {
+            device_fingerprint: fixed32(device)?,
+            lamport: u64::try_from(lamport)?,
+            entry_hash: fixed32(hash)?,
+        })
+    })
+    .collect::<anyhow::Result<_>>()
+}
+
+fn chain_frontier(
+    conn: &Connection,
+    stream_id: [u8; 32],
+    device_fingerprint: [u8; 32],
+) -> anyhow::Result<TableSyncFrontier> {
+    let accepted = accepted_chain_tail(conn, stream_id, device_fingerprint)?;
+    let witness = conn
+        .query_row(
+            "SELECT lamport, entry_hash FROM table_sync_chain_tips
+              WHERE stream_id = ?1 AND device_fingerprint = ?2",
+            params![stream_id.as_slice(), device_fingerprint.as_slice()],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .optional()?
+        .map(|(lamport, hash)| -> anyhow::Result<_> {
+            Ok((u64::try_from(lamport)?, fixed32(hash)?))
+        })
+        .transpose()?;
+    match (accepted, witness) {
+        (None, None) => Ok(TableSyncFrontier::Empty),
+        (Some((lamport, entry_hash)), None) =>
+            Ok(TableSyncFrontier::Accepted { lamport, entry_hash }),
+        (None, Some((lamport, entry_hash))) =>
+            Ok(TableSyncFrontier::Restore { lamport, entry_hash }),
+        (Some(accepted), Some(witness)) if accepted == witness =>
+            Ok(TableSyncFrontier::Accepted { lamport: accepted.0, entry_hash: accepted.1 }),
+        (Some(accepted), Some(witness)) if witness.0 > accepted.0 =>
+            Ok(TableSyncFrontier::Restore { lamport: witness.0, entry_hash: witness.1 }),
+        (Some(accepted), Some(witness)) => anyhow::bail!(
+            "table-sync chain tip witness {witness:?} conflicts with accepted tail {accepted:?}"
+        ),
+    }
+}
+
+fn accepted_chain_tail(
+    conn: &Connection,
+    stream_id: [u8; 32],
+    device_fingerprint: [u8; 32],
+) -> anyhow::Result<Option<(u64, [u8; 32])>> {
+    conn.query_row(
+        "SELECT lamport, entry_hash FROM table_sync_entries
+          WHERE stream_id = ?1 AND device_fingerprint = ?2
+          ORDER BY lamport DESC LIMIT 1",
+        params![stream_id.as_slice(), device_fingerprint.as_slice()],
+        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+    )
+    .optional()?
+    .map(|(lamport, hash)| -> anyhow::Result<_> { Ok((u64::try_from(lamport)?, fixed32(hash)?)) })
+    .transpose()
+}
+
+fn accepted_chain_entries(
+    conn: &Connection,
+    stream_id: [u8; 32],
+    device_fingerprint: [u8; 32],
+    start: TableSyncEntryStart,
+    limit: usize,
+) -> anyhow::Result<Vec<TableSyncChainEntry>> {
+    let (minimum_lamport, inclusive) = match start {
+        TableSyncEntryStart::Beginning => (None, false),
+        TableSyncEntryStart::After { lamport, entry_hash } => {
+            anyhow::ensure!(
+                cursor_matches(conn, stream_id, device_fingerprint, lamport, entry_hash)?,
+                "table-sync accepted chain cursor is not present locally"
+            );
+            (Some(lamport), false)
+        },
+        TableSyncEntryStart::At { lamport, entry_hash } => {
+            if cursor_matches(conn, stream_id, device_fingerprint, lamport, entry_hash)? {
+                (Some(lamport), true)
+            } else {
+                let successor = direct_successor_lamport(
+                    conn,
+                    stream_id,
+                    device_fingerprint,
+                    lamport,
+                    entry_hash,
+                )?;
+                let Some(successor) = successor else {
+                    anyhow::bail!(
+                        "table-sync restore cursor has neither its tip nor a direct successor"
+                    )
+                };
+                (Some(successor), true)
+            }
+        },
+    };
+    let comparison = if inclusive { ">=" } else { ">" };
+    let sql = format!(
+        "SELECT lamport, entry_hash, signed_bytes FROM table_sync_entries
+          WHERE stream_id = ?1 AND device_fingerprint = ?2
+            AND (?3 IS NULL OR lamport {comparison} ?3)
+          ORDER BY lamport LIMIT ?4"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    stmt.query_map(
+        params![
+            stream_id.as_slice(),
+            device_fingerprint.as_slice(),
+            minimum_lamport.map(i64::try_from).transpose()?,
+            i64::try_from(limit)?,
+        ],
+        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?)),
+    )?
+    .map(|row| {
+        let (lamport, hash, signed_bytes) = row?;
+        Ok(TableSyncChainEntry {
+            lamport: u64::try_from(lamport)?,
+            entry_hash: fixed32(hash)?,
+            signed_bytes,
+        })
+    })
+    .collect::<anyhow::Result<_>>()
+}
+
+fn direct_successor_lamport(
+    conn: &Connection,
+    stream_id: [u8; 32],
+    device_fingerprint: [u8; 32],
+    witness_lamport: u64,
+    entry_hash: [u8; 32],
+) -> anyhow::Result<Option<u64>> {
+    conn.query_row(
+        "SELECT lamport FROM table_sync_entries
+          WHERE stream_id = ?1 AND device_fingerprint = ?2 AND prev_hash = ?3 AND lamport > ?4
+          ORDER BY lamport LIMIT 1",
+        params![
+            stream_id.as_slice(),
+            device_fingerprint.as_slice(),
+            entry_hash.as_slice(),
+            i64::try_from(witness_lamport)?,
+        ],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()?
+    .map(u64::try_from)
+    .transpose()
+    .map_err(Into::into)
+}
+
+fn cursor_matches(
+    conn: &Connection,
+    stream_id: [u8; 32],
+    device_fingerprint: [u8; 32],
+    lamport: u64,
+    entry_hash: [u8; 32],
+) -> anyhow::Result<bool> {
+    let stored = conn
+        .query_row(
+            "SELECT entry_hash FROM table_sync_entries
+              WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport = ?3",
+            params![stream_id.as_slice(), device_fingerprint.as_slice(), i64::try_from(lamport)?,],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .optional()?;
+    let Some(stored) = stored else { return Ok(false) };
+    anyhow::ensure!(
+        fixed32(stored)? == entry_hash,
+        "table-sync chain cursor hash conflicts at lamport {lamport}"
+    );
+    Ok(true)
+}
+
+fn fixed32(bytes: Vec<u8>) -> anyhow::Result<[u8; 32]> {
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!("stored table-sync hash must be 32 bytes, got {}", bytes.len())
+    })
 }
 
 fn ingest_against(
@@ -337,7 +599,171 @@ mod tests {
             ],
         )
         .unwrap();
-        assert_eq!(accepted_entries(&conn, stream.stream_id).unwrap(), vec![vec![1]]);
+        let accepted = accepted_chain_entries(
+            &conn,
+            stream.stream_id,
+            [2; 32],
+            TableSyncEntryStart::Beginning,
+            10,
+        )
+        .unwrap();
+        assert_eq!(accepted.len(), 1);
+        assert_eq!(accepted[0].signed_bytes, vec![1]);
+    }
+
+    #[test]
+    fn accepted_device_chains_page_canonically_and_resume_from_exact_frontiers() {
+        let conn = database();
+        let stream = supported_streams_against(&conn, account(), &[REPO_SPEC]).unwrap().remove(0);
+        for (device, lamport, hash) in [(2u8, 1i64, 11u8), (2, 3, 13), (4, 2, 22)] {
+            conn.execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, signed_bytes,
+                     received_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+                params![
+                    [hash; 32].as_slice(),
+                    stream.stream_id.as_slice(),
+                    [device; 32].as_slice(),
+                    lamport,
+                    vec![hash],
+                ],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO table_sync_chain_tips(
+                     stream_id, device_fingerprint, lamport, entry_hash)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(stream_id, device_fingerprint) DO UPDATE SET
+                     lamport = excluded.lamport, entry_hash = excluded.entry_hash
+                 WHERE excluded.lamport > table_sync_chain_tips.lamport",
+                params![
+                    stream.stream_id.as_slice(),
+                    [device; 32].as_slice(),
+                    lamport,
+                    [hash; 32].as_slice(),
+                ],
+            )
+            .unwrap();
+        }
+
+        let first = accepted_chain_page(&conn, stream.stream_id, None, 1).unwrap();
+        assert_eq!(first, vec![TableSyncChainHead {
+            device_fingerprint: [2; 32],
+            lamport: 3,
+            entry_hash: [13; 32],
+        }]);
+        let second = accepted_chain_page(&conn, stream.stream_id, Some([2; 32]), 1).unwrap();
+        assert_eq!(second[0].device_fingerprint, [4; 32]);
+        assert_eq!(
+            chain_frontier(&conn, stream.stream_id, [2; 32]).unwrap(),
+            TableSyncFrontier::Accepted { lamport: 3, entry_hash: [13; 32] }
+        );
+
+        let page = accepted_chain_entries(
+            &conn,
+            stream.stream_id,
+            [2; 32],
+            TableSyncEntryStart::Beginning,
+            1,
+        )
+        .unwrap();
+        assert_eq!(page[0].signed_bytes, vec![11]);
+        let suffix = accepted_chain_entries(
+            &conn,
+            stream.stream_id,
+            [2; 32],
+            TableSyncEntryStart::After { lamport: 1, entry_hash: [11; 32] },
+            10,
+        )
+        .unwrap();
+        assert_eq!(suffix.iter().map(|entry| entry.signed_bytes[0]).collect::<Vec<_>>(), [13]);
+        assert!(
+            accepted_chain_entries(
+                &conn,
+                stream.stream_id,
+                [2; 32],
+                TableSyncEntryStart::After { lamport: 1, entry_hash: [99; 32] },
+                10,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("cursor hash conflicts")
+        );
+    }
+
+    #[test]
+    fn a_witness_without_an_accepted_tail_requests_the_tip_inclusively() {
+        let source = database();
+        let destination = database();
+        let source_stream =
+            supported_streams_against(&source, account(), &[REPO_SPEC]).unwrap().remove(0);
+        let destination_stream =
+            supported_streams_against(&destination, account(), &[REPO_SPEC]).unwrap().remove(0);
+        let device = [2; 32];
+        let tip = [9; 32];
+        source
+            .execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, signed_bytes,
+                     received_at_ms)
+                 VALUES (?1, ?2, ?3, 7, x'09', 0)",
+                params![tip.as_slice(), source_stream.stream_id.as_slice(), device.as_slice()],
+            )
+            .unwrap();
+        for (conn, stream) in [(&source, &source_stream), (&destination, &destination_stream)] {
+            conn.execute(
+                "INSERT INTO table_sync_chain_tips(
+                     stream_id, device_fingerprint, lamport, entry_hash)
+                 VALUES (?1, ?2, 7, ?3)",
+                params![stream.stream_id.as_slice(), device.as_slice(), tip.as_slice()],
+            )
+            .unwrap();
+        }
+
+        let frontier = chain_frontier(&destination, destination_stream.stream_id, device).unwrap();
+        assert_eq!(frontier, TableSyncFrontier::Restore { lamport: 7, entry_hash: tip });
+        let TableSyncFrontier::Restore { lamport, entry_hash } = frontier else { unreachable!() };
+        let restored = accepted_chain_entries(
+            &source,
+            source_stream.stream_id,
+            device,
+            TableSyncEntryStart::At { lamport, entry_hash },
+            1,
+        )
+        .unwrap();
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].entry_hash, tip);
+
+        let successor_source = database();
+        let successor_stream =
+            supported_streams_against(&successor_source, account(), &[REPO_SPEC])
+                .unwrap()
+                .remove(0);
+        successor_source
+            .execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                     received_at_ms)
+                 VALUES (?1, ?2, ?3, 8, ?4, x'0a', 0)",
+                params![
+                    [10u8; 32].as_slice(),
+                    successor_stream.stream_id.as_slice(),
+                    device.as_slice(),
+                    tip.as_slice(),
+                ],
+            )
+            .unwrap();
+        let successor = accepted_chain_entries(
+            &successor_source,
+            successor_stream.stream_id,
+            device,
+            TableSyncEntryStart::At { lamport, entry_hash },
+            1,
+        )
+        .unwrap();
+        assert_eq!(successor.len(), 1);
+        assert_eq!(successor[0].entry_hash, [10; 32]);
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -138,10 +138,11 @@ pub fn table_sync_ingest(
     conn: &Connection,
     account_id: AccountId,
     stream: &TableSyncStream,
+    expected_device: [u8; 32],
     signed_bytes: &[u8],
     now_ms: i64,
 ) -> anyhow::Result<TableSyncIngestOutcome> {
-    ingest_against(conn, account_id, stream, signed_bytes, now_ms, SYNCABLE_TABLES)
+    ingest_against(conn, account_id, stream, expected_device, signed_bytes, now_ms, SYNCABLE_TABLES)
 }
 
 fn repo_registry(registry: &[TableSpec]) -> Vec<TableSpec> {
@@ -421,6 +422,7 @@ fn ingest_against(
     conn: &Connection,
     account_id: AccountId,
     stream: &TableSyncStream,
+    expected_device: [u8; 32],
     signed_bytes: &[u8],
     now_ms: i64,
     registry: &[TableSpec],
@@ -435,6 +437,9 @@ fn ingest_against(
         return Ok(TableSyncIngestOutcome::NoChange);
     }
     let signer = signed.entry.device_fingerprint;
+    if signer.to_bytes() != expected_device {
+        return Ok(TableSyncIngestOutcome::NoChange);
+    }
     let Some(pubkey_bytes) =
         account::stored_device_pubkeys(conn, account_id)?.get(&signer).copied()
     else {
@@ -551,7 +556,7 @@ mod tests {
         for route in [&stale, &unknown, &forged] {
             assert!(!validate_stream_against(&conn, account(), route, &[REPO_SPEC]).unwrap());
             assert_eq!(
-                ingest_against(&conn, account(), route, &[0], 0, &[REPO_SPEC]).unwrap(),
+                ingest_against(&conn, account(), route, [0; 32], &[0], 0, &[REPO_SPEC]).unwrap(),
                 TableSyncIngestOutcome::NoChange,
             );
         }
@@ -804,6 +809,7 @@ mod tests {
             )
             .unwrap();
         let local = crate::load_local_device(&source).unwrap().unwrap();
+        let author = local.public().fingerprint().to_bytes();
         let tx = source.transaction().unwrap();
         let ctx = SyncCtx {
             repo_id: "repo-a",
@@ -838,11 +844,18 @@ mod tests {
 
         let destination = restore(false);
         assert_eq!(
-            ingest_against(&destination, account, &route, &authored[0], 1, &[REPO_SPEC]).unwrap(),
+            ingest_against(&destination, account, &route, [0; 32], &authored[0], 1, &[REPO_SPEC],)
+                .unwrap(),
+            TableSyncIngestOutcome::NoChange,
+        );
+        assert_eq!(
+            ingest_against(&destination, account, &route, author, &authored[0], 1, &[REPO_SPEC],)
+                .unwrap(),
             TableSyncIngestOutcome::Stored,
         );
         assert_eq!(
-            ingest_against(&destination, account, &route, &authored[0], 2, &[REPO_SPEC]).unwrap(),
+            ingest_against(&destination, account, &route, author, &authored[0], 2, &[REPO_SPEC],)
+                .unwrap(),
             TableSyncIngestOutcome::NoChange,
         );
         let title: String = destination
@@ -856,7 +869,8 @@ mod tests {
 
         let removed = restore(true);
         assert_eq!(
-            ingest_against(&removed, account, &route, &authored[0], 1, &[REPO_SPEC]).unwrap(),
+            ingest_against(&removed, account, &route, author, &authored[0], 1, &[REPO_SPEC],)
+                .unwrap(),
             TableSyncIngestOutcome::NoChange,
         );
         let accepted: i64 = removed

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -620,7 +620,16 @@ pub async fn connect_and_table_reconcile<S: TableSyncStore + NodeAuth>(
             entries_received: report.entries_received,
             entries_newly_stored: report.entries_newly_stored,
         };
-        if let ReconcileStep::Stop { converged } = reconcile_step(&session, rounds, max_rounds) {
+        let step = if report.continuation_pending {
+            if rounds >= max_rounds {
+                ReconcileStep::Stop { converged: false }
+            } else {
+                ReconcileStep::Continue
+            }
+        } else {
+            reconcile_step(&session, rounds, max_rounds)
+        };
+        if let ReconcileStep::Stop { converged } = step {
             return Ok(ReconcileReport { rounds, entries_newly_stored, entries_sent, converged });
         }
     }
@@ -1097,16 +1106,83 @@ mod tests {
             Ok(self.supported.contains(item))
         }
 
-        fn snapshot(
+        fn chain_page(
             &self,
             item: &crate::table_wire::ManifestItem,
-        ) -> anyhow::Result<Vec<([u8; 32], Vec<u8>)>> {
-            Ok(self
+            after_device: Option<[u8; 32]>,
+            limit: usize,
+        ) -> anyhow::Result<Vec<crate::table_wire::ChainHead>> {
+            let mut devices: Vec<_> = self
                 .entries
                 .get(&item.stream_id)
                 .into_iter()
                 .flatten()
-                .map(|(hash, bytes)| (*hash, bytes.clone()))
+                .map(|(hash, _)| *hash)
+                .filter(|device| after_device.is_none_or(|after| *device > after))
+                .collect();
+            devices.sort();
+            Ok(devices
+                .into_iter()
+                .take(limit)
+                .map(|device| crate::table_wire::ChainHead {
+                    device_fingerprint: device,
+                    lamport: 0,
+                    entry_hash: device,
+                })
+                .collect())
+        }
+
+        fn frontier(
+            &self,
+            item: &crate::table_wire::ManifestItem,
+            device: [u8; 32],
+        ) -> anyhow::Result<crate::table_wire::FrontierState> {
+            Ok(
+                if self
+                    .entries
+                    .get(&item.stream_id)
+                    .is_some_and(|entries| entries.contains_key(&device))
+                {
+                    crate::table_wire::FrontierState::Accepted { lamport: 0, entry_hash: device }
+                } else {
+                    crate::table_wire::FrontierState::Empty
+                },
+            )
+        }
+
+        fn entries(
+            &self,
+            item: &crate::table_wire::ManifestItem,
+            device: [u8; 32],
+            start: crate::table_session::ChainStart,
+            limit: usize,
+        ) -> anyhow::Result<Vec<crate::table_session::ChainEntry>> {
+            if limit == 0 {
+                return Ok(Vec::new());
+            }
+            let Some(bytes) =
+                self.entries.get(&item.stream_id).and_then(|entries| entries.get(&device))
+            else {
+                return Ok(Vec::new());
+            };
+            let include = match start {
+                crate::table_session::ChainStart::Beginning => true,
+                crate::table_session::ChainStart::After { lamport, entry_hash } => {
+                    if lamport != 0 || entry_hash != device {
+                        return Ok(Vec::new());
+                    }
+                    false
+                },
+                crate::table_session::ChainStart::At { lamport, entry_hash } =>
+                    lamport == 0 && entry_hash == device,
+            };
+            Ok(include
+                .then(|| crate::table_session::ChainEntry {
+                    lamport: 0,
+                    entry_hash: device,
+                    signed_bytes: bytes.clone(),
+                })
+                .into_iter()
                 .collect())
         }
 

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -1189,12 +1189,16 @@ mod tests {
         fn ingest(
             &mut self,
             item: &crate::table_wire::ManifestItem,
+            expected_device: [u8; 32],
             signed_bytes: &[u8],
         ) -> anyhow::Result<crate::session::Ingested> {
             if !self.supported.contains(item) {
                 return Ok(crate::session::Ingested::NoChange);
             }
             let hash: [u8; 32] = signed_bytes[..32].try_into()?;
+            if hash != expected_device {
+                return Ok(crate::session::Ingested::NoChange);
+            }
             Ok(match self.entries.entry(item.stream_id).or_default().entry(hash) {
                 std::collections::hash_map::Entry::Occupied(_) =>
                     crate::session::Ingested::NoChange,

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -53,6 +53,12 @@ pub use session::{
     run_session, run_session_with_idle_timeout,
 };
 pub use store::{OplogContentSyncStore, OplogSyncStore, OplogTableSyncStore};
-pub use table_session::{TableSessionError, TableSessionReport, TableSyncStore, run_table_session};
-pub use table_wire::{Manifest, ManifestItem, TABLE_SYNC_ALPN, TableFrame, TableWireError};
+pub use table_session::{
+    ChainEntry, ChainStart, TableSessionError, TableSessionReport, TableSyncStore,
+    run_table_session,
+};
+pub use table_wire::{
+    ChainFrontier, ChainHead, FrontierState, Manifest, ManifestItem, TABLE_SYNC_ALPN, TableFrame,
+    TableWireError,
+};
 pub use wire::{CONTENT_SYNC_ALPN, Frame, SYNC_ALPN, WireError};

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -16,8 +16,8 @@ use rusqlite::Connection;
 
 use crate::auth::{LocalAuth, NodeAuth, PeerAuthorization, PeerCapability};
 use crate::session::{Ingested, SyncStore};
-use crate::table_session::TableSyncStore;
-use crate::table_wire::ManifestItem;
+use crate::table_session::{ChainEntry, ChainStart, TableSyncStore};
+use crate::table_wire::{ChainHead, FrontierState, ManifestItem};
 
 /// Mint this account's signed node binding for `local_node`. A store with no local device yet (a
 /// fresh peer being onboarded) has nothing to prove, so it returns an EMPTY binding rather than
@@ -333,14 +333,73 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
         )
     }
 
-    fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<([u8; 32], Vec<u8>)>> {
-        Ok(rag_rat_oplog::table_sync_entries_for_stream(
+    fn chain_page(
+        &self,
+        item: &ManifestItem,
+        after_device: Option<[u8; 32]>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<ChainHead>> {
+        Ok(rag_rat_oplog::table_sync_chain_page_after(
             self.conn,
             self.account_id,
             &to_oplog_stream(item),
+            after_device,
+            limit,
         )?
         .into_iter()
-        .map(|bytes| (rag_rat_oplog::table_sync_signed_hash(&bytes), bytes))
+        .map(|chain| ChainHead {
+            device_fingerprint: chain.device_fingerprint,
+            lamport: chain.lamport,
+            entry_hash: chain.entry_hash,
+        })
+        .collect())
+    }
+
+    fn frontier(&self, item: &ManifestItem, device: [u8; 32]) -> anyhow::Result<FrontierState> {
+        Ok(
+            match rag_rat_oplog::table_sync_chain_frontier(
+                self.conn,
+                self.account_id,
+                &to_oplog_stream(item),
+                device,
+            )? {
+                rag_rat_oplog::TableSyncFrontier::Empty => FrontierState::Empty,
+                rag_rat_oplog::TableSyncFrontier::Accepted { lamport, entry_hash } =>
+                    FrontierState::Accepted { lamport, entry_hash },
+                rag_rat_oplog::TableSyncFrontier::Restore { lamport, entry_hash } =>
+                    FrontierState::Restore { lamport, entry_hash },
+            },
+        )
+    }
+
+    fn entries(
+        &self,
+        item: &ManifestItem,
+        device: [u8; 32],
+        start: ChainStart,
+        limit: usize,
+    ) -> anyhow::Result<Vec<ChainEntry>> {
+        let start = match start {
+            ChainStart::Beginning => rag_rat_oplog::TableSyncEntryStart::Beginning,
+            ChainStart::After { lamport, entry_hash } =>
+                rag_rat_oplog::TableSyncEntryStart::After { lamport, entry_hash },
+            ChainStart::At { lamport, entry_hash } =>
+                rag_rat_oplog::TableSyncEntryStart::At { lamport, entry_hash },
+        };
+        Ok(rag_rat_oplog::table_sync_chain_entries(
+            self.conn,
+            self.account_id,
+            &to_oplog_stream(item),
+            device,
+            start,
+            limit,
+        )?
+        .into_iter()
+        .map(|entry| ChainEntry {
+            lamport: entry.lamport,
+            entry_hash: entry.entry_hash,
+            signed_bytes: entry.signed_bytes,
+        })
         .collect())
     }
 
@@ -404,7 +463,9 @@ mod tests {
         assert!(!store.has_streams().unwrap());
         assert!(store.supported_streams().unwrap().is_empty());
         assert!(!store.validates(&item).unwrap());
-        assert!(store.snapshot(&item).unwrap().is_empty());
+        assert!(store.chain_page(&item, None, 1).unwrap().is_empty());
+        assert_eq!(store.frontier(&item, [4; 32]).unwrap(), FrontierState::Empty);
+        assert!(store.entries(&item, [4; 32], ChainStart::Beginning, 1).unwrap().is_empty());
         assert_eq!(store.ingest(&item, &[0]).unwrap(), Ingested::NoChange);
     }
 }

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -403,12 +403,18 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
         .collect())
     }
 
-    fn ingest(&mut self, item: &ManifestItem, signed_bytes: &[u8]) -> anyhow::Result<Ingested> {
+    fn ingest(
+        &mut self,
+        item: &ManifestItem,
+        expected_device: [u8; 32],
+        signed_bytes: &[u8],
+    ) -> anyhow::Result<Ingested> {
         Ok(
             match rag_rat_oplog::table_sync_ingest(
                 self.conn,
                 self.account_id,
                 &to_oplog_stream(item),
+                expected_device,
                 signed_bytes,
                 (self.now_fn)(),
             )? {
@@ -466,6 +472,6 @@ mod tests {
         assert!(store.chain_page(&item, None, 1).unwrap().is_empty());
         assert_eq!(store.frontier(&item, [4; 32]).unwrap(), FrontierState::Empty);
         assert!(store.entries(&item, [4; 32], ChainStart::Beginning, 1).unwrap().is_empty());
-        assert_eq!(store.ingest(&item, &[0]).unwrap(), Ingested::NoChange);
+        assert_eq!(store.ingest(&item, [4; 32], &[0]).unwrap(), Ingested::NoChange);
     }
 }

--- a/crates/rag-rat-sync/src/table_codec.rs
+++ b/crates/rag-rat-sync/src/table_codec.rs
@@ -90,6 +90,7 @@ mod tests {
         let mut sink = tokio::io::sink();
         let oversized = TableFrame::Entries {
             stream_id: [0; 32],
+            device_fingerprint: [1; 32],
             entries: vec![vec![0; MAX_TABLE_FRAME_BYTES as usize]],
         };
         assert!(matches!(

--- a/crates/rag-rat-sync/src/table_codec.rs
+++ b/crates/rag-rat-sync/src/table_codec.rs
@@ -91,7 +91,6 @@ mod tests {
         let oversized = TableFrame::Entries {
             stream_id: [0; 32],
             entries: vec![vec![0; MAX_TABLE_FRAME_BYTES as usize]],
-            more: false,
         };
         assert!(matches!(
             write_frame(&mut sink, &oversized).await,

--- a/crates/rag-rat-sync/src/table_session.rs
+++ b/crates/rag-rat-sync/src/table_session.rs
@@ -35,7 +35,12 @@ pub trait TableSyncStore {
         start: ChainStart,
         limit: usize,
     ) -> anyhow::Result<Vec<ChainEntry>>;
-    fn ingest(&mut self, item: &ManifestItem, signed_bytes: &[u8]) -> anyhow::Result<Ingested>;
+    fn ingest(
+        &mut self,
+        item: &ManifestItem,
+        expected_device: Hash,
+        signed_bytes: &[u8],
+    ) -> anyhow::Result<Ingested>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -357,6 +362,7 @@ where
                         send,
                         &TableFrame::Entries {
                             stream_id: item.stream_id,
+                            device_fingerprint: chain.device_fingerprint,
                             entries: entries.into_iter().map(|entry| entry.signed_bytes).collect(),
                         },
                         idle_timeout,
@@ -456,8 +462,11 @@ where
                     .await?;
                     loop {
                         match read_before(recv, idle_timeout).await? {
-                            TableFrame::Entries { stream_id, entries }
-                                if stream_id == item.stream_id =>
+                            TableFrame::Entries { stream_id, device_fingerprint, entries }
+                                if stream_id == item.stream_id
+                                    && chains.iter().any(|chain| {
+                                        chain.device_fingerprint == device_fingerprint
+                                    }) =>
                             {
                                 received += entries.len();
                                 if received > limits.entries_per_session {
@@ -468,7 +477,7 @@ where
                                 }
                                 for bytes in entries {
                                     if store
-                                        .ingest(item, &bytes)
+                                        .ingest(item, device_fingerprint, &bytes)
                                         .map_err(TableSessionError::Store)?
                                         == Ingested::Stored
                                     {
@@ -771,13 +780,21 @@ mod tests {
                 .collect())
         }
 
-        fn ingest(&mut self, item: &ManifestItem, bytes: &[u8]) -> anyhow::Result<Ingested> {
+        fn ingest(
+            &mut self,
+            item: &ManifestItem,
+            expected_device: Hash,
+            bytes: &[u8],
+        ) -> anyhow::Result<Ingested> {
             if !self.supported.contains(item) {
                 return Ok(Ingested::NoChange);
             }
             let hash: Hash = bytes[..32].try_into()?;
             let device = [bytes[32]; 32];
             let lamport = u64::from_be_bytes(bytes[33..41].try_into()?);
+            if device != expected_device {
+                return Ok(Ingested::NoChange);
+            }
             Ok(match self.entries.entry(item.stream_id).or_default().entry(hash) {
                 std::collections::hash_map::Entry::Occupied(_) => Ingested::NoChange,
                 std::collections::hash_map::Entry::Vacant(slot) => {
@@ -1055,6 +1072,50 @@ mod tests {
                 matches!(result, Err(TableSessionError::Protocol(message)) if message.contains("cap"))
             );
         }
+    }
+
+    #[tokio::test]
+    async fn entry_pages_must_name_a_chain_in_the_current_inventory() {
+        let shared = item("repo-a", 1);
+        let streams = vec![shared.clone()];
+        let mut store = MemStore::new(streams.clone());
+        let (mut receiver_send, mut peer_recv) = tokio::io::duplex(4096);
+        let (mut peer_send, mut receiver_recv) = tokio::io::duplex(4096);
+        let peer = async move {
+            table_codec::write_frame(&mut peer_send, &TableFrame::ChainInventory {
+                stream_id: shared.stream_id,
+                chains: vec![ChainHead {
+                    device_fingerprint: [1; 32],
+                    lamport: 0,
+                    entry_hash: [1; 32],
+                }],
+            })
+            .await
+            .unwrap();
+            assert!(matches!(
+                table_codec::read_frame(&mut peer_recv).await.unwrap(),
+                TableFrame::ChainFrontiers { .. }
+            ));
+            table_codec::write_frame(&mut peer_send, &TableFrame::Entries {
+                stream_id: shared.stream_id,
+                device_fingerprint: [2; 32],
+                entries: vec![vec![0; 41]],
+            })
+            .await
+            .unwrap();
+        };
+        let receiver = receive_direction(
+            &mut store,
+            &streams,
+            &mut receiver_send,
+            &mut receiver_recv,
+            true,
+            DEFAULT_IDLE_TIMEOUT,
+            TableSessionLimits::default(),
+        );
+        let (result, ()) = tokio::join!(receiver, peer);
+        assert!(matches!(result, Err(TableSessionError::Protocol(_))));
+        assert!(store.entries.is_empty());
     }
 
     #[tokio::test]

--- a/crates/rag-rat-sync/src/table_session.rs
+++ b/crates/rag-rat-sync/src/table_session.rs
@@ -1,6 +1,6 @@
 //! Authenticated multi-stream table reconciliation over one bidirectional stream.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -9,7 +9,8 @@ use crate::auth::{AuthRole, SessionCapabilities};
 use crate::session::{DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES};
 use crate::table_codec::{self, TableCodecError};
 use crate::table_wire::{
-    MAX_TABLE_ENTRIES_PER_PAGE, MAX_TABLE_ENTRY_BYTES, MAX_TABLE_INVENTORY_HASHES, Manifest,
+    ChainFrontier, ChainHead, FrontierState, MAX_TABLE_CHAINS_PER_PAGE,
+    MAX_TABLE_CHAINS_PER_SESSION, MAX_TABLE_ENTRIES_PER_PAGE, MAX_TABLE_ENTRY_BYTES, Manifest,
     ManifestItem, TableFrame,
 };
 
@@ -20,8 +21,35 @@ pub trait TableSyncStore {
     fn account_id(&self) -> Hash;
     fn supported_streams(&self) -> anyhow::Result<Vec<ManifestItem>>;
     fn validates(&self, item: &ManifestItem) -> anyhow::Result<bool>;
-    fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<(Hash, Vec<u8>)>>;
+    fn chain_page(
+        &self,
+        item: &ManifestItem,
+        after_device: Option<Hash>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<ChainHead>>;
+    fn frontier(&self, item: &ManifestItem, device: Hash) -> anyhow::Result<FrontierState>;
+    fn entries(
+        &self,
+        item: &ManifestItem,
+        device: Hash,
+        start: ChainStart,
+        limit: usize,
+    ) -> anyhow::Result<Vec<ChainEntry>>;
     fn ingest(&mut self, item: &ManifestItem, signed_bytes: &[u8]) -> anyhow::Result<Ingested>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainStart {
+    Beginning,
+    After { lamport: u64, entry_hash: Hash },
+    At { lamport: u64, entry_hash: Hash },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainEntry {
+    pub lamport: u64,
+    pub entry_hash: Hash,
+    pub signed_bytes: Vec<u8>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +58,7 @@ pub struct TableSessionReport {
     pub entries_sent: usize,
     pub entries_received: usize,
     pub entries_newly_stored: usize,
+    pub continuation_pending: bool,
 }
 
 #[derive(Debug)]
@@ -71,8 +100,8 @@ where
 
 async fn run_table_session_with_idle_timeout<S, R, W>(
     store: &mut S,
-    mut send: W,
-    mut recv: R,
+    send: W,
+    recv: R,
     role: AuthRole,
     capabilities: SessionCapabilities,
     idle_timeout: Duration,
@@ -82,6 +111,55 @@ where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
+    run_table_session_with_limits(
+        store,
+        send,
+        recv,
+        role,
+        capabilities,
+        idle_timeout,
+        TableSessionLimits::default(),
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+struct TableSessionLimits {
+    chains_per_page: usize,
+    chains_per_session: usize,
+    entries_per_page: usize,
+    entries_per_session: usize,
+}
+
+impl Default for TableSessionLimits {
+    fn default() -> Self {
+        Self {
+            chains_per_page: MAX_TABLE_CHAINS_PER_PAGE,
+            chains_per_session: MAX_TABLE_CHAINS_PER_SESSION,
+            entries_per_page: MAX_TABLE_ENTRIES_PER_PAGE,
+            entries_per_session: MAX_SESSION_ENTRIES,
+        }
+    }
+}
+
+async fn run_table_session_with_limits<S, R, W>(
+    store: &mut S,
+    mut send: W,
+    mut recv: R,
+    role: AuthRole,
+    capabilities: SessionCapabilities,
+    idle_timeout: Duration,
+    limits: TableSessionLimits,
+) -> Result<TableSessionReport, TableSessionError>
+where
+    S: TableSyncStore,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    debug_assert!(limits.chains_per_page > 0);
+    debug_assert!(limits.chains_per_page <= limits.chains_per_session);
+    debug_assert!(limits.entries_per_page > 0);
+    debug_assert!(limits.entries_per_page <= MAX_TABLE_ENTRIES_PER_PAGE);
     let local_manifest =
         Manifest::new(store.supported_streams().map_err(TableSessionError::Store)?)
             .map_err(|error| TableSessionError::Store(error.into()))?;
@@ -103,164 +181,366 @@ where
         }
     }
     let streams = intersection.len();
-    let mut snapshots = HashMap::with_capacity(streams);
-    for item in &intersection {
-        let snapshot = store.snapshot(item).map_err(TableSessionError::Store)?;
-        if snapshot.iter().any(|(_, bytes)| bytes.len() > MAX_TABLE_ENTRY_BYTES) {
-            return Err(TableSessionError::Store(anyhow::anyhow!(
-                "local table-sync entry exceeds {MAX_TABLE_ENTRY_BYTES} bytes"
-            )));
-        }
-        snapshots.insert(item.stream_id, snapshot);
-    }
-
-    let (inventory_tx, mut inventory_rx) =
-        tokio::sync::mpsc::channel::<(Hash, HashSet<Hash>)>(streams.max(1));
-    let send_intersection = intersection.clone();
-
-    let sender = async move {
-        for item in &send_intersection {
-            let snapshot = snapshots.get(&item.stream_id).ok_or_else(|| {
-                TableSessionError::Protocol("intersection names an unsupported local stream".into())
-            })?;
-            let have =
-                snapshot.iter().map(|(hash, _)| *hash).take(MAX_TABLE_INVENTORY_HASHES).collect();
-            write_before(
+    let (entries_sent, entries_received, entries_newly_stored, continuation_pending) = match role {
+        AuthRole::Dialer => {
+            let (entries_sent, local_pending) = send_direction(
+                store,
+                &intersection,
                 &mut send,
-                &TableFrame::Inventory { stream_id: item.stream_id, have },
+                &mut recv,
+                capabilities.local.can_push(),
                 idle_timeout,
+                limits,
             )
             .await?;
-        }
-
-        let mut sent = 0;
-        for item in &send_intersection {
-            let Some((stream_id, peer_have)) = inventory_rx.recv().await else {
-                return Ok((send, sent));
-            };
-            if stream_id != item.stream_id {
-                return Err(TableSessionError::Protocol(
-                    "peer inventories arrived out of canonical stream order".into(),
-                ));
-            }
-            let remaining = MAX_SESSION_ENTRIES.saturating_sub(sent);
-            let mut entries: Vec<Vec<u8>> = if capabilities.local.can_push() {
-                snapshots[&item.stream_id]
-                    .iter()
-                    .filter(|(hash, _)| !peer_have.contains(hash))
-                    .take(remaining)
-                    .map(|(_, bytes)| bytes.clone())
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            sent += entries.len();
-            while !entries.is_empty() {
-                let tail = entries.split_off(entries.len().min(MAX_TABLE_ENTRIES_PER_PAGE));
-                let page = std::mem::replace(&mut entries, tail);
-                let more = !entries.is_empty();
-                write_before(
-                    &mut send,
-                    &TableFrame::Entries { stream_id: item.stream_id, entries: page, more },
-                    idle_timeout,
-                )
-                .await?;
-            }
-            write_before(
+            let (entries_received, entries_newly_stored, peer_pending) = receive_direction(
+                store,
+                &intersection,
                 &mut send,
-                &TableFrame::StreamDone { stream_id: item.stream_id },
+                &mut recv,
+                capabilities.peer.can_push(),
                 idle_timeout,
+                limits,
             )
             .await?;
-        }
-        write_before(&mut send, &TableFrame::Done, idle_timeout).await?;
-        Ok::<_, TableSessionError>((send, sent))
+            (entries_sent, entries_received, entries_newly_stored, local_pending || peer_pending)
+        },
+        AuthRole::Acceptor => {
+            let (entries_received, entries_newly_stored, peer_pending) = receive_direction(
+                store,
+                &intersection,
+                &mut send,
+                &mut recv,
+                capabilities.peer.can_push(),
+                idle_timeout,
+                limits,
+            )
+            .await?;
+            let (entries_sent, local_pending) = send_direction(
+                store,
+                &intersection,
+                &mut send,
+                &mut recv,
+                capabilities.local.can_push(),
+                idle_timeout,
+                limits,
+            )
+            .await?;
+            (entries_sent, entries_received, entries_newly_stored, local_pending || peer_pending)
+        },
     };
+    complete(&mut send, &mut recv, role, idle_timeout).await?;
+    Ok(TableSessionReport {
+        streams,
+        entries_sent,
+        entries_received,
+        entries_newly_stored,
+        continuation_pending,
+    })
+}
 
-    let receiver = async {
-        for item in &intersection {
-            let TableFrame::Inventory { stream_id, have } =
-                read_before(&mut recv, idle_timeout).await?
+async fn send_direction<S, R, W>(
+    store: &S,
+    streams: &[ManifestItem],
+    send: &mut W,
+    recv: &mut R,
+    can_push: bool,
+    idle_timeout: Duration,
+    limits: TableSessionLimits,
+) -> Result<(usize, bool), TableSessionError>
+where
+    S: TableSyncStore,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut sent = 0;
+    let mut offered_chains: usize = 0;
+    let mut continuation_pending = false;
+    for item in streams {
+        let mut after_device = None;
+        let mut stream_pending = false;
+        loop {
+            if !can_push {
+                break;
+            }
+            if sent >= limits.entries_per_session {
+                stream_pending = true;
+                break;
+            }
+            if offered_chains >= limits.chains_per_session {
+                let has_more = !store
+                    .chain_page(item, after_device, 1)
+                    .map_err(TableSessionError::Store)?
+                    .is_empty();
+                if has_more {
+                    return Err(TableSessionError::Store(anyhow::anyhow!(
+                        "table-sync manifest intersection exceeds the {}-device chain ceiling",
+                        limits.chains_per_session
+                    )));
+                }
+                break;
+            }
+            let chain_limit = limits
+                .chains_per_page
+                .min(limits.chains_per_session.saturating_sub(offered_chains));
+            let chains = store
+                .chain_page(item, after_device, chain_limit)
+                .map_err(TableSessionError::Store)?;
+            if chains.is_empty() {
+                break;
+            }
+            if chains.len() > chain_limit {
+                return Err(TableSessionError::Store(anyhow::anyhow!(
+                    "local table-sync chain page exceeds {} chains",
+                    chain_limit
+                )));
+            }
+            offered_chains += chains.len();
+            validate_chain_page(&chains).map_err(TableSessionError::Store)?;
+            write_before(
+                send,
+                &TableFrame::ChainInventory { stream_id: item.stream_id, chains: chains.clone() },
+                idle_timeout,
+            )
+            .await?;
+            let TableFrame::ChainFrontiers { stream_id, frontiers } =
+                read_before(recv, idle_timeout).await?
             else {
                 return Err(TableSessionError::Protocol(
-                    "peer did not send the expected stream inventory".into(),
+                    "peer did not answer a table chain inventory".into(),
                 ));
             };
-            if stream_id != item.stream_id {
+            if stream_id != item.stream_id
+                || frontiers.len() != chains.len()
+                || !frontiers.iter().zip(&chains).all(|(frontier, chain)| {
+                    frontier.device_fingerprint == chain.device_fingerprint
+                })
+            {
                 return Err(TableSessionError::Protocol(
-                    "peer inventory names the wrong stream".into(),
+                    "peer chain frontiers do not match the offered inventory".into(),
                 ));
             }
-            inventory_tx.send((stream_id, have.into_iter().collect())).await.map_err(|_| {
-                TableSessionError::Protocol("local sender stopped during inventory exchange".into())
-            })?;
-        }
 
-        let mut received = 0;
-        let mut newly_stored = 0;
-        for item in &intersection {
-            let mut saw_page = false;
-            let mut saw_final = false;
-            loop {
-                match read_before(&mut recv, idle_timeout).await? {
-                    TableFrame::Entries { stream_id, entries, more } => {
-                        if !capabilities.peer.can_push() {
-                            return Err(TableSessionError::UnauthorizedPush);
-                        }
-                        if stream_id != item.stream_id {
-                            return Err(TableSessionError::Protocol(
-                                "peer entry page names the wrong stream".into(),
-                            ));
-                        }
-                        if entries.is_empty() || saw_final {
-                            return Err(TableSessionError::Protocol(
-                                "peer sent an empty or after-final table entry page".into(),
-                            ));
-                        }
-                        for bytes in entries {
-                            received += 1;
-                            if received > MAX_SESSION_ENTRIES {
-                                return Err(TableSessionError::Protocol(format!(
-                                    "peer streamed more than {MAX_SESSION_ENTRIES} table entries"
-                                )));
-                            }
-                            if store.ingest(item, &bytes).map_err(TableSessionError::Store)?
-                                == Ingested::Stored
-                            {
-                                newly_stored += 1;
-                            }
-                        }
-                        saw_page = true;
-                        saw_final = !more;
+            for (chain, frontier) in chains.iter().zip(frontiers) {
+                let mut start = match chain_plan(chain, frontier.state)? {
+                    ChainPlan::Complete => continue,
+                    ChainPlan::Send(start) => start,
+                    ChainPlan::Pending => {
+                        stream_pending = true;
+                        continue;
                     },
-                    TableFrame::StreamDone { stream_id } => {
-                        if stream_id != item.stream_id || (saw_page && !saw_final) {
-                            return Err(TableSessionError::Protocol(
-                                "peer ended the wrong or incomplete table stream".into(),
-                            ));
-                        }
+                };
+                while sent < limits.entries_per_session {
+                    let page_limit = limits
+                        .entries_per_page
+                        .min(limits.entries_per_session.saturating_sub(sent));
+                    let entries = store
+                        .entries(item, chain.device_fingerprint, start, page_limit)
+                        .map_err(TableSessionError::Store)?;
+                    if entries.is_empty() {
                         break;
-                    },
-                    _ => {
-                        return Err(TableSessionError::Protocol(
-                            "peer sent an out-of-sequence table frame".into(),
-                        ));
-                    },
+                    }
+                    if entries.len() > page_limit
+                        || entries
+                            .iter()
+                            .any(|entry| entry.signed_bytes.len() > MAX_TABLE_ENTRY_BYTES)
+                    {
+                        return Err(TableSessionError::Store(anyhow::anyhow!(
+                            "local table-sync entry page exceeds its transport bound"
+                        )));
+                    }
+                    let last = entries.last().expect("non-empty page checked above");
+                    start =
+                        ChainStart::After { lamport: last.lamport, entry_hash: last.entry_hash };
+                    sent += entries.len();
+                    write_before(
+                        send,
+                        &TableFrame::Entries {
+                            stream_id: item.stream_id,
+                            entries: entries.into_iter().map(|entry| entry.signed_bytes).collect(),
+                        },
+                        idle_timeout,
+                    )
+                    .await?;
+                }
+                if sent >= limits.entries_per_session {
+                    break;
                 }
             }
+            write_before(
+                send,
+                &TableFrame::InventoryDone { stream_id: item.stream_id },
+                idle_timeout,
+            )
+            .await?;
+            if sent >= limits.entries_per_session {
+                stream_pending = true;
+                break;
+            }
+            after_device = chains.last().map(|chain| chain.device_fingerprint);
         }
-        if read_before(&mut recv, idle_timeout).await? != TableFrame::Done {
-            return Err(TableSessionError::Protocol(
-                "peer did not finish after its streams".into(),
-            ));
-        }
-        Ok::<_, TableSessionError>((recv, streams, received, newly_stored))
-    };
+        write_before(
+            send,
+            &TableFrame::StreamDone {
+                stream_id: item.stream_id,
+                continuation_pending: stream_pending,
+            },
+            idle_timeout,
+        )
+        .await?;
+        continuation_pending |= stream_pending;
+    }
+    write_before(send, &TableFrame::Done, idle_timeout).await?;
+    Ok((sent, continuation_pending))
+}
 
-    let ((mut send, entries_sent), (mut recv, streams, entries_received, entries_newly_stored)) =
-        tokio::try_join!(sender, receiver)?;
-    complete(&mut send, &mut recv, role, idle_timeout).await?;
-    Ok(TableSessionReport { streams, entries_sent, entries_received, entries_newly_stored })
+async fn receive_direction<S, R, W>(
+    store: &mut S,
+    streams: &[ManifestItem],
+    send: &mut W,
+    recv: &mut R,
+    peer_can_push: bool,
+    idle_timeout: Duration,
+    limits: TableSessionLimits,
+) -> Result<(usize, usize, bool), TableSessionError>
+where
+    S: TableSyncStore,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut received = 0;
+    let mut newly_stored = 0;
+    let mut offered_chains: usize = 0;
+    let mut continuation_pending = false;
+    for item in streams {
+        let mut last_device = None;
+        loop {
+            match read_before(recv, idle_timeout).await? {
+                TableFrame::ChainInventory { stream_id, chains } => {
+                    if !peer_can_push {
+                        return Err(TableSessionError::UnauthorizedPush);
+                    }
+                    let ordered_after_previous = chains.first().is_some_and(|first| {
+                        last_device.is_none_or(|previous| first.device_fingerprint > previous)
+                    });
+                    if stream_id != item.stream_id
+                        || chains.len() > limits.chains_per_page
+                        || offered_chains.saturating_add(chains.len()) > limits.chains_per_session
+                        || !ordered_after_previous
+                    {
+                        return Err(TableSessionError::Protocol(
+                            "peer chain inventory names the wrong stream or exceeds the session \
+                             cap"
+                            .into(),
+                        ));
+                    }
+                    offered_chains += chains.len();
+                    last_device = chains.last().map(|chain| chain.device_fingerprint);
+                    let frontiers = chains
+                        .iter()
+                        .map(|chain| {
+                            store.frontier(item, chain.device_fingerprint).map(|state| {
+                                ChainFrontier {
+                                    device_fingerprint: chain.device_fingerprint,
+                                    state,
+                                }
+                            })
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()
+                        .map_err(TableSessionError::Store)?;
+                    write_before(
+                        send,
+                        &TableFrame::ChainFrontiers { stream_id, frontiers },
+                        idle_timeout,
+                    )
+                    .await?;
+                    loop {
+                        match read_before(recv, idle_timeout).await? {
+                            TableFrame::Entries { stream_id, entries }
+                                if stream_id == item.stream_id =>
+                            {
+                                received += entries.len();
+                                if received > limits.entries_per_session {
+                                    return Err(TableSessionError::Protocol(format!(
+                                        "peer streamed more than {} table entries",
+                                        limits.entries_per_session
+                                    )));
+                                }
+                                for bytes in entries {
+                                    if store
+                                        .ingest(item, &bytes)
+                                        .map_err(TableSessionError::Store)?
+                                        == Ingested::Stored
+                                    {
+                                        newly_stored += 1;
+                                    }
+                                }
+                            },
+                            TableFrame::InventoryDone { stream_id }
+                                if stream_id == item.stream_id =>
+                                break,
+                            _ => {
+                                return Err(TableSessionError::Protocol(
+                                    "peer sent an out-of-sequence table inventory response".into(),
+                                ));
+                            },
+                        }
+                    }
+                },
+                TableFrame::StreamDone { stream_id, continuation_pending: pending }
+                    if stream_id == item.stream_id =>
+                {
+                    continuation_pending |= pending;
+                    break;
+                },
+                _ => {
+                    return Err(TableSessionError::Protocol(
+                        "peer sent an out-of-sequence table stream frame".into(),
+                    ));
+                },
+            }
+        }
+    }
+    if read_before(recv, idle_timeout).await? != TableFrame::Done {
+        return Err(TableSessionError::Protocol("peer did not finish after its streams".into()));
+    }
+    Ok((received, newly_stored, continuation_pending))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChainPlan {
+    Complete,
+    Send(ChainStart),
+    Pending,
+}
+
+fn chain_plan(local: &ChainHead, frontier: FrontierState) -> Result<ChainPlan, TableSessionError> {
+    match frontier {
+        FrontierState::Empty => Ok(ChainPlan::Send(ChainStart::Beginning)),
+        FrontierState::Accepted { lamport, .. } if lamport > local.lamport =>
+            Ok(ChainPlan::Complete),
+        FrontierState::Accepted { lamport, entry_hash } if lamport == local.lamport => {
+            if entry_hash != local.entry_hash {
+                return Err(TableSessionError::Protocol(
+                    "peer chain frontier conflicts with the offered tip".into(),
+                ));
+            }
+            Ok(ChainPlan::Complete)
+        },
+        FrontierState::Accepted { lamport, entry_hash } =>
+            Ok(ChainPlan::Send(ChainStart::After { lamport, entry_hash })),
+        FrontierState::Restore { lamport, .. } if lamport > local.lamport => Ok(ChainPlan::Pending),
+        FrontierState::Restore { lamport, entry_hash } =>
+            Ok(ChainPlan::Send(ChainStart::At { lamport, entry_hash })),
+    }
+}
+
+fn validate_chain_page(chains: &[ChainHead]) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        chains.windows(2).all(|pair| pair[0].device_fingerprint < pair[1].device_fingerprint),
+        "local table-sync chain page is not canonical"
+    );
+    Ok(())
 }
 
 async fn complete<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
@@ -332,13 +612,22 @@ async fn read_before<R: AsyncRead + Unpin>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
     use super::*;
+
+    #[derive(Clone)]
+    struct TestEntry {
+        device: Hash,
+        lamport: u64,
+        bytes: Vec<u8>,
+    }
 
     #[derive(Clone)]
     struct MemStore {
         account: Hash,
         supported: Vec<ManifestItem>,
-        entries: HashMap<Hash, HashMap<Hash, Vec<u8>>>,
+        entries: HashMap<Hash, HashMap<Hash, TestEntry>>,
         forbidden_snapshots: HashSet<Hash>,
     }
 
@@ -353,9 +642,19 @@ mod tests {
         }
 
         fn insert(&mut self, stream: Hash, seed: u8) {
-            let mut bytes = vec![seed; 40];
+            self.insert_chain(stream, seed, 0, seed);
+        }
+
+        fn insert_chain(&mut self, stream: Hash, device: u8, lamport: u64, seed: u8) {
+            let mut bytes = vec![seed; 41];
             bytes[..32].copy_from_slice(&[seed; 32]);
-            self.entries.entry(stream).or_default().insert([seed; 32], bytes);
+            bytes[32] = device;
+            bytes[33..41].copy_from_slice(&lamport.to_be_bytes());
+            self.entries.entry(stream).or_default().insert([seed; 32], TestEntry {
+                device: [device; 32],
+                lamport,
+                bytes,
+            });
         }
 
         fn forbid_snapshot(&mut self, stream: Hash) {
@@ -376,17 +675,99 @@ mod tests {
             Ok(self.supported.contains(item))
         }
 
-        fn snapshot(&self, item: &ManifestItem) -> anyhow::Result<Vec<(Hash, Vec<u8>)>> {
+        fn chain_page(
+            &self,
+            item: &ManifestItem,
+            after_device: Option<Hash>,
+            limit: usize,
+        ) -> anyhow::Result<Vec<ChainHead>> {
             anyhow::ensure!(
                 !self.forbidden_snapshots.contains(&item.stream_id),
                 "non-intersecting stream was snapshotted"
             );
+            let mut chains = BTreeMap::new();
+            for (hash, entry) in self.entries.get(&item.stream_id).into_iter().flatten() {
+                let head = chains.entry(entry.device).or_insert((entry.lamport, *hash));
+                if entry.lamport > head.0 {
+                    *head = (entry.lamport, *hash);
+                }
+            }
+            Ok(chains
+                .into_iter()
+                .filter(|(device, _)| after_device.is_none_or(|after| *device > after))
+                .take(limit)
+                .map(|(device, (lamport, entry_hash))| ChainHead {
+                    device_fingerprint: device,
+                    lamport,
+                    entry_hash,
+                })
+                .collect())
+        }
+
+        fn frontier(&self, item: &ManifestItem, device: Hash) -> anyhow::Result<FrontierState> {
             Ok(self
                 .entries
                 .get(&item.stream_id)
                 .into_iter()
                 .flatten()
-                .map(|(hash, bytes)| (*hash, bytes.clone()))
+                .filter(|(_, entry)| entry.device == device)
+                .max_by_key(|(_, entry)| entry.lamport)
+                .map_or(FrontierState::Empty, |(hash, entry)| FrontierState::Accepted {
+                    lamport: entry.lamport,
+                    entry_hash: *hash,
+                }))
+        }
+
+        fn entries(
+            &self,
+            item: &ManifestItem,
+            device: Hash,
+            start: ChainStart,
+            limit: usize,
+        ) -> anyhow::Result<Vec<ChainEntry>> {
+            if limit == 0 {
+                return Ok(Vec::new());
+            }
+            let entries = self.entries.get(&item.stream_id);
+            let (minimum, inclusive) = match start {
+                ChainStart::Beginning => (None, false),
+                ChainStart::After { lamport, entry_hash } => {
+                    if !entries.is_some_and(|entries| {
+                        entries
+                            .get(&entry_hash)
+                            .is_some_and(|entry| entry.device == device && entry.lamport == lamport)
+                    }) {
+                        anyhow::bail!("test cursor is not present")
+                    }
+                    (Some(lamport), false)
+                },
+                ChainStart::At { lamport, entry_hash } => {
+                    if !entries.is_some_and(|entries| {
+                        entries
+                            .get(&entry_hash)
+                            .is_some_and(|entry| entry.device == device && entry.lamport == lamport)
+                    }) {
+                        anyhow::bail!("test restore cursor is not present")
+                    }
+                    (Some(lamport), true)
+                },
+            };
+            let mut chain: Vec<_> =
+                entries.into_iter().flatten().filter(|(_, entry)| entry.device == device).collect();
+            chain.sort_by_key(|(_, entry)| entry.lamport);
+            Ok(chain
+                .into_iter()
+                .filter(|(_, entry)| {
+                    minimum.is_none_or(|minimum| {
+                        entry.lamport > minimum || (inclusive && entry.lamport == minimum)
+                    })
+                })
+                .take(limit)
+                .map(|(hash, entry)| ChainEntry {
+                    lamport: entry.lamport,
+                    entry_hash: *hash,
+                    signed_bytes: entry.bytes.clone(),
+                })
                 .collect())
         }
 
@@ -395,10 +776,12 @@ mod tests {
                 return Ok(Ingested::NoChange);
             }
             let hash: Hash = bytes[..32].try_into()?;
+            let device = [bytes[32]; 32];
+            let lamport = u64::from_be_bytes(bytes[33..41].try_into()?);
             Ok(match self.entries.entry(item.stream_id).or_default().entry(hash) {
                 std::collections::hash_map::Entry::Occupied(_) => Ingested::NoChange,
                 std::collections::hash_map::Entry::Vacant(slot) => {
-                    slot.insert(bytes.to_vec());
+                    slot.insert(TestEntry { device, lamport, bytes: bytes.to_vec() });
                     Ingested::Stored
                 },
             })
@@ -415,25 +798,48 @@ mod tests {
     }
 
     async fn pair(a: &mut MemStore, b: &mut MemStore) -> (TableSessionReport, TableSessionReport) {
+        pair_with_limits(a, b, TableSessionLimits::default()).await
+    }
+
+    async fn pair_with_limits(
+        a: &mut MemStore,
+        b: &mut MemStore,
+        limits: TableSessionLimits,
+    ) -> (TableSessionReport, TableSessionReport) {
+        let (a, b) = try_pair_with_limits(a, b, limits).await;
+        (a.unwrap(), b.unwrap())
+    }
+
+    async fn try_pair_with_limits(
+        a: &mut MemStore,
+        b: &mut MemStore,
+        limits: TableSessionLimits,
+    ) -> (
+        Result<TableSessionReport, TableSessionError>,
+        Result<TableSessionReport, TableSessionError>,
+    ) {
         let (a_send, b_recv) = tokio::io::duplex(1 << 20);
         let (b_send, a_recv) = tokio::io::duplex(1 << 20);
-        let (a, b) = tokio::join!(
-            run_table_session(
+        tokio::join!(
+            run_table_session_with_limits(
                 a,
                 a_send,
                 a_recv,
                 AuthRole::Dialer,
                 SessionCapabilities::bidirectional(),
+                DEFAULT_IDLE_TIMEOUT,
+                limits,
             ),
-            run_table_session(
+            run_table_session_with_limits(
                 b,
                 b_send,
                 b_recv,
                 AuthRole::Acceptor,
                 SessionCapabilities::bidirectional(),
+                DEFAULT_IDLE_TIMEOUT,
+                limits,
             ),
-        );
-        (a.unwrap(), b.unwrap())
+        )
     }
 
     #[tokio::test]
@@ -469,6 +875,189 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn capped_sessions_advance_from_durable_frontiers_until_quiet() {
+        let shared = item("repo-a", 1);
+        let mut source = MemStore::new(vec![shared.clone()]);
+        let mut destination = MemStore::new(vec![shared.clone()]);
+        for seed in 1..=5 {
+            source.insert_chain(shared.stream_id, 7, u64::from(seed), seed);
+        }
+        let limits = TableSessionLimits {
+            chains_per_page: 2,
+            chains_per_session: 8,
+            entries_per_page: 1,
+            entries_per_session: 2,
+        };
+
+        let mut moved = Vec::new();
+        let mut pending = Vec::new();
+        for _ in 0..4 {
+            let (source_report, destination_report) =
+                pair_with_limits(&mut source, &mut destination, limits).await;
+            moved.push(source_report.entries_sent);
+            pending.push(source_report.continuation_pending);
+            assert_eq!(source_report.entries_sent, destination_report.entries_newly_stored);
+        }
+        assert_eq!(moved, [2, 2, 1, 0]);
+        assert_eq!(pending, [true, true, false, false]);
+        assert_eq!(destination.entries[&shared.stream_id].len(), 5);
+    }
+
+    #[tokio::test]
+    async fn lost_completion_ack_does_not_consume_or_repeat_progress() {
+        let shared = item("repo-a", 1);
+        let mut source = MemStore::new(vec![shared.clone()]);
+        let mut destination = MemStore::new(vec![shared.clone()]);
+        source.insert(shared.stream_id, 1);
+        let limits = TableSessionLimits::default();
+        let (mut source_send, mut destination_recv) = tokio::io::duplex(4096);
+        let (mut destination_send, mut source_recv) = tokio::io::duplex(4096);
+        let streams = vec![shared];
+        let (sent, received) = tokio::join!(
+            send_direction(
+                &source,
+                &streams,
+                &mut source_send,
+                &mut source_recv,
+                true,
+                DEFAULT_IDLE_TIMEOUT,
+                limits,
+            ),
+            receive_direction(
+                &mut destination,
+                &streams,
+                &mut destination_send,
+                &mut destination_recv,
+                true,
+                DEFAULT_IDLE_TIMEOUT,
+                limits,
+            ),
+        );
+        assert_eq!(sent.unwrap(), (1, false));
+        assert_eq!(received.unwrap(), (1, 1, false));
+
+        let (source_report, destination_report) = pair(&mut source, &mut destination).await;
+        assert_eq!(source_report.entries_sent + destination_report.entries_sent, 0);
+        assert_eq!(source_report.entries_newly_stored + destination_report.entries_newly_stored, 0);
+    }
+
+    #[test]
+    fn peer_frontiers_must_be_provable_prefixes_and_restore_debt_stays_pending() {
+        let local = ChainHead { device_fingerprint: [1; 32], lamport: 3, entry_hash: [3; 32] };
+        assert!(matches!(
+            chain_plan(&local, FrontierState::Accepted { lamport: 3, entry_hash: [4; 32] }),
+            Err(TableSessionError::Protocol(_))
+        ));
+        assert_eq!(
+            chain_plan(&local, FrontierState::Accepted { lamport: 4, entry_hash: [4; 32] })
+                .unwrap(),
+            ChainPlan::Complete
+        );
+        assert_eq!(
+            chain_plan(&local, FrontierState::Accepted { lamport: 2, entry_hash: [2; 32] })
+                .unwrap(),
+            ChainPlan::Send(ChainStart::After { lamport: 2, entry_hash: [2; 32] })
+        );
+        assert_eq!(
+            chain_plan(&local, FrontierState::Restore { lamport: 4, entry_hash: [4; 32] }).unwrap(),
+            ChainPlan::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn local_chain_inventory_enforces_the_exact_session_ceiling() {
+        let shared = item("repo-a", 1);
+        let mut source = MemStore::new(vec![shared.clone()]);
+        let mut destination = MemStore::new(vec![shared.clone()]);
+        source.insert_chain(shared.stream_id, 1, 0, 1);
+        source.insert_chain(shared.stream_id, 2, 0, 2);
+        let limits = TableSessionLimits {
+            chains_per_page: 1,
+            chains_per_session: 2,
+            entries_per_page: 1,
+            entries_per_session: 3,
+        };
+
+        let (source_report, destination_report) =
+            pair_with_limits(&mut source, &mut destination, limits).await;
+        assert_eq!(source_report.entries_sent, 2);
+        assert_eq!(destination_report.entries_newly_stored, 2);
+
+        source.insert_chain(shared.stream_id, 3, 0, 3);
+        let (source_result, peer_result) =
+            try_pair_with_limits(&mut source, &mut destination, limits).await;
+        assert!(matches!(
+            source_result,
+            Err(TableSessionError::Store(error)) if error.to_string().contains("ceiling")
+        ));
+        assert!(peer_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn peer_chain_inventory_must_advance_order_and_respect_the_session_ceiling() {
+        for devices in [vec![2, 2], vec![1, 2, 3]] {
+            let shared = item("repo-a", 1);
+            let streams = vec![shared.clone()];
+            let mut store = MemStore::new(streams.clone());
+            let limits = TableSessionLimits {
+                chains_per_page: 1,
+                chains_per_session: 2,
+                entries_per_page: 1,
+                entries_per_session: 2,
+            };
+            let (mut receiver_send, mut peer_recv) = tokio::io::duplex(4096);
+            let (mut peer_send, mut receiver_recv) = tokio::io::duplex(4096);
+            let peer = async move {
+                for device in &devices[..devices.len() - 1] {
+                    table_codec::write_frame(&mut peer_send, &TableFrame::ChainInventory {
+                        stream_id: shared.stream_id,
+                        chains: vec![ChainHead {
+                            device_fingerprint: [*device; 32],
+                            lamport: 0,
+                            entry_hash: [*device; 32],
+                        }],
+                    })
+                    .await
+                    .unwrap();
+                    assert!(matches!(
+                        table_codec::read_frame(&mut peer_recv).await.unwrap(),
+                        TableFrame::ChainFrontiers { .. }
+                    ));
+                    table_codec::write_frame(&mut peer_send, &TableFrame::InventoryDone {
+                        stream_id: shared.stream_id,
+                    })
+                    .await
+                    .unwrap();
+                }
+                let device = devices[devices.len() - 1];
+                table_codec::write_frame(&mut peer_send, &TableFrame::ChainInventory {
+                    stream_id: shared.stream_id,
+                    chains: vec![ChainHead {
+                        device_fingerprint: [device; 32],
+                        lamport: 0,
+                        entry_hash: [device; 32],
+                    }],
+                })
+                .await
+                .unwrap();
+            };
+            let receiver = receive_direction(
+                &mut store,
+                &streams,
+                &mut receiver_send,
+                &mut receiver_recv,
+                true,
+                DEFAULT_IDLE_TIMEOUT,
+                limits,
+            );
+            let (result, ()) = tokio::join!(receiver, peer);
+            assert!(
+                matches!(result, Err(TableSessionError::Protocol(message)) if message.contains("cap"))
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn a_peer_that_stops_reading_cannot_block_writes_forever() {
         let shared = item("repo-a", 1);
         let mut store = MemStore::new(vec![shared.clone()]);
@@ -480,8 +1069,14 @@ mod tests {
         let peer = async move {
             for frame in [
                 TableFrame::Manifest(Manifest::new(vec![shared.clone()]).unwrap()),
-                TableFrame::Inventory { stream_id: shared.stream_id, have: Vec::new() },
-                TableFrame::StreamDone { stream_id: shared.stream_id },
+                TableFrame::ChainFrontiers {
+                    stream_id: shared.stream_id,
+                    frontiers: vec![ChainFrontier {
+                        device_fingerprint: [1; 32],
+                        state: FrontierState::Empty,
+                    }],
+                },
+                TableFrame::StreamDone { stream_id: shared.stream_id, continuation_pending: false },
                 TableFrame::Done,
             ] {
                 table_codec::write_frame(&mut peer_send, &frame).await.unwrap();

--- a/crates/rag-rat-sync/src/table_wire.rs
+++ b/crates/rag-rat-sync/src/table_wire.rs
@@ -95,7 +95,7 @@ pub enum TableFrame {
     Manifest(Manifest),
     ChainInventory { stream_id: Hash, chains: Vec<ChainHead> },
     ChainFrontiers { stream_id: Hash, frontiers: Vec<ChainFrontier> },
-    Entries { stream_id: Hash, entries: Vec<Vec<u8>> },
+    Entries { stream_id: Hash, device_fingerprint: Hash, entries: Vec<Vec<u8>> },
     InventoryDone { stream_id: Hash },
     StreamDone { stream_id: Hash, continuation_pending: bool },
     Done,
@@ -189,11 +189,12 @@ impl TableFrame {
                     }
                 }
             },
-            Self::Entries { stream_id, entries } => {
-                enc.array(4).expect(INFALLIBLE);
+            Self::Entries { stream_id, device_fingerprint, entries } => {
+                enc.array(5).expect(INFALLIBLE);
                 enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
                 enc.u8(tag::ENTRIES).expect(INFALLIBLE);
                 enc.bytes(stream_id).expect(INFALLIBLE);
+                enc.bytes(device_fingerprint).expect(INFALLIBLE);
                 enc.array(entries.len() as u64).expect(INFALLIBLE);
                 for entry in entries {
                     enc.bytes(entry).expect(INFALLIBLE);
@@ -236,7 +237,8 @@ impl TableFrame {
         let tag = dec.u8().map_err(m)?;
         let expected = match tag {
             tag::MANIFEST => 3,
-            tag::CHAIN_INVENTORY | tag::CHAIN_FRONTIERS | tag::ENTRIES | tag::STREAM_DONE => 4,
+            tag::CHAIN_INVENTORY | tag::CHAIN_FRONTIERS | tag::STREAM_DONE => 4,
+            tag::ENTRIES => 5,
             tag::INVENTORY_DONE => 3,
             tag::DONE | tag::ACK => 2,
             other => return Err(TableWireError::Malformed(format!("unknown frame tag {other}"))),
@@ -317,6 +319,7 @@ impl TableFrame {
             },
             tag::ENTRIES => {
                 let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
+                let device_fingerprint = fixed32(dec.bytes().map_err(m)?, "device_fingerprint")?;
                 let count =
                     bounded_count(dec.array().map_err(m)?, "entries", MAX_TABLE_ENTRIES_PER_PAGE)?;
                 if count == 0 {
@@ -333,7 +336,7 @@ impl TableFrame {
                     }
                     entries.push(entry.to_vec());
                 }
-                Self::Entries { stream_id, entries }
+                Self::Entries { stream_id, device_fingerprint, entries }
             },
             tag::INVENTORY_DONE =>
                 Self::InventoryDone { stream_id: fixed32(dec.bytes().map_err(m)?, "stream_id")? },
@@ -470,7 +473,11 @@ mod tests {
                     state: FrontierState::Restore { lamport: 4, entry_hash: [5; 32] },
                 }],
             },
-            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]] },
+            TableFrame::Entries {
+                stream_id: [2; 32],
+                device_fingerprint: [3; 32],
+                entries: vec![vec![4, 5]],
+            },
             TableFrame::InventoryDone { stream_id: [2; 32] },
             TableFrame::StreamDone { stream_id: [2; 32], continuation_pending: true },
             TableFrame::Done,
@@ -501,7 +508,11 @@ mod tests {
                     state: FrontierState::Accepted { lamport: 4, entry_hash: [5; 32] },
                 }],
             },
-            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]] },
+            TableFrame::Entries {
+                stream_id: [2; 32],
+                device_fingerprint: [3; 32],
+                entries: vec![vec![4, 5]],
+            },
             TableFrame::InventoryDone { stream_id: [2; 32] },
             TableFrame::StreamDone { stream_id: [2; 32], continuation_pending: false },
             TableFrame::Done,
@@ -514,8 +525,8 @@ mod tests {
             golden.extend_from_slice(&bytes);
         }
         assert_eq!(Sha256::digest(golden).as_slice(), &[
-            179, 118, 122, 4, 77, 8, 88, 205, 193, 56, 51, 53, 77, 23, 6, 51, 102, 205, 50, 183,
-            175, 163, 252, 103, 196, 7, 156, 70, 198, 195, 198, 251,
+            207, 130, 172, 222, 118, 237, 28, 115, 145, 245, 148, 105, 68, 107, 217, 78, 66, 164,
+            248, 205, 81, 83, 160, 84, 91, 124, 119, 163, 184, 98, 21, 236,
         ]);
     }
 
@@ -567,15 +578,17 @@ mod tests {
 
         let mut entries = Vec::new();
         let mut enc = Encoder::new(&mut entries);
-        enc.array(4).unwrap();
+        enc.array(5).unwrap();
         enc.str(FRAME_DOMAIN).unwrap();
         enc.u8(tag::ENTRIES).unwrap();
         enc.bytes(&[1; 32]).unwrap();
+        enc.bytes(&[2; 32]).unwrap();
         enc.array((MAX_TABLE_ENTRIES_PER_PAGE + 1) as u64).unwrap();
         assert!(matches!(TableFrame::decode(&entries), Err(TableWireError::OverCap(_))));
 
         let oversized = TableFrame::Entries {
             stream_id: [1; 32],
+            device_fingerprint: [2; 32],
             entries: vec![vec![0; MAX_TABLE_ENTRY_BYTES + 1]],
         }
         .encode();

--- a/crates/rag-rat-sync/src/table_wire.rs
+++ b/crates/rag-rat-sync/src/table_wire.rs
@@ -5,13 +5,16 @@ use std::collections::BTreeMap;
 use minicbor::{Decoder, Encoder};
 
 /// Dedicated ALPN for table-stream sync. Existing account/content/enrollment ALPNs do not move.
-pub const TABLE_SYNC_ALPN: &[u8] = b"rag-rat/table-sync/1";
+pub const TABLE_SYNC_ALPN: &[u8] = b"rag-rat/table-sync/2";
 
-const FRAME_DOMAIN: &str = "rag-rat/table-sync-frame/1";
+const FRAME_DOMAIN: &str = "rag-rat/table-sync-frame/2";
 pub const MAX_MANIFEST_ITEMS: usize = 1024;
 pub const MAX_REPO_ID_BYTES: usize = 1024;
 pub const MAX_SCOPE_ID_BYTES: usize = 128;
-pub const MAX_TABLE_INVENTORY_HASHES: usize = 65_536;
+pub const MAX_TABLE_CHAINS_PER_PAGE: usize = 1024;
+/// Hard protocol ceiling on historical device chains across one manifest intersection. Entry
+/// history within those chains remains incrementally unbounded.
+pub const MAX_TABLE_CHAINS_PER_SESSION: usize = 65_536;
 pub const MAX_TABLE_ENTRIES_PER_PAGE: usize = 32;
 pub const MAX_TABLE_ENTRY_BYTES: usize = rag_rat_oplog::TABLE_SYNC_ENTRY_MAX_BYTES;
 
@@ -64,24 +67,50 @@ impl Manifest {
     }
 }
 
-/// Table-session frames. Every inventory and entry page is explicitly stream-qualified.
+/// The accepted tip of one device chain offered by a sender.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainHead {
+    pub device_fingerprint: Hash,
+    pub lamport: u64,
+    pub entry_hash: Hash,
+}
+
+/// Durable receiver progress for one offered device chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontierState {
+    Empty,
+    Accepted { lamport: u64, entry_hash: Hash },
+    Restore { lamport: u64, entry_hash: Hash },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainFrontier {
+    pub device_fingerprint: Hash,
+    pub state: FrontierState,
+}
+
+/// Table-session frames. Every chain and entry page is explicitly stream-qualified.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TableFrame {
     Manifest(Manifest),
-    Inventory { stream_id: Hash, have: Vec<Hash> },
-    Entries { stream_id: Hash, entries: Vec<Vec<u8>>, more: bool },
-    StreamDone { stream_id: Hash },
+    ChainInventory { stream_id: Hash, chains: Vec<ChainHead> },
+    ChainFrontiers { stream_id: Hash, frontiers: Vec<ChainFrontier> },
+    Entries { stream_id: Hash, entries: Vec<Vec<u8>> },
+    InventoryDone { stream_id: Hash },
+    StreamDone { stream_id: Hash, continuation_pending: bool },
     Done,
     Ack,
 }
 
 mod tag {
     pub const MANIFEST: u8 = 0;
-    pub const INVENTORY: u8 = 1;
-    pub const ENTRIES: u8 = 2;
-    pub const STREAM_DONE: u8 = 3;
-    pub const DONE: u8 = 4;
-    pub const ACK: u8 = 5;
+    pub const CHAIN_INVENTORY: u8 = 1;
+    pub const CHAIN_FRONTIERS: u8 = 2;
+    pub const ENTRIES: u8 = 3;
+    pub const INVENTORY_DONE: u8 = 4;
+    pub const STREAM_DONE: u8 = 5;
+    pub const DONE: u8 = 6;
+    pub const ACK: u8 = 7;
 }
 
 #[derive(Debug)]
@@ -119,18 +148,49 @@ impl TableFrame {
                     enc.bytes(&item.stream_id).expect(INFALLIBLE);
                 }
             },
-            Self::Inventory { stream_id, have } => {
+            Self::ChainInventory { stream_id, chains } => {
                 enc.array(4).expect(INFALLIBLE);
                 enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
-                enc.u8(tag::INVENTORY).expect(INFALLIBLE);
+                enc.u8(tag::CHAIN_INVENTORY).expect(INFALLIBLE);
                 enc.bytes(stream_id).expect(INFALLIBLE);
-                enc.array(have.len() as u64).expect(INFALLIBLE);
-                for hash in have {
-                    enc.bytes(hash).expect(INFALLIBLE);
+                enc.array(chains.len() as u64).expect(INFALLIBLE);
+                for chain in chains {
+                    enc.array(3).expect(INFALLIBLE);
+                    enc.bytes(&chain.device_fingerprint).expect(INFALLIBLE);
+                    enc.u64(chain.lamport).expect(INFALLIBLE);
+                    enc.bytes(&chain.entry_hash).expect(INFALLIBLE);
                 }
             },
-            Self::Entries { stream_id, entries, more } => {
-                enc.array(5).expect(INFALLIBLE);
+            Self::ChainFrontiers { stream_id, frontiers } => {
+                enc.array(4).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::CHAIN_FRONTIERS).expect(INFALLIBLE);
+                enc.bytes(stream_id).expect(INFALLIBLE);
+                enc.array(frontiers.len() as u64).expect(INFALLIBLE);
+                for frontier in frontiers {
+                    enc.array(4).expect(INFALLIBLE);
+                    enc.bytes(&frontier.device_fingerprint).expect(INFALLIBLE);
+                    match frontier.state {
+                        FrontierState::Empty => {
+                            enc.u8(0).expect(INFALLIBLE);
+                            enc.null().expect(INFALLIBLE);
+                            enc.null().expect(INFALLIBLE);
+                        },
+                        FrontierState::Accepted { lamport, entry_hash } => {
+                            enc.u8(1).expect(INFALLIBLE);
+                            enc.u64(lamport).expect(INFALLIBLE);
+                            enc.bytes(&entry_hash).expect(INFALLIBLE);
+                        },
+                        FrontierState::Restore { lamport, entry_hash } => {
+                            enc.u8(2).expect(INFALLIBLE);
+                            enc.u64(lamport).expect(INFALLIBLE);
+                            enc.bytes(&entry_hash).expect(INFALLIBLE);
+                        },
+                    }
+                }
+            },
+            Self::Entries { stream_id, entries } => {
+                enc.array(4).expect(INFALLIBLE);
                 enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
                 enc.u8(tag::ENTRIES).expect(INFALLIBLE);
                 enc.bytes(stream_id).expect(INFALLIBLE);
@@ -138,13 +198,19 @@ impl TableFrame {
                 for entry in entries {
                     enc.bytes(entry).expect(INFALLIBLE);
                 }
-                enc.bool(*more).expect(INFALLIBLE);
             },
-            Self::StreamDone { stream_id } => {
+            Self::InventoryDone { stream_id } => {
                 enc.array(3).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::INVENTORY_DONE).expect(INFALLIBLE);
+                enc.bytes(stream_id).expect(INFALLIBLE);
+            },
+            Self::StreamDone { stream_id, continuation_pending } => {
+                enc.array(4).expect(INFALLIBLE);
                 enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
                 enc.u8(tag::STREAM_DONE).expect(INFALLIBLE);
                 enc.bytes(stream_id).expect(INFALLIBLE);
+                enc.bool(*continuation_pending).expect(INFALLIBLE);
             },
             Self::Done => {
                 enc.array(2).expect(INFALLIBLE);
@@ -170,9 +236,8 @@ impl TableFrame {
         let tag = dec.u8().map_err(m)?;
         let expected = match tag {
             tag::MANIFEST => 3,
-            tag::INVENTORY => 4,
-            tag::ENTRIES => 5,
-            tag::STREAM_DONE => 3,
+            tag::CHAIN_INVENTORY | tag::CHAIN_FRONTIERS | tag::ENTRIES | tag::STREAM_DONE => 4,
+            tag::INVENTORY_DONE => 3,
             tag::DONE | tag::ACK => 2,
             other => return Err(TableWireError::Malformed(format!("unknown frame tag {other}"))),
         };
@@ -183,23 +248,80 @@ impl TableFrame {
         }
         let frame = match tag {
             tag::MANIFEST => Self::Manifest(decode_manifest(&mut dec)?),
-            tag::INVENTORY => {
+            tag::CHAIN_INVENTORY => {
                 let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
                 let count = bounded_count(
                     dec.array().map_err(m)?,
-                    "inventory hashes",
-                    MAX_TABLE_INVENTORY_HASHES,
+                    "device chains",
+                    MAX_TABLE_CHAINS_PER_PAGE,
                 )?;
-                let mut have = Vec::with_capacity(count);
-                for _ in 0..count {
-                    have.push(fixed32(dec.bytes().map_err(m)?, "inventory hash")?);
+                if count == 0 {
+                    return Err(TableWireError::Malformed("empty chain inventory page".into()));
                 }
-                Self::Inventory { stream_id, have }
+                let mut chains = Vec::with_capacity(count);
+                for _ in 0..count {
+                    if dec.array().map_err(m)? != Some(3) {
+                        return Err(TableWireError::Malformed("chain head arity".into()));
+                    }
+                    chains.push(ChainHead {
+                        device_fingerprint: fixed32(dec.bytes().map_err(m)?, "device_fingerprint")?,
+                        lamport: dec.u64().map_err(m)?,
+                        entry_hash: fixed32(dec.bytes().map_err(m)?, "entry_hash")?,
+                    });
+                }
+                validate_devices(chains.iter().map(|chain| chain.device_fingerprint))?;
+                Self::ChainInventory { stream_id, chains }
+            },
+            tag::CHAIN_FRONTIERS => {
+                let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
+                let count = bounded_count(
+                    dec.array().map_err(m)?,
+                    "chain frontiers",
+                    MAX_TABLE_CHAINS_PER_PAGE,
+                )?;
+                if count == 0 {
+                    return Err(TableWireError::Malformed("empty chain frontier page".into()));
+                }
+                let mut frontiers = Vec::with_capacity(count);
+                for _ in 0..count {
+                    if dec.array().map_err(m)? != Some(4) {
+                        return Err(TableWireError::Malformed("chain frontier arity".into()));
+                    }
+                    let device_fingerprint =
+                        fixed32(dec.bytes().map_err(m)?, "device_fingerprint")?;
+                    let state = match dec.u8().map_err(m)? {
+                        0 => {
+                            dec.null().map_err(m)?;
+                            dec.null().map_err(m)?;
+                            FrontierState::Empty
+                        },
+                        mode @ 1..=2 => {
+                            let lamport = dec.u64().map_err(m)?;
+                            let entry_hash = fixed32(dec.bytes().map_err(m)?, "entry_hash")?;
+                            if mode == 1 {
+                                FrontierState::Accepted { lamport, entry_hash }
+                            } else {
+                                FrontierState::Restore { lamport, entry_hash }
+                            }
+                        },
+                        mode => {
+                            return Err(TableWireError::Malformed(format!(
+                                "unknown chain frontier mode {mode}"
+                            )));
+                        },
+                    };
+                    frontiers.push(ChainFrontier { device_fingerprint, state });
+                }
+                validate_devices(frontiers.iter().map(|frontier| frontier.device_fingerprint))?;
+                Self::ChainFrontiers { stream_id, frontiers }
             },
             tag::ENTRIES => {
                 let stream_id = fixed32(dec.bytes().map_err(m)?, "stream_id")?;
                 let count =
                     bounded_count(dec.array().map_err(m)?, "entries", MAX_TABLE_ENTRIES_PER_PAGE)?;
+                if count == 0 {
+                    return Err(TableWireError::Malformed("empty table entry page".into()));
+                }
                 let mut entries = Vec::with_capacity(count);
                 for _ in 0..count {
                     let entry = dec.bytes().map_err(m)?;
@@ -211,10 +333,14 @@ impl TableFrame {
                     }
                     entries.push(entry.to_vec());
                 }
-                Self::Entries { stream_id, entries, more: dec.bool().map_err(m)? }
+                Self::Entries { stream_id, entries }
             },
-            tag::STREAM_DONE =>
-                Self::StreamDone { stream_id: fixed32(dec.bytes().map_err(m)?, "stream_id")? },
+            tag::INVENTORY_DONE =>
+                Self::InventoryDone { stream_id: fixed32(dec.bytes().map_err(m)?, "stream_id")? },
+            tag::STREAM_DONE => Self::StreamDone {
+                stream_id: fixed32(dec.bytes().map_err(m)?, "stream_id")?,
+                continuation_pending: dec.bool().map_err(m)?,
+            },
             tag::DONE => Self::Done,
             tag::ACK => Self::Ack,
             _ => unreachable!(),
@@ -224,6 +350,19 @@ impl TableFrame {
         }
         Ok(frame)
     }
+}
+
+fn validate_devices(devices: impl IntoIterator<Item = Hash>) -> Result<(), TableWireError> {
+    let mut previous = None;
+    for device in devices {
+        if previous.is_some_and(|previous| previous >= device) {
+            return Err(TableWireError::Malformed(
+                "device chains are not in canonical sorted/deduplicated order".into(),
+            ));
+        }
+        previous = Some(device);
+    }
+    Ok(())
 }
 
 fn decode_manifest(dec: &mut Decoder<'_>) -> Result<Manifest, TableWireError> {
@@ -302,6 +441,10 @@ mod tests {
         }
     }
 
+    fn head(device: u8, lamport: u64, hash: u8) -> ChainHead {
+        ChainHead { device_fingerprint: [device; 32], lamport, entry_hash: [hash; 32] }
+    }
+
     #[test]
     fn manifest_sorts_and_collapses_exact_duplicates_but_rejects_conflicts() {
         let a = item("repo-a", 1, "anchors/1", 2);
@@ -319,9 +462,17 @@ mod tests {
         let manifest = Manifest::new(vec![item("r", 1, "s", 2)]).unwrap();
         let frames = [
             TableFrame::Manifest(manifest.clone()),
-            TableFrame::Inventory { stream_id: [2; 32], have: vec![[3; 32]] },
-            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]], more: false },
-            TableFrame::StreamDone { stream_id: [2; 32] },
+            TableFrame::ChainInventory { stream_id: [2; 32], chains: vec![head(3, 4, 5)] },
+            TableFrame::ChainFrontiers {
+                stream_id: [2; 32],
+                frontiers: vec![ChainFrontier {
+                    device_fingerprint: [3; 32],
+                    state: FrontierState::Restore { lamport: 4, entry_hash: [5; 32] },
+                }],
+            },
+            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]] },
+            TableFrame::InventoryDone { stream_id: [2; 32] },
+            TableFrame::StreamDone { stream_id: [2; 32], continuation_pending: true },
             TableFrame::Done,
             TableFrame::Ack,
         ];
@@ -331,9 +482,9 @@ mod tests {
         assert_eq!(TableFrame::Done.encode(), [
             0x82, 0x78, 0x1a, b'r', b'a', b'g', b'-', b'r', b'a', b't', b'/', b't', b'a', b'b',
             b'l', b'e', b'-', b's', b'y', b'n', b'c', b'-', b'f', b'r', b'a', b'm', b'e', b'/',
-            b'1', 0x04,
+            b'2', 0x06,
         ]);
-        assert_eq!(TABLE_SYNC_ALPN, b"rag-rat/table-sync/1");
+        assert_eq!(TABLE_SYNC_ALPN, b"rag-rat/table-sync/2");
     }
 
     #[test]
@@ -342,9 +493,17 @@ mod tests {
 
         let frames = [
             TableFrame::Manifest(Manifest::new(vec![item("r", 1, "s", 2)]).unwrap()),
-            TableFrame::Inventory { stream_id: [2; 32], have: vec![[3; 32]] },
-            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]], more: false },
-            TableFrame::StreamDone { stream_id: [2; 32] },
+            TableFrame::ChainInventory { stream_id: [2; 32], chains: vec![head(3, 4, 5)] },
+            TableFrame::ChainFrontiers {
+                stream_id: [2; 32],
+                frontiers: vec![ChainFrontier {
+                    device_fingerprint: [3; 32],
+                    state: FrontierState::Accepted { lamport: 4, entry_hash: [5; 32] },
+                }],
+            },
+            TableFrame::Entries { stream_id: [2; 32], entries: vec![vec![4, 5]] },
+            TableFrame::InventoryDone { stream_id: [2; 32] },
+            TableFrame::StreamDone { stream_id: [2; 32], continuation_pending: false },
             TableFrame::Done,
             TableFrame::Ack,
         ];
@@ -355,8 +514,8 @@ mod tests {
             golden.extend_from_slice(&bytes);
         }
         assert_eq!(Sha256::digest(golden).as_slice(), &[
-            127, 65, 177, 170, 94, 248, 249, 42, 4, 84, 175, 14, 138, 115, 103, 182, 228, 64, 61,
-            105, 158, 189, 214, 59, 224, 146, 228, 176, 152, 213, 72, 222,
+            179, 118, 122, 4, 77, 8, 88, 205, 193, 56, 51, 53, 77, 23, 6, 51, 102, 205, 50, 183,
+            175, 163, 252, 103, 196, 7, 156, 70, 198, 195, 198, 251,
         ]);
     }
 
@@ -396,19 +555,19 @@ mod tests {
     }
 
     #[test]
-    fn inventory_entry_count_and_entry_width_are_bounded_from_declared_lengths() {
+    fn chain_entry_counts_and_entry_width_are_bounded_from_declared_lengths() {
         let mut inventory = Vec::new();
         let mut enc = Encoder::new(&mut inventory);
         enc.array(4).unwrap();
         enc.str(FRAME_DOMAIN).unwrap();
-        enc.u8(tag::INVENTORY).unwrap();
+        enc.u8(tag::CHAIN_INVENTORY).unwrap();
         enc.bytes(&[1; 32]).unwrap();
-        enc.array((MAX_TABLE_INVENTORY_HASHES + 1) as u64).unwrap();
+        enc.array((MAX_TABLE_CHAINS_PER_PAGE + 1) as u64).unwrap();
         assert!(matches!(TableFrame::decode(&inventory), Err(TableWireError::OverCap(_))));
 
         let mut entries = Vec::new();
         let mut enc = Encoder::new(&mut entries);
-        enc.array(5).unwrap();
+        enc.array(4).unwrap();
         enc.str(FRAME_DOMAIN).unwrap();
         enc.u8(tag::ENTRIES).unwrap();
         enc.bytes(&[1; 32]).unwrap();
@@ -418,7 +577,6 @@ mod tests {
         let oversized = TableFrame::Entries {
             stream_id: [1; 32],
             entries: vec![vec![0; MAX_TABLE_ENTRY_BYTES + 1]],
-            more: false,
         }
         .encode();
         assert!(matches!(TableFrame::decode(&oversized), Err(TableWireError::OverCap(_))));
@@ -448,6 +606,30 @@ mod tests {
         // Bypass `Manifest::new` only inside this module to handcraft noncanonical wire.
         let bytes = TableFrame::Manifest(Manifest(reversed)).encode();
         assert!(matches!(TableFrame::decode(&bytes), Err(TableWireError::Malformed(_))));
+    }
+
+    #[test]
+    fn chain_pages_reject_empty_duplicate_and_out_of_order_devices() {
+        let empty = TableFrame::ChainInventory { stream_id: [1; 32], chains: Vec::new() }.encode();
+        assert!(matches!(TableFrame::decode(&empty), Err(TableWireError::Malformed(_))));
+
+        for chains in [vec![head(2, 0, 2), head(2, 1, 3)], vec![head(2, 0, 2), head(1, 1, 3)]] {
+            let bytes = TableFrame::ChainInventory { stream_id: [1; 32], chains }.encode();
+            assert!(matches!(TableFrame::decode(&bytes), Err(TableWireError::Malformed(_))));
+        }
+
+        let duplicate_frontiers = TableFrame::ChainFrontiers {
+            stream_id: [1; 32],
+            frontiers: vec![
+                ChainFrontier { device_fingerprint: [2; 32], state: FrontierState::Empty },
+                ChainFrontier { device_fingerprint: [2; 32], state: FrontierState::Empty },
+            ],
+        }
+        .encode();
+        assert!(matches!(
+            TableFrame::decode(&duplicate_frontiers),
+            Err(TableWireError::Malformed(_))
+        ));
     }
 
     #[test]

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -278,13 +278,13 @@ mod tests {
     }
 
     /// The ALPN identifiers are a frozen wire contract — an accidental rename would silently split
-    /// peers (an old peer declines the handshake). Pin both, and that they are distinct so the
-    /// acceptor can route account-log vs content by ALPN.
+    /// peers (an old peer declines the handshake). Pin all of them and their distinctness so the
+    /// acceptor can route each protocol by ALPN.
     #[test]
     fn alpn_identifiers_are_frozen() {
         assert_eq!(SYNC_ALPN, b"rag-rat/sync/4");
         assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/3");
-        assert_eq!(crate::table_wire::TABLE_SYNC_ALPN, b"rag-rat/table-sync/1");
+        assert_eq!(crate::table_wire::TABLE_SYNC_ALPN, b"rag-rat/table-sync/2");
         assert_eq!(crate::enrollment::ENROLL_ALPN, b"rag-rat/enroll/1");
         assert_ne!(SYNC_ALPN, CONTENT_SYNC_ALPN);
         assert_ne!(SYNC_ALPN, crate::enrollment::ENROLL_ALPN);


### PR DESCRIPTION
## Summary

- replace truncated exact-hash inventories with bounded per-device chain pages and durable accepted-tail frontiers
- resume retained histories across connections without peer-specific cursor state; lost acknowledgements retry idempotently
- distinguish accepted tails from purge-retained restore witnesses, including direct-successor restoration
- keep chain pages, entry pages, and total historical device chains hard-bounded; cap interruptions remain honestly non-converged
- advance the incompatible table wire contract to `rag-rat/table-sync/2` while leaving account, content, and enrollment protocols unchanged

The production table registry remains empty. This does not register a table or add accepted-history compaction.

## Verification

- `cargo nextest run -p rag-rat-oplog -p rag-rat-sync` (1,069 passed, 2 skipped)
- `cargo clippy -p rag-rat-oplog -p rag-rat-sync --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #1099
Part of #892