### PR TITLE
feat(lens): public read-only web appliance — code-server + Lens + rag-rat serve (#1106)

### DIFF
--- a/.github/workflows/deploy-appliance.yml
+++ b/.github/workflows/deploy-appliance.yml
@@ -1,0 +1,106 @@
+name: deploy-appliance
+
+# Deploys the Lens web appliance (editors/appliance, #1106) to the production host over
+# SSH. The host's IP/hostname lives ONLY in the `appliance-prod` environment's secrets —
+# never in this file — and the public URL is a CNAME to the Cloudflare named tunnel, so
+# no DNS record ever points at the box.
+on:
+  push:
+    branches: [main]
+    paths:
+      - editors/appliance/**
+      - editors/vscode/**
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+  workflow_dispatch:
+
+env:
+  DEPLOY_DIR: /opt/rag-rat-appliance
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Holds DEPLOY_HOST, DEPLOY_HOST_KEY, DEPLOY_SSH_KEY (and can require reviewers).
+    environment: appliance-prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build the rag-rat binary (dist profile)
+        run: cargo build --profile dist -p rag-rat
+
+      - name: Package the Lens extension (identical to the published artifact)
+        working-directory: editors/vscode
+        run: |
+          npm ci
+          npm run package
+          npx --yes @vscode/vsce package --no-dependencies --out rag-rat-lens.vsix
+
+      - name: Stage artifacts into the build context
+        run: editors/appliance/stage-artifacts.sh
+
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Pin the host key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' '${{ secrets.DEPLOY_HOST_KEY }}' > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Sync the appliance to the host
+        run: |
+          ssh ragrat@${{ secrets.DEPLOY_HOST }} "mkdir -p '$DEPLOY_DIR'"
+          rsync -az --delete --exclude artifacts --exclude '.env*' editors/appliance/ \
+            ragrat@${{ secrets.DEPLOY_HOST }}:$DEPLOY_DIR/
+          rsync -az editors/appliance/artifacts/ \
+            ragrat@${{ secrets.DEPLOY_HOST }}:$DEPLOY_DIR/artifacts/
+
+      # The served index is commit-scoped: the clone must sit at the deployed SHA and the
+      # DB must be reindexed against it, or commit-scoped views (callers/callees) serve
+      # nothing while repo-scoped memories still work. `git checkout -f` keeps the clone
+      # pristine across deploys; the host-side database path override is then re-applied
+      # idempotently (config has no env override). Incremental `index` self-heals what
+      # the new binary owes (schema/graph migrations run on open).
+      - name: Pin the clone to the deployed SHA and reindex the DB
+        timeout-minutes: 45
+        run: |
+          ssh ragrat@${{ secrets.DEPLOY_HOST }} 'bash -se' <<'DEPLOY'
+            set -e
+            DEPLOY_DIR=/opt/rag-rat-appliance
+            install -m 755 "$DEPLOY_DIR/artifacts/rag-rat" "$HOME/.local/bin/rag-rat"
+            cd /srv/rag-rat/repo
+            git fetch -q origin
+            git checkout -qf "${{ github.sha }}"
+            grep -q '^database = ' rag-rat.toml || \
+              sed -i 's|^root = "\."|root = "."\ndatabase = "/srv/rag-rat/db/rag-rat.sqlite"|' rag-rat.toml
+            # Stop BOTH container writers before the checkout + reindex: the old serve's
+            # watcher stays live on the shared DB otherwise, and the newly installed
+            # binary would index/migrate alongside a different version's writer.
+            cd "$DEPLOY_DIR" && docker compose stop code-server serve
+            # Index from the HOST checkout: its rag-rat.toml resolves root + database to
+            # the host paths. Running from $DEPLOY_DIR would load the appliance config
+            # with the container-only /srv/workspace and /srv/db instead.
+            cd /srv/rag-rat/repo
+            "$HOME/.local/bin/rag-rat" index
+          DEPLOY
+
+      - name: Rebuild and restart
+        run: |
+          ssh ragrat@${{ secrets.DEPLOY_HOST }} \
+            "cd '$DEPLOY_DIR' && docker compose build --pull \
+              && docker compose rm -sf code-server serve \
+              && (docker volume rm rag-rat-appliance_lens_ext || true) \
+              && docker compose --profile tunnel up -d"
+        # lens_ext is a named volume: it initializes from the image ONCE and then shadows
+        # every newer extension bundle (a stale vsix kept serving long after rebuilds —
+        # the demoFile onboarding was invisible until the volume was dropped). Removing
+        # it on every deploy re-initializes from the fresh image. The parens keep
+        # `|| true` scoped to the volume removal alone: a build or compose failure must
+        # fail the deploy, not quietly serve the previous image.

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -206,6 +206,13 @@ pub(crate) struct ServeArgs {
     /// for multiple trusted origins.
     #[arg(long, value_name = "ORIGIN", value_parser = parse_lens_origin)]
     pub allow_origin: Vec<String>,
+    /// Publish the Lens discovery file advertising this URL instead of the bind address. Needed
+    /// when the server runs in a sibling container/VM whose bind address the extension cannot
+    /// dial (the extension refuses `0.0.0.0`); without it, non-loopback serving publishes no
+    /// discovery file. Plain HTTP is only acceptable on a trusted network — terminate TLS in a
+    /// reverse proxy for public serving.
+    #[arg(long, value_name = "URL")]
+    pub advertise_url: Option<String>,
 }
 
 /// clap `value_parser` for `--allow-origin`: an Origin header is `scheme://host[:port]` with no

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -458,7 +458,9 @@ fn run_mcp(explicit: Option<&str>, json: bool) -> anyhow::Result<()> {
 }
 
 fn serve_http(config: Config, args: &ServeArgs) -> anyhow::Result<()> {
-    if !args.bind.is_loopback() && (args.token_env.is_none() || args.allow_origin.is_empty()) {
+    if (!args.bind.is_loopback() || args.advertise_url.is_some())
+        && (args.token_env.is_none() || args.allow_origin.is_empty())
+    {
         anyhow::bail!(
             "non-loopback `rag-rat serve` requires --token-env and at least one --allow-origin"
         );
@@ -482,6 +484,7 @@ fn serve_http(config: Config, args: &ServeArgs) -> anyhow::Result<()> {
     let _watcher = rag_rat_core::watch::Watcher::spawn(config.clone());
     let address = std::net::SocketAddr::new(args.bind, args.port);
     let allowed_origins = args.allow_origin.clone();
+    let advertise_url = args.advertise_url.clone();
     let runtime =
         tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
     runtime.block_on(async move {
@@ -489,8 +492,11 @@ fn serve_http(config: Config, args: &ServeArgs) -> anyhow::Result<()> {
             config,
             workspace_root,
             address,
-            token,
-            allowed_origins,
+            rag_rat_mcp::lens_server::StandaloneServeOptions {
+                auth_token: token,
+                allowed_origins,
+                advertise_url,
+            },
             election_lock,
             shutdown_signal(),
         )

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -353,15 +353,26 @@ async fn run_on_ports(
     .context("serving lens HTTP API")
 }
 
+/// Options for [`serve_standalone`] beyond the bind address: the bearer credential, the
+/// CORS allowlist, and the optional advertised discovery URL.
+#[derive(Debug, Default)]
+pub struct StandaloneServeOptions {
+    pub auth_token: String,
+    pub allowed_origins: Vec<String>,
+    /// Publish discovery advertising this URL instead of the bind address (the
+    /// container-split shape: the extension dials this, not the bind IP).
+    pub advertise_url: Option<String>,
+}
+
 pub async fn serve_standalone(
     config: Config,
     workspace_root: PathBuf,
     address: SocketAddr,
-    auth_token: String,
-    allowed_origins: Vec<String>,
+    options: StandaloneServeOptions,
     election_lock: FileLock,
     shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
 ) -> anyhow::Result<()> {
+    let StandaloneServeOptions { auth_token, allowed_origins, advertise_url } = options;
     // The caller acquires the election lock before any side effects (index heal, watcher) so a
     // contended worktree fails fast.
     let _election_lock = election_lock;
@@ -376,22 +387,45 @@ pub async fn serve_standalone(
     .ok()
     .map(|identity| identity.repo_id);
     let indexed_root = indexed_root_relative(&config, &workspace_root)?;
-    let discovery = LensDiscovery::new(
+    let mut discovery = LensDiscovery::new(
         listener.local_addr()?,
         repo_id,
         indexed_root,
         path_case_insensitive(&workspace_root),
         auth_token.clone(),
     );
-    // Only loopback standalone serving publishes discovery: a non-loopback bind advertises an
-    // address the extension refuses to dial, and the file would carry the hosted bearer token
-    // into a workspace file it could be committed from.
-    let _discovery = if listener.local_addr()?.ip().is_loopback() {
+    if let Some(advertise) = advertise_url.as_deref() {
+        // The advertised URL replaces the bind address in the published discovery: the
+        // extension dials it, so it must parse and carry a usable host + port (a
+        // sibling-container bind like 0.0.0.0 or 172.x is exactly the case this exists
+        // for). The bind address still decides where the listener lives.
+        let parsed = url::Url::parse(advertise)
+            .with_context(|| format!("invalid --advertise-url `{advertise}`"))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("--advertise-url `{advertise}` has no host"))?
+            .to_string();
+        let port = parsed
+            .port_or_known_default()
+            .ok_or_else(|| anyhow::anyhow!("--advertise-url `{advertise}` has no port"))?;
+        discovery.url = format!("{}://{host}:{port}", parsed.scheme());
+        discovery.host = host;
+        discovery.port = port;
+    }
+    // Discovery publishes on loopback (the extension shares the host) or when an
+    // explicit --advertise-url names a reachable address. A bare non-loopback bind
+    // publishes nothing: the file would carry the hosted bearer token into a workspace
+    // file while advertising an address the extension refuses to dial.
+    let _discovery = if listener.local_addr()?.ip().is_loopback() || advertise_url.is_some() {
+        if !listener.local_addr()?.ip().is_loopback() {
+            eprintln!(
+                "non-loopback serve is plain HTTP — terminate TLS in a trusted reverse proxy"
+            );
+        }
         Some(DiscoveryGuard::publish(lens_discovery_path(&workspace_root), &discovery)?)
     } else {
         eprintln!(
-            "non-loopback serve is plain HTTP — terminate TLS in a trusted reverse proxy; no \
-             workspace discovery file published"
+            "non-loopback serve without --advertise-url: no workspace discovery file published"
         );
         None
     };
@@ -1370,8 +1404,11 @@ mod tests {
                 config.clone(),
                 root.clone(),
                 SocketAddr::new(bind_ip, port),
-                "standalone-token".to_string(),
-                Vec::new(),
+                StandaloneServeOptions {
+                    auth_token: "standalone-token".to_string(),
+                    allowed_origins: Vec::new(),
+                    advertise_url: None,
+                },
                 election,
                 async move {
                     let _ = wait_for_stop.await;
@@ -1413,6 +1450,64 @@ mod tests {
                 .expect("a clean shutdown is not an error");
             let _ = fs::remove_dir_all(root);
         }
+    }
+
+    /// `--advertise-url` publishes discovery on a non-loopback bind with the ADVERTISED
+    /// address — the container-split shape: the listener binds the docker-network IP,
+    /// and the extension dials the URL it is told to.
+    #[tokio::test]
+    async fn standalone_serving_publishes_the_advertise_url_when_given() {
+        let root = temp_dir();
+        let mut config = test_config(root.clone());
+        config.allow_empty = true;
+        drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
+        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let election = FileLock::try_acquire(&root.join("election.lock"))
+            .unwrap()
+            .expect("an uncontended election lock");
+        let (stop, wait_for_stop) = tokio::sync::oneshot::channel::<()>();
+        let served = tokio::spawn(serve_standalone(
+            config.clone(),
+            root.clone(),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+            StandaloneServeOptions {
+                auth_token: "standalone-token".to_string(),
+                allowed_origins: Vec::new(),
+                advertise_url: Some("http://lens.internal:18120".to_string()),
+            },
+            election,
+            async move {
+                let _ = wait_for_stop.await;
+                Ok(())
+            },
+        ));
+
+        let discovery_path = lens_discovery_path(&root);
+        for _ in 0..200 {
+            if discovery_path.is_file() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let published: LensDiscovery = serde_json::from_slice(
+            &fs::read(&discovery_path).expect("an advertise-url serve must publish discovery"),
+        )
+        .unwrap();
+        assert_eq!(published.url, "http://lens.internal:18120");
+        assert_eq!(published.host, "lens.internal");
+        assert_eq!(published.port, 18120);
+        assert_eq!(published.ownership_token, "standalone-token");
+
+        let _ = stop.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(10), served)
+            .await
+            .expect("standalone serve must return once its shutdown future resolves")
+            .expect("the serve task must not panic")
+            .expect("a clean shutdown is not an error");
+        let _ = fs::remove_dir_all(root);
     }
 
     fn test_config(root: PathBuf) -> Config {

--- a/editors/appliance/.gitignore
+++ b/editors/appliance/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/editors/appliance/Dockerfile
+++ b/editors/appliance/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# Lens web appliance (#1106): unmodified code-server (Code-OSS) + the published Lens
+# extension vsix + the rag-rat binary + the Lens backend (`rag-rat serve`).
+#
+# The build context is editors/appliance. CI stages two artifacts before building:
+#   artifacts/rag-rat           (`cargo build --profile dist -p rag-rat`)
+#   artifacts/rag-rat-lens.vsix (`npm run package` in editors/vscode — the SAME
+#                                artifact that is published to the marketplaces)
+# For local builds, stage those two files by hand, or run ./stage-artifacts.sh.
+
+# Pinned by digest: `latest` would let `docker compose build --pull` swap Code-OSS for
+# an unreviewed upstream release on an unchanged repo revision — including changes to
+# the public security surface. Bump deliberately; the tag stays for readability.
+FROM codercom/code-server:4.131.0@sha256:3623e6362abdec6258472882b06fdeec9d6ce2ad3fda316b3c5d7ed092b89add
+
+USER root
+COPY artifacts/rag-rat /usr/local/bin/rag-rat
+COPY --chown=coder:coder artifacts/rag-rat-lens.vsix /tmp/rag-rat-lens.vsix
+COPY rag-rat.toml /srv/config/rag-rat.toml
+# Overwrite code-server's bootstrapped default config: the extension install below
+# already ran code-server once, which wrote a config.yaml containing a generated
+# password — a credential no public visitor should be able to browse.
+COPY --chown=coder:coder code-server.yaml /home/coder/.config/code-server/config.yaml
+# VS Code user settings for the public read-only demo. code-server's user-data dir is
+# ~/.local/share/code-server; compose ALSO bind-mounts this file read-only over that
+# path so a public session cannot flip the terminal/task/debug profiles back to a real
+# shell through the Settings UI. The image copy keeps the same defaults for runs that
+# do not use the compose bind.
+COPY --chown=coder:coder settings.json /home/coder/.local/share/code-server/User/settings.json
+COPY entrypoint.sh /usr/local/bin/lens-appliance-entrypoint
+COPY serve-entrypoint.sh /usr/local/bin/lens-serve-entrypoint
+COPY loopback-proxy.js /usr/local/bin/lens-loopback-proxy.js
+RUN chmod +x /usr/local/bin/rag-rat /usr/local/bin/lens-appliance-entrypoint \
+    /usr/local/bin/lens-serve-entrypoint \
+    && mkdir -p /opt/lens-ext/extensions \
+    && chown -R coder:coder /opt/lens-ext
+
+USER coder
+# Install at image build so the extension in the container is byte-identical to the
+# published vsix; no marketplace round-trip at runtime. The extensions dir is mounted
+# READ-ONLY at runtime (public demo: no extension installs).
+RUN code-server --install-extension /tmp/rag-rat-lens.vsix --extensions-dir /opt/lens-ext \
+    && rm /tmp/rag-rat-lens.vsix
+# The demo is STATELESS per boot: no user-data in the image. Runtime state lives on a
+# size-bounded tmpfs (compose), recreated empty at every start — nothing a visitor does
+# accumulates, and there is nothing to browse from previous sessions.
+RUN rm -rf /home/coder/.local/share/code-server
+
+ENTRYPOINT ["/usr/local/bin/lens-appliance-entrypoint"]

--- a/editors/appliance/README.md
+++ b/editors/appliance/README.md
@@ -1,0 +1,151 @@
+# Lens web appliance (#1106)
+
+A turnkey, shareable browser appliance around the rag-rat Lens extension and its HTTP/SSE
+backend, for users who do not run VS Code or Cursor locally. It is **unmodified
+code-server (Code-OSS)** with the *same* extension vsix that is published to the
+marketplaces, plus the `rag-rat` binary serving the Lens API, plus a Cloudflare Tunnel
+sidecar for TLS+DNS-less sharing.
+
+Layout:
+
+- `Dockerfile` — code-server base + `artifacts/rag-rat` + `artifacts/rag-rat-lens.vsix`
+- `entrypoint.sh` — workbench entrypoint (code-server only)
+- `serve-entrypoint.sh` — Lens backend entrypoint (the only container with the DB mount)
+- `docker-compose.yml` — workbench + `serve` + `cloudflared` sidecar
+
+Two containers, deliberately: the workbench public visitors drive has **no DB mount and
+no outbound network**, so a process spawned from a task or debug config (which settings
+cannot pin — a task can name its own shell) has no index to reach or corrupt. The
+backend publishes its discovery file with `--advertise-url` (the docker-network
+address), which the extension reads from the shared `lens_runtime` volume.
+- `rag-rat.toml` — container-side config (root + database paths; both are bind mounts)
+- `stage-artifacts.sh` — copies the CI-built binary + vsix into the build context
+- `.github/workflows/deploy-appliance.yml` — CI deploy to the production host
+
+## One command
+
+```sh
+cd editors/appliance
+./stage-artifacts.sh            # or let CI do it
+docker compose up -d --build
+```
+
+Local-only: reach the workbench with an SSH forward
+(`ssh -N -L 8080:127.0.0.1:8080 ragrat@<host>`) and open <http://127.0.0.1:8080>.
+Shared: attach the named Cloudflare tunnel (below) and open the tunnel hostname.
+
+## What the browser sees, and how auth works
+
+- code-server serves the workbench on container port 8080 **without a login gate**
+  (`--auth none` — the demo is public and read-only). Containment is structural, not a
+  password: NO DB MOUNT in the workbench container (the `serve` container owns it),
+  read-only workspace, read-only extensions dir (no installs), a dead terminal shell
+  (`/bin/false`), no docker socket, bounded CPU/memory/pids, ro rootfs, no-new-privs,
+  cap_drop ALL, and an `internal: true` compose network so the workbench has **no
+  outbound internet** — only the `cloudflared` sidecar has egress. Treat any future
+  switch back to editable mode as a security review.
+- The Lens backend (`rag-rat serve`) runs in its own `serve` container on the internal
+  network, mints a bearer token per boot, and publishes it to
+  `/srv/workspace/.rag-rat/sockets/lens.json` with `--advertise-url` — the file the
+  extension's automatic discovery reads. No token handling in the UI; the workbench
+  mounts that volume read-only. CORS allows exactly the public origin (the extension's
+  fetch Origin when it runs in a browser worker).
+- `.rag-rat` is a dedicated volume mounted over the read-only workspace so the discovery
+  publish succeeds without making the repo writable; the workbench sees it read-only.
+
+## Bind mounts (host-owned state)
+
+| host path | container path | mode | owner |
+|---|---|---|---|
+| `/srv/rag-rat/repo` | `/srv/workspace` | **ro** | operator |
+| `/srv/rag-rat/db` | `/srv/db` | **rw** | operator |
+
+The workspace **is the rag-rat repo itself** (the appliance dogfoods rag-rat's own
+index): `/srv/rag-rat/repo` is a clone of `cq27-dev/rag-rat`, and the container config's
+`[target_bindings]` mirror the repo's own `rag-rat.toml` (`rust = ["crates"]`,
+`markdown = ["docs"]`).
+
+Host-side setup for that state:
+
+```sh
+git clone https://github.com/cq27-dev/rag-rat /srv/rag-rat/repo
+cd /srv/rag-rat/repo && rag-rat index          # writes /srv/rag-rat/db/rag-rat.sqlite
+```
+
+The DB is **written manually on the host** (`rag-rat index` / `reconcile` against
+`/srv/rag-rat/db/rag-rat.sqlite`; point the host's `rag-rat.toml` `database` there).
+The whole DIRECTORY is mounted (not the bare file) because `rag-rat serve` needs sibling
+writes — the locks dir and SQLite's `-wal`/`-shm` sidecars. Read-write deliberately: serve
+migrates on open and self-heals, so a read-only mount breaks serving when a migration is
+owed. Keep the host and container
+rag-rat binaries on the **same release** — if the container is newer, its migration
+makes the DB unreadable to the host binary.
+
+### Retirement
+
+The bind-mounted DB and the manual host-side indexing flow are **transitional**. Once
+memory/op-log sync lands, the appliance consumes the synced store (or a sync peer), the
+host write path goes away, and the compose drops both bind mounts. Remove this section
+then.
+
+## Cloudflare Tunnel (shared posture)
+
+1. Create a **named tunnel** in the Zero Trust dashboard; copy its token.
+2. Add a public hostname (e.g. `rag-rat-demo.cq27.dev`) → service `http://code-server:8080`.
+   The hostname is a CNAME to the tunnel — no DNS record ever names the host IP.
+3. Put `TUNNEL_TOKEN=…` (and `APPLIANCE_PASSWORD=…`) in `.env` next to
+   `docker-compose.yml`, `chmod 600`.
+4. Recommended: put **Cloudflare Access** in front of the hostname for SSO
+   (Google/GitHub/OTP, per-email policy) instead of relying on the password alone.
+
+The tunnel dials outbound only; the host needs no inbound ports beyond SSH. TLS is
+terminated at Cloudflare's edge, which is what the workbench's service workers require —
+do not expose port 8080 directly over plain HTTP; webviews will not load without a
+secure context.
+
+### Edge hardening (dashboard, one-time)
+
+- **Bot Fight Mode** on (Security → Bots).
+- **Rate limiting**: one free rule — path `/` ≥ ~100 req/10s per IP → Managed Challenge
+  (don't go below ~50/10s; the workbench pulls many assets on load).
+- **HSTS** on (SSL/TLS → Edge Certificates) with the nosniff toggle.
+- **Response Header Transform Rule**: `X-Content-Type-Options: nosniff`,
+  `Referrer-Policy: strict-origin-when-cross-origin`, `X-Frame-Options: SAMEORIGIN`
+  (the demo is never legitimately iframed).
+- **Notifications**: DDoS alert, origin error rate, tunnel health.
+- **Abuse lever**: if the demo gets hammered, put Cloudflare Access (One-Time PIN) in
+  front of the hostname — quasi-public, adds identity and a kill switch.
+
+## Production host (one-time setup)
+
+```sh
+useradd -m -s /bin/bash ragrat && usermod -aG docker ragrat          # CI deploys as this user; no sudo
+ufw default deny incoming
+ufw allow ssh
+ufw enable
+mkdir -p /opt/rag-rat-appliance /srv/rag-rat
+```
+
+GitHub `appliance-prod` environment secrets:
+
+- `DEPLOY_HOST` — host IP/hostname (kept out of the repo and masked in logs)
+- `DEPLOY_HOST_KEY` — `ssh-keyscan` output, pinned (prevents silent host swaps)
+- `DEPLOY_SSH_KEY` — dedicated ed25519 deploy key in `ragrat`'s `authorized_keys`
+
+## Lifecycle and cleanup
+
+- Upgrade: push to `main` touching the appliance/extension/crates → CI rebuilds and
+  restarts. The deploy also **pins the host clone to the deployed SHA** (`git checkout
+  -qf <sha>`), installs the freshly built host binary, stops the workbench, and runs
+  `rag-rat index` before restarting — the served graph is commit-scoped, so the clone,
+  the DB, and the binary must move together. Roll back by re-running the workflow from
+  the previous commit (the same pin+reindex restores that state).
+- code-server user data is a tmpfs (ephemeral per boot); `.rag-rat` runtime is the
+  `lens_runtime` volume. The `lens_ext` volume initializes from the image ONCE and then
+  shadows newer extension bundles — the deploy drops it before `up` for exactly this
+  reason; drop it manually when rebuilding by hand (`docker volume rm
+  rag-rat-appliance_lens_ext`).
+- The image embeds the pinned code-server/cloudflared bases — rebuilds pull new bases
+  (`docker compose build --pull`).
+- Local launcher flow (non-Docker, future #1106 follow-up): downloads land in
+  `~/.local/lib/code-server-*`; delete that directory to reclaim them.

--- a/editors/appliance/code-server.yaml
+++ b/editors/appliance/code-server.yaml
@@ -1,0 +1,9 @@
+# Static code-server config for the appliance. No credentials: code-server's default
+# bootstrap writes a config.yaml with a GENERATED PASSWORD the first time it runs
+# (including at image-build extension install), and that file is browsable by any
+# visitor of this public instance. All security posture lives in the entrypoint flags,
+# which take precedence over this file.
+bind-addr: 0.0.0.0:8080
+auth: none
+cert: false
+disable-telemetry: true

--- a/editors/appliance/docker-compose.yml
+++ b/editors/appliance/docker-compose.yml
@@ -1,0 +1,214 @@
+services:
+  # One-shot: hand the fresh lens_runtime volume to the coder user (uid 1000). Fresh
+  # named volumes are root-owned, and the serve-side discovery publish chmods the
+  # directory owner-only — as coder — so a root-owned volume fails startup.
+  init-runtime:
+    image: alpine:3
+    user: root
+    volumes:
+      - lens_runtime:/rt
+    command: ["sh", "-c", "chown 1000:1000 /rt && install -d -o 1000 -g 1000 /rt/sockets"]
+    restart: "no"
+    networks: [internal]
+
+  # The Lens backend — the ONLY container with the DB mount. A visitor who spawns a
+  # task/debug process in the workbench container has no DB to reach: this, not the
+  # settings pins, is the execution boundary for the public demo. Docker's restart
+  # policy supervises it (a backend failure is a container exit, not a silent zombie
+  # beside a "healthy" workbench).
+  serve:
+    build: .
+    entrypoint: ["/usr/local/bin/lens-serve-entrypoint"]
+    restart: unless-stopped
+    depends_on:
+      init-runtime:
+        condition: service_completed_successfully
+    # The DB dir is host-owned by the operator's uid and shared group-write+setgid;
+    # this container's coder user joins that group so serve can write locks and WAL
+    # sidecars. The GID is the HOST operator group — set LENS_DB_GID=$(id -g ragrat) in
+    # .env (default 1002 matches the documented provisioning). The workbench does NOT
+    # get this group.
+    group_add: ["${LENS_DB_GID:-1002}"]
+    networks:
+      internal:
+        # Fixed IP: under gVisor (runsc) Docker's embedded DNS does not resolve service
+        # names inside the workbench, so the loopback proxy targets this address
+        # instead of the `serve` name.
+        ipv4_address: 172.31.255.20
+    environment:
+      # The extension's fetch Origin (a web worker in the visitor's browser), allowed
+      # exactly by the backend's CORS gate.
+      LENS_PUBLIC_ORIGIN: https://rag-rat-demo.cq27.dev
+    mem_limit: 1g
+    memswap_limit: 1g
+    cpus: 1.0
+    pids_limit: 128
+    ulimits:
+      nofile: { soft: 4096, hard: 8192 }
+      core: 0
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3", compress: "true" }
+    init: true
+    user: "1000:1000"
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    read_only: true
+    tmpfs: ["/tmp:rw,noexec,nosuid,size=64m"]
+    volumes:
+      # Host-owned clone of the rag-rat repo itself, strictly read-only.
+      - /srv/rag-rat/repo:/srv/workspace:ro
+      # Writable overlay for `.rag-rat/sockets/lens.json` — the discovery credential the
+      # workbench reads back from the same volume (mounted ro there).
+      - lens_runtime:/srv/workspace/.rag-rat
+      # Host-managed DB DIRECTORY (not the file): serve needs sibling writes — the locks
+      # dir, and SQLite's -wal/-shm sidecars — so mounting the bare file breaks both.
+      # Read-write deliberately: serve migrates on open and self-heals. Host perms are
+      # 2770/0660: group-shared, world-nothing.
+      # TRANSITIONAL: retired when memory/op-log sync lands — the appliance will consume
+      # the synced store and both bind mounts go away. See README "Retirement".
+      - /srv/rag-rat/db:/srv/db
+
+  # The workbench — the container public visitors drive. It has NO DB mount and no
+  # outbound network, so nothing a visitor spawns (a task or debug config with its own
+  # shell, which settings cannot pin) can reach or corrupt the index.
+  code-server:
+    build: .
+    restart: unless-stopped
+    # gVisor (runsc): the public workbench is the untrusted boundary — a visitor who
+    # lands code execution here (task/debug) must not share the host kernel. serve
+    # stays on runc: SQLite's fsync-heavy I/O pays gofer overhead under gVisor, and it
+    # runs no visitor code.
+    runtime: runsc
+    depends_on:
+      init-runtime:
+        condition: service_completed_successfully
+      serve:
+        condition: service_started
+    # Docker does NOT program port publishes attached to an `internal` network (it
+    # silently no-ops — NetworkSettings.Ports stays null). The documented local flow's
+    # host listener therefore lives on the tiny `edge` forwarder below; this container
+    # itself only exposes to the internal network.
+    expose: ["8080"]
+    environment:
+      # The loopback proxy's upstream — the serve container's fixed internal IP
+      # (embedded DNS is unavailable inside runsc).
+      LENS_BACKEND_HOST: 172.31.255.20
+    networks:
+      internal:
+        # Fixed IP: the `edge` forwarder dials this address (embedded DNS is similarly
+        # unavailable to it, and static addresses keep the whole internal topology
+        # explicit).
+        ipv4_address: 172.31.255.10
+    init: true
+    user: "1000:1000"
+    mem_limit: 2g
+    # memswap == mem: Docker's default would silently allow another 2g of swap on top.
+    memswap_limit: 2g
+    cpus: 1.5
+    pids_limit: 256
+    # Docker inherits dockerd's limits (systemd: ~1M fds) when unset — a visitor's fd
+    # exhaustion would otherwise hit the host's other services.
+    ulimits:
+      nofile: { soft: 4096, hard: 8192 }
+      core: 0
+    # json-file's default is unbounded: `yes` in a spawned process would fill the host
+    # disk and burn dockerd CPU. Rotate.
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3", compress: "true" }
+    # OS-level containment (stronger than a chroot inside the container — same kernel,
+    # fewer privileges): no privilege escalation, no capabilities, read-only rootfs.
+    # Writable paths are exactly the tmpfs mounts (the lens_runtime mount is ro here).
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    read_only: true
+    tmpfs:
+      - "/tmp:rw,noexec,nosuid,size=64m"
+      # code-server user data is ephemeral: a bounded tmpfs, wiped on every restart.
+      # The pinned settings.json is bind-mounted over a path inside it (entrypoint
+      # recreates the User dir first).
+      - "/home/coder/.local/share/code-server:rw,noexec,nosuid,size=128m"
+    volumes:
+      # Host-owned clone of the rag-rat repo itself (the appliance dogfoods rag-rat's own
+      # index), strictly read-only to the container.
+      - /srv/rag-rat/repo:/srv/workspace:ro
+      # The discovery credential, read-only here: written by the serve container.
+      - lens_runtime:/srv/workspace/.rag-rat:ro
+      # The hardening settings are pinned OUTSIDE visitor control: a read-only bind
+      # mount of the repo's settings.json over the writable user-data tmpfs. A public
+      # session can still write UI state to the tmpfs, but editing User settings via
+      # the Settings UI fails at the filesystem — the /bin/false terminal/task/debug
+      # profiles cannot be flipped back to a real shell by a visitor.
+      - ./settings.json:/home/coder/.local/share/code-server/User/settings.json:ro
+      # Preinstalled Lens extension, read-only so a public session cannot install or
+      # update extensions (extension code runs with the container's privileges).
+      - lens_ext:/opt/lens-ext:ro
+
+  # Loopback host listener for the local (no-tunnel) flow: forwards 127.0.0.1:8080 on
+  # the host to code-server:8080 over the internal network. Needed because Docker does
+  # not program port publishes on an `internal` network; `hostpublish` is the
+  # non-internal bridge the publish can attach to. The workbench stays off it.
+  edge:
+    build: .
+    entrypoint: ["/usr/lib/code-server/lib/node", "/usr/local/bin/lens-loopback-proxy.js"]
+    restart: unless-stopped
+    depends_on:
+      code-server:
+        condition: service_started
+    environment:
+      LENS_BACKEND_HOST: 172.31.255.10
+      LENS_BACKEND_PORT: "8080"
+      LENS_LOOPBACK_PORT: "8080"
+      # docker-proxy forwards the host publish to this container's eth IP, not its
+      # loopback — the forwarder must listen on all interfaces here.
+      LENS_LISTEN_HOST: 0.0.0.0
+    networks: [internal, hostpublish]
+    ports: ["127.0.0.1:8080:8080"]
+    init: true
+    user: "1000:1000"
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    read_only: true
+    pids_limit: 64
+    mem_limit: 128m
+    memswap_limit: 128m
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3", compress: "true" }
+
+  tunnel:
+    # Pinned by digest — the sole public ingress must not float on a mutable tag.
+    image: cloudflare/cloudflared:latest@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf
+    restart: unless-stopped
+    # Profile-gated: the local-only flow (`docker compose up -d --build`) must not
+    # require a Cloudflare token; the shared flow opts in explicitly
+    # (`docker compose --profile tunnel up -d`).
+    profiles: ["tunnel"]
+    command: tunnel --no-autoupdate run
+    # Only the tunnel talks to the outside world: it reaches code-server over the
+    # internal network and Cloudflare's edge over egress.
+    networks: [internal, egress]
+    environment:
+      # Empty by default so the no-profile (local) flow parses and starts without one;
+      # starting the tunnel with an empty token fails loudly in the cloudflared logs.
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:-}
+
+volumes:
+  lens_runtime:
+  lens_ext:
+
+networks:
+  internal:
+    internal: true
+    # Explicit, stable subnet: the host firewall drops INPUT from it (the documented
+    # `internal` isolation covers FORWARD but leaves host daemons — sshd on 0.0.0.0 —
+    # reachable via the gateway IP). Stability matters so the host rule survives
+    # network recreations.
+    ipam:
+      config:
+        - subnet: 172.31.255.0/24
+  egress:
+  # The non-internal bridge the loopback host publish attaches to. Only the `edge`
+  # forwarder sits on it; the workbench and serve never do.
+  hostpublish:

--- a/editors/appliance/entrypoint.sh
+++ b/editors/appliance/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Workbench entrypoint: Code-OSS only. The Lens backend runs in its OWN container
+# (serve-entrypoint.sh) so this container — the one public visitors drive — carries no
+# DB mount and no write path to the index at all.
+set -eu
+
+# code-server user data is a fresh tmpfs at every boot (see compose): recreate the
+# directory the read-only settings.json bind mounts into.
+install -d /home/coder/.local/share/code-server/User
+
+# Make the sibling `serve` container reachable at 127.0.0.1:18120: the extension's
+# discovery contract accepts loopback URLs only, so the backend appears loopback-shaped
+# from here while the DB mount stays exclusively in the serve container.
+/usr/lib/code-server/lib/node /usr/local/bin/lens-loopback-proxy.js &
+
+# PUBLIC READ-ONLY DEMO: no login gate (--auth none). The containment is structural,
+# not a password: this container has no DB mount and no outbound network, the workspace
+# and extensions dir are read-only, the default terminal shell is /bin/false, and the
+# cgroup bounds are in compose (see docker-compose.yml and settings.json).
+# --disable-proxy: kill the /proxy/<port> routes. A public session could otherwise
+# reach container-local services (the Lens API on 18120) through the workbench,
+# bypassing the backend's bearer auth; remote.autoForwardPorts stays off in the
+# pinned settings for the same reason.
+# --disable-file-downloads: the workbench file dialog can browse the whole container
+# filesystem; without this a visitor could exfiltrate browsed files through the UI's
+# download action. --disable-file-uploads closes the other direction (drag-drop a
+# runnable payload into the workspace, then debug it — F5 needs no launch.json).
+exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check \
+  --auth none --disable-proxy --disable-file-downloads --disable-file-uploads \
+  --extensions-dir /opt/lens-ext /srv/workspace

--- a/editors/appliance/loopback-proxy.js
+++ b/editors/appliance/loopback-proxy.js
@@ -1,0 +1,28 @@
+// Loopback→backend TCP forwarder for the two-container appliance.
+//
+// The Lens extension's discovery contract accepts LOOPBACK URLs only (a discovery file
+// pointing off-loopback is a hard boundary violation). The backend lives in the sibling
+// `serve` container, so this forwarder makes it appear at 127.0.0.1:18120 from the
+// workbench's view — discovery stays loopback-shaped and the extension dials it
+// happily, while the DB mount still lives exclusively in the serve container.
+const net = require('net');
+
+const targetHost = process.env.LENS_BACKEND_HOST || 'serve';
+const targetPort = Number(process.env.LENS_BACKEND_PORT || 18120);
+const listenPort = Number(process.env.LENS_LOOPBACK_PORT || 18120);
+// The workbench sidecar binds loopback (the extension dials 127.0.0.1); the `edge`
+// service binds all interfaces (docker-proxy forwards host traffic to the container IP).
+const listenHost = process.env.LENS_LISTEN_HOST || '127.0.0.1';
+
+net
+  .createServer((client) => {
+    const upstream = net.connect(targetPort, targetHost);
+    client.pipe(upstream).pipe(client);
+    const drop = () => {
+      client.destroy();
+      upstream.destroy();
+    };
+    client.on('error', drop);
+    upstream.on('error', drop);
+  })
+  .listen(listenPort, listenHost);

--- a/editors/appliance/rag-rat.toml
+++ b/editors/appliance/rag-rat.toml
@@ -1,0 +1,18 @@
+# Container-side rag-rat config. The workspace IS the rag-rat repo itself (dogfooding):
+# the host clones cq27-dev/rag-rat to /srv/rag-rat/repo and indexes + writes the DB
+# MANUALLY (`rag-rat index` on the host against this same file); the appliance only
+# serves it. Both paths are bind mounts defined in docker-compose.yml — keep them in
+# sync with it.
+#
+# Schema compatibility: the host and container rag-rat binaries must be the same release.
+# `rag-rat serve` migrates on open; if the container is newer it rewrites the DB to a
+# schema the host binary can no longer read.
+[index]
+root = "/srv/workspace"
+database = "/srv/db/rag-rat.sqlite"
+
+# Mirror the repo's own rag-rat.toml targets so the served scope matches what the host
+# indexed.
+[target_bindings]
+rust = ["crates"]
+markdown = ["docs"]

--- a/editors/appliance/serve-entrypoint.sh
+++ b/editors/appliance/serve-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Lens backend container entrypoint (#1106 two-container split): the ONLY process with
+# the DB mount. A visitor who spawns a task/debug process in the workbench container
+# has no DB to reach — the execution boundary the public demo needs.
+set -eu
+
+# Group-share created files (locks, WAL sidecars) with the host operator: the DB dir is
+# group-write setgid on the host and the container default umask 022 would stamp them
+# group-read-only.
+umask 002
+
+# Non-loopback serve REQUIRES an explicit bearer token (no loopback auto-generation).
+# Mint one per boot; serve publishes it in the discovery file the extension reads.
+RAG_RAT_LENS_TOKEN=$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')
+export RAG_RAT_LENS_TOKEN
+
+# The extension runs server-side in the WORKBENCH container and its discovery contract
+# accepts loopback URLs only — so the discovery advertises 127.0.0.1, where a tiny
+# forwarder in the workbench relays to this container over the internal network. CORS
+# allows exactly the public origin for the case the extension runs in a browser worker.
+LENS_ADVERTISE_URL="${LENS_ADVERTISE_URL:-http://127.0.0.1:18120}"
+export LENS_ADVERTISE_URL
+exec rag-rat --config /srv/config/rag-rat.toml serve \
+  --bind "$(hostname -i)" --port 18120 \
+  --token-env RAG_RAT_LENS_TOKEN \
+  --allow-origin "${LENS_PUBLIC_ORIGIN:?set LENS_PUBLIC_ORIGIN to the public https origin}" \
+  --advertise-url "$LENS_ADVERTISE_URL"

--- a/editors/appliance/settings.json
+++ b/editors/appliance/settings.json
@@ -1,0 +1,64 @@
+{
+  // The pinned settings.json itself is read-only (compose ro-bind). A visitor (or a
+  // stale browser backup from before the pin) can still open it in an editor and get a
+  // dirty buffer; with autosave on, VS Code then retries the doomed write on a schedule
+  // and toasts EROFS every startup. Autosave off: the write only fails if someone
+  // explicitly saves — the honest signal, without the loop.
+  "files.autoSave": "off",
+  // Hot exit is what restores a dirty settings.json buffer (and reopens the file) on
+  // every reload even with autosave off. Off: dirty buffers are discarded on close,
+  // nothing is restored, no doomed write is retried.
+  "files.hotExit": "off",
+  // Public read-only demo hardening. The workspace is mounted read-only; these make the
+  // integrated terminal and task runner dead ends too (a public code-server otherwise
+  // hands out code execution to anyone). A defaultProfile pointing at /bin/false does
+  // NOT work (it names a profile, not a shell) — the profiles themselves must die.
+  "terminal.integrated.profiles.linux": {
+    // VS Code AUTODETECTS installed shells (bash, sh, zsh, dash, fish…) and lists them
+    // in the new-terminal dropdown — pinning only the default leaves them selectable.
+    // Null every autodetected profile and keep only the dead one.
+    "sh-false": { "path": "/bin/false" },
+    "bash": null,
+    "sh": null,
+    "zsh": null,
+    "dash": null,
+    "fish": null,
+    "pwsh": null,
+    "rbash": null
+  },
+  "terminal.integrated.defaultProfile.linux": "sh-false",
+  "terminal.integrated.automationProfile.linux": { "path": "/bin/false" },
+  "terminal.integrated.hideOnStartup": "always",
+  // Manual Run Task stays possible regardless (there is no tasks.enabled upstream), but
+  // auto-detection of npm/grunt/gulp/jake scripts is pure surface with no demo value.
+  "task.autoDetect": "off",
+  "npm.autoDetect": "off",
+  "grunt.autoDetect": "off",
+  "gulp.autoDetect": "off",
+  "jake.autoDetect": "off",
+  // No port forwarding: the Ports panel must not auto-forward, and code-server itself
+  // is started with --disable-proxy — a public session must not reach container-local
+  // services (the Lens backend) through the workbench's proxy routes.
+  "remote.autoForwardPorts": false,
+  "remote.autoForwardPortsSource": "process",
+  "task.allowAutomaticTasks": "off",
+  "task.verboseLogging": false,
+  "debug.openDebug": "neverOpen",
+  // String enum in current VS Code — a deprecated boolean here makes VS Code's settings
+  // migration rewrite the file on startup, which both fails (the file is a read-only
+  // bind) and auto-opens it. This value is what the migration would write anyway.
+  "extensions.autoUpdate": "off",
+  "extensions.autoCheckUpdates": false,
+  "update.mode": "none",
+  // No AI provider exists here (no egress, no marketplace): hide the chat/agent
+  // sidebar, inline chat, and "sign in to use AI" prompts instead of teasing a
+  // feature that cannot work.
+  "chat.disableAIFeatures": true,
+  // Single-pane demo layout: no secondary (right) sidebar — the Lens views live in the
+  // primary activity-bar sidebar.
+  "workbench.secondarySideBar.defaultVisibility": "hidden",
+  "telemetry.telemetryLevel": "off",
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "security.workspace.trust.enabled": false
+}

--- a/editors/appliance/stage-artifacts.sh
+++ b/editors/appliance/stage-artifacts.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Stage CI-built artifacts into the build context (used by the deploy workflow and by
+# hand for local image builds).
+set -eu
+here=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+root=$(CDPATH='' cd -- "$here/../.." && pwd)
+
+mkdir -p "$here/artifacts"
+cp "$root/target/dist/rag-rat" "$here/artifacts/rag-rat"
+vsix=$(ls -t "$root"/editors/vscode/rag-rat-lens*.vsix | head -1)
+cp "$vsix" "$here/artifacts/rag-rat-lens.vsix"
+echo "staged: artifacts/rag-rat, artifacts/rag-rat-lens.vsix (from $vsix)"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -179,6 +179,12 @@
           "default": 100,
           "minimum": 0,
           "description": "Hide clone classes whose medoid body is smaller than this many tokens. ~100 keeps only actionable (refactor-worthy) duplication; enum matchers and trivial accessors sit at 28-86. 0 shows everything."
+        },
+        "rag-rat-lens.demoFile": {
+          "type": "string",
+          "default": "",
+          "scope": "machine-overridable",
+          "description": "Optional repo-relative file opened once per browser session on startup (public demo onboarding: land visitors on memory-dense code). Empty disables."
         }
       }
     }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -526,6 +526,24 @@ export function activate(context: vscode.ExtensionContext): void {
     logInfo(ok ? 'lens server connected' : 'lens server offline at startup')
   );
   void watchVersions(streamController.signal);
+
+  // Public-demo onboarding: open a configured showcase file once per browser session, so
+  // a first-time visitor lands on memory-dense code with the overlays already drawn.
+  // Empty default keeps ordinary installs inert. workspaceState is per-browser-session
+  // (the appliance's user data is ephemeral), so it fires once per session, not per boot.
+  const demoFile = config.get<string>('demoFile', '').trim();
+  if (demoFile && isSafeRepoPath(demoFile) && !context.workspaceState.get('demoFileShown')) {
+    void context.workspaceState.update('demoFileShown', true);
+    const uri = resolver.uriOf(demoFile);
+    if (uri) {
+      void vscode.workspace
+        .openTextDocument(uri)
+        .then((doc) => vscode.window.showTextDocument(doc, { preview: true, preserveFocus: true }));
+      // Land with the Lens view open, not just the file: reveal the sidebar's Memories
+      // view (the onboarding's whole point is the bound-memory overlays).
+      void vscode.commands.executeCommand('rag-rat-lens.memories.focus');
+    }
+  }
 }
 
 export function deactivate(): void {}

--- a/editors/vscode/src/hover.ts
+++ b/editors/vscode/src/hover.ts
@@ -25,7 +25,9 @@ export class GraphHoverProvider implements vscode.HoverProvider {
     const md = new vscode.MarkdownString('', true);
     md.isTrusted = { enabledCommands: ['rag-rat-lens.showCallers'] };
     const parts = [
-      `**${escapeMarkdown(s.kind)}** \`${escapeMarkdown(s.name)}\``,
+      // The name goes in a code span UNESCAPED: backslash escapes are not processed inside
+      // code spans, so escaping here renders literal `\_` before every underscore.
+      `**${escapeMarkdown(s.kind)}** ${codeSpan(s.name)}`,
       s.fan_in_bucket !== 'low' ? `**⚑ ${s.fan_in_bucket} load** (fan-in ${s.fan_in_score})` : null,
       total > 0
         ? `⤴ ${total} callers — ${[
@@ -66,4 +68,10 @@ export class GraphHoverProvider implements vscode.HoverProvider {
 
 function escapeMarkdown(value: string): string {
   return value.replace(/[\\`*_{}[\]()<>#+\-.!|]/g, '\\$&');
+}
+
+/// Raw code span for identifier text: no escaping (code spans render literally); a name
+/// containing a backtick gets a double-backtick fence instead.
+function codeSpan(value: string): string {
+  return value.includes('`') ? `\`\` ${value} \`\`` : `\`${value}\``;
 }

--- a/editors/vscode/src/memories.ts
+++ b/editors/vscode/src/memories.ts
@@ -75,8 +75,9 @@ export async function showMemoriesQuickPick(
     void vscode.window.showInformationMessage(MEMORY_PICK_MESSAGES[outcome.kind]);
     return;
   }
-  const doc = await vscode.workspace.openTextDocument(outcome.uri);
-  await vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, true);
+  // Rendered markdown, not the raw source: the doc is markdown-shaped (`.md` suffix on
+  // the custom scheme), so the built-in preview resolves it through the same provider.
+  await vscode.commands.executeCommand('markdown.showPreviewToSide', outcome.uri);
 }
 
 function renderMemoryDoc(m: FileMemory): string {

--- a/editors/vscode/test/client.test.cjs
+++ b/editors/vscode/test/client.test.cjs
@@ -2346,6 +2346,9 @@ test('the memory picker routes through the revalidating open, not the captured o
     Range: class {},
     CodeLens: class {},
     ViewColumn: { Beside: 2 },
+    commands: {
+      executeCommand: async (name, uri) => shown.push([name, uri]),
+    },
     window: {
       showQuickPick: async (items) => items[0],
       showTextDocument: async (doc) => shown.push(doc),
@@ -2371,7 +2374,8 @@ test('the memory picker routes through the revalidating open, not the captured o
   await showMemoriesQuickPick([captured], 'src/lib.rs', documents);
   assert.deepEqual(calls.openPicked, [['mem-1', 'src/lib.rs']], 'the pick must be re-read by id');
   assert.deepEqual(calls.update, [], 'the captured object must never be rendered directly');
-  assert.equal(shown.length, 1);
+  assert.deepEqual(shown, [['markdown.showPreviewToSide', 'rag-rat-memory:/mem-1.md']],
+    'the memory opens as a rendered markdown preview, not the raw source');
 
   // A memory deleted while the picker was open is reported, not opened — and now sayable as a
   // removal, because only a lane that answered can produce this outcome.


### PR DESCRIPTION
Part of #1106 (packaging slice; the Rust launcher that fetches/starts the distribution is the remaining slice).

## What this adds

`editors/appliance/` — a turnkey, publicly shareable **read-only** browser appliance around the same Lens extension and HTTP backend: unmodified **code-server (Code-OSS, digest-pinned)** with the **published Lens vsix** installed at image build (byte-identical artifact), plus `.github/workflows/deploy-appliance.yml` for CI deploy to the production host.

## Architecture (four containers, one untrusted)

- **workbench** (code-server, **gVisor/runsc**) — the container public visitors drive. No login gate; containment is structural: **no DB mount, no outbound network**, read-only workspace + extensions dir, terminal/task/debug shells pinned to `/bin/false`, no file downloads/uploads, no proxy/port-forwarding, immutable settings (ro bind), stateless tmpfs user-data, cgroup bounds (pids 256 / mem 2g+0 swap / cpus 1.5 / nofile 8k), cap_drop ALL, no-new-privileges, ro rootfs, log rotation.
- **serve** (`rag-rat serve`, runc) — the only container with the host DB mount (group-shared, world-nothing). Docker-supervised; mints a per-boot bearer token and publishes discovery with `--advertise-url`.
- **edge** — tiny TCP forwarder holding the loopback host publish for the local flow (Docker won't program publishes on an `internal` network).
- **tunnel** (cloudflared, digest-pinned, profile-gated) — the only egress; TLS + DNS at Cloudflare's edge, no A record to the host IP. Local flow needs no token: `docker compose up -d --build`; shared: `docker compose --profile tunnel up -d`.

The extension's loopback-only discovery contract is preserved by a small forwarder inside the workbench (`127.0.0.1:18120` → serve over the internal network).

## Product changes riding along

- `rag-rat serve --advertise-url`: publishes the Lens discovery file with a reachable URL on non-loopback binds (previously none), with a regression test.
- Lens extension: memory opens as a rendered markdown preview; hover no longer escapes identifiers inside code spans; opt-in `demoFile` startup onboarding (default off).

## CI deploy

Builds the dist binary + vsix, rsyncs the appliance (host `.env` excluded), **stops both container writers**, pins the host clone to the deployed SHA, reindexes the DB from the host checkout, rebuilds and restarts (`--profile tunnel`). Host/IP/host-key only in the `appliance-prod` environment secrets; workflow token scoped to `contents: read`; triggers include the root Cargo.toml.

## Verified on the production host

Workbench healthy without a login at https://rag-rat-demo.cq27.dev; Lens API enforcing bearer auth and serving graph callers/callees + memories against the host-pinned index; dead terminal; no egress from the workbench (gVisor runtime); host gateway (sshd) unreachable from containers (explicit subnet + INPUT drop); extension auto-discovers via loopback; settings immutable (VS Code migration has nothing to rewrite); local loopback listener answers; tunnel registered.