### PR TITLE
config: replace hand-rolled target glob matching with globset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4972,6 +4972,7 @@ dependencies = [
  "dunce",
  "filetime",
  "gix",
+ "globset",
  "libc",
  "minicbor",
  "path-slash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,10 @@ futures-util = { version = "0.3", default-features = false, features = ["alloc"]
 # `rand`/`rand_core` pulled in for this), keeping `from_seed` the sole key constructor.
 getrandom = "0.4"
 gix = { version = "0.86.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
+# The glob matcher behind a target's include/exclude patterns. Already compiled on every build as
+# `ignore`'s own matching layer (the same one ripgrep uses), so depending on it directly adds
+# nothing to the lock file, the audit gate or the deny gate.
+globset = "0.4.19"
 httpdate = "1.0"
 libc = "0.2"
 # Win32 bindings for the Lens discovery credential's owner-only DACL. Unix keeps the token private

--- a/crates/rag-rat-base/Cargo.toml
+++ b/crates/rag-rat-base/Cargo.toml
@@ -17,6 +17,7 @@ unicode-normalization.workspace = true
 anyhow.workspace = true
 dunce.workspace = true
 gix.workspace = true
+globset.workspace = true
 libc.workspace = true
 path-slash.workspace = true
 serde.workspace = true

--- a/crates/rag-rat-base/src/config/globs.rs
+++ b/crates/rag-rat-base/src/config/globs.rs
@@ -1,0 +1,148 @@
+//! The glob matcher behind a target's `include` / `exclude` patterns.
+//!
+//! **Real globs, via [`globset`].** This used to be a hand-written cascade over three shapes — a
+//! `**/*.ext` suffix, a `dir/**` subtree, and a literal — whose last line fell through to
+//! `path.contains(pattern.trim_matches('*'))`. Substring containment is not glob matching: `*.rs`
+//! became `contains(".rs")` and claimed `notes.rs.bak` and `src/lib.rs.orig`, and `*` (which trims
+//! to the empty string, contained by every path) claimed the whole tree. Those are wrong answers
+//! about which files are indexed, and they fail silently. [`globset`] is `ignore`'s own matching
+//! layer — already compiled on every build, and the matcher ripgrep uses for this exact job — so
+//! `**`, `*`, `?`, `[…]` and `{…}` now mean what a glob says they mean.
+//!
+//! Three options are pinned explicitly rather than taken from the defaults, because each default is
+//! wrong for a repo-relative config pattern:
+//!
+//! 1. **`literal_separator(true)`.** `globset` defaults it to *false*, where `*` and `?` match `/`
+//!    as well — so `src/*.rs` would claim `src/a/b/deep.rs`. A config pattern names path
+//!    components, so a wildcard must stop at a separator; only `**` crosses one.
+//! 2. **`backslash_escape(true)`.** `globset` defaults this to `!is_separator('\\')` — *true* on
+//!    Unix, *false* on Windows. Left unpinned, one `rag-rat.toml` would claim different files on
+//!    different platforms. Pinned on, `\` escapes the next character everywhere, so a pattern
+//!    reaches a Unix file whose NAME contains a backslash by spelling it `\\`.
+//! 3. **The candidate is built from the rendered BYTES**, never re-derived through a [`Path`]. The
+//!    caller already holds the `/`-separated rendering `files.path` is stored with
+//!    ([`crate::paths::path_string`]); round-tripping it through `Path` would re-run
+//!    platform-specific separator handling over a string that is already canonical.
+//!
+//! One shape is normalized before compiling rather than pinned as an option: a trailing `/` names a
+//! subtree, so `src/` compiles as `src/**` (see [`compile`]).
+//!
+//! [`Path`]: std::path::Path
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
+
+use globset::{Candidate, GlobBuilder, GlobMatcher};
+
+/// Compiled matchers keyed by the pattern text, so a pattern is turned into a regex once per
+/// process instead of once per file.
+///
+/// [`super::ResolvedTarget::globs_claim`] is the per-file gate of the indexing walk and is also
+/// asked once per path (across every target) by the incremental resolver, so pattern compilation
+/// must not sit on that path. The pattern set is bounded by the config file, so the map needs no
+/// eviction. A pattern that fails to compile is memoized as [`None`] — the compile error is
+/// reported once, not once per file.
+static COMPILED: LazyLock<RwLock<HashMap<String, Option<GlobMatcher>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Whether one config glob claims `path`, a `/`-separated repo-relative rendering.
+///
+/// A pattern that is not a legal glob (an unclosed `[`, a dangling `\`) claims NOTHING and is
+/// reported once. Config load does not reject such a pattern today, so the matcher has to answer
+/// something; claiming nothing keeps a typo from silently widening an `include`.
+pub(crate) fn pattern_claims(path: &str, pattern: &str) -> bool {
+    let candidate = Candidate::from_bytes(path.as_bytes());
+    let cached = COMPILED.read().ok().and_then(|compiled| {
+        compiled
+            .get(pattern)
+            .map(|matcher| matcher.as_ref().is_some_and(|m| m.is_match_candidate(&candidate)))
+    });
+    if let Some(claims) = cached {
+        return claims;
+    }
+    let matcher = compile(pattern);
+    let claims = matcher.as_ref().is_some_and(|m| m.is_match_candidate(&candidate));
+    if let Ok(mut compiled) = COMPILED.write() {
+        compiled.entry(pattern.to_string()).or_insert(matcher);
+    }
+    claims
+}
+
+/// Compile one pattern, or [`None`] (plus a warning) when it is not a legal glob.
+///
+/// A trailing `/` names a ROOT-ANCHORED SUBTREE, so `src/` compiles as `src/**`. As a bare glob it
+/// would name a single path ending in a separator and claim nothing at all — and a target whose
+/// `include` silently claims nothing indexes zero files, a worse and quieter failure than the
+/// over-claiming this replacement removes. This is rag-rat's own target dialect: close to but not
+/// identical to gitignore's trailing slash, which matches unanchored (a `src/` there would also
+/// match `a/src/`). Here `src/` is the ROOT `src/`, matching what the old substring fallback got
+/// *approximately* right — it matched `src/` by containment, but also claimed `a/src/lib.rs`.
+/// Normalizing to `src/**` keeps the intent and adds the anchor the fallback lacked.
+fn compile(pattern: &str) -> Option<GlobMatcher> {
+    let subtree = pattern.strip_suffix('/').map(|dir| format!("{dir}/**"));
+    let pattern = subtree.as_deref().unwrap_or(pattern);
+    match GlobBuilder::new(pattern).literal_separator(true).backslash_escape(true).build() {
+        Ok(glob) => Some(glob.compile_matcher()),
+        Err(error) => {
+            tracing::warn!(
+                pattern,
+                %error,
+                "target include/exclude pattern is not a valid glob; it claims no files",
+            );
+            None
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wildcard_does_not_cross_a_separator() {
+        // `literal_separator` is OFF by default in globset, which would make `*` match `/`.
+        assert!(pattern_claims("src/lib.rs", "src/*.rs"));
+        assert!(!pattern_claims("src/a/deep.rs", "src/*.rs"));
+        assert!(pattern_claims("src/a/deep.rs", "src/**/*.rs"));
+    }
+
+    #[test]
+    fn a_backslash_escape_is_pinned_on_every_platform() {
+        // globset's default here is platform-dependent (`!is_separator('\\')`), so one config would
+        // otherwise claim different files on Unix and Windows. Pinned ON: `\\` is one literal `\`.
+        assert!(pattern_claims("drafts\\secret.md", "drafts\\\\secret.md"));
+        assert!(!pattern_claims("drafts/secret.md", "drafts\\\\secret.md"));
+    }
+
+    #[test]
+    fn a_trailing_slash_names_the_subtree_and_anchors_it() {
+        assert!(pattern_claims("src/lib.rs", "src/"));
+        assert!(pattern_claims("src/a/b/deep.rs", "src/"));
+        // The anchor the substring fallback lacked: `src/` is the ROOT `src/`, not any `src/`.
+        assert!(!pattern_claims("a/src/lib.rs", "src/"));
+        assert!(!pattern_claims("srcx/lib.rs", "src/"));
+        // …and the directory itself is not one of its own children.
+        assert!(!pattern_claims("src", "src/"));
+    }
+
+    #[test]
+    fn an_illegal_glob_claims_nothing_instead_of_everything() {
+        // A dangling escape is a compile error; the matcher must not fall back to "matches all".
+        assert!(!pattern_claims("src/lib.rs", "src/lib.rs\\"));
+        // The memoized failure answers the same way on the second call.
+        assert!(!pattern_claims("src/lib.rs", "src/lib.rs\\"));
+    }
+
+    #[test]
+    fn a_compiled_pattern_is_reused_across_calls() {
+        // Second call must come off the memo and agree with the first — the property the per-file
+        // hot path depends on.
+        let pattern = "**/*.reused-in-a-test";
+        assert!(pattern_claims("a/b.reused-in-a-test", pattern));
+        assert!(pattern_claims("a/b.reused-in-a-test", pattern));
+        assert!(
+            COMPILED.read().expect("cache lock").contains_key(pattern),
+            "the pattern must be compiled once and memoized",
+        );
+    }
+}

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use crate::language::LanguageError;
 
 mod discovery;
+mod globs;
 mod load;
 mod raw;
 mod types;

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -3359,3 +3359,113 @@ fn a_directory_include_glob_does_not_claim_a_backslash_named_sibling() {
     assert!(!target.globs_claim("foo\\bar.rs"), "a file NAMED `foo\\bar.rs` is not under foo/");
     assert!(!target.globs_claim("foobar.rs"), "a prefix of the NAME is not a directory boundary");
 }
+
+/// A target carrying exactly the given patterns; the language/kind are irrelevant to
+/// [`ResolvedTarget::globs_claim`], which reads only `include` and `exclude`.
+fn glob_target(include: &[&str], exclude: &[&str]) -> ResolvedTarget {
+    ResolvedTarget {
+        name: "globs".to_string(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from(".")],
+        include: include.iter().map(|pattern| (*pattern).to_string()).collect(),
+        exclude: exclude.iter().map(|pattern| (*pattern).to_string()).collect(),
+        kind: TargetKind::Source,
+    }
+}
+
+/// A `*` is a WILDCARD over one path component, not a substring probe. The matcher used to fall
+/// through to `path.contains(pattern.trim_matches('*'))`, so `*.rs` asked only whether `.rs`
+/// appeared anywhere in the path — claiming a backup (`notes.rs.bak`) and a conflict leftover
+/// (`src/lib.rs.orig`) as Rust sources, and a wrong answer about what gets indexed.
+#[test]
+fn a_star_glob_matches_a_name_instead_of_containing_a_substring() {
+    let target = glob_target(&["*.rs"], &[]);
+
+    assert!(target.globs_claim("lib.rs"), "a root-level `.rs` file is claimed");
+    assert!(!target.globs_claim("notes.rs.bak"), "`.rs` inside the NAME is not a `.rs` file");
+    assert!(!target.globs_claim("src/lib.rs.orig"), "nor is a conflict leftover");
+    // A single `*` stops at a separator, so an unanchored `*.rs` is root-level only. `**/*.rs` (the
+    // shipped default) is the pattern that reaches every depth.
+    assert!(!target.globs_claim("src/lib.rs"), "one `*` does not cross a separator");
+    assert!(glob_target(&["**/*.rs"], &[]).globs_claim("src/lib.rs"), "`**/` does");
+}
+
+/// The same fallthrough made a bare `*` claim the entire tree: `"*".trim_matches('*')` is the empty
+/// string, and every path contains it. `*` is one component's worth of wildcard.
+#[test]
+fn a_bare_star_claims_one_component_not_the_whole_tree() {
+    let target = glob_target(&["*"], &[]);
+
+    assert!(target.globs_claim("README.md"), "a root-level file is claimed");
+    assert!(!target.globs_claim("src/lib.rs"), "a nested file is not");
+    assert!(!target.globs_claim("docs/deep/guide.md"), "nor a deeper one");
+    assert!(glob_target(&["**"], &[]).globs_claim("docs/deep/guide.md"), "`**` is the tree");
+}
+
+/// A pattern with no wildcard names a PATH, not a substring of one — on both sides. The old
+/// fallthrough let a literal claim any path it appeared inside, so an `exclude` of `vendor` also
+/// excluded `x/vendor/dep.rs` while an `include` of `src/lib.rs` also claimed `src/lib.rs.orig`.
+#[test]
+fn a_literal_pattern_names_a_path_not_a_substring_of_one() {
+    let include = glob_target(&["src/lib.rs", "README.md"], &[]);
+    assert!(include.globs_claim("src/lib.rs"), "the literal path itself is claimed");
+    assert!(!include.globs_claim("src/lib.rs.orig"), "a longer name is not that path");
+    assert!(!include.globs_claim("a/src/lib.rs"), "nor is the same tail deeper in the tree");
+    assert!(include.globs_claim("README.md"), "a root-level literal is claimed");
+    assert!(!include.globs_claim("docs/README.md"), "a same-named file elsewhere is not");
+
+    let exclude = glob_target(&["**/*.rs"], &["vendor"]);
+    assert!(
+        exclude.globs_claim("vendor/dep.rs"),
+        "`vendor` excludes the FILE `vendor`, not a tree"
+    );
+    assert!(exclude.globs_claim("x/vendor/dep.rs"), "and certainly not one nested elsewhere");
+    assert!(
+        !glob_target(&["**/*.rs"], &["vendor/**"]).globs_claim("vendor/dep.rs"),
+        "`vendor/**` is how a subtree is excluded",
+    );
+}
+
+/// The vocabulary is now real glob syntax, not the three hand-recognized shapes. Character classes,
+/// alternates, `?`, and a `**` in the MIDDLE of a pattern all used to fall through to substring
+/// containment over the pattern with its outer `*`s trimmed.
+#[test]
+fn the_full_glob_vocabulary_is_available() {
+    assert!(glob_target(&["**/*.[ch]"], &[]).globs_claim("include/lib.h"), "character class");
+    assert!(!glob_target(&["**/*.[ch]"], &[]).globs_claim("include/lib.hpp"), "and it is bounded");
+    assert!(glob_target(&["{lib,main}.rs"], &[]).globs_claim("main.rs"), "alternates");
+    assert!(!glob_target(&["{lib,main}.rs"], &[]).globs_claim("other.rs"), "and they are bounded");
+    assert!(glob_target(&["a?c.rs"], &[]).globs_claim("abc.rs"), "single-character wildcard");
+    assert!(!glob_target(&["a?c.rs"], &[]).globs_claim("ac.rs"), "which matches exactly one");
+    assert!(glob_target(&["src/**/*.rs"], &[]).globs_claim("src/a/b/deep.rs"), "interior `**`");
+    assert!(glob_target(&["src/**/*.rs"], &[]).globs_claim("src/lib.rs"), "which spans zero dirs");
+    assert!(
+        !glob_target(&["**/*.rs"], &["**/generated/**"]).globs_claim("src/generated/api.rs"),
+        "an interior `**` on the exclude side excludes a generated subtree at any depth",
+    );
+}
+
+/// Every shipped default is a `**/*.ext` suffix ([`Language::default_include_globs`]), the one
+/// shape the old cascade got right. Replacing the matcher must not move a single one of them.
+#[test]
+fn the_shipped_default_globs_claim_exactly_what_they_did() {
+    let target = glob_target(&["**/*.rs"], &[]);
+
+    for claimed in ["lib.rs", "src/lib.rs", "src/a/b/deep.rs", "foo\\bar.rs", ".rs"] {
+        assert!(target.globs_claim(claimed), "`**/*.rs` claims {claimed}");
+    }
+    for unclaimed in ["lib.h", "notes.rs.bak", "src/lib.rs.orig", "my.rs.template"] {
+        assert!(!target.globs_claim(unclaimed), "`**/*.rs` does not claim {unclaimed}");
+    }
+}
+
+/// Config load does not reject a malformed pattern, so the matcher has to answer something for one.
+/// It claims NOTHING: a typo that silently widened an `include` to the whole tree, or narrowed an
+/// `exclude` away, is the failure this whole function exists to stop.
+#[test]
+fn a_pattern_that_is_not_a_legal_glob_claims_nothing() {
+    // A dangling escape — `\` with nothing after it — is a globset compile error.
+    assert!(!glob_target(&["src/lib.rs\\"], &[]).globs_claim("src/lib.rs"));
+    // On the exclude side an uncompilable pattern excludes nothing, so the include still stands.
+    assert!(glob_target(&["**/*.rs"], &["oops\\"]).globs_claim("src/lib.rs"));
+}

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use super::ConfigError;
+use super::{ConfigError, globs};
 use crate::embedding_models::{
     Backend, EmbeddingModelSpec, FASTEMBED_MODEL_ID, MODEL2VEC_MODEL_ID, spec,
 };
@@ -1101,30 +1101,21 @@ impl ResolvedTarget {
     ///
     /// The single definition of that matching, deliberately: the walk decides what to index and
     /// the per-path resolver decides what an already-known path belongs to, and a second copy of
-    /// the rules lets those two answers drift.
+    /// the rules lets those two answers drift. The patterns are real globs, matched by
+    /// [`globs::pattern_claims`] — the only place a target pattern is interpreted, and the only
+    /// place the glob dialect (see that module for the three pinned `globset` options) is decided.
+    ///
+    /// The boundary a `dir/**` prefix needs — it claims what is INSIDE `dir/`, so it must end at a
+    /// separator, never at a prefix of a NAME (`drafts/**` is not `draftsman.md`, and not the Unix
+    /// file named `drafts\secret.md`) — is now correct by construction: `globset` compiles a
+    /// trailing `/**` to a regex that requires the separator, and `*` cannot cross one at all.
+    /// Pinned by `a_directory_glob_needs_a_separator_after_its_prefix` and
+    /// `a_directory_include_glob_does_not_claim_a_backslash_named_sibling`, not by a hand-written
+    /// prefix check.
     pub fn globs_claim(&self, relative_path: &str) -> bool {
-        !self.exclude.iter().any(|pattern| glob_claims(relative_path, pattern))
-            && self.include.iter().any(|pattern| glob_claims(relative_path, pattern))
+        !self.exclude.iter().any(|pattern| globs::pattern_claims(relative_path, pattern))
+            && self.include.iter().any(|pattern| globs::pattern_claims(relative_path, pattern))
     }
-}
-
-/// Whether one config glob claims `path` (a `/`-separated repo-relative rendering). Three shapes:
-/// a `**/*.ext` suffix, a `dir/**` subtree, and a literal (exact or substring).
-///
-/// A `dir/**` subtree requires the prefix to END AT A SEPARATOR. A bare `starts_with` reads a
-/// PREFIX OF A NAME as a directory boundary, so `drafts/**` also claimed the Unix file
-/// `drafts\secret.md` (and `draftsman.md`), excluding a file that is not in `drafts/` at all —
-/// which is exactly what preserving a literal backslash in the rendering exists to prevent.
-fn glob_claims(path: &str, pattern: &str) -> bool {
-    if let Some(extension) = pattern.strip_prefix("**/*.") {
-        return path.ends_with(&format!(".{extension}"));
-    }
-    if let Some(prefix) = pattern.strip_suffix("/**") {
-        return path
-            .strip_prefix(prefix)
-            .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'));
-    }
-    path == pattern || path.contains(pattern.trim_matches('*'))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -470,6 +470,42 @@ mod worktree_scope_tests {
         }
     }
 
+    /// The wildcard half of the same class, and the direction a per-path spec does NOT survive by
+    /// accident. `*` is legal in a Unix file name and a wildcard in gix's shell-glob mode, so the
+    /// spec `a*b.rs` also matches `axb.rs`: an untouched file is reported dirty because a SIBLING
+    /// has uncommitted edits, and blame then refuses the committed attribution it should have used.
+    /// The literal byte compare that rescues an exact spelling cannot help here — the extra match
+    /// is a different path, not the same one spelled oddly.
+    ///
+    /// Escaping the spec as a GLOB (`globset::escape`, which brackets `? * [ ] { }`) would cover
+    /// only this case: it leaves `\` and a leading `:` untouched, and neither is glob syntax —
+    /// they are an escape and a magic signature, parsed before globbing. `:(literal)` is what
+    /// covers all three, which is why the spec is built that way rather than escaped.
+    ///
+    /// Unix-only: Windows forbids `*` in a name, so the fixture cannot exist there.
+    #[cfg(unix)]
+    #[test]
+    fn a_wildcard_named_file_is_not_dirty_because_a_sibling_is() {
+        let dir = temp_dir("pathspec-wildcard-clean");
+        git(&dir, &["init", "-q"]);
+        // `a*b.rs` is the file under test; `axb.rs` is what its name matches read as a pattern.
+        for name in ["a*b.rs", "axb.rs"] {
+            std::fs::write(dir.join(name), "pub fn a() {}\n").unwrap();
+        }
+        git(&dir, &["add", "-A", "."]);
+        git(&dir, &["commit", "-q", "-m", "seed"]);
+
+        // Only the sibling is edited.
+        std::fs::write(dir.join("axb.rs"), "pub fn a2() {}\n").unwrap();
+
+        let repo = discover_repo(&dir).unwrap();
+        assert!(path_is_dirty(&repo, Path::new("axb.rs")), "the sibling really is dirty");
+        assert!(
+            !path_is_dirty(&repo, Path::new("a*b.rs")),
+            "a wildcard in the NAME must not let a sibling's edits report this file as dirty",
+        );
+    }
+
     #[test]
     fn linked_worktree_selects_its_overlay_on_the_base_commit() {
         let (_scratch, main) = init_repo("linked-main");

--- a/docs/config/targets.md
+++ b/docs/config/targets.md
@@ -35,6 +35,35 @@ include = ["**/*.ts"]
 exclude = ["**/*.map"]
 ```
 
+## `include` / `exclude` pattern syntax
+
+Both lists are globs, matched against the `/`-separated repo-relative path. `exclude` is applied
+first, so an excluded path is never claimed back by a broader `include`.
+
+| Pattern | Matches |
+| --- | --- |
+| `**/*.ts` | that extension at any depth (this is what every default binding uses) |
+| `*.ts` | that extension at the repo root only — one `*` does not cross a `/` |
+| `src/**` | everything inside `src/`, and nothing whose name merely starts with `src` |
+| `src/` | the same subtree; a trailing `/` is shorthand for `/**` |
+| `src/*.ts` | direct children of `src/` only |
+| `src/**/*.ts` | that extension anywhere under `src/` |
+| `**/generated/**` | any `generated/` directory's contents, at any depth |
+| `README.md` | that exact path, at the repo root — not `docs/README.md` |
+| `{lib,main}.rs`, `a?c.rs`, `**/*.[ch]` | alternates, single-character wildcard, character class |
+
+A pattern that is not a legal glob (an unclosed `[`, a dangling `\`) claims no files and is logged
+at `warn`.
+
+**Behaviour change.** These were previously matched by a small hand-written cascade that recognized
+`**/*.ext` and `dir/**` and fell back to *substring containment* for everything else. Patterns of
+those two shapes are unaffected — including every shipped default — but a pattern that relied on the
+fallback now means what a glob says it means. Notably `*.rs` matched any path *containing* `.rs`
+(claiming `notes.rs.bak` and `src/lib.rs.orig`) and now matches a root-level `.rs` file; a bare `*`
+matched the whole tree and now matches root-level files only; and a literal such as `README.md` or
+`vendor` matched any path containing it (`docs/README.md`, `x/vendor/dep.rs`) and now names one
+path. A target `include` that relied on the old containment should be spelled with `**/`.
+
 Supported languages are `rust`, `typescript`, `kotlin`, `c`, `cpp`, `python`, `swift`, `go`, and
 `markdown`. Rust, TypeScript/TSX, Kotlin, C, C++, Python, Swift, and Go source use tree-sitter
 structural indexing when files are under the parser size cap.


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `glob_claims` in `rag-rat-base` with `globset` for target `include`/`exclude` matching. The old matcher's fallback line — `path == pattern || path.contains(pattern.trim_matches('*'))` — degraded any pattern that missed its two special cases into substring containment, so `*.rs` became `path.contains(".rs")` (claiming `notes.rs.bak`) and a bare `*` claimed the entire tree.

## Related Issues and Pull Requests

Fixes #1072

## Changes

- **`crates/rag-rat-base/src/config/globs.rs`** (new) — `pattern_claims` + a compile step, with three options pinned against globset's platform-dependent defaults: `literal_separator(true)` (so `*` doesn't cross `/`), `backslash_escape(true)`, and `Candidate::from_bytes` (the caller already holds the canonical `/`-spelled path; it must not be re-derived through `Path`). Per-pattern memoisation in a process-wide `RwLock<HashMap<..>>`; an uncompilable pattern claims nothing and is `warn`-logged once.
- **`crates/rag-rat-base/src/config/types.rs`** — `glob_claims` deleted, `globs_claim` delegates. **No caller signature changed** (`globs_claim(&self, &str) -> bool` is intact), so `walker.rs` and `discovery.rs` are untouched. The recorded `globs_claim` invariant is *updated* (not deleted) to name the new single source of truth.
- **`crates/rag-rat-core/src/index/git_context.rs`** — one new regression test for the pathspec wildcard case (see below).
- **`docs/config/targets.md`** — pattern-syntax section + the behaviour-change callout.
- **`Cargo.toml`, `crates/rag-rat-base/Cargo.toml`, `Cargo.lock`** — `globset` as a direct `rag-rat-base` dependency. The `Cargo.lock` diff is **one line**: `globset` already resolves via `ignore`, so no package is added and nothing is version-bumped (which is why the `cargo-deny`/`cargo-audit` graph is unchanged).

### Why globset and not the `ignore` matcher

Your issue asks whether `ignore`'s own matcher — already built for gitignore handling — could serve this and remove a parallel path. I evaluated that first. Four things block it:

1. **It's a different question, so nothing parallel is removed.** `IgnoreMatcher` compiles `.gitignore` *files* on disk, anchored per directory; target patterns come from `rag-rat.toml`, per target. The walker consults both in sequence — they compose, neither replaces the other — and `globs_claim` is also called from `discovery.rs` with no `IgnoreMatcher` in scope. Adopting `ignore` there still builds a second matcher per target.
2. **Layering.** `glob_claims` lives in `rag-rat-base`, which has no `ignore` dep (only `rag-rat-core` does). `globset` is `ignore`'s own matching sub-crate — the layer `ignore` itself calls.
3. **`ignore` silently rewrites the patterns.** `Gitignore::add_line` prefixes `**/` to any pattern without a `/` (so `*.rs` becomes `**/*.rs`, and root-anchoring is unexpressible), rewrites trailing `/**`, treats a leading `!` as a whitelist and a leading `#` as a comment. A target pattern for `#notes.md` would be dropped entirely.
4. **Inverted verdicts and the wrong input type.** `ignore`'s `Override` returns `Match::Ignore(Glob::unmatched())` for a path matching no glob when whitelists exist, and `Gitignore::matched` needs an `is_dir` flag `globs_claim` doesn't have plus a `&Path` it re-`strip`s — feeding the `/`-spelled rendering back through `Path` is the exact hazard #1052 exists to prevent.

## Testing

Gates from `.github/workflows/ci.yml` (`rustfmt`, `clippy` no-default + all-features, `test`, `build`) and `security.yml`:

- `cargo +nightly fmt --all --check` → clean. **Note:** `rustfmt.toml` uses nightly-only options, so `cargo fmt --check` on *stable* reports ~1188 spurious diffs across untouched files — CI runs fmt on nightly, which is clean. A local stable run is not a real failure.
- `cargo clippy --workspace --all-targets` (both feature sets) → exit 0, 0 lint errors.
- `cargo nextest run --workspace` → **4893 passed**, 7 skipped (the 1 pre-existing leaky test is unrelated).
- `cargo build --workspace --locked` → exit 0.

**Both named defects bite against the implementation that had them.** Reverting only the production matcher and keeping the new tests: `*.rs` claiming `notes.rs.bak` fails against current `main`; the `drafts/**` boundary tests were already passing on `main` because #1052 fixed that class — so they're pinned, not re-fixed.

## The behaviour change, enumerated (for the release-note callout you asked for)

Built mechanically by running the pre-fix matcher (copied verbatim) beside the new one over a 25-pattern × 37-path corpus: **60 of 925 verdicts change.** **Zero shipped defaults move** — every default is a `**/*.ext` suffix, and all 21 real extensions were confirmed unchanged.

The changes fall in five groups:

1. **`*` no longer crosses `/`** — the bulk. The substring fallback is gone, so `*` matches one path component, not "contains the stripped literal". A bare `*` no longer claims the whole tree.
2. **A literal names one path**, not any path containing it: `README.md` no longer claims `docs/README.md`; `vendor` no longer claims `vendor/dep.rs`.
3. **Real glob syntax now works** where it previously fell into containment: `**/*.[ch]`, `{lib,main}.rs`, `a?c.rs`, interior `src/**/*.rs`, `**/generated/**`, `docs/*.md`.
4. **`src/` is root-anchored** — one row, `a/src/lib.rs` (see the review decision below).
5. **`drafts/**` no longer claims the path `drafts` itself** — unreachable in practice; both callers gate on a target extension first and `drafts` has none.

<details><summary>Full 60-row diff</summary>

| pattern | path | old | new |
|---|---|---|---|
| `**/*.[ch]` | `lib.h` | no | claims |
| `**/*.[ch]` | `lib.c` | no | claims |
| `src/*.rs` | `src/lib.rs` | no | claims |
| `src/**/*.rs` | `src/lib.rs` | no | claims |
| `src/**/*.rs` | `src/a/b/deep.rs` | no | claims |
| `src/**/*.rs` | `src/latest/x.rs` | no | claims |
| `src/**/*.rs` | `src/generated/api.rs` | no | claims |
| `**/generated/**` | `src/generated/api.rs` | no | claims |
| `**/generated/**` | `generated/api.rs` | no | claims |
| `docs/*.md` | `docs/README.md` | no | claims |
| `docs/*.md` | `docs/guide.md` | no | claims |
| `a?c.rs` | `abc.rs` | no | claims |
| `a?c.rs` | `axc.rs` | no | claims |
| `{lib,main}.rs` | `lib.rs` | no | claims |
| `{lib,main}.rs` | `main.rs` | no | claims |
| `drafts/**` | `drafts` | claims | no |
| `*.rs` | `src/lib.rs` | claims | no |
| `*.rs` | `src/a/b/deep.rs` | claims | no |
| `*.rs` | `notes.rs.bak` | claims | no |
| `*.rs` | `src/lib.rs.orig` | claims | no |
| `*.rs` | `vendor/dep.rs` | claims | no |
| `*.rs` | `x/vendor/dep.rs` | claims | no |
| `*.rs` | `a/b/c.rs` | claims | no |
| `*.rs` | `a/b.rs` | claims | no |
| `*.rs` | `src/latest/x.rs` | claims | no |
| `*.rs` | `src/generated/api.rs` | claims | no |
| `*.rs` | `generated/api.rs` | claims | no |
| `*.rs` | `foo/bar.rs` | claims | no |
| `*.rs` | `a/c.rs` | claims | no |
| `*.rs` | `target/debug/x.rs` | claims | no |
| `*.rs` | `my.rs.template` | claims | no |
| `*.rs` | `srcx/lib.rs` | claims | no |
| `*.rs` | `a/src/lib.rs` | claims | no |
| `src/lib.rs` | `src/lib.rs.orig` | claims | no |
| `src/lib.rs` | `a/src/lib.rs` | claims | no |
| `README.md` | `docs/README.md` | claims | no |
| `vendor` | `vendor/dep.rs` | claims | no |
| `vendor` | `x/vendor/dep.rs` | claims | no |
| `.gen.rs` | `schema.gen.rs` | claims | no |
| `*test*` | `src/latest/x.rs` | claims | no |
| `src/` | `a/src/lib.rs` | claims | no |
| `*` | `src/lib.rs` | claims | no |
| `*` | `src/a/b/deep.rs` | claims | no |
| `*` | `src/lib.rs.orig` | claims | no |
| `*` | `drafts/secret.md` | claims | no |
| `*` | `drafts/deep/secret.md` | claims | no |
| `*` | `docs/README.md` | claims | no |
| `*` | `docs/guide.md` | claims | no |
| `*` | `vendor/dep.rs` | claims | no |
| `*` | `x/vendor/dep.rs` | claims | no |
| `*` | `a/b/c.rs` | claims | no |
| `*` | `a/b.rs` | claims | no |
| `*` | `src/latest/x.rs` | claims | no |
| `*` | `src/generated/api.rs` | claims | no |
| `*` | `generated/api.rs` | claims | no |
| `*` | `foo/bar.rs` | claims | no |
| `*` | `a/c.rs` | claims | no |
| `*` | `target/debug/x.rs` | claims | no |
| `*` | `srcx/lib.rs` | claims | no |
| `*` | `a/src/lib.rs` | claims | no |

</details>

## Follow-ups / Known Limitations

**A decision I'd like you to weigh — trailing `/`.** Under strict glob, `include = ["src/"]` names one path ending in a separator and claims *nothing* — a target that silently indexes zero files, a quieter failure than the over-claiming being removed. **31 fixtures across 17 files** in this repo spell it `src/`, and 3 tests failed on it. I normalise a trailing `/` to `/**` (root-anchored: `src/` still does not claim `a/src/lib.rs`). But `dir/` was never documented vocabulary, so a clean break — reject trailing-`/` patterns, edit the 31 fixtures — is a legitimate alternative you may prefer. It's ~3 lines plus fixture churn to switch; say which you want.

**The pathspec case: your premise looks stale, so I did something different.** The issue says a repo-relative root "currently renders straight into a gix pathspec" and suggests wrapping it with `globset::escape()`. On current `main`, `git_context.rs` already emits `:(literal){path}` (landed by `238971f`, #1052) — and it's the only site that renders a path into a pathspec. `globset::escape()` would in fact **regress** it: it brackets `? * [ ] { }` but leaves `\` and `:` untouched, so swapping it for `:(literal)` re-breaks the leading-`:` magic-signature case (verified — the substitution passes the wildcard test and fails the `:notes.rs` one). So I kept `:(literal)` and instead added the one genuinely-missing regression test: a wildcard-named file (`a*b.rs`) beside a dirty sibling, confirming it isn't read as a pattern. If I've misread the state here, tell me.

**Per-pattern memo, not a per-target `GlobSet`.** You suggested compiling a pattern list into one `GlobSet`. That needs either a field on `ResolvedTarget` (85 construction sites) or a signature change on the hot `discovery.rs` path — beyond this issue. What ships is one lock-read + hash-lookup + regex-match per pattern per file; a `GlobSet` on `ResolvedTarget` is a clean follow-up.

Branch is based on `e1728c6`; `main` has since moved one unrelated perf commit — merges cleanly, but worth a rebase before merge.

## Footer

Generated by Claude Opus 5 (brief, review, implementation, verification)
