### PR TITLE
fix(sync): persist discovery advertisements across restarts

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -80,28 +80,6 @@ fn effective_relay_url(config: &Config) -> String {
     }
 }
 
-/// The peer-discovery service this invocation queries: `RAG_RAT_SYNC_DISCOVERY_NODE` (ops/tests)
-/// overrides the configured `[sync] discovery_node_id`, which itself defaults to the shipped
-/// service. A NODE ID, not a URL — the service is a separate iroh peer reached through the relay.
-fn effective_discovery_node(config: &Config) -> String {
-    discovery_node_or_configured(
-        std::env::var("RAG_RAT_SYNC_DISCOVERY_NODE").ok().as_deref(),
-        config,
-    )
-}
-
-/// The precedence rule behind [`effective_discovery_node`], with the environment read lifted out.
-///
-/// Split so the rule is testable without mutating process-global state: env-var tests are
-/// invisible under a per-process test runner and race under an in-process one, and this repository
-/// is verified under both.
-fn discovery_node_or_configured(from_env: Option<&str>, config: &Config) -> String {
-    match from_env {
-        Some(value) if !value.trim().is_empty() => value.trim().to_string(),
-        _ => config.sync.discovery_node_id.clone(),
-    }
-}
-
 /// A one-time enrollment invite `sync init` mints as it starts hosting the pairing exchange.
 struct InviteMint {
     role: rag_rat_oplog::DeviceRole,
@@ -216,69 +194,15 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
         };
         let policy = AuthPolicy::Closed;
 
-        // Advertise this host to the account's other devices for as long as it serves.
-        //
-        // `serve` is the node that most needs announcing — it is the always-on peer a laptop
-        // behind NAT is trying to reach — and it is the one node the device-sync path can never
-        // announce, because that path only runs on the maintenance hook and `serve` has no
-        // maintenance hook. Without its own timer the only publishers would be the only fetchers.
-        //
-        // Not gated on the roster count the device path uses: `serve` outlives the roster it
-        // started with, and a host that stopped advertising because it was alone when it booted
-        // would be invisible to the device enrolled an hour later. `--once` does not publish — it
-        // is a scripted single-connection check, not a host.
-        let advertising =
-            serve_should_advertise(config.sync.discovery, config.sync.discoverable, once);
-        let discovery_tag = advertising
-            .then(|| rag_rat_sync::discovery::discovery_secret(conn))
-            .transpose()?
-            .flatten()
-            .map(|secret| rag_rat_sync::discovery::account_tag(&secret));
-        // Seal ONCE per roster change, not once per publish, and hand the advertiser the bytes.
-        //
-        // Sealing needs a connection; the advertiser is a spawned task and cannot hold one. So this
-        // loop — which already owns the connection and already folds the WAL between sessions — is
-        // where sealing happens, and the watch carries the result. Republishing identical bytes is
-        // safe (same key, same nonce, same plaintext) and keeps the advertiser database-free.
-        //
-        // A sealing error here is LOGGED, not swallowed: the advertiser cannot reseal on its own,
-        // and the between-sessions reseal below only runs after an inbound connection — which a
-        // host that was never advertised may never receive. A silent empty value would leave it
-        // undiscoverable with nothing in the log saying why. Recovering without inbound traffic is
-        // a known gap (#1086).
-        let mut announcement = discovery_tag.map(|tag| {
-            let sealed = seal_announcement(conn, &tag, &local_node);
-            let observed = rag_rat_oplog::discovery::roster_stamp(conn).ok().flatten();
-            let stamp = stamp_after_seal(observed, None, sealed.is_ok());
-            let bytes = match sealed {
-                Ok(bytes) => bytes,
-                Err(error) => {
-                    tracing::warn!(%error, "sealing this host's announcement failed; it will not be discoverable until the next successful reseal");
-                    None
-                },
-            };
-            let (tx, rx) = tokio::sync::watch::channel(bytes);
-            (tag, tx, rx, stamp)
+        // A host is advertised by the same persisted controller the resident MCP host uses. It
+        // owns its timer and DB handles, so resealing never waits for (or cancels) an inbound sync.
+        let _advertiser = (!once).then(|| {
+            AbortOnDrop(tokio::spawn(rag_rat_core::sync_driver::advertise_host(
+                config.clone(),
+                endpoint.clone(),
+                config.database.clone(),
+            )))
         });
-        // Aborted on the way out of this scope, so the loop cannot outlive the endpoint it
-        // advertises.
-        let _advertiser = announcement
-            .as_ref()
-            .map(|(tag, _, rx, _)| (*tag, rx.clone()))
-            .zip(discovery_service_addr(config, &relay))
-            .map(|((tag, announcement), service)| {
-                AbortOnDrop(tokio::spawn(rag_rat_sync::discovery::advertise(
-                    rag_rat_sync::discovery::Advertise {
-                        endpoint: endpoint.clone(),
-                        service,
-                        tag,
-                        announcement,
-                        ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
-                            config.sync.push_interval_secs,
-                        ),
-                    },
-                )))
-            });
 
         tracing::info!(
             node_id = %endpoint.id(),
@@ -368,49 +292,6 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
             // `-wal` sidecar grows unbounded (passive autocheckpoint is pinned off). Size-gated and
             // best-effort, mirroring the watcher's per-pass fold.
             db.fold_wal();
-            // Re-seal between sessions, where the roster can have moved: an accept-loop ingest is
-            // the only way it changes under a serving host, since the session lock excludes a
-            // colocated device sync and no command authors roster changes. A device enrolled while
-            // this host is running therefore becomes a recipient at the next renewal; the
-            // advertiser re-reads the watch every tick, so the update needs no signal beyond this.
-            if let Some((tag, tx, _, stamp)) = &mut announcement {
-                // Compare the ROSTER, not the envelope. Sealing draws a fresh ephemeral per wrap,
-                // so two seals of an unchanged roster differ in every byte — comparing envelopes
-                // would re-seal after every session, the advertiser would stop recognising its own
-                // live announcement, and it would republish on every tick until the tag was full of
-                // its own copies. That is precisely the failure seal-once exists to avoid.
-                let observed =
-                    rag_rat_oplog::discovery::roster_stamp(conn).unwrap_or_else(|error| {
-                        tracing::warn!(%error, "could not read the roster; keeping the current announcement");
-                        *stamp
-                    });
-                // The comparison itself is out of reach of a test — `serve_with` binds an endpoint,
-                // takes the session lock, and loops until interrupted — so what it depends on is
-                // pinned elsewhere instead: `stamp_after_seal` carries the bookkeeping rule, and
-                // the op-log crate pins the two facts that make the bug possible and this fix
-                // correct (two seals of an unchanged roster differ in every byte; the stamp does
-                // not).
-                if observed != *stamp {
-                    tracing::debug!("the roster moved; re-sealing this host's announcement");
-                    let resealed = seal_announcement(conn, tag, &local_node);
-                    *stamp = stamp_after_seal(observed, *stamp, resealed.is_ok());
-                    match resealed {
-                        Ok(bytes) => {
-                            let _ = tx.send(bytes);
-                        },
-                        // The roster moved but re-sealing failed. Withdraw the previous envelope
-                        // rather than let the advertiser keep renewing it: it is sealed to the OLD
-                        // roster, so a just-removed device could otherwise keep opening it — and
-                        // being observed through it — indefinitely, well past the one-TTL revocation
-                        // window. The stamp is left unchanged (a failed seal keeps it), so the next
-                        // session retries against the moved roster.
-                        Err(error) => {
-                            tracing::warn!(%error, "re-sealing failed after a roster change; withdrawing the stale announcement until a re-seal succeeds");
-                            let _ = tx.send(None);
-                        },
-                    }
-                }
-            }
             if once {
                 break;
             }
@@ -650,143 +531,6 @@ fn accumulate_reconcile_report(
     total.converged = report.converged;
 }
 
-/// The discovery service's dialable address, or `None` (logged) when the configured id is unusable.
-///
-/// One seam for both callers — the device-sync pass and the serving host — so the resolution rule,
-/// the `[sync] discovery` switch, and the malformed-id warning cannot drift apart. `None` means
-/// this invocation does not talk to the discovery service, for either reason. The service is a
-/// separate iroh peer reached BY NODE ID through the same relay as the peers, not the relay
-/// itself.
-fn discovery_service_addr(config: &Config, relay: &str) -> Option<rag_rat_sync::EndpointAddr> {
-    // The single switch. Gating HERE rather than at each caller is what makes
-    // `[sync] discovery = false` mean "no contact with the service" rather than "no contact from
-    // whichever paths someone remembered to check" — a new caller inherits it by construction.
-    if !config.sync.discovery {
-        return None;
-    }
-    let discovery_node = effective_discovery_node(config);
-    match rag_rat_sync::peer_addr(&discovery_node, relay) {
-        Ok(addr) => Some(addr),
-        Err(error) => {
-            tracing::warn!(
-                service = discovery_node,
-                %error,
-                "skipping peer discovery: [sync] discovery_node_id is not a usable node id"
-            );
-            None
-        },
-    }
-}
-
-/// Seal this host's announcement to the account's current roster, or `None` when there is nothing
-/// to advertise.
-///
-/// `None` covers a store with no account and a roster holding only this device — the latter has no
-/// one to be discovered BY, so publishing would spend a slot to tell nobody. A sealing failure is
-/// logged and treated the same way: discovery is routing advice, and a host that cannot advertise
-/// still serves every peer that reaches it through a configured `server_peers` entry.
-/// `Ok(None)` and `Err` mean different things and the caller must not conflate them: `Ok(None)` is
-/// a settled decision not to advertise (no account, a lone device, a roster too large to seal),
-/// while `Err` is an attempt that failed and is worth repeating. See [`stamp_after_seal`].
-fn seal_announcement(
-    conn: &Connection,
-    tag: &[u8; 32],
-    local_node: &[u8; 32],
-) -> anyhow::Result<Option<Vec<u8>>> {
-    let Some(sealed) =
-        rag_rat_oplog::discovery::seal_discovery_announcement(conn, tag, local_node)?
-    else {
-        return Ok(None);
-    };
-    Ok(match classify_announcement(sealed.recipients, sealed.bytes.len()) {
-        AnnouncementVerdict::Advertise => Some(sealed.bytes),
-        AnnouncementVerdict::SoleRosterMember => {
-            tracing::debug!("not advertising: this device is the account's only roster member");
-            None
-        },
-        AnnouncementVerdict::TooLargeToPublish => {
-            tracing::warn!(
-                recipients = sealed.recipients,
-                bytes = sealed.bytes.len(),
-                max_bytes = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES,
-                "not advertising: this account's roster is too large to seal into one announcement"
-            );
-            None
-        },
-    })
-}
-
-/// The roster stamp to remember after an attempt to seal — the bookkeeping that decides whether the
-/// next session re-seals.
-///
-/// **Record the roster that was OBSERVED, never one derived from the sealing result.** A seal that
-/// deliberately produces no announcement — a lone device, or a roster too large to fit one publish
-/// — still reacted to a real roster, and forgetting it makes every later session see a change that
-/// did not happen. For an oversized roster that is a full re-seal, dozens of X25519 operations, and
-/// a repeated warning after every sync session, forever, on an account that never changed. Taking
-/// the announcement bytes as an input is what made that mistake expressible; this signature cannot
-/// see them.
-///
-/// A FAILED attempt keeps the previous stamp instead, so the next session retries it. That is the
-/// one case where repeating the work is the point: the failure is transient, and recording the new
-/// roster would mean never sealing against it.
-fn stamp_after_seal(
-    observed: Option<rag_rat_oplog::discovery::RosterStamp>,
-    last: Option<rag_rat_oplog::discovery::RosterStamp>,
-    sealed_ok: bool,
-) -> Option<rag_rat_oplog::discovery::RosterStamp> {
-    if sealed_ok { observed } else { last }
-}
-
-/// Why a sealed announcement is, or is not, worth publishing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AnnouncementVerdict {
-    Advertise,
-    /// No one to be discovered BY, so publishing would spend a slot to tell nobody.
-    SoleRosterMember,
-    /// Past what the service accepts in one publish.
-    TooLargeToPublish,
-}
-
-/// Decide whether a sealed announcement should be published, from its recipient count and size.
-///
-/// **The size rule is the one that fails silently without it.** An envelope grows 80 bytes per
-/// roster-effective device, so an account past roughly 25 of them seals something the service will
-/// refuse — and a refusal looks exactly like a transient one, so the host keeps retrying while
-/// being absent from discovery, with nothing anywhere saying why. Catching it here turns that into
-/// one warning naming the count, the size, and the limit.
-///
-/// It does NOT truncate the recipient list to fit. Which recipients were dropped would decide who
-/// can find this host, and choosing them arbitrarily is a worse failure than not advertising —
-/// splitting the envelope across several announcements is the way past the ceiling.
-///
-/// Named and tested separately for the same reason as [`serve_should_advertise`]: its caller needs
-/// a database with a roster of a given size, and the composition it feeds runs an accept loop until
-/// interrupted.
-fn classify_announcement(recipients: usize, bytes: usize) -> AnnouncementVerdict {
-    if bytes > rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES {
-        AnnouncementVerdict::TooLargeToPublish
-    } else if recipients > 1 {
-        AnnouncementVerdict::Advertise
-    } else {
-        AnnouncementVerdict::SoleRosterMember
-    }
-}
-
-/// Whether a serving host should advertise itself.
-///
-/// Three independent reasons not to, each easy to get wrong by omission rather than by writing
-/// something false: `[sync] discovery` turns the service off entirely, `[sync] discoverable` is
-/// opt-in on top of that, and `--once` is a scripted single-connection check rather than a host —
-/// advertising from it would publish an announcement that outlives the process by a whole TTL,
-/// pointing peers at a node that has already exited.
-///
-/// Named and tested separately because the composition it feeds is not reachable from a test: the
-/// caller binds an endpoint, takes the session lock, and runs an accept loop until interrupted.
-fn serve_should_advertise(discovery: bool, discoverable: bool, once: bool) -> bool {
-    discovery && discoverable && !once
-}
-
 /// A spawned task that is aborted when this guard drops, so a background loop cannot outlive the
 /// resources it borrows conceptually (here: the endpoint `serve` advertises).
 struct AbortOnDrop(tokio::task::JoinHandle<()>);
@@ -891,10 +635,8 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        AnnouncementVerdict, DeviceSyncOutcome, accumulate_reconcile_report, classify_announcement,
-        decode_node_secret, device_can_serve, device_sync_run, discovery_node_or_configured,
-        discovery_service_addr, ensure_founder_table_repo_incarnations, join, node_secret,
-        serve_should_advertise, stamp_after_seal,
+        DeviceSyncOutcome, accumulate_reconcile_report, decode_node_secret, device_can_serve,
+        device_sync_run, ensure_founder_table_repo_incarnations, join, node_secret,
     };
 
     fn account_of(conn: &Connection) -> rag_rat_oplog::AccountId {
@@ -936,143 +678,6 @@ mod tests {
         let config =
             Config::minimal_for_database(dir.path().join("db.sqlite"), dir.path().to_path_buf());
         (config, dir)
-    }
-
-    /// The env override exists for ops and tests; without it, pointing a checkout at a throwaway
-    /// discovery service would mean editing committed config.
-    #[test]
-    fn the_discovery_node_env_override_wins_over_the_configured_service() {
-        let mut config = min_config();
-        config.sync.discovery_node_id = "configured-node".to_string();
-        assert_eq!(
-            discovery_node_or_configured(Some("  env-node  "), &config),
-            "env-node",
-            "the override wins and is trimmed"
-        );
-        for absent in [None, Some(""), Some("   ")] {
-            assert_eq!(
-                discovery_node_or_configured(absent, &config),
-                "configured-node",
-                "an unset or blank override falls through to the configured service ({absent:?})"
-            );
-        }
-    }
-
-    /// Both reasons a serving host stays silent, enumerated — each is an omission-shaped mistake.
-    ///
-    /// `--once` matters more than it looks: an announcement outlives the process by a whole TTL, so
-    /// a one-shot check that advertised would leave peers dialing a node that has already exited.
-    #[test]
-    fn a_serving_host_advertises_only_when_opted_in_and_not_running_one_shot() {
-        assert!(
-            serve_should_advertise(true, true, false),
-            "a discoverable long-running host advertises"
-        );
-        assert!(!serve_should_advertise(true, false, false), "[sync] discoverable is opt-in");
-        assert!(
-            !serve_should_advertise(false, true, false),
-            "[sync] discovery = false means there is no service to advertise to, whatever else \
-             says"
-        );
-        assert!(
-            !serve_should_advertise(true, true, true),
-            "--once is a scripted check, not a host; its announcement would outlive the process"
-        );
-        assert!(!serve_should_advertise(false, false, true));
-    }
-
-    /// The roster size at which a host stops being able to advertise, pinned exactly.
-    ///
-    /// Two properties, and the second is the one that was missing. Sealing to more devices than fit
-    /// one publish is not a hypothetical: an envelope is one version byte plus 80 bytes per
-    /// roster-effective device, so the ceiling arrives at 25 recipients — well inside the roster
-    /// sizes accounts are otherwise built for. Without this branch the oversized publish is refused
-    /// by the service, the refusal is indistinguishable from a transient error, and the host
-    /// retries forever while absent from discovery with nothing explaining why.
-    ///
-    /// Asserted at the boundary on BOTH sides, because an off-by-one here is invisible in
-    /// production — it costs the largest accounts their discovery and nothing else changes.
-    #[test]
-    fn a_roster_too_large_to_seal_into_one_announcement_is_refused_not_truncated() {
-        const VERSION_BYTE: usize = 1;
-        const WRAP_LEN: usize = 32 + 48;
-        let envelope_len = |recipients: usize| VERSION_BYTE + recipients * WRAP_LEN;
-        let max = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES;
-
-        let fits = (1..).take_while(|n| envelope_len(*n) <= max).last().expect("some roster fits");
-        assert_eq!(fits, 25, "the documented recipient ceiling moved");
-
-        assert_eq!(
-            classify_announcement(fits, envelope_len(fits)),
-            AnnouncementVerdict::Advertise,
-            "the largest roster that fits must still advertise"
-        );
-        assert_eq!(
-            classify_announcement(fits + 1, envelope_len(fits + 1)),
-            AnnouncementVerdict::TooLargeToPublish,
-            "one recipient past the limit must be refused, not truncated to fit"
-        );
-
-        // The sole-member rule still applies, and size is judged first: a lone device is not
-        // advertised whatever its envelope weighs.
-        assert_eq!(
-            classify_announcement(1, envelope_len(1)),
-            AnnouncementVerdict::SoleRosterMember
-        );
-        assert_eq!(classify_announcement(2, envelope_len(2)), AnnouncementVerdict::Advertise);
-    }
-
-    /// An unchanged roster must never look like a changed one — including when it seals to nothing.
-    ///
-    /// The trap is that "nothing to advertise" has two causes with opposite handling. A lone device
-    /// or an oversized roster is a SETTLED decision about a roster that was really observed, and
-    /// forgetting it makes every subsequent session detect a phantom change and re-seal: for a
-    /// 25-plus-device account that is dozens of X25519 operations and a repeated warning after
-    /// every sync, forever. A transient failure is the opposite — there the previous stamp must
-    /// survive so the next session tries again.
-    #[test]
-    fn the_remembered_roster_is_the_one_observed_not_the_one_successfully_advertised() {
-        let roster = Some([7u8; 32]);
-        let older = Some([3u8; 32]);
-
-        assert_eq!(
-            stamp_after_seal(roster, None, true),
-            roster,
-            "a roster that sealed to no announcement is still a roster we reacted to"
-        );
-        assert_eq!(stamp_after_seal(roster, older, true), roster, "a real change is recorded");
-        assert_eq!(
-            stamp_after_seal(roster, older, false),
-            older,
-            "a failed seal keeps the old stamp so the next session retries"
-        );
-        assert_eq!(
-            stamp_after_seal(roster, None, false),
-            None,
-            "a first attempt that failed leaves nothing recorded, so it is retried"
-        );
-    }
-
-    /// `[sync] discovery = false` silences the service for BOTH callers, because both resolve its
-    /// address through one seam. Gating at each call site instead would leave a new caller talking
-    /// to the service by default.
-    #[test]
-    fn switching_discovery_off_leaves_no_service_address_for_anyone_to_use() {
-        let (mut config, _dir) = config_with_real_lock_dir();
-        assert!(
-            discovery_service_addr(&config, "https://relay.invalid").is_some(),
-            "the shipped default resolves, or the negative below proves nothing"
-        );
-
-        config.sync.discovery = false;
-        assert!(
-            discovery_service_addr(&config, "https://relay.invalid").is_none(),
-            "no address means no fetch and nothing to advertise to"
-        );
-        assert!(
-            !serve_should_advertise(config.sync.discovery, true, false),
-            "and a host cannot advertise even with discoverable set"
-        );
     }
 
     /// A pass with NO configured peers and a roster that shows only this device still runs.

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -1,6 +1,6 @@
 //! Shared device-sync driver for the CLI fallback and the active MCP resident host.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,6 +12,7 @@ use rag_rat_sync::{
     AuthPolicy, NodeAuth, OplogContentSyncStore, OplogSyncStore, PeerAuthorization, PeerCapability,
 };
 use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 const LOCK_TIMEOUT: Duration = Duration::from_secs(1);
@@ -21,6 +22,8 @@ const RESIDENT_NUDGE: &str = "sync_resident_nudge_at_ms";
 const HEARTBEAT_MAX_AGE_MS: i64 = 30_000;
 const HEARTBEAT_INTERVAL_MS: i64 = HEARTBEAT_MAX_AGE_MS / 2;
 const NODE_SECRET: &str = "sync_node_secret";
+const DISCOVERY_ADVERTISEMENT: &str = "sync_discovery_advertisement";
+const ADVERTISEMENT_REFRESH: Duration = Duration::from_secs(1);
 /// Bound pre-auth peers as well as authenticated sessions: each task owns a SQLite connection
 /// until the stream-idle timeout expires.
 const RESIDENT_SESSION_MAX: usize = 8;
@@ -208,22 +211,13 @@ async fn resident_loop(
     mut shutdown: tokio::sync::oneshot::Receiver<()>,
 ) {
     let accept = tokio::task::spawn_local(accept_loop(endpoint.clone(), account, database.clone()));
-    let mut announcement = resident_announcement(&config, &endpoint, &database);
-    let advertiser = announcement.as_ref().zip(discovery_addr(&config, &relay_url(&config))).map(
-        |((tag, _, _, receiver, _), service)| {
-            tokio::task::spawn_local(rag_rat_sync::discovery::advertise(
-                rag_rat_sync::discovery::Advertise {
-                    endpoint: endpoint.clone(),
-                    service,
-                    tag: *tag,
-                    announcement: receiver.clone(),
-                    ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
-                        config.sync.push_interval_secs,
-                    ),
-                },
-            ))
-        },
-    );
+    // Advertising owns a separate timer and short-lived DB handles. Inbound sessions stay on their
+    // own task, so a seal retry cannot cancel or delay a session already in flight.
+    let advertiser = tokio::task::spawn_local(advertise_host(
+        config.clone(),
+        endpoint.clone(),
+        database.clone(),
+    ));
     let mut poll = tokio::time::interval(Duration::from_secs(1));
     let mut handled_nudge = 0;
     let mut last_heartbeat = 0;
@@ -235,7 +229,6 @@ async fn resident_loop(
         let result = async {
             let storage = IndexConnection::open(&database)?;
             let conn = storage.connection();
-            refresh_announcement(conn, &mut announcement)?;
             let nudge = rag_rat_db::meta::read_meta(conn, RESIDENT_NUDGE)?
                 .and_then(|value| value.parse::<i64>().ok())
                 .unwrap_or_default();
@@ -261,86 +254,159 @@ async fn resident_loop(
         }
     }
     accept.abort();
-    if let Some(advertiser) = advertiser {
-        advertiser.abort();
+    advertiser.abort();
+}
+
+/// Persisted local state for one serving endpoint's announcement. The service appends rather than
+/// replaces, so the exact sealed bytes and their possible liveness must survive a restart.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct PersistedAdvertisement {
+    tag: [u8; 32],
+    node: [u8; 32],
+    roster_stamp: Option<[u8; 32]>,
+    envelope: Option<Vec<u8>>,
+    published_at_ms: Option<i64>,
+    ttl_seconds: u32,
+}
+
+impl PersistedAdvertisement {
+    fn matches(&self, tag: &[u8; 32], node: &[u8; 32], stamp: &Option<[u8; 32]>) -> bool {
+        self.tag == *tag && self.node == *node && self.roster_stamp == *stamp
+    }
+
+    fn live(&self, now_ms: i64) -> bool {
+        self.envelope.is_some()
+            && self.published_at_ms.is_some_and(|published_at| {
+                // A backwards wall-clock step must not turn one possibly-live publication into a
+                // burst of appends. The next normal clock reading renews it.
+                published_at > now_ms
+                    || now_ms.saturating_sub(published_at)
+                        < i64::try_from(
+                            rag_rat_sync::discovery::renew_after(self.ttl_seconds).as_millis(),
+                        )
+                        .unwrap_or(i64::MAX)
+            })
     }
 }
 
-type ResidentAnnouncement = (
-    [u8; 32],
-    [u8; 32],
-    tokio::sync::watch::Sender<Option<Vec<u8>>>,
-    tokio::sync::watch::Receiver<Option<Vec<u8>>>,
-    Option<rag_rat_oplog::discovery::RosterStamp>,
-);
+struct Publication {
+    tag: [u8; 32],
+    node: [u8; 32],
+    envelope: Vec<u8>,
+    ttl_seconds: u32,
+}
 
-fn resident_announcement(
-    config: &Config,
-    endpoint: &iroh::Endpoint,
-    database: &std::path::Path,
-) -> Option<ResidentAnnouncement> {
+/// Maintain a serving host's discovery announcement independently of its inbound session loop.
+///
+/// The record in `index_meta` is reused only for the same endpoint identity, account tag, and
+/// roster stamp. This preserves byte identity across a restart while making a roster move reseal
+/// promptly. The timer retries an initial or replacement seal even when no peer ever connects.
+pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: PathBuf) {
     if !config.sync.discovery || !config.sync.discoverable {
-        return None;
+        return;
     }
-    let storage = match IndexConnection::open(database) {
-        Ok(storage) => storage,
-        Err(error) => {
-            tracing::warn!(%error, "could not open the resident sync announcement store");
-            return None;
-        },
+    let relay = relay_url(&config);
+    let Some(service) = discovery_addr(&config, &relay) else {
+        return;
     };
+    let ttl_seconds = rag_rat_sync::discovery::publish_ttl_seconds(config.sync.push_interval_secs);
+    let node = *endpoint.id().as_bytes();
+    let mut refresh = tokio::time::interval(ADVERTISEMENT_REFRESH);
+    loop {
+        refresh.tick().await;
+        let publication = match prepare_advertisement(&database, &node, time::now_ms(), ttl_seconds)
+        {
+            Ok(Some(publication)) => publication,
+            Ok(None) => continue,
+            Err(error) => {
+                tracing::warn!(%error, "could not prepare this host's discovery announcement");
+                continue;
+            },
+        };
+        let attempted_at_ms = time::now_ms();
+        let outcome =
+            rag_rat_sync::discovery::exchange(rag_rat_sync::discovery::DiscoveryExchange {
+                endpoint: &endpoint,
+                service: service.clone(),
+                tag: publication.tag,
+                fetch: false,
+                publish: Some(&publication.envelope),
+                ttl_seconds,
+            })
+            .await;
+        if rag_rat_sync::discovery::records_liveness(outcome.publish)
+            && let Err(error) =
+                record_advertisement_liveness(&database, &publication, attempted_at_ms)
+        {
+            tracing::warn!(%error, "could not persist this host's discovery liveness");
+        }
+        match outcome.degraded {
+            Some(reason) => tracing::warn!(reason, "advertising this host degraded"),
+            None => tracing::debug!(state = ?outcome.publish, "advertised this host"),
+        }
+    }
+}
+
+fn prepare_advertisement(
+    database: &Path,
+    node: &[u8; 32],
+    now_ms: i64,
+    ttl_seconds: u32,
+) -> anyhow::Result<Option<Publication>> {
+    let storage = IndexConnection::open(database)?;
     let conn = storage.connection();
-    let tag = match rag_rat_sync::discovery::discovery_secret(conn) {
-        Ok(Some(secret)) => rag_rat_sync::discovery::account_tag(&secret),
-        Ok(None) => return None,
-        Err(error) => {
-            tracing::warn!(%error, "could not read the resident sync discovery secret");
-            return None;
+    let Some(secret) = rag_rat_sync::discovery::discovery_secret(conn)? else {
+        return Ok(None);
+    };
+    let tag = rag_rat_sync::discovery::account_tag(&secret);
+    let stamp = rag_rat_oplog::discovery::roster_stamp(conn)?;
+    let persisted = read_advertisement(conn)?;
+    let current = persisted.filter(|record| record.matches(&tag, node, &stamp));
+    let record = match current {
+        Some(record) => record,
+        None => {
+            let envelope = seal_advertisement(conn, &tag, node)?;
+            let record = PersistedAdvertisement {
+                tag,
+                node: *node,
+                roster_stamp: stamp,
+                envelope,
+                published_at_ms: None,
+                ttl_seconds,
+            };
+            write_advertisement(conn, &record)?;
+            record
         },
     };
-    let (bytes, seal_succeeded) = match seal_announcement(conn, &tag, endpoint.id().as_bytes()) {
-        Ok(bytes) => (bytes, true),
-        Err(error) => {
-            tracing::warn!(%error, "could not seal the resident sync announcement");
-            (None, false)
-        },
-    };
-    // A failed initial seal must leave this unset so the periodic refresh retries against the same
-    // roster rather than treating an unpublished announcement as current.
-    let stamp = if seal_succeeded {
-        rag_rat_oplog::discovery::roster_stamp(conn).ok().flatten()
-    } else {
-        None
-    };
-    let (sender, receiver) = tokio::sync::watch::channel(bytes);
-    Some((tag, *endpoint.id().as_bytes(), sender, receiver, stamp))
+    if record.live(now_ms) {
+        return Ok(None);
+    }
+    Ok(record.envelope.map(|envelope| Publication { tag, node: *node, envelope, ttl_seconds }))
 }
 
-fn refresh_announcement(
-    conn: &Connection,
-    announcement: &mut Option<ResidentAnnouncement>,
+fn record_advertisement_liveness(
+    database: &Path,
+    publication: &Publication,
+    attempted_at_ms: i64,
 ) -> anyhow::Result<()> {
-    let Some((tag, node, sender, _, stamp)) = announcement else {
+    let storage = IndexConnection::open(database)?;
+    let conn = storage.connection();
+    let stamp = rag_rat_oplog::discovery::roster_stamp(conn)?;
+    let Some(mut record) = read_advertisement(conn)? else {
         return Ok(());
     };
-    let observed = rag_rat_oplog::discovery::roster_stamp(conn)?;
-    if observed == *stamp {
+    // Never make a publish from a roster that moved during the network exchange look current.
+    if !record.matches(&publication.tag, &publication.node, &stamp)
+        || record.envelope.as_deref() != Some(publication.envelope.as_slice())
+    {
         return Ok(());
     }
-    match seal_announcement(conn, tag, node) {
-        Ok(bytes) => {
-            *stamp = observed;
-            let _ = sender.send(bytes);
-        },
-        Err(error) => {
-            tracing::warn!(%error, "could not refresh the resident sync announcement");
-            let _ = sender.send(None);
-        },
-    }
-    Ok(())
+    record.published_at_ms = Some(attempted_at_ms);
+    record.ttl_seconds = publication.ttl_seconds;
+    write_advertisement(conn, &record)
 }
 
-fn seal_announcement(
+fn seal_advertisement(
     conn: &Connection,
     tag: &[u8; 32],
     node: &[u8; 32],
@@ -349,12 +415,36 @@ fn seal_announcement(
     else {
         return Ok(None);
     };
-    if sealed.recipients <= 1
-        || sealed.bytes.len() > rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES
-    {
+    if sealed.recipients <= 1 {
+        return Ok(None);
+    }
+    if sealed.bytes.len() > rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES {
+        tracing::warn!(
+            recipients = sealed.recipients,
+            bytes = sealed.bytes.len(),
+            max_bytes = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES,
+            "not advertising: this account's roster is too large to seal into one announcement"
+        );
         return Ok(None);
     }
     Ok(Some(sealed.bytes))
+}
+
+fn read_advertisement(conn: &Connection) -> anyhow::Result<Option<PersistedAdvertisement>> {
+    let Some(encoded) = rag_rat_db::meta::read_meta(conn, DISCOVERY_ADVERTISEMENT)? else {
+        return Ok(None);
+    };
+    match serde_json::from_str(&encoded) {
+        Ok(record) => Ok(Some(record)),
+        Err(error) => {
+            tracing::warn!(%error, "ignoring a malformed persisted discovery advertisement");
+            Ok(None)
+        },
+    }
+}
+
+fn write_advertisement(conn: &Connection, record: &PersistedAdvertisement) -> anyhow::Result<()> {
+    rag_rat_db::meta::set_meta(conn, DISCOVERY_ADVERTISEMENT, &serde_json::to_string(record)?)
 }
 
 async fn accept_loop(
@@ -545,6 +635,7 @@ fn discovery_addr(config: &Config, relay: &str) -> Option<rag_rat_sync::Endpoint
     let node = std::env::var("RAG_RAT_SYNC_DISCOVERY_NODE")
         .ok()
         .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_string())
         .unwrap_or_else(|| config.sync.discovery_node_id.clone());
     rag_rat_sync::peer_addr(&node, relay).map_err(|error| {
         tracing::warn!(%error, "skipping peer discovery: configured node id is invalid")
@@ -643,7 +734,9 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        DeviceSyncOutcome, RESIDENT_NUDGE, can_host, can_sync, device_sync_run, nudge_resident_host,
+        DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PersistedAdvertisement, RESIDENT_NUDGE,
+        can_host, can_sync, device_sync_run, nudge_resident_host, read_advertisement,
+        write_advertisement,
     };
 
     #[test]
@@ -677,5 +770,51 @@ mod tests {
         assert!(can_host(Some(rag_rat_sync::PeerCapability::ReadWrite)));
         assert!(!can_host(Some(rag_rat_sync::PeerCapability::ReadOnly)));
         assert!(can_sync(Some(rag_rat_sync::PeerCapability::ReadOnly)));
+    }
+
+    #[test]
+    fn persisted_advertisement_matches_only_the_same_endpoint_tag_and_roster() {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        let record = PersistedAdvertisement {
+            tag: [1; 32],
+            node: [2; 32],
+            roster_stamp: Some([3; 32]),
+            envelope: Some(vec![4, 5, 6]),
+            published_at_ms: Some(7),
+            ttl_seconds: 60,
+        };
+
+        write_advertisement(&conn, &record).unwrap();
+        let restored = read_advertisement(&conn).unwrap().expect("the record was persisted");
+        assert_eq!(restored, record, "the exact sealed envelope survives a host restart");
+        assert!(restored.matches(&[1; 32], &[2; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[9; 32], &[2; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[1; 32], &[9; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[1; 32], &[2; 32], &Some([9; 32])));
+        assert!(
+            rag_rat_db::meta::read_meta(&conn, DISCOVERY_ADVERTISEMENT).unwrap().is_some(),
+            "the controller stores its state in index_meta"
+        );
+    }
+
+    #[test]
+    fn a_restart_reuses_matching_liveness_until_renewal_is_due() {
+        let record = PersistedAdvertisement {
+            tag: [1; 32],
+            node: [2; 32],
+            roster_stamp: Some([3; 32]),
+            envelope: Some(vec![4, 5, 6]),
+            published_at_ms: Some(1_000),
+            ttl_seconds: 60,
+        };
+        assert!(
+            record.live(30_999),
+            "a restarted host keeps using its still-live byte-identical envelope"
+        );
+        assert!(
+            !record.live(31_000),
+            "the first renewal is still due at the established half-life"
+        );
     }
 }

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -296,6 +296,25 @@ struct Publication {
     ttl_seconds: u32,
 }
 
+struct RefusedPublication {
+    envelope: Vec<u8>,
+    attempted_at: tokio::time::Instant,
+}
+
+fn refused_publication_is_due(
+    refusal: Option<&RefusedPublication>,
+    envelope: &[u8],
+    now: tokio::time::Instant,
+    retry_after: Duration,
+) -> bool {
+    !matches!(
+        refusal,
+        Some(refusal)
+            if refusal.envelope == envelope
+                && now.duration_since(refusal.attempted_at) < retry_after
+    )
+}
+
 /// Maintain a serving host's discovery announcement independently of its inbound session loop.
 ///
 /// The record in `index_meta` is reused only for the same endpoint identity, account tag, and
@@ -310,8 +329,10 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
         return;
     };
     let ttl_seconds = rag_rat_sync::discovery::publish_ttl_seconds(config.sync.push_interval_secs);
+    let retry_after = rag_rat_sync::discovery::retry_after_refusal(ttl_seconds);
     let node = *endpoint.id().as_bytes();
     let mut refresh = tokio::time::interval(ADVERTISEMENT_REFRESH);
+    let mut last_refused = None;
     loop {
         refresh.tick().await;
         let publication = match prepare_advertisement(&database, &node, time::now_ms(), ttl_seconds)
@@ -323,6 +344,15 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
                 continue;
             },
         };
+        let attempted_at = tokio::time::Instant::now();
+        if !refused_publication_is_due(
+            last_refused.as_ref(),
+            &publication.envelope,
+            attempted_at,
+            retry_after,
+        ) {
+            continue;
+        }
         let attempted_at_ms = time::now_ms();
         let outcome =
             rag_rat_sync::discovery::exchange(rag_rat_sync::discovery::DiscoveryExchange {
@@ -340,6 +370,11 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
         {
             tracing::warn!(%error, "could not persist this host's discovery liveness");
         }
+        last_refused = match outcome.publish {
+            rag_rat_sync::discovery::PublishState::Refused =>
+                Some(RefusedPublication { envelope: publication.envelope, attempted_at }),
+            _ => None,
+        };
         match outcome.degraded {
             Some(reason) => tracing::warn!(reason, "advertising this host degraded"),
             None => tracing::debug!(state = ?outcome.publish, "advertised this host"),
@@ -729,14 +764,15 @@ fn decode_secret(encoded: &str) -> anyhow::Result<Zeroizing<[u8; 32]>> {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::time::Duration;
 
     use rag_rat_base::config::Config;
     use rusqlite::Connection;
 
     use super::{
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PersistedAdvertisement, RESIDENT_NUDGE,
-        can_host, can_sync, device_sync_run, nudge_resident_host, read_advertisement,
-        write_advertisement,
+        RefusedPublication, can_host, can_sync, device_sync_run, nudge_resident_host,
+        read_advertisement, refused_publication_is_due, write_advertisement,
     };
 
     #[test]
@@ -815,6 +851,34 @@ mod tests {
         assert!(
             !record.live(31_000),
             "the first renewal is still due at the established half-life"
+        );
+    }
+
+    #[test]
+    fn a_refused_advertisement_uses_the_ttl_derived_retry_delay() {
+        let retry_after = rag_rat_sync::discovery::retry_after_refusal(60);
+        assert_eq!(retry_after, Duration::from_millis(7_500));
+
+        let attempted_at = tokio::time::Instant::now();
+        let refusal = RefusedPublication { envelope: vec![1, 2, 3], attempted_at };
+        assert!(
+            !refused_publication_is_due(
+                Some(&refusal),
+                &[1, 2, 3],
+                attempted_at + retry_after - Duration::from_millis(1),
+                retry_after,
+            ),
+            "the fine controller timer must not turn a refusal into a request per second"
+        );
+        assert!(refused_publication_is_due(
+            Some(&refusal),
+            &[1, 2, 3],
+            attempted_at + retry_after,
+            retry_after,
+        ));
+        assert!(
+            refused_publication_is_due(Some(&refusal), &[9], attempted_at, retry_after),
+            "a roster reseal is a new envelope and should not wait behind an old refusal"
         );
     }
 }

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -263,6 +263,7 @@ async fn resident_loop(
 struct PersistedAdvertisement {
     tag: [u8; 32],
     node: [u8; 32],
+    service: [u8; 32],
     roster_stamp: Option<[u8; 32]>,
     envelope: Option<Vec<u8>>,
     published_at_ms: Option<i64>,
@@ -270,8 +271,17 @@ struct PersistedAdvertisement {
 }
 
 impl PersistedAdvertisement {
-    fn matches(&self, tag: &[u8; 32], node: &[u8; 32], stamp: &Option<[u8; 32]>) -> bool {
-        self.tag == *tag && self.node == *node && self.roster_stamp == *stamp
+    fn matches(
+        &self,
+        tag: &[u8; 32],
+        node: &[u8; 32],
+        service: &[u8; 32],
+        stamp: &Option<[u8; 32]>,
+    ) -> bool {
+        self.tag == *tag
+            && self.node == *node
+            && self.service == *service
+            && self.roster_stamp == *stamp
     }
 
     fn live(&self, now_ms: i64) -> bool {
@@ -292,6 +302,7 @@ impl PersistedAdvertisement {
 struct Publication {
     tag: [u8; 32],
     node: [u8; 32],
+    service: [u8; 32],
     envelope: Vec<u8>,
     ttl_seconds: u32,
 }
@@ -331,12 +342,18 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
     let ttl_seconds = rag_rat_sync::discovery::publish_ttl_seconds(config.sync.push_interval_secs);
     let retry_after = rag_rat_sync::discovery::retry_after_refusal(ttl_seconds);
     let node = *endpoint.id().as_bytes();
+    let service_node = *service.id.as_bytes();
     let mut refresh = tokio::time::interval(ADVERTISEMENT_REFRESH);
     let mut last_refused = None;
     loop {
         refresh.tick().await;
-        let publication = match prepare_advertisement(&database, &node, time::now_ms(), ttl_seconds)
-        {
+        let publication = match prepare_advertisement(
+            &database,
+            &node,
+            &service_node,
+            time::now_ms(),
+            ttl_seconds,
+        ) {
             Ok(Some(publication)) => publication,
             Ok(None) => continue,
             Err(error) => {
@@ -385,6 +402,7 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
 fn prepare_advertisement(
     database: &Path,
     node: &[u8; 32],
+    service: &[u8; 32],
     now_ms: i64,
     ttl_seconds: u32,
 ) -> anyhow::Result<Option<Publication>> {
@@ -396,7 +414,7 @@ fn prepare_advertisement(
     let tag = rag_rat_sync::discovery::account_tag(&secret);
     let stamp = rag_rat_oplog::discovery::roster_stamp(conn)?;
     let persisted = read_advertisement(conn)?;
-    let current = persisted.filter(|record| record.matches(&tag, node, &stamp));
+    let current = persisted.filter(|record| record.matches(&tag, node, service, &stamp));
     let record = match current {
         Some(record) => record,
         None => {
@@ -404,6 +422,7 @@ fn prepare_advertisement(
             let record = PersistedAdvertisement {
                 tag,
                 node: *node,
+                service: *service,
                 roster_stamp: stamp,
                 envelope,
                 published_at_ms: None,
@@ -416,7 +435,13 @@ fn prepare_advertisement(
     if record.live(now_ms) {
         return Ok(None);
     }
-    Ok(record.envelope.map(|envelope| Publication { tag, node: *node, envelope, ttl_seconds }))
+    Ok(record.envelope.map(|envelope| Publication {
+        tag,
+        node: *node,
+        service: *service,
+        envelope,
+        ttl_seconds,
+    }))
 }
 
 fn record_advertisement_liveness(
@@ -431,7 +456,7 @@ fn record_advertisement_liveness(
         return Ok(());
     };
     // Never make a publish from a roster that moved during the network exchange look current.
-    if !record.matches(&publication.tag, &publication.node, &stamp)
+    if !record.matches(&publication.tag, &publication.node, &publication.service, &stamp)
         || record.envelope.as_deref() != Some(publication.envelope.as_slice())
     {
         return Ok(());
@@ -809,12 +834,13 @@ mod tests {
     }
 
     #[test]
-    fn persisted_advertisement_matches_only_the_same_endpoint_tag_and_roster() {
+    fn persisted_advertisement_matches_only_the_same_endpoint_service_tag_and_roster() {
         let conn = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         let record = PersistedAdvertisement {
             tag: [1; 32],
             node: [2; 32],
+            service: [3; 32],
             roster_stamp: Some([3; 32]),
             envelope: Some(vec![4, 5, 6]),
             published_at_ms: Some(7),
@@ -824,10 +850,11 @@ mod tests {
         write_advertisement(&conn, &record).unwrap();
         let restored = read_advertisement(&conn).unwrap().expect("the record was persisted");
         assert_eq!(restored, record, "the exact sealed envelope survives a host restart");
-        assert!(restored.matches(&[1; 32], &[2; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[9; 32], &[2; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[1; 32], &[9; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[1; 32], &[2; 32], &Some([9; 32])));
+        assert!(restored.matches(&[1; 32], &[2; 32], &[3; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[9; 32], &[2; 32], &[3; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[1; 32], &[9; 32], &[3; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[1; 32], &[2; 32], &[9; 32], &Some([3; 32])));
+        assert!(!restored.matches(&[1; 32], &[2; 32], &[3; 32], &Some([9; 32])));
         assert!(
             rag_rat_db::meta::read_meta(&conn, DISCOVERY_ADVERTISEMENT).unwrap().is_some(),
             "the controller stores its state in index_meta"
@@ -839,6 +866,7 @@ mod tests {
         let record = PersistedAdvertisement {
             tag: [1; 32],
             node: [2; 32],
+            service: [3; 32],
             roster_stamp: Some([3; 32]),
             envelope: Some(vec![4, 5, 6]),
             published_at_ms: Some(1_000),

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -264,6 +264,7 @@ struct PersistedAdvertisement {
     tag: [u8; 32],
     node: [u8; 32],
     service: [u8; 32],
+    relay: String,
     roster_stamp: Option<[u8; 32]>,
     envelope: Option<Vec<u8>>,
     published_at_ms: Option<i64>,
@@ -276,11 +277,13 @@ impl PersistedAdvertisement {
         tag: &[u8; 32],
         node: &[u8; 32],
         service: &[u8; 32],
+        relay: &str,
         stamp: &Option<[u8; 32]>,
     ) -> bool {
         self.tag == *tag
             && self.node == *node
             && self.service == *service
+            && self.relay == relay
             && self.roster_stamp == *stamp
     }
 
@@ -303,6 +306,7 @@ struct Publication {
     tag: [u8; 32],
     node: [u8; 32],
     service: [u8; 32],
+    relay: String,
     envelope: Vec<u8>,
     ttl_seconds: u32,
 }
@@ -351,6 +355,7 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
             &database,
             &node,
             &service_node,
+            &relay,
             time::now_ms(),
             ttl_seconds,
         ) {
@@ -403,6 +408,7 @@ fn prepare_advertisement(
     database: &Path,
     node: &[u8; 32],
     service: &[u8; 32],
+    relay: &str,
     now_ms: i64,
     ttl_seconds: u32,
 ) -> anyhow::Result<Option<Publication>> {
@@ -414,7 +420,7 @@ fn prepare_advertisement(
     let tag = rag_rat_sync::discovery::account_tag(&secret);
     let stamp = rag_rat_oplog::discovery::roster_stamp(conn)?;
     let persisted = read_advertisement(conn)?;
-    let current = persisted.filter(|record| record.matches(&tag, node, service, &stamp));
+    let current = persisted.filter(|record| record.matches(&tag, node, service, relay, &stamp));
     let record = match current {
         Some(record) => record,
         None => {
@@ -423,6 +429,7 @@ fn prepare_advertisement(
                 tag,
                 node: *node,
                 service: *service,
+                relay: relay.to_owned(),
                 roster_stamp: stamp,
                 envelope,
                 published_at_ms: None,
@@ -439,6 +446,7 @@ fn prepare_advertisement(
         tag,
         node: *node,
         service: *service,
+        relay: relay.to_owned(),
         envelope,
         ttl_seconds,
     }))
@@ -456,8 +464,13 @@ fn record_advertisement_liveness(
         return Ok(());
     };
     // Never make a publish from a roster that moved during the network exchange look current.
-    if !record.matches(&publication.tag, &publication.node, &publication.service, &stamp)
-        || record.envelope.as_deref() != Some(publication.envelope.as_slice())
+    if !record.matches(
+        &publication.tag,
+        &publication.node,
+        &publication.service,
+        &publication.relay,
+        &stamp,
+    ) || record.envelope.as_deref() != Some(publication.envelope.as_slice())
     {
         return Ok(());
     }
@@ -834,13 +847,14 @@ mod tests {
     }
 
     #[test]
-    fn persisted_advertisement_matches_only_the_same_endpoint_service_tag_and_roster() {
+    fn persisted_advertisement_matches_only_the_same_endpoint_service_relay_tag_and_roster() {
         let conn = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         let record = PersistedAdvertisement {
             tag: [1; 32],
             node: [2; 32],
             service: [3; 32],
+            relay: "https://relay.one".to_owned(),
             roster_stamp: Some([3; 32]),
             envelope: Some(vec![4, 5, 6]),
             published_at_ms: Some(7),
@@ -850,11 +864,48 @@ mod tests {
         write_advertisement(&conn, &record).unwrap();
         let restored = read_advertisement(&conn).unwrap().expect("the record was persisted");
         assert_eq!(restored, record, "the exact sealed envelope survives a host restart");
-        assert!(restored.matches(&[1; 32], &[2; 32], &[3; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[9; 32], &[2; 32], &[3; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[1; 32], &[9; 32], &[3; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[1; 32], &[2; 32], &[9; 32], &Some([3; 32])));
-        assert!(!restored.matches(&[1; 32], &[2; 32], &[3; 32], &Some([9; 32])));
+        assert!(restored.matches(
+            &[1; 32],
+            &[2; 32],
+            &[3; 32],
+            "https://relay.one",
+            &Some([3; 32]),
+        ));
+        assert!(!restored.matches(
+            &[9; 32],
+            &[2; 32],
+            &[3; 32],
+            "https://relay.one",
+            &Some([3; 32]),
+        ));
+        assert!(!restored.matches(
+            &[1; 32],
+            &[9; 32],
+            &[3; 32],
+            "https://relay.one",
+            &Some([3; 32]),
+        ));
+        assert!(!restored.matches(
+            &[1; 32],
+            &[2; 32],
+            &[9; 32],
+            "https://relay.one",
+            &Some([3; 32]),
+        ));
+        assert!(!restored.matches(
+            &[1; 32],
+            &[2; 32],
+            &[3; 32],
+            "https://relay.two",
+            &Some([3; 32]),
+        ));
+        assert!(!restored.matches(
+            &[1; 32],
+            &[2; 32],
+            &[3; 32],
+            "https://relay.one",
+            &Some([9; 32]),
+        ));
         assert!(
             rag_rat_db::meta::read_meta(&conn, DISCOVERY_ADVERTISEMENT).unwrap().is_some(),
             "the controller stores its state in index_meta"
@@ -867,6 +918,7 @@ mod tests {
             tag: [1; 32],
             node: [2; 32],
             service: [3; 32],
+            relay: "https://relay.one".to_owned(),
             roster_stamp: Some([3; 32]),
             envelope: Some(vec![4, 5, 6]),
             published_at_ms: Some(1_000),

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -316,6 +316,14 @@ struct RefusedPublication {
     attempted_at: tokio::time::Instant,
 }
 
+fn retry_is_due(
+    last_attempt: Option<tokio::time::Instant>,
+    now: tokio::time::Instant,
+    retry_after: Duration,
+) -> bool {
+    last_attempt.is_none_or(|attempted_at| now.duration_since(attempted_at) >= retry_after)
+}
+
 fn refused_publication_is_due(
     refusal: Option<&RefusedPublication>,
     envelope: &[u8],
@@ -326,7 +334,7 @@ fn refused_publication_is_due(
         refusal,
         Some(refusal)
             if refusal.envelope == envelope
-                && now.duration_since(refusal.attempted_at) < retry_after
+                && !retry_is_due(Some(refusal.attempted_at), now, retry_after)
     )
 }
 
@@ -348,9 +356,14 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
     let node = *endpoint.id().as_bytes();
     let service_node = *service.id.as_bytes();
     let mut refresh = tokio::time::interval(ADVERTISEMENT_REFRESH);
+    let mut last_prepare_failure = None;
     let mut last_refused = None;
     loop {
         refresh.tick().await;
+        let now = tokio::time::Instant::now();
+        if !retry_is_due(last_prepare_failure, now, retry_after) {
+            continue;
+        }
         let publication = match prepare_advertisement(
             &database,
             &node,
@@ -359,9 +372,16 @@ pub async fn advertise_host(config: Config, endpoint: iroh::Endpoint, database: 
             time::now_ms(),
             ttl_seconds,
         ) {
-            Ok(Some(publication)) => publication,
-            Ok(None) => continue,
+            Ok(Some(publication)) => {
+                last_prepare_failure = None;
+                publication
+            },
+            Ok(None) => {
+                last_prepare_failure = None;
+                continue;
+            },
             Err(error) => {
+                last_prepare_failure = Some(now);
                 tracing::warn!(%error, "could not prepare this host's discovery announcement");
                 continue;
             },
@@ -810,7 +830,7 @@ mod tests {
     use super::{
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PersistedAdvertisement, RESIDENT_NUDGE,
         RefusedPublication, can_host, can_sync, device_sync_run, nudge_resident_host,
-        read_advertisement, refused_publication_is_due, write_advertisement,
+        read_advertisement, refused_publication_is_due, retry_is_due, write_advertisement,
     };
 
     #[test]
@@ -960,5 +980,17 @@ mod tests {
             refused_publication_is_due(Some(&refusal), &[9], attempted_at, retry_after),
             "a roster reseal is a new envelope and should not wait behind an old refusal"
         );
+    }
+
+    #[test]
+    fn a_preparation_error_uses_the_ttl_derived_retry_delay() {
+        let retry_after = rag_rat_sync::discovery::retry_after_refusal(60);
+        let attempted_at = tokio::time::Instant::now();
+        assert!(!retry_is_due(
+            Some(attempted_at),
+            attempted_at + retry_after - Duration::from_millis(1),
+            retry_after,
+        ));
+        assert!(retry_is_due(Some(attempted_at), attempted_at + retry_after, retry_after,));
     }
 }

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -410,8 +410,15 @@ async fn exchange_inner(
 /// The cost of treating a genuinely-failed `Uncertain` as live is one renewal interval of
 /// undiscoverability before the next republish; the cost of the other error is unbounded slot
 /// churn. This trades the bounded harm for the unbounded one.
-fn records_liveness(state: PublishState) -> bool {
+pub fn records_liveness(state: PublishState) -> bool {
     matches!(state, PublishState::Published | PublishState::Uncertain)
+}
+
+/// How long a locally recorded publication remains live before it is renewed.
+///
+/// Kept beside [`advertise`] so every host uses the same slot-budget policy.
+pub fn renew_after(ttl_seconds: u32) -> Duration {
+    Duration::from_millis(u64::from(ttl_seconds * RENEW_AFTER_NUM / RENEW_AFTER_DEN) * 1000)
 }
 
 /// A long-running host's standing advertisement — see [`advertise`].
@@ -463,18 +470,15 @@ pub async fn advertise(params: Advertise) {
     // Milliseconds, and `.max(1)`, so the period stays positive for any TTL the service's floor
     // could ever permit — `interval` panics on a zero period.
     let period = Duration::from_millis((u64::from(ttl_seconds) * 1000 / TICKS_PER_TTL).max(1));
-    let renew_after =
-        Duration::from_millis(u64::from(ttl_seconds * RENEW_AFTER_NUM / RENEW_AFTER_DEN) * 1000);
+    let renew_after = renew_after(ttl_seconds);
     let mut ticks = tokio::time::interval(period);
     // What the service last accepted from this host, and when. A MONOTONIC instant, not the wall
     // clock and not the service's `expires_at_ms`: this is a pure "how long since we published"
     // question, so it needs neither a clock that can step backwards nor a comparison across two
     // machines' clocks.
     //
-    // In memory only, so a restart forgets it — and because a fresh seal is byte-distinct, the
-    // restarted host cannot recognise its still-live announcement and appends another. Bounded and
-    // self-healing after one restart; a crash loop or rapid redeploy is the case that bites.
-    // Persisting or reusing the envelope across restart is #1086.
+    // This low-level task deliberately knows only its watch channel. A serving host that survives
+    // restarts persists this same pair through its controller instead.
     let mut published: Option<(Vec<u8>, tokio::time::Instant)> = None;
     loop {
         ticks.tick().await;

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -173,7 +173,7 @@ pub fn publish_ttl_seconds(push_interval_secs: u64) -> u32 {
     push_interval_secs.saturating_mul(2).clamp(MIN_TTL, MAX_TTL) as u32
 }
 
-/// How often [`advertise`] wakes, as a divisor of the TTL.
+/// How long a refused publish waits before retrying, as a divisor of the TTL.
 ///
 /// Only ticks where a renewal is actually due cost anything — the rest compare two local values and
 /// go back to sleep — so this is free to be fine, and being fine is what buys retry attempts. The
@@ -184,6 +184,15 @@ pub fn publish_ttl_seconds(push_interval_secs: u64) -> u32 {
 /// It was NOT free while liveness came from a fetch, when every tick was a full round trip. That
 /// coupling is gone.
 const TICKS_PER_TTL: u64 = 8;
+
+/// The retry delay after a publish the service definitely did not store.
+///
+/// Serving-host controllers may check their local state more frequently for roster changes, but
+/// must retain this pacing for repeated network attempts against the same envelope.
+pub fn retry_after_refusal(ttl_seconds: u32) -> Duration {
+    // `.max(1)` keeps the duration positive if a future service permits a sub-second TTL.
+    Duration::from_millis((u64::from(ttl_seconds) * 1000 / TICKS_PER_TTL).max(1))
+}
 
 /// Renew once half the TTL has elapsed.
 ///
@@ -467,9 +476,7 @@ pub struct Advertise {
 /// the other way round.
 pub async fn advertise(params: Advertise) {
     let Advertise { endpoint, service, tag, mut announcement, ttl_seconds } = params;
-    // Milliseconds, and `.max(1)`, so the period stays positive for any TTL the service's floor
-    // could ever permit — `interval` panics on a zero period.
-    let period = Duration::from_millis((u64::from(ttl_seconds) * 1000 / TICKS_PER_TTL).max(1));
+    let period = retry_after_refusal(ttl_seconds);
     let renew_after = renew_after(ttl_seconds);
     let mut ticks = tokio::time::interval(period);
     // What the service last accepted from this host, and when. A MONOTONIC instant, not the wall


### PR DESCRIPTION
Closes #1086.

## Summary
- persist and reuse matching host discovery envelopes across restarts
- renew/reseal advertisements on a timer without interrupting active sessions
- centralize serving-host advertising for CLI and active MCP hosts

## Verification
- cargo +nightly fmt --all -- --check
- cargo clippy -p rag-rat-core -p rag-rat-sync -p rag-rat --all-targets -- -D warnings
- cargo nextest run -p rag-rat-core persisted_advertisement_matches_only_the_same_endpoint_tag_and_roster
- cargo nextest run -p rag-rat-core a_restart_reuses_matching_liveness_until_renewal_is_due
- cargo nextest run -p rag-rat-sync discovery::tests
- cargo nextest run -p rag-rat commands::sync