### PR TITLE
feat(sync): re-adopt rows orphaned by a removed writer

### DIFF
--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -590,6 +590,31 @@ mod tests {
             ]],
         )
         .unwrap();
+        // The re-adoption tables are swept through the same directory (#997): a pending repair and
+        // its provenance both name the stream, so each needs a seed row for the orphan check to
+        // observe.
+        conn.execute(
+            "INSERT INTO table_sync_readoption_work(account_id, device_fingerprint, stream_id, \
+             roster_ref, removed_at_epoch, enqueued_at_ms) VALUES (?1, ?2, ?3, ?4, 1, 0)",
+            params![vec![seed; 32], vec![seed; 32], stream_id, vec![seed ^ 0x11; 32]],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO table_sync_readoption_audit(account_id, removed_fingerprint, \
+             adopter_fingerprint, stream_id, repo_id, scope_id, table_name, row_pk, \
+             original_lamport, original_entry_hash, adopted_entry_hash, adopted_at_ms) VALUES \
+             (?1, ?2, ?3, ?4, ?5, 'demo/1', 't', 'aa', 1, ?6, ?7, 0)",
+            params![
+                vec![seed; 32],
+                vec![seed; 32],
+                vec![seed ^ 0x22; 32],
+                stream_id,
+                repo_id,
+                vec![seed; 32],
+                vec![seed ^ 0x33; 32]
+            ],
+        )
+        .unwrap();
         stream_id
     }
 
@@ -640,6 +665,8 @@ mod tests {
             ("clone_df_epoch", "build_generation", generation_in),
             ("table_sync_entries", "stream_id", blob_literal(stream_id)),
             ("table_sync_gapped_entries", "stream_id", blob_literal(stream_id)),
+            ("table_sync_readoption_work", "stream_id", blob_literal(stream_id)),
+            ("table_sync_readoption_audit", "stream_id", blob_literal(stream_id)),
         ];
         for (table, column, in_body) in checks {
             let count: i64 = conn

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 103, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 104, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
@@ -1958,6 +1958,40 @@ fn migration_103_syncable_memory_bindings() {
         )
         .unwrap();
     assert_eq!(preserved, ("src/lib.rs".into(), 3, 4, 5, "relocated".into(), 9));
+}
+
+/// V104 (#997) adds the durable re-adoption worklist and audit provenance.
+#[test]
+fn migration_104_table_sync_readoption() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    let work_strict: i64 = conn
+        .query_row(
+            "SELECT strict FROM pragma_table_list
+             WHERE schema = 'main' AND name = 'table_sync_readoption_work'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(work_strict, 1);
+    let audit_strict: i64 = conn
+        .query_row(
+            "SELECT strict FROM pragma_table_list
+             WHERE schema = 'main' AND name = 'table_sync_readoption_audit'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(audit_strict, 1);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '104_table_sync_readoption'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1);
 }
 
 /// V091 (#949) tracks the live key-target count each invite reservation covers, so fold-time

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -7377,6 +7377,49 @@ fn table_is_strict(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
     )
 }
 
+/// V104 (#997): the durable re-adoption worklist and audit log.
+///
+/// An effective `DeviceRemove` makes the #935 ingest gate refuse every later copy of that
+/// device's entries, so rows whose whole-row LWW winner is the removed writer never reach a
+/// replica enrolled after the removal. The account fold records each removal here, and a
+/// roster-effective writer drains the worklist by re-authoring the surviving state under its
+/// own chain. `roster_ref` is NOT a foreign key: the projection deletes and rewrites roster
+/// history on every fold, and the worklist must survive that rewrite.
+pub fn apply_table_sync_readoption(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS table_sync_readoption_work(
+              account_id BLOB NOT NULL CHECK(length(account_id) = 32),
+              device_fingerprint BLOB NOT NULL CHECK(length(device_fingerprint) = 32),
+              stream_id BLOB NOT NULL CHECK(length(stream_id) = 32),
+              roster_ref BLOB NOT NULL CHECK(length(roster_ref) = 32),
+              removed_at_epoch INTEGER NOT NULL,
+              enqueued_at_ms INTEGER NOT NULL,
+              processed_at_ms INTEGER,
+              PRIMARY KEY(account_id, device_fingerprint, stream_id)
+          ) STRICT;
+          CREATE INDEX IF NOT EXISTS table_sync_readoption_work_pending
+              ON table_sync_readoption_work(account_id, stream_id)
+              WHERE processed_at_ms IS NULL;
+          CREATE TABLE IF NOT EXISTS table_sync_readoption_audit(
+              audit_id INTEGER PRIMARY KEY,
+              account_id BLOB NOT NULL CHECK(length(account_id) = 32),
+              removed_fingerprint BLOB NOT NULL CHECK(length(removed_fingerprint) = 32),
+              adopter_fingerprint BLOB NOT NULL CHECK(length(adopter_fingerprint) = 32),
+              stream_id BLOB NOT NULL CHECK(length(stream_id) = 32),
+              repo_id TEXT NOT NULL,
+              scope_id TEXT NOT NULL,
+              table_name TEXT NOT NULL,
+              row_pk TEXT NOT NULL,
+              original_lamport INTEGER NOT NULL,
+              original_entry_hash BLOB NOT NULL CHECK(length(original_entry_hash) = 32),
+              adopted_entry_hash BLOB NOT NULL CHECK(length(adopted_entry_hash) = 32),
+              adopted_at_ms INTEGER NOT NULL
+          ) STRICT;
+          CREATE INDEX IF NOT EXISTS table_sync_readoption_audit_stream
+              ON table_sync_readoption_audit(account_id, stream_id);",
+    )
+}
+
 fn primary_key_columns(conn: &Connection, table: &str) -> rusqlite::Result<Vec<String>> {
     let mut stmt =
         conn.prepare("SELECT name FROM pragma_table_info(?1) WHERE pk > 0 ORDER BY pk")?;

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 103;
+pub const LATEST_SCHEMA_VERSION: u32 = 104;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -780,6 +780,12 @@ const MIGRATION_103_CHECKSUM: &str = "sha256:rag-rat-syncable-memory-bindings-v1
 const MIGRATION_103_DESCRIPTION: &str = "Rebuild memory bindings as a strict, repository-keyed, \
                                          dependency-free table suitable for deterministic \
                                          anchors/1 whole-row replication";
+const MIGRATION_104_ID: &str = "104_table_sync_readoption";
+const MIGRATION_104_CHECKSUM: &str = "sha256:rag-rat-table-sync-readoption-v104";
+const MIGRATION_104_DESCRIPTION: &str =
+    "Add the durable table-sync re-adoption worklist and audit log (#997): an effective \
+     DeviceRemove enqueues one item per affected stream, which a current writer drains by \
+     re-authoring the removed writer's surviving LWW state under its own chain";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1631,6 +1637,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_103_CHECKSUM,
         description: MIGRATION_103_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_syncable_memory_bindings),
+    },
+    Migration {
+        id: MIGRATION_104_ID,
+        checksum: MIGRATION_104_CHECKSUM,
+        description: MIGRATION_104_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_table_sync_readoption),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -165,6 +165,21 @@ const TRANSITIVE_SCOPED_TABLES: &[TransitiveTable] = &[
         id_column: "stream_id",
         parent_ids: purge_ids::STREAMS,
     },
+    // Re-adoption work for removed writers on this repo's streams. It must not survive the
+    // directory: stream identity is derived, so a re-registered repo must never let an old
+    // removal re-author rows into its fresh stream.
+    TransitiveTable {
+        table: "table_sync_readoption_work",
+        id_column: "stream_id",
+        parent_ids: purge_ids::STREAMS,
+    },
+    // Re-adoption provenance for those same streams, retained only while the repo's accepted
+    // history is retained.
+    TransitiveTable {
+        table: "table_sync_readoption_audit",
+        id_column: "stream_id",
+        parent_ids: purge_ids::STREAMS,
+    },
     // Entries held awaiting a chain predecessor. Same reasoning as the accepted log above, and for
     // the same reason it must not be exempted: these are signed operations on a stream whose id is
     // derived, so retaining them across a re-registration of the repo would replay a removed
@@ -357,6 +372,26 @@ pub fn purge_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
             [],
         )?;
     }
+    // Re-adoption work parked under the all-zero placeholder stream has no directory row to scope
+    // through and would otherwise survive forever. It exists only while its account has no
+    // table-sync streams at all, so there is no authored history it could still repair, and any
+    // removal it records is already folded into every peer's roster. Scoped to the accounts that
+    // hold incarnation authority for THIS repository: a parked row is account-scoped, and an
+    // unrelated account's repair must not be collateral of this purge. Rows already copied into a
+    // real stream were handled above through purge_ids::STREAMS.
+    if crate::schema::table_exists(conn, "table_sync_readoption_work")?
+        && crate::schema::table_exists(conn, "account_repo_incarnation_current")?
+    {
+        conn.execute(
+            "DELETE FROM table_sync_readoption_work
+             WHERE stream_id = zeroblob(32)
+               AND account_id IN (
+                   SELECT account_id FROM account_repo_incarnation_current
+                    WHERE repository_id = ?1
+               )",
+            params![repo_id],
+        )?;
+    }
     // chunk_fts is contentless FTS5 keyed by chunk.id: delete by rowid from the captured chunk set
     // (it carries no repo_id and no FK, so neither the sweep nor a cascade would ever reach it).
     conn.execute(
@@ -477,5 +512,52 @@ mod tests {
         let counts = count_repo_rows(&conn, "some-repo")
             .expect("planning must survive a store whose directory table predates the entry log");
         assert_eq!(counts.total_rows, 0, "nothing is counted for an unknown repo");
+    }
+
+    /// Parked re-adoption work is account-scoped: purging one account's repo must not delete
+    /// another account's repair.
+    #[test]
+    fn purging_parked_readoption_work_leaves_unrelated_accounts_untouched() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        conn.execute_batch(
+            "INSERT INTO account_repo_incarnation_current(
+                 account_id, repository_id, incarnation_ref
+             ) VALUES (zeroblob(32), 'repo-x', zeroblob(32)),
+                      (x'1100000000000000000000000000000000000000000000000000000000000000',
+                       'repo-y', zeroblob(32));
+             INSERT INTO table_sync_readoption_work(
+                 account_id, device_fingerprint, stream_id, roster_ref, removed_at_epoch,
+                 enqueued_at_ms
+             ) VALUES (zeroblob(32), zeroblob(32), zeroblob(32), zeroblob(32), 1, 2),
+                      (x'1100000000000000000000000000000000000000000000000000000000000000',
+                       zeroblob(32), zeroblob(32), zeroblob(32), 1, 2);
+             INSERT INTO table_sync_readoption_work(
+                 account_id, device_fingerprint, stream_id, roster_ref, removed_at_epoch,
+                 enqueued_at_ms, processed_at_ms
+             ) VALUES (zeroblob(32), \
+             x'2200000000000000000000000000000000000000000000000000000000000000',
+                       zeroblob(32), \
+             x'2200000000000000000000000000000000000000000000000000000000000000',
+                       1, 2, 3);",
+        )
+        .unwrap();
+
+        purge_repo_rows(&conn, "repo-x").unwrap();
+
+        let remaining: Vec<Vec<u8>> = conn
+            .prepare("SELECT account_id FROM table_sync_readoption_work")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        let mut expected = vec![0x11];
+        expected.extend([0; 31]);
+        assert_eq!(
+            remaining,
+            vec![expected],
+            "repo-y's parked work survives; repo-x's rows are gone, stamped or not"
+        );
     }
 }

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -1489,6 +1489,10 @@ mod repo_id_scope_coverage {
         ),
         ("sync_row_clocks", "per-row last-writer-wins clocks, same keying"),
         ("sync_row_tombstones", "per-row delete clocks, same keying"),
+        (
+            "table_sync_readoption_audit",
+            "re-adoption provenance, keyed to its stream like the directory's other children",
+        ),
     ];
 
     /// `(table, what is unresolved)` — the dream-v2 verification siblings on the LATE-MERGE path

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -1280,7 +1280,7 @@ fn fold_account_state_in_tx(
         )?;
         statuses.insert(row.entry_hash, status);
     }
-    rewrite_authority_projection(tx, account_id, &projection.history)?;
+    rewrite_authority_projection(tx, account_id, &projection.history, now_ms)?;
     // Re-derive secrets-log (log 1) acceptance from the just-rewritten authority projection, in
     // this SAME txn (§15, C4.2b). The main loop above wrote `retained_unfolded` for every log-1
     // row (the declassify baseline); this pass OVERWRITES that — in both `account_entry_status`
@@ -1332,6 +1332,7 @@ fn rewrite_authority_projection(
     tx: &Transaction<'_>,
     account_id: AccountId,
     history: &fold::AccountAuthHistory,
+    now_ms: i64,
 ) -> anyhow::Result<()> {
     let account = account_id.to_bytes();
     for table in [
@@ -1374,6 +1375,11 @@ fn rewrite_authority_projection(
     for (roster_ref, fact) in history.roster_facts() {
         let (control_kind, control_seq, control_hash) = stored_boundary(fact.control_boundary);
         let (secrets_kind, secrets_seq, secrets_hash) = stored_boundary(fact.secrets_boundary);
+        if let Some(closed_at) = fact.closed_at {
+            enqueue_readoption_for_closed_fact(
+                tx, account_id, roster_ref, fact, closed_at, now_ms,
+            )?;
+        }
         tx.execute(
             "INSERT INTO account_roster_history(
                  roster_ref, account_id, device_fingerprint, role, effective_at, closed_at,
@@ -1481,6 +1487,57 @@ fn rewrite_authority_projection(
                 ],
             )?;
         }
+    }
+    Ok(())
+}
+
+/// Enqueue table-sync re-adoption for one roster fact the fold just closed (#997).
+///
+/// This runs inside the authority projection rewrite, before the roster row itself is inserted,
+/// because the fold is the one place that knows the removal is effective. One durable work item is
+/// recorded per stream that currently has table-sync context for this account; a stream that
+/// first learns of the removal before its directory row exists gets the work attached when the
+/// first entry is authored or ingested. `roster_ref` is intentionally not a FK: this table rewrites
+/// roster history wholesale on every fold, while the worklist must survive that rewrite.
+fn enqueue_readoption_for_closed_fact(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    roster_ref: &[u8; 32],
+    fact: &fold::RosterFact,
+    closed_at: u64,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let mut stmt = tx.prepare(
+        "SELECT stream_id FROM table_sync_streams WHERE account_id = ?1 ORDER BY stream_id",
+    )?;
+    let streams = stmt
+        .query_map([account_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if streams.is_empty() {
+        // A stream whose first local contact happens after this removal still owes repair. Park
+        // the removal under the impossible zero stream until the first authored/ingested entry
+        // records the real context.
+        crate::table_sync::enqueue_readoption_work(
+            tx,
+            account_id,
+            fact.authority.device_fingerprint,
+            StreamId::from_bytes([0; 32]),
+            *roster_ref,
+            closed_at,
+            now_ms,
+        )?;
+        return Ok(());
+    }
+    for stream in streams {
+        crate::table_sync::enqueue_readoption_work(
+            tx,
+            account_id,
+            fact.authority.device_fingerprint,
+            StreamId::from_bytes(fixed::<32>(&stream)?),
+            *roster_ref,
+            closed_at,
+            now_ms,
+        )?;
     }
     Ok(())
 }

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -418,6 +418,19 @@ fn current_row_clock(
     current_row_clock_on_stream(tx, StreamId::from_bytes([0; 32]), repo_id, table, row_pk)
 }
 
+/// The row's live whole-row-LWW winner on `stream` as `(lamport, device hex)` — the merge-table
+/// half of the re-adoption verdict (#997). The fingerprint is stored as the lowercase hex the
+/// applier wrote (`OpMeta::device.to_string()`); callers compare the hex strings directly.
+pub(crate) fn row_clock_winner_on_stream(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<(u64, String)>> {
+    current_row_clock_on_stream(tx, stream, repo_id, table, row_pk)
+}
+
 /// Raise the row's write clock to `(lamport, device_hex)` under LWW — a later-arriving but older
 /// write never lowers it.
 fn raise_row_clock(
@@ -469,6 +482,18 @@ fn current_tombstone(
         )
         .optional()?;
     row.map(|(lamport, device)| Ok((u64::try_from(lamport)?, device))).transpose()
+}
+
+/// The row's current tombstone winner on `stream` as `(lamport, device hex)` — the deletion half
+/// of the re-adoption verdict (#997).
+pub(crate) fn tombstone_winner_on_stream(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<(u64, String)>> {
+    current_tombstone(tx, stream, repo_id, table, row_pk)
 }
 
 /// Raise the row's tombstone to `(lamport, device_hex)` under LWW — a lower clock never lowers it.
@@ -1035,6 +1060,16 @@ fn clear_published(
         rusqlite::params![stream.to_bytes().as_slice(), repo_id, table, row_pk],
     )?;
     Ok(())
+}
+
+/// Build the re-adoption `Remove` for an orphaned tombstone: just the row pk (a delete carries no
+/// after-image).
+pub(crate) fn readopt_remove(spec: &TableSpec, row_pk: &str) -> anyhow::Result<RowOp> {
+    Ok(RowOp::Remove {
+        table: spec.name.to_string(),
+        spec_version: spec.spec_version,
+        pk: row_op::row_pk_values(row_pk)?,
+    })
 }
 
 // ── value / identifier plumbing ──────────────────────────────────────────────────────────────

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -14,6 +14,7 @@ use rusqlite::Transaction;
 
 use super::apply::{self, ApplyOutcome};
 use super::registry::TableSpec;
+use super::row_op::{self, RowOp};
 use super::scope_stream::scope_stream_id;
 use super::store::{self, AcceptOutcome};
 use super::{produce, refold};
@@ -164,6 +165,183 @@ pub(crate) fn produce_and_author(
     // after that edit is authored, and loses on the merits instead of by default.
     refold::replay_deferred_entries(tx, ctx.registry)?;
     Ok(authored)
+}
+
+/// Re-author the removed writer's surviving state on this stream under the local device key, then
+/// mark the removal handled (#997). Runs inside the producer transaction: it sees the just-authored
+/// local rows and is protected by the same current-incarnation and projector gates as authoring.
+///
+/// Returns `None` when the removal CANNOT be fully drained here — the local device is not
+/// currently a roster-effective writer, the stream has no recorded apply context, or a row exists
+/// that cannot be carried in an op today (an unreadable synced column: retried after the cell is
+/// repaired, never written off). `Some(n)` means the work item completed (n re-authored rows,
+/// possibly 0): the caller must not treat "could not drain" and "nothing to re-author" as the
+/// same outcome.
+pub(crate) fn process_readoption_work_for_stream(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+    stream: crate::stream::StreamId,
+) -> anyhow::Result<Option<usize>> {
+    let Some(work) = store::readoption_work_for_stream(tx, ctx.account_id, stream)? else {
+        return Ok(Some(0));
+    };
+    if !crate::account::device_is_effective_writer(tx, ctx.account_id, ctx.device.fingerprint())? {
+        return Ok(None);
+    }
+    // Re-verify the removal still stands: a device re-invited before this pass is effective again,
+    // so its entries ingest directly on every replica and re-authoring them here would only steal
+    // clock ownership from an active writer. Completing (not deleting) keeps the row idempotent.
+    if crate::account::device_is_effective_writer(tx, ctx.account_id, work.device_fingerprint)? {
+        store::complete_readoption_work(
+            tx,
+            ctx.account_id,
+            work.device_fingerprint,
+            stream,
+            ctx.now_ms,
+        )?;
+        return Ok(Some(0));
+    }
+    let Some(context) = store::stream_context(tx, stream)? else {
+        return Ok(None);
+    };
+    let removed = work.device_fingerprint;
+    let removed_hex = removed.to_string();
+    let mut authored = 0;
+    let mut unrepairable = 0;
+    for candidate in store::readoption_candidates(tx, stream, work.device_fingerprint)? {
+        let Some(spec) = ctx
+            .registry
+            .iter()
+            .find(|spec| spec.scope_id == context.scope_id && spec.name == candidate.table_name)
+        else {
+            continue;
+        };
+        let op = match readoption_repair_op(tx, ctx, spec, stream, &candidate.row_pk, &removed_hex)?
+        {
+            ReadoptionRepair::Skip => continue,
+            ReadoptionRepair::Unrepairable => {
+                unrepairable += 1;
+                continue;
+            },
+            ReadoptionRepair::Repair(op) => op,
+        };
+        let signed = store::author_row_entry(tx, stream, ctx.device.secret(), &op, ctx.now_ms)?;
+        let meta =
+            OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
+        match apply::apply_row_op_on_stream(tx, spec, ctx.repo_id, stream, &op, meta)? {
+            ApplyOutcome::Applied => {
+                store::record_readoption_audit(tx, store::ReadoptionAudit {
+                    account_id: ctx.account_id,
+                    removed,
+                    adopter: ctx.device.fingerprint(),
+                    stream,
+                    repo_id: context.repo_id.clone(),
+                    scope_id: context.scope_id.clone(),
+                    table_name: spec.name.to_string(),
+                    row_pk: candidate.row_pk.clone(),
+                    original_lamport: candidate.original_lamport,
+                    original_entry_hash: candidate.entry_hash,
+                    adopted_entry_hash: signed.entry.entry_hash,
+                    adopted_at_ms: ctx.now_ms,
+                })?;
+                authored += 1;
+            },
+            ApplyOutcome::Superseded => {
+                // Same diagnosis as the produce path: a locally-authored op takes the stream's
+                // MAX(lamport)+1, so losing its own self-apply means the row's clock carries a
+                // lamport from ANOTHER stream — the shape a scope or account move leaves behind.
+                // Swallowing it would mark the removal complete with the orphan unrepaired and no
+                // retry left. Fail the pass instead: the work item stays pending and the rollback
+                // drops the just-inserted entry.
+                anyhow::bail!(
+                    "table-sync: a re-adoption op lost its own self-apply on `{}` — the row's \
+                     write clock carries a lamport from another stream",
+                    spec.name
+                );
+            },
+            outcome @ (ApplyOutcome::Quarantined(_) | ApplyOutcome::Unprojectable(_)) => {
+                anyhow::bail!(
+                    "table-sync: a re-adoption op did not self-apply on `{}`: {outcome:?}",
+                    spec.name
+                );
+            },
+        }
+    }
+    if unrepairable > 0 {
+        // A row the pass cannot carry today is NOT written off: completing here would abandon it
+        // to anti-echo silence (a later content-identical repair authors nothing, so a fresh
+        // replica never receives the row — the divergence this pass exists to fix). Report
+        // "could not drain" and leave the item pending; a pass after the cell is repaired
+        // completes it. Already re-authored rows above stay committed.
+        return Ok(None);
+    }
+    store::complete_readoption_work(
+        tx,
+        ctx.account_id,
+        work.device_fingerprint,
+        stream,
+        ctx.now_ms,
+    )?;
+    Ok(Some(authored))
+}
+
+/// What the drain can do with one candidate row.
+enum ReadoptionRepair {
+    /// Re-author this op under the local key.
+    Repair(RowOp),
+    /// Nothing owed: the row is settled under another writer, or physically consistent with its
+    /// merge state (an absent row under a live clock is the producer's `Remove` to author, not
+    /// this pass's).
+    Skip,
+    /// The physical row exists but a synced column cannot be read as its declared type. NOT
+    /// abandoned: the work item stays pending so a pass after the cell is repaired still
+    /// converges the fresh replica.
+    Unrepairable,
+}
+
+/// The physical-table repair for one still-orphaned candidate row.
+fn readoption_repair_op(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+    spec: &TableSpec,
+    stream: crate::stream::StreamId,
+    row_pk: &str,
+    removed_hex: &str,
+) -> anyhow::Result<ReadoptionRepair> {
+    let clock = apply::row_clock_winner_on_stream(tx, stream, ctx.repo_id, spec.name, row_pk)?;
+    let tombstone = apply::tombstone_winner_on_stream(tx, stream, ctx.repo_id, spec.name, row_pk)?;
+    Ok(match (clock, tombstone) {
+        // A live clock and a tombstone can only coexist with the clock newer: a remove raises the
+        // tombstone at its own lamport, and a remove that BEATS the clock clears the clock. So a
+        // live clock always owns the row; re-adopt it while the removed writer is that winner.
+        // What the PHYSICAL row allows decides the repair: carried (re-author), absent (the
+        // producer's Remove owns it), or unreadable (stay pending until repaired).
+        (Some((_, winner)), _) if winner == removed_hex => {
+            let pk = row_op::row_pk_values(row_pk)?;
+            match apply::read_synced_cells(tx, spec, &pk)? {
+                apply::SyncedRow::Cells(cells) => ReadoptionRepair::Repair(RowOp::Upsert {
+                    table: spec.name.to_string(),
+                    spec_version: spec.spec_version,
+                    pk,
+                    cells,
+                }),
+                apply::SyncedRow::Absent => ReadoptionRepair::Skip,
+                apply::SyncedRow::Unreadable(_) => ReadoptionRepair::Unrepairable,
+            }
+        },
+        // A tombstone with no live clock owns the deletion. Re-adopt it only while no physical
+        // row exists; otherwise a live local row would be destroyed by a stale repair.
+        (None, Some((_, winner))) if winner == removed_hex => {
+            let pk = row_op::row_pk_values(row_pk)?;
+            match apply::read_synced_cells(tx, spec, &pk)? {
+                apply::SyncedRow::Absent =>
+                    ReadoptionRepair::Repair(apply::readopt_remove(spec, row_pk)?),
+                apply::SyncedRow::Cells(_) => ReadoptionRepair::Skip,
+                apply::SyncedRow::Unreadable(_) => ReadoptionRepair::Unrepairable,
+            }
+        },
+        _ => ReadoptionRepair::Skip,
+    })
 }
 
 /// **The caller MUST roll back on `Err`.** Everything here runs in the caller's transaction and
@@ -557,6 +735,39 @@ mod tests {
         .unwrap();
     }
 
+    /// Close `fp`'s roster row — the device is removed from the account, so its entries fail the
+    /// #935 gate and the drain-time effectiveness re-check sees the removal.
+    fn remove_writer(
+        conn: &rusqlite::Connection,
+        account: AccountId,
+        fp: crate::op::DeviceFingerprint,
+    ) {
+        let closed = conn
+            .execute(
+                "UPDATE account_roster_history SET closed_at = 1
+                 WHERE account_id = ?1 AND device_fingerprint = ?2 AND closed_at IS NULL",
+                rusqlite::params![account.to_bytes().as_slice(), fp.to_bytes().as_slice()],
+            )
+            .unwrap();
+        assert_eq!(closed, 1, "the device was on the roster to remove");
+    }
+
+    /// Re-open `fp`'s closed roster row — the device is re-invited and effective again.
+    fn reinvite_writer(
+        conn: &rusqlite::Connection,
+        account: AccountId,
+        fp: crate::op::DeviceFingerprint,
+    ) {
+        let reopened = conn
+            .execute(
+                "UPDATE account_roster_history SET closed_at = NULL
+                 WHERE account_id = ?1 AND device_fingerprint = ?2 AND closed_at IS NOT NULL",
+                rusqlite::params![account.to_bytes().as_slice(), fp.to_bytes().as_slice()],
+            )
+            .unwrap();
+        assert_eq!(reopened, 1, "the device was removed to re-invite");
+    }
+
     fn seed_incarnation(conn: &rusqlite::Connection) {
         conn.execute(
             "INSERT INTO account_repo_incarnation_current(
@@ -568,6 +779,667 @@ mod tests {
             ],
         )
         .unwrap();
+    }
+
+    #[test]
+    fn readoption_re_authors_a_removed_writers_row_and_uses_it_to_converge_a_fresh_replica() {
+        let mut a = Device::new(); // the original author, later removed from the roster
+        let mut c = Device::new(); // a current writer that already holds A's row
+        let mut d = Device::new(); // a replica enrolled only AFTER A had left
+
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'distilled')", []).unwrap();
+        let entry = a.produce();
+        assert_eq!(entry.len(), 1);
+
+        enroll_writer(&c.conn, AccountId::from_bytes([42; 32]), a.pubkey().fingerprint());
+        enroll_writer(&c.conn, AccountId::from_bytes([42; 32]), c.local.fingerprint());
+        assert_eq!(c.ingest_all(&entry, &a.pubkey()), vec![IngestOutcome::Applied]);
+        assert_eq!(c.title().as_deref(), Some("distilled"));
+        let account = AccountId::from_bytes([42; 32]);
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+        let removal_ref = [7; 32];
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                removal_ref,
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+
+        let reauthored = c.produce();
+        assert!(reauthored.is_empty(), "ordinary production does not re-adopt without the driver");
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            let processed = process_readoption_work_for_stream(&tx, &ctx, stream).unwrap();
+            tx.commit().unwrap();
+            assert_eq!(processed, Some(1), "the orphaned row is re-authored once");
+        }
+        let audit_count: i64 = c
+            .conn
+            .query_row("SELECT COUNT(*) FROM table_sync_readoption_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(audit_count, 1, "the re-authorship carries its provenance");
+
+        let reauthored = {
+            let tail: Vec<u8> = c
+                .conn
+                .query_row(
+                    "SELECT signed_bytes FROM table_sync_entries
+                     WHERE stream_id = ?1 AND device_fingerprint = ?2
+                     ORDER BY lamport DESC LIMIT 1",
+                    rusqlite::params![
+                        stream.to_bytes().as_slice(),
+                        c.local.fingerprint().to_bytes().as_slice()
+                    ],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            vec![tail]
+        };
+
+        enroll_writer(&d.conn, AccountId::from_bytes([42; 32]), c.local.fingerprint());
+        assert_eq!(d.ingest_all(&reauthored, &c.pubkey()), vec![IngestOutcome::Applied]);
+        assert_eq!(d.title().as_deref(), Some("distilled"));
+    }
+
+    #[test]
+    fn readoption_never_authors_a_remove_while_the_physical_row_is_live() {
+        let mut a = Device::new(); // creates AND deletes r1, then leaves the roster
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'created')", []).unwrap();
+        let create = a.produce();
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        c.ingest_all(&create, &a.pubkey());
+        a.delete_row();
+        let delete = a.produce();
+        assert_eq!(delete.len(), 1);
+        c.ingest_all(&delete, &a.pubkey());
+        assert_eq!(c.title(), None, "A's delete landed: r1 is gone, tombstoned under A");
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+
+        // Recreate the pk locally without publishing it. This is exactly the state the scan-based
+        // design destroyed: tombstone state says removed-author delete wins, while the physical
+        // table says the row is live again.
+        c.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'recreated')", []).unwrap();
+
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [8; 32],
+                11,
+                12,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(
+                process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(),
+                Some(0),
+                "the physical-liveness guard declines the stale tombstone repair",
+            );
+            tx.commit().unwrap();
+        }
+        let out = c.produce();
+        assert_eq!(out.len(), 1, "only the legitimate local upsert is authored");
+        assert_eq!(c.title().as_deref(), Some("recreated"));
+        let removes: i64 = c
+            .conn
+            .query_row("SELECT COUNT(*) FROM table_sync_readoption_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(removes, 0, "no stale tombstone re-adoption can delete a live row");
+    }
+
+    /// A device removed, drained, re-invited, and removed again must have its SECOND removal
+    /// re-arm the worklist — the roster_ref distinguishes the two removals (#997 review).
+    #[test]
+    fn a_second_removal_after_drain_re_adopts_the_devices_new_rows() {
+        let mut a = Device::new(); // invited, removed, re-invited, removed again
+        let mut c = Device::new(); // the current writer that holds every copy
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+
+        // Round one: A authors r1, C ingests it, A is removed, and C drains the work.
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'first')", []).unwrap();
+        let first = a.produce();
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        c.ingest_all(&first, &a.pubkey());
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [7; 32],
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(), Some(1));
+            tx.commit().unwrap();
+        }
+
+        // Re-invite: A is roster-effective again, authors r2, and C ingests it. A's SECOND
+        // removal carries a new roster_ref.
+        reinvite_writer(&c.conn, account, a.pubkey().fingerprint());
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'second')", []).unwrap();
+        let second = a.produce();
+        c.ingest_all(&second, &a.pubkey());
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [9; 32],
+                21,
+                22,
+            )
+            .unwrap();
+            assert!(
+                store::readoption_work_for_stream(&tx, account, stream).unwrap().is_some(),
+                "a different roster_ref resets processed_at_ms",
+            );
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            // r1's clock winner is C after round one; only r2 is still orphaned under A.
+            assert_eq!(
+                process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(),
+                Some(1),
+                "the second removal re-adopts only the newly orphaned rows",
+            );
+            tx.commit().unwrap();
+        }
+        let audit_count: i64 = c
+            .conn
+            .query_row("SELECT COUNT(*) FROM table_sync_readoption_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(audit_count, 2, "both rounds left their provenance");
+
+        // An idempotent re-fold of the SAME removal does not re-arm the drained row.
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [9; 32],
+                21,
+                23,
+            )
+            .unwrap();
+            assert!(
+                store::readoption_work_for_stream(&tx, account, stream).unwrap().is_none(),
+                "the same roster_ref is a re-fold, not a new removal",
+            );
+            tx.commit().unwrap();
+        }
+    }
+
+    /// A row written twice by the removed device must have its audit name the entry the row's
+    /// LWW clock actually points at — the latest one, not the first.
+    #[test]
+    fn the_audit_names_the_winning_entry_for_a_row_written_twice() {
+        let mut a = Device::new();
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'v1')", []).unwrap();
+        let first = a.produce();
+        a.conn.execute("UPDATE t_demo SET title = 'v2' WHERE id = 'r1'", []).unwrap();
+        let second = a.produce();
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1, "the edit authors a second entry for the same row");
+
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        c.ingest_all(&first, &a.pubkey());
+        c.ingest_all(&second, &a.pubkey());
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [7; 32],
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(), Some(1));
+            tx.commit().unwrap();
+        }
+        let (original_lamport, original_hash): (i64, Vec<u8>) = c
+            .conn
+            .query_row(
+                "SELECT original_lamport, original_entry_hash FROM table_sync_readoption_audit",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let winner_lamport: i64 = c
+            .conn
+            .query_row(
+                "SELECT MAX(lamport) FROM table_sync_entries
+                 WHERE stream_id = ?1 AND device_fingerprint = ?2",
+                rusqlite::params![
+                    stream.to_bytes().as_slice(),
+                    a.pubkey().fingerprint().to_bytes().as_slice()
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            original_lamport, winner_lamport,
+            "original_* names the winning entry, not the first write"
+        );
+        let winner_hash: Vec<u8> = c
+            .conn
+            .query_row(
+                "SELECT entry_hash FROM table_sync_entries
+                 WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport = ?3",
+                rusqlite::params![
+                    stream.to_bytes().as_slice(),
+                    a.pubkey().fingerprint().to_bytes().as_slice(),
+                    original_lamport
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(original_hash, winner_hash, "the audit joins back by (lamport, hash)");
+    }
+
+    /// A later write that quarantined never owned the row's clock, so the audit must not name it:
+    /// dedup follows the clock, not the device's latest entry.
+    #[test]
+    fn the_audit_skips_a_quarantined_later_write_that_never_owned_the_clock() {
+        let mut a = Device::new();
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'v1')", []).unwrap();
+        let first = a.produce();
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        c.ingest_all(&first, &a.pubkey());
+        let first_hash = crate::entry::decode_signed(&first[0]).unwrap().entry.entry_hash;
+
+        // A's second write carries a wrongly-typed cell: stored and quarantined, never applied,
+        // so the row's clock still points at the FIRST entry.
+        let bad_op = RowOp::Upsert {
+            spec_version: 1,
+            table: "t_demo".to_string(),
+            pk: vec![row_op::TypedValue::Text("r1".to_string())],
+            cells: vec![row_op::Cell {
+                column: "title".to_string(),
+                value: row_op::TypedValue::I64(1),
+            }],
+        };
+        let bad = crate::entry::sign_entry_from_op_bytes(
+            a.local.secret(),
+            stream,
+            Some(first_hash),
+            1,
+            row_op::encode(&bad_op),
+        );
+        let outcomes = c.ingest_all(std::slice::from_ref(&bad.signed_bytes), &a.pubkey());
+        assert!(
+            matches!(outcomes.as_slice(), [IngestOutcome::Quarantined(_)]),
+            "the malformed write quarantines instead of taking the clock: {outcomes:?}",
+        );
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [7; 32],
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(), Some(1));
+            tx.commit().unwrap();
+        }
+        let original_lamport: i64 = c
+            .conn
+            .query_row("SELECT original_lamport FROM table_sync_readoption_audit", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(original_lamport, 0, "the audit names the entry the clock points at");
+    }
+
+    /// A device re-invited before the drain is effective again: its entries ingest directly, so
+    /// the pending removal completes WITHOUT re-authoring its rows.
+    #[test]
+    fn a_reinvited_devices_pending_removal_completes_without_reauthoring() {
+        let mut a = Device::new();
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'v')", []).unwrap();
+        let entry = a.produce();
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        c.ingest_all(&entry, &a.pubkey());
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [7; 32],
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        // A is re-invited (roster-effective again) before any sync pass drains the work.
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(), Some(0));
+            tx.commit().unwrap();
+        }
+        let audit_count: i64 = c
+            .conn
+            .query_row("SELECT COUNT(*) FROM table_sync_readoption_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(audit_count, 0, "an effective writer keeps its own clock ownership");
+        {
+            let tx = c.conn.transaction().unwrap();
+            assert!(
+                !store::has_pending_readoption_work(&tx, account, stream).unwrap(),
+                "the stale work item is completed, not left to re-author later",
+            );
+            tx.commit().unwrap();
+        }
+    }
+
+    /// An unreadable synced column must not be written off: the work item stays pending, and a
+    /// pass after the cell is repaired still re-adopts the row.
+    #[test]
+    fn an_unreadable_orphan_stays_pending_until_the_cell_is_repaired() {
+        const BOOL_SPEC: TableSpec = TableSpec {
+            name: "t_typed",
+            scope_id: "demo/1",
+            spec_version: 1,
+            pk: &[ColumnSpec::required("id", ValueType::Text)],
+            columns: &[ColumnSpec::required("flag", ValueType::Bool)],
+            local_columns: &[],
+            repo_column: None,
+        };
+        const BOOL_REGISTRY: &[TableSpec] = &[BOOL_SPEC];
+
+        let mut a = Device::new();
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+        for device in [&a, &c] {
+            device
+                .conn
+                .execute_batch("CREATE TABLE t_typed(id TEXT PRIMARY KEY, flag INTEGER) STRICT;")
+                .unwrap();
+        }
+
+        a.conn.execute("INSERT INTO t_typed(id, flag) VALUES ('r1', 1)", []).unwrap();
+        let entry = {
+            let tx = a.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &a.local,
+                registry: BOOL_REGISTRY,
+                now_ms: 0,
+            };
+            let out = produce_and_author(&tx, &ctx).unwrap();
+            tx.commit().unwrap();
+            out
+        };
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: BOOL_REGISTRY,
+                now_ms: 0,
+            };
+            for bytes in &entry {
+                ingest(&tx, &ctx, "demo/1", bytes, &a.pubkey()).unwrap();
+            }
+            tx.commit().unwrap();
+        }
+        // A raw write leaves the cell unreadable as its declared type (STRICT stores the integer;
+        // reading it as Bool rejects anything but 0/1).
+        c.conn.execute("UPDATE t_typed SET flag = 2 WHERE id = 'r1'", []).unwrap();
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [7; 32],
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: BOOL_REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(
+                process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(),
+                None,
+                "an unreadable row cannot be drained today",
+            );
+            assert!(
+                store::has_pending_readoption_work(&tx, account, stream).unwrap(),
+                "and the removal is NOT written off",
+            );
+            tx.commit().unwrap();
+        }
+
+        // Repair the cell content-identically: anti-echo means the producer authors nothing, so
+        // only the re-adoption pass can carry the row to a fresh replica.
+        c.conn.execute("UPDATE t_typed SET flag = 1 WHERE id = 'r1'", []).unwrap();
+        {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: BOOL_REGISTRY,
+                now_ms: 0,
+            };
+            assert_eq!(
+                process_readoption_work_for_stream(&tx, &ctx, stream).unwrap(),
+                Some(1),
+                "the repaired row is re-adopted by the retry",
+            );
+            tx.commit().unwrap();
+        }
+        let audit_count: i64 = c
+            .conn
+            .query_row("SELECT COUNT(*) FROM table_sync_readoption_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(audit_count, 1);
+    }
+
+    /// Two devices removed on one stream drain in ONE pass — the second repair does not wait a
+    /// whole sync session.
+    #[test]
+    fn one_pass_drains_every_pending_removal_on_a_stream() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'from-a')", []).unwrap();
+        b.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r2', 'from-b')", []).unwrap();
+        let from_a = a.produce();
+        let from_b = b.produce();
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, b.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        c.ingest_all(&from_a, &a.pubkey());
+        c.ingest_all(&from_b, &b.pubkey());
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        remove_writer(&c.conn, account, b.pubkey().fingerprint());
+
+        for (fingerprint, roster_ref) in
+            [(a.pubkey().fingerprint(), [7; 32]), (b.pubkey().fingerprint(), [8; 32])]
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(&tx, account, fingerprint, stream, roster_ref, 9, 10)
+                .unwrap();
+            tx.commit().unwrap();
+        }
+
+        let tx = c.conn.transaction().unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo",
+            account_id: account,
+            incarnation_ref: [0x44; 32],
+            device: &c.local,
+            registry: REGISTRY,
+            now_ms: 0,
+        };
+        while store::has_pending_readoption_work(&tx, account, stream).unwrap() {
+            process_readoption_work_for_stream(&tx, &ctx, stream).unwrap();
+        }
+        tx.commit().unwrap();
+
+        let audit_count: i64 = c
+            .conn
+            .query_row("SELECT COUNT(*) FROM table_sync_readoption_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(audit_count, 2, "both removals were repaired in the same pass");
+        assert_eq!(c.title().as_deref(), Some("from-a"));
+        let r2: String = c
+            .conn
+            .query_row("SELECT title FROM t_demo WHERE id = 'r2'", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(r2, "from-b");
     }
 
     /// Three rows authored in order on A, then delivered to B in REVERSE. Before entries awaiting

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -33,6 +33,7 @@ pub(crate) use registry::{ColumnSpec, TableSpec, ValueType};
 pub(crate) use row_op::{Cell, RowOp, TypedValue};
 #[cfg(test)]
 pub(crate) use scope_stream::scope_stream_id;
+pub(crate) use store::enqueue_readoption_work;
 #[cfg(test)]
 pub(crate) use store::{
     PendingReason, author_row_entry, mark_entry_pending, record_stream_context,

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -1009,6 +1009,310 @@ pub(crate) struct StreamContext {
     pub(crate) scope_id: String,
 }
 
+/// One roster-effective `DeviceRemove`'s stream-scoped repair obligation (#997).
+pub(crate) struct ReadoptionWork {
+    pub(crate) device_fingerprint: DeviceFingerprint,
+    pub(crate) roster_ref: [u8; 32],
+    pub(crate) removed_at_epoch: u64,
+}
+
+/// One row the removed writer authored on this stream, with the entry hash audit needs.
+#[derive(Clone)]
+pub(crate) struct ReadoptionCandidate {
+    pub(crate) table_name: String,
+    pub(crate) row_pk: String,
+    /// The removed writer's own entry coordinates — what the audit row's `original_*` columns
+    /// name. Carried alongside the hash so the audit joins back by `(lamport, hash)`.
+    pub(crate) original_lamport: u64,
+    pub(crate) entry_hash: [u8; 32],
+}
+
+/// The provenance one re-adopted row carries into the audit log.
+pub(crate) struct ReadoptionAudit {
+    pub(crate) account_id: AccountId,
+    pub(crate) removed: DeviceFingerprint,
+    pub(crate) adopter: DeviceFingerprint,
+    pub(crate) stream: StreamId,
+    pub(crate) repo_id: String,
+    pub(crate) scope_id: String,
+    pub(crate) table_name: String,
+    pub(crate) row_pk: String,
+    pub(crate) original_lamport: u64,
+    pub(crate) original_entry_hash: [u8; 32],
+    pub(crate) adopted_entry_hash: [u8; 32],
+    pub(crate) adopted_at_ms: i64,
+}
+
+/// Record the roster removal re-adoption owes, idempotently. The account fold calls this when it
+/// sees a roster fact close; re-folding the same removal never duplicates work.
+///
+/// The conflict update is MONOTONIC on `removed_at_epoch`: successive removals of one device are
+/// effective entries at strictly increasing epochs, so only a strictly newer removal re-arms a
+/// drained (or pending) row. Without the comparison, a device removed twice has two closed facts
+/// the fold enqueues in arbitrary `HashMap` order — each overwriting the other, re-arming a
+/// drained row on every fold and never letting the item settle. A same-epoch re-fold of the same
+/// removal is equally inert under this rule.
+pub(crate) fn enqueue_readoption_work(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    device_fingerprint: DeviceFingerprint,
+    stream: StreamId,
+    roster_ref: [u8; 32],
+    removed_at_epoch: u64,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO table_sync_readoption_work(
+             account_id, device_fingerprint, stream_id, roster_ref, removed_at_epoch,
+             enqueued_at_ms
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(account_id, device_fingerprint, stream_id) DO UPDATE SET
+             roster_ref = excluded.roster_ref,
+             removed_at_epoch = excluded.removed_at_epoch,
+             enqueued_at_ms = excluded.enqueued_at_ms,
+             processed_at_ms = NULL
+         WHERE excluded.removed_at_epoch > table_sync_readoption_work.removed_at_epoch",
+        params![
+            account_id.to_bytes().as_slice(),
+            device_fingerprint.to_bytes().as_slice(),
+            stream.to_bytes().as_slice(),
+            roster_ref.as_slice(),
+            i64::try_from(removed_at_epoch)?,
+            now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Attach removals this account folded while `stream` had no directory row. Stored under a zero
+/// stream id until first contact; the current processor rejects that placeholder because it is
+/// neither current nor registered.
+///
+/// Known limitation: the copy lands only in the FIRST stream to record a context — a stream
+/// created later for a different scope never learns of the removal. Unreachable today: a removal
+/// parked before any stream existed can have orphaned nothing on a stream created afterwards
+/// (the #935 gate drops the removed writer's new entries there), and production registers a
+/// single scope. Revisit if multi-scope registries arrive.
+fn enqueue_precontext_readoption_work(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    account_id: AccountId,
+) -> anyhow::Result<()> {
+    let precontext = StreamId::from_bytes([0; 32]).to_bytes();
+    let mut stmt = tx.prepare(
+        "SELECT device_fingerprint, roster_ref, removed_at_epoch, enqueued_at_ms
+         FROM table_sync_readoption_work
+         WHERE account_id = ?1 AND stream_id = ?2 AND processed_at_ms IS NULL",
+    )?;
+    let rows = stmt
+        .query_map(params![account_id.to_bytes().as_slice(), precontext.as_slice()], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for (device, roster_ref, epoch, enqueued_at_ms) in rows {
+        enqueue_readoption_work(
+            tx,
+            account_id,
+            DeviceFingerprint::from_bytes(fixed32(device)?),
+            stream,
+            fixed32(roster_ref)?,
+            u64::try_from(epoch)?,
+            enqueued_at_ms,
+        )?;
+    }
+    // The parked copy has served its purpose: without this stamp, it would copy itself into every
+    // later stream's first context as well.
+    tx.execute(
+        "UPDATE table_sync_readoption_work SET processed_at_ms = enqueued_at_ms
+         WHERE account_id = ?1 AND stream_id = ?2 AND processed_at_ms IS NULL",
+        params![account_id.to_bytes().as_slice(), precontext.as_slice()],
+    )?;
+    Ok(())
+}
+
+/// The pending repair owed by `stream`, if its remove was folded before this stream's first
+/// locally-known entry recorded the directory context. `None` also covers an already-drained item.
+pub(crate) fn readoption_work_for_stream(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    stream: StreamId,
+) -> anyhow::Result<Option<ReadoptionWork>> {
+    let row = tx
+        .query_row(
+            "SELECT device_fingerprint, roster_ref, removed_at_epoch
+             FROM table_sync_readoption_work
+             WHERE account_id = ?1 AND stream_id = ?2 AND processed_at_ms IS NULL",
+            params![account_id.to_bytes().as_slice(), stream.to_bytes().as_slice()],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, i64>(2)?)),
+        )
+        .optional()?;
+    row.map(|(device, roster_ref, epoch)| -> anyhow::Result<_> {
+        Ok(ReadoptionWork {
+            device_fingerprint: DeviceFingerprint::from_bytes(fixed32(device)?),
+            roster_ref: fixed32(roster_ref)?,
+            removed_at_epoch: u64::try_from(epoch)?,
+        })
+    })
+    .transpose()
+}
+
+/// Whether `stream` owes any unprocessed re-adoption — the drain loop's progress condition.
+pub(crate) fn has_pending_readoption_work(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    stream: StreamId,
+) -> anyhow::Result<bool> {
+    Ok(tx.query_row(
+        "SELECT EXISTS(
+                 SELECT 1 FROM table_sync_readoption_work
+                 WHERE account_id = ?1 AND stream_id = ?2 AND processed_at_ms IS NULL
+             )",
+        params![account_id.to_bytes().as_slice(), stream.to_bytes().as_slice()],
+        |row| row.get::<_, i64>(0),
+    )? == 1)
+}
+
+/// Every row op the removed device authored on this stream, reduced to its row identity and
+/// provenance hash. This is the bounded candidate set the #997 redesign requires: the device's own
+/// accepted history, never a scan of every clock or deletion the merge tables have ever seen.
+pub(crate) fn readoption_candidates(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device_fingerprint: DeviceFingerprint,
+) -> anyhow::Result<Vec<ReadoptionCandidate>> {
+    let mut stmt = tx.prepare(
+        "SELECT lamport, entry_hash, signed_bytes FROM table_sync_entries
+         WHERE stream_id = ?1 AND device_fingerprint = ?2
+         ORDER BY lamport",
+    )?;
+    let rows = stmt
+        .query_map(
+            params![stream.to_bytes().as_slice(), device_fingerprint.to_bytes().as_slice()],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?)),
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut candidates = Vec::with_capacity(rows.len());
+    for (lamport, hash, signed_bytes) in rows {
+        let Ok(signed) = entry::decode_signed(&signed_bytes) else {
+            continue;
+        };
+        let op = match row_op::decode(&signed.entry.op_bytes) {
+            Ok(DecodedRowOp::Known(op)) => op,
+            // Retained but not understood here; its table/row identity cannot be established.
+            _ => continue,
+        };
+        candidates.push(ReadoptionCandidate {
+            table_name: op.table().to_string(),
+            row_pk: row_op::row_pk_string(op.pk()),
+            original_lamport: u64::try_from(lamport)?,
+            entry_hash: fixed32(hash)?,
+        });
+    }
+    // One candidate per row, and it must be the entry the row's whole-row LWW clock points AT: the
+    // audit's `original_*` columns are provenance for the winning entry, so a later entry that was
+    // quarantined and never owned the clock must not be named. Rows arrive in lamport order, so
+    // the last per row is the fallback when the clock row is gone.
+    let mut by_row: std::collections::HashMap<(String, String), Vec<ReadoptionCandidate>> =
+        std::collections::HashMap::new();
+    for candidate in candidates {
+        by_row
+            .entry((candidate.table_name.clone(), candidate.row_pk.clone()))
+            .or_default()
+            .push(candidate);
+    }
+    let mut out = Vec::with_capacity(by_row.len());
+    for ((table_name, row_pk), entries) in by_row {
+        let winner = winner_lamport_for_row(tx, stream, &table_name, &row_pk)?;
+        let chosen = entries
+            .iter()
+            .find(|candidate| Some(candidate.original_lamport) == winner)
+            .or(entries.last())
+            .expect("one entry per grouped row");
+        out.push(chosen.clone());
+    }
+    out.sort_by_key(|candidate| candidate.original_lamport);
+    Ok(out)
+}
+
+/// The lamport the row's merge state currently crowns — the live clock when present and newer, the
+/// tombstone otherwise. `None` when the row has no merge state at all.
+fn winner_lamport_for_row(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    table_name: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<u64>> {
+    let mut stmt = tx.prepare(
+        "SELECT MAX(lamport) FROM (
+             SELECT lamport FROM sync_row_clocks
+              WHERE stream_id = ?1 AND table_name = ?2 AND row_pk = ?3
+             UNION ALL
+             SELECT lamport FROM sync_row_tombstones
+              WHERE stream_id = ?1 AND table_name = ?2 AND row_pk = ?3
+         )",
+    )?;
+    let highest: Option<i64> = stmt
+        .query_row(params![stream.to_bytes().as_slice(), table_name, row_pk], |row| row.get(0))?;
+    highest.map(u64::try_from).transpose().map_err(Into::into)
+}
+
+/// Record one re-authored row operation with the removed writer's original entry as provenance.
+pub(crate) fn record_readoption_audit(
+    tx: &Transaction<'_>,
+    audit: ReadoptionAudit,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO table_sync_readoption_audit(
+             account_id, removed_fingerprint, adopter_fingerprint, stream_id, repo_id, scope_id,
+             table_name, row_pk, original_lamport, original_entry_hash, adopted_entry_hash,
+             adopted_at_ms
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        params![
+            audit.account_id.to_bytes().as_slice(),
+            audit.removed.to_bytes().as_slice(),
+            audit.adopter.to_bytes().as_slice(),
+            audit.stream.to_bytes().as_slice(),
+            audit.repo_id,
+            audit.scope_id,
+            audit.table_name,
+            audit.row_pk,
+            i64::try_from(audit.original_lamport)?,
+            audit.original_entry_hash.as_slice(),
+            audit.adopted_entry_hash.as_slice(),
+            audit.adopted_at_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Mark one removal's stream repair complete. The work row remains as the durable witness that
+/// this removal was handled; re-processing is gated on `processed_at_ms IS NULL`.
+pub(crate) fn complete_readoption_work(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    device_fingerprint: DeviceFingerprint,
+    stream: StreamId,
+    processed_at_ms: i64,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "UPDATE table_sync_readoption_work SET processed_at_ms = ?4
+         WHERE account_id = ?1 AND device_fingerprint = ?2 AND stream_id = ?3
+           AND processed_at_ms IS NULL",
+        params![
+            account_id.to_bytes().as_slice(),
+            device_fingerprint.to_bytes().as_slice(),
+            stream.to_bytes().as_slice(),
+            processed_at_ms,
+        ],
+    )?;
+    Ok(())
+}
+
 pub(crate) fn assert_current_incarnation(
     tx: &Transaction<'_>,
     account_id: AccountId,
@@ -1066,6 +1370,7 @@ pub(crate) fn record_stream_context(
             && recorded.3 == scope_id,
         "table-sync stream context conflicts with its existing directory row",
     );
+    enqueue_precontext_readoption_work(tx, stream, account_id)?;
     Ok(())
 }
 
@@ -1173,6 +1478,115 @@ mod tests {
             table: "t".to_string(),
             pk: vec![TypedValue::Text(id.to_string())],
         }
+    }
+
+    #[test]
+    fn readoption_work_enqueues_reads_rearms_and_completes() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        let device = DeviceFingerprint::from_bytes([7; 32]);
+
+        assert!(!has_pending_readoption_work(&tx, account(), stream()).unwrap());
+        assert!(readoption_work_for_stream(&tx, account(), stream()).unwrap().is_none());
+
+        enqueue_readoption_work(&tx, account(), device, stream(), [3; 32], 11, 12).unwrap();
+        let work = readoption_work_for_stream(&tx, account(), stream()).unwrap().unwrap();
+        assert_eq!(work.device_fingerprint, device);
+        assert_eq!(work.roster_ref, [3; 32]);
+        assert_eq!(work.removed_at_epoch, 11);
+        assert!(has_pending_readoption_work(&tx, account(), stream()).unwrap());
+
+        // A same-roster_ref re-enqueue (an idempotent re-fold) changes nothing.
+        enqueue_readoption_work(&tx, account(), device, stream(), [3; 32], 11, 99).unwrap();
+        let work = readoption_work_for_stream(&tx, account(), stream()).unwrap().unwrap();
+        assert_eq!(work.removed_at_epoch, 11, "a re-fold of the same removal is inert");
+
+        // A new removal (re-invite, newer epoch) re-arms the row even before completion.
+        enqueue_readoption_work(&tx, account(), device, stream(), [4; 32], 21, 22).unwrap();
+        let work = readoption_work_for_stream(&tx, account(), stream()).unwrap().unwrap();
+        assert_eq!(work.roster_ref, [4; 32]);
+        assert_eq!(work.removed_at_epoch, 21, "the new removal replaces the stale record");
+
+        complete_readoption_work(&tx, account(), device, stream(), 30).unwrap();
+        assert!(readoption_work_for_stream(&tx, account(), stream()).unwrap().is_none());
+        assert!(!has_pending_readoption_work(&tx, account(), stream()).unwrap());
+
+        // A STALE removal (an older closed fact, enqueued late by an arbitrary fold order) must
+        // not re-arm the drained row: the update is monotonic on removed_at_epoch.
+        enqueue_readoption_work(&tx, account(), device, stream(), [3; 32], 11, 40).unwrap();
+        assert!(
+            !has_pending_readoption_work(&tx, account(), stream()).unwrap(),
+            "an older removal never re-arms a settled row",
+        );
+
+        // A genuinely newer removal still re-arms after completion.
+        enqueue_readoption_work(&tx, account(), device, stream(), [5; 32], 31, 41).unwrap();
+        let work = readoption_work_for_stream(&tx, account(), stream()).unwrap().unwrap();
+        assert_eq!(work.roster_ref, [5; 32]);
+        assert_eq!(work.removed_at_epoch, 31);
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn a_first_stream_context_adopts_parked_work_and_stamps_it() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        let device = DeviceFingerprint::from_bytes([7; 32]);
+        let parked = StreamId::from_bytes([0; 32]);
+
+        // The removal folded while this account had NO streams: the work parks under the
+        // placeholder stream id.
+        enqueue_readoption_work(&tx, account(), device, parked, [3; 32], 11, 12).unwrap();
+        assert!(!has_pending_readoption_work(&tx, account(), stream()).unwrap());
+
+        // The first authored or ingested entry records this stream's context, and the parked
+        // work moves onto it — once, never again.
+        record_stream_context(&tx, stream(), "repo", account(), [0x44; 32], "demo/1").unwrap();
+        let work = readoption_work_for_stream(&tx, account(), stream()).unwrap().unwrap();
+        assert_eq!(work.roster_ref, [3; 32]);
+        assert!(
+            !has_pending_readoption_work(&tx, account(), parked).unwrap(),
+            "the placeholder copy is stamped processed when it is adopted"
+        );
+        // Recording another stream does NOT re-adopt the same removal.
+        let other = StreamId::from_bytes([6; 32]);
+        record_stream_context(&tx, other, "repo", account(), [0x44; 32], "demo/2").unwrap();
+        assert!(
+            readoption_work_for_stream(&tx, account(), other).unwrap().is_none(),
+            "a stamped placeholder does not copy into later streams"
+        );
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn readoption_audit_records_provenance() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        record_readoption_audit(&tx, ReadoptionAudit {
+            account_id: account(),
+            removed: DeviceFingerprint::from_bytes([7; 32]),
+            adopter: DeviceFingerprint::from_bytes([8; 32]),
+            stream: stream(),
+            repo_id: "repo".to_string(),
+            scope_id: "demo/1".to_string(),
+            table_name: "t".to_string(),
+            row_pk: "aa".to_string(),
+            original_lamport: 7,
+            original_entry_hash: [1; 32],
+            adopted_entry_hash: [2; 32],
+            adopted_at_ms: 42,
+        })
+        .unwrap();
+        let row: (i64, Vec<u8>, Vec<u8>, i64) = tx
+            .query_row(
+                "SELECT original_lamport, original_entry_hash, adopted_entry_hash, adopted_at_ms
+                 FROM table_sync_readoption_audit",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (7, vec![1; 32], vec![2; 32], 42));
+        tx.commit().unwrap();
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -11,6 +11,7 @@ use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, 
 use super::engine::{self, IngestOutcome, SyncCtx};
 use super::registry::{SYNCABLE_TABLES, TableSpec};
 use super::scope_stream::scope_stream_id;
+use super::store;
 use crate::AccountId;
 use crate::account::{self, RepoIncarnationState};
 use crate::device::DevicePublic;
@@ -81,6 +82,9 @@ pub fn table_sync_supported_streams(
 }
 
 /// Author every unpublished local row in the production registry before a table manifest is built.
+///
+/// The count includes entries authored by re-adoption (#997): a removal drain can be the only
+/// thing this pass authors, and a caller using the return as "did anything change" must see it.
 pub fn table_sync_author_pending(
     conn: &Connection,
     account_id: AccountId,
@@ -101,15 +105,42 @@ pub fn table_sync_author_pending(
     let mut authored = 0;
     for (repo_id, incarnation_ref) in repos {
         let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-        authored += engine::produce_and_author(&tx, &SyncCtx {
+        let ctx = SyncCtx {
             repo_id: &repo_id,
             account_id,
             incarnation_ref,
             device: &device,
             registry: SYNCABLE_TABLES,
             now_ms,
-        })?
-        .len();
+        };
+        // INVARIANT: the account fold enqueues re-adoption work for EVERY stream in
+        // table_sync_streams, while this drain only walks repo-scoped specs' streams. The two
+        // sets coincide as long as every registered production table is repo-scoped — registering
+        // an account-scoped table must derive the drain set from the work table instead.
+        let mut streams: Vec<crate::stream::StreamId> = SYNCABLE_TABLES
+            .iter()
+            .filter(|spec| spec.repo_column.is_some())
+            .map(|spec| scope_stream_id(&repo_id, account_id, incarnation_ref, spec.scope_id))
+            .collect();
+        authored += engine::produce_and_author(&tx, &ctx)?.len();
+        streams.sort_unstable();
+        streams.dedup();
+        for stream in streams {
+            // Drain EVERY pending removal, not one: two devices removed on one stream must not
+            // wait a whole sync session for the second repair. Each call completes one removal, so
+            // `has_pending` makes progress — UNLESS the pass cannot drain: a row whose synced
+            // column is unreadable today (retried once the cell is repaired), or a stream with no
+            // recorded apply context. `None` is that case: stop rather than spin on a work item
+            // this pass cannot finish.
+            while store::has_pending_readoption_work(&tx, account_id, stream)? {
+                let Some(reauthored) =
+                    engine::process_readoption_work_for_stream(&tx, &ctx, stream)?
+                else {
+                    break;
+                };
+                authored += reauthored;
+            }
+        }
         tx.commit()?;
     }
     Ok(authored)


### PR DESCRIPTION
Closes #997.

## Summary
- record each effective roster removal as durable stream-scoped re-adoption work during the authority projection rewrite
- drain that work from the producer transaction by walking only the removed writer’s accepted table entries
- re-author surviving whole-row state under the current writer, with physical-table liveness and audit provenance

## Verification
- cargo +nightly fmt --all -- --check
- cargo clippy -p rag-rat-oplog -p rag-rat-db --all-targets -- -D warnings
- cargo test -p rag-rat-oplog readoption --lib
- cargo test -p rag-rat-oplog --lib
- cargo test -p rag-rat-db --lib