### PR TITLE
ci(lens): rebuild the clone graph on every appliance deploy

### DIFF
--- a/.github/workflows/deploy-appliance.yml
+++ b/.github/workflows/deploy-appliance.yml
@@ -89,6 +89,10 @@ jobs:
             # with the container-only /srv/workspace and /srv/db instead.
             cd /srv/rag-rat/repo
             "$HOME/.local/bin/rag-rat" index
+            # The clone lane is a separate derived artifact: a plain index leaves the
+            # precomputed clone graph stamped against the old source revision, and the
+            # Clone Classes view serves stale data until it is rebuilt.
+            "$HOME/.local/bin/rag-rat" clones --precompute
           DEPLOY
 
       - name: Rebuild and restart


### PR DESCRIPTION
A plain `rag-rat index` leaves the precomputed clone graph stamped against the old source revision — the Clone Classes lane in the appliance served stale data after the first CI deploy. Run `rag-rat clones --precompute` in the same deploy step, before the restart.

Verified manually on the production host: after precompute, `/api/treemap` and the clone lane serve the current generation.