### PR TITLE
chore: release v0.23.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.22.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.23.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "rag-rat",
       "source": "plugin",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "homepage": "https://github.com/cq27-dev/rag-rat",
       "repository": "https://github.com/cq27-dev/rag-rat",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16
+
+### Added
+
+- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))
+
+### Fixed
+
+- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
+
 ## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-08-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4963,7 +4963,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-base"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "dunce",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-clones"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5110,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-db"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-dream"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-llm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oplog"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oracle"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "protobuf",
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-papertrail"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-query"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-sync"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -38,18 +38,18 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-base = { version = "0.22.0", path = "crates/rag-rat-base", default-features = false }
-rag-rat-clones = { version = "0.22.0", path = "crates/rag-rat-clones", default-features = false }
-rag-rat-db = { version = "0.22.0", path = "crates/rag-rat-db", default-features = false }
-rag-rat-dream = { version = "0.22.0", path = "crates/rag-rat-dream", default-features = false }
-rag-rat-llm = { version = "0.22.0", path = "crates/rag-rat-llm", default-features = false }
-rag-rat-oracle = { version = "0.22.0", path = "crates/rag-rat-oracle", default-features = false }
-rag-rat-oplog = { version = "0.22.0", path = "crates/rag-rat-oplog", default-features = false }
-rag-rat-papertrail = { version = "0.22.0", path = "crates/rag-rat-papertrail", default-features = false }
-rag-rat-query = { version = "0.22.0", path = "crates/rag-rat-query", default-features = false }
-rag-rat-core = { version = "0.22.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.22.0", path = "crates/rag-rat-mcp", default-features = false }
-rag-rat-sync = { version = "0.22.0", path = "crates/rag-rat-sync", default-features = false }
+rag-rat-base = { version = "0.23.0", path = "crates/rag-rat-base", default-features = false }
+rag-rat-clones = { version = "0.23.0", path = "crates/rag-rat-clones", default-features = false }
+rag-rat-db = { version = "0.23.0", path = "crates/rag-rat-db", default-features = false }
+rag-rat-dream = { version = "0.23.0", path = "crates/rag-rat-dream", default-features = false }
+rag-rat-llm = { version = "0.23.0", path = "crates/rag-rat-llm", default-features = false }
+rag-rat-oracle = { version = "0.23.0", path = "crates/rag-rat-oracle", default-features = false }
+rag-rat-oplog = { version = "0.23.0", path = "crates/rag-rat-oplog", default-features = false }
+rag-rat-papertrail = { version = "0.23.0", path = "crates/rag-rat-papertrail", default-features = false }
+rag-rat-query = { version = "0.23.0", path = "crates/rag-rat-query", default-features = false }
+rag-rat-core = { version = "0.23.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.23.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-sync = { version = "0.23.0", path = "crates/rag-rat-sync", default-features = false }
 anyhow = "1.0"
 axum = "0.8"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.22.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.23.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.22.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.23.0", "mcp"]
     }
   }
 }

--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/plugin-opencode",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
   "license": "MIT",
   "type": "module",

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -3,7 +3,7 @@
 // opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
 // additionalContext channel on tool.execute.before), so this module is a thin shim over the same
 // shared pieces the other harnesses use:
-//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.22.0<version> mcp` (pinned; kept
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.23.0<version> mcp` (pinned; kept
 //     in lockstep with the release by tools/sync-plugin-version.mjs).
 //   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
 //     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
@@ -35,7 +35,7 @@ const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
 
 // Single source of truth for the version: the pinned npm package (kept in lockstep with the
 // release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
-const MCP_PACKAGE = "@rag-rat/bin@0.22.0";
+const MCP_PACKAGE = "@rag-rat/bin@0.23.0";
 const VERSION = MCP_PACKAGE.split("@").pop()!;
 
 const TOOL_TIMEOUT_MS = 10_000;

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.22.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.23.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cq27-dev/rag-rat",
   "title": "rag-rat",
   "description": "Repository intelligence, code graph, history, papertrail, and cross-agent memory for coding agents.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "websiteUrl": "https://rag-rat.cq27.dev/",
   "repository": {
     "url": "https://github.com/cq27-dev/rag-rat",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@rag-rat/bin",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-base`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-db`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-clones`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-llm`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-papertrail`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-query`: 0.22.0 -> 0.23.0 (⚠ API breaking changes)
* `rag-rat-dream`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-oplog`: 0.22.0 -> 0.23.0 (⚠ API breaking changes)
* `rag-rat-oracle`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-sync`: 0.22.0 -> 0.23.0 (⚠ API breaking changes)
* `rag-rat-core`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat-mcp`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `rag-rat`: 0.22.0 -> 0.23.0

### ⚠ `rag-rat-query` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EvidencePack.has_live_binding in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-query/src/memory/evidence.rs:151
```

### ⚠ `rag-rat-oplog` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TableSyncChainHead.floor in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-oplog/src/table_sync/transport.rs:45

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_oplog::table_sync_ingest now takes 7 parameters instead of 6, in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-oplog/src/table_sync/transport.rs:383
```

### ⚠ `rag-rat-sync` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SessionReport.peer_capability in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/session.rs:116
  field SessionReport.peer_capability in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/session.rs:116
  field ChainHead.floor in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/table_wire.rs:78
  field ChainHead.floor in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/table_wire.rs:78
  field ReconcileReport.peer_capability in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/endpoint.rs:540
  field ReconcileReport.peer_capability in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/endpoint.rs:540

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthPolicy:PublicRead in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/auth.rs:71
  variant AuthPolicy:PublicRead in /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/auth.rs:71

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AuthPolicy::InviteToken, previously in file /tmp/.tmpxSyOO7/rag-rat-sync/src/auth.rs:57
  variant AuthPolicy::InviteToken, previously in file /tmp/.tmpxSyOO7/rag-rat-sync/src/auth.rs:57

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method rag_rat_sync::session::SyncStore::set_serve_scope in file /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/session.rs:83
  trait method rag_rat_sync::SyncStore::set_serve_scope in file /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/session.rs:83

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  TableSyncStore::ingest now takes 4 instead of 3 parameters, in file /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/table_session.rs:41
  TableSyncStore::ingest now takes 4 instead of 3 parameters, in file /tmp/.tmpXXNoPL/rag-rat/crates/rag-rat-sync/src/table_session.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-base`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-db`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-clones`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-llm`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-papertrail`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-query`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-dream`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-oplog`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-oracle`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-sync`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-core`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>

## `rag-rat`

<blockquote>

## [0.23.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.22.0...rag-rat-base-v0.23.0) - 2026-08-16

### Added

- *(sync)* sync devices through active MCP ([#1114](https://github.com/cq27-dev/rag-rat/pull/1114))

### Fixed

- *(index)* match target include/exclude patterns as globs ([#1072](https://github.com/cq27-dev/rag-rat/pull/1072)) ([#1118](https://github.com/cq27-dev/rag-rat/pull/1118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).