### PR TITLE
ci: fail when a shipped skill copy drifts from its source

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -1,6 +1,7 @@
 name: plugin-test
 
 # Exercises the plugin install/run surfaces that unit tests can't:
+#   * each shipped skill still byte-matches its .agents/skills source
 #   * launcher × Linux glibc/musl matrix (does the binary run + does the launcher wire MCP stdio?)
 #   * Claude Code non-interactive plugin install + manifest validation
 #   * Codex marketplace-add manifest validation
@@ -11,6 +12,9 @@ on:
   pull_request:
     paths:
       - "plugin/**"
+      # The skill sources: drift between a source and its shipped copy can be introduced from
+      # either side, and a .agents-only edit touches nothing under plugin/ (#1075).
+      - ".agents/skills/**"
       - ".cursor-plugin/**"
       - ".github/workflows/plugin-test.yml"
   workflow_dispatch:
@@ -28,6 +32,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── plugin/skills/<name> is a hand-maintained copy of .agents/skills/<name>; diff every pair ─────
+  # ── No build, so no `if:` guard — it costs seconds and is worth running in the dispatch mode too. ─
+  skill-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash plugin/test/verify-skill-parity.sh
+
   # ── Build a rag-rat once so the launcher matrix can drive a real MCP handshake ──────────────────
   build-binary:
     if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '') }}

--- a/plugin/test/README.md
+++ b/plugin/test/README.md
@@ -4,6 +4,7 @@ Layered so each layer is as cheap and un-flaky as possible. Driven by `.github/w
 
 | Layer | What it proves | Auth? | Runner |
 |---|---|---|---|
+| **L0 skill parity** | every `plugin/skills/<name>` still byte-matches its `.agents/skills/<name>` source | none | plain checkout |
 | **L1 launcher × glibc/musl** | the binary runs on a distro **and** the launcher wires MCP stdio | none | Docker matrix |
 | **L2 Claude install** | manifests validate; MCP + skills + **hooks** register (asserts `Hooks (≥1)`) | none | `npm i -g @anthropic-ai/claude-code` |
 | **L2 Codex install** | `plugin add`/`list` install + enable; components stage into cache | none | `npm i -g @openai/codex` |
@@ -16,6 +17,9 @@ session would need an API key and is **deliberately out of scope** — see the n
 ## Run locally
 
 ```bash
+# L0 — no dependencies at all, just the checkout:
+bash plugin/test/verify-skill-parity.sh
+
 # L1 — launcher against a local build (full handshake):
 RAG_RAT_BIN="$(command -v rag-rat)" sh plugin/test/verify-launcher.sh
 # L1 — logic only (no binary): syntax + --no-install no-op; handshake skipped

--- a/plugin/test/verify-skill-parity.sh
+++ b/plugin/test/verify-skill-parity.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Every skill under plugin/skills/ is a hand-maintained COPY of its .agents/skills/ source (#1075).
+# .claude/skills and .codex/skills are symlinks into .agents, so those always agree; the plugin copy
+# is the one that ships to users, and nothing else in the repo notices when the two diverge — no
+# build, test or lint reads them. #1074 had to edit both and the drift was caught only by an
+# unrelated `diff -q`. This is that diff, run on every PR that touches either side.
+#
+# Direction: plugin/skills/ defines the SHIPPED set, so the loop walks it. The reverse is not an
+# error — repository-only contributor skills (e.g. rust-modern-style) live under .agents/skills and
+# are deliberately absent from the installer (skills/README.md); they're listed here, not failed on.
+# Pairs are discovered, never listed: a hardcoded list would itself go stale the next time a skill is
+# added, which is the defect this check exists to prevent.
+set -u
+ROOT="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+SRC_ROOT="$ROOT/.agents/skills"
+SHIPPED_ROOT="$ROOT/plugin/skills"
+step() { echo; echo "### $*"; }
+pass() { echo "PASS: $*"; }
+# Unlike the install scripts, fail() does NOT exit: with several skills it is worth naming EVERY
+# diverged pair in one run rather than making the author re-run CI per skill.
+failures=0
+fail() { echo "FAIL: $*" >&2; failures=$((failures + 1)); }
+
+[ -d "$SHIPPED_ROOT" ] || { echo "FAIL: no shipped skills directory at $SHIPPED_ROOT" >&2; exit 1; }
+[ -d "$SRC_ROOT" ] || { echo "FAIL: no skill source directory at $SRC_ROOT" >&2; exit 1; }
+
+step "diff each shipped skill against its source"
+pairs=0
+for shipped in "$SHIPPED_ROOT"/*/; do
+  [ -d "$shipped" ] || continue # unexpanded glob: no shipped skills at all
+  name="$(basename "$shipped")"
+  src="$SRC_ROOT/$name"
+  pairs=$((pairs + 1))
+  if [ ! -d "$src" ]; then
+    fail "plugin/skills/$name ships with no source at .agents/skills/$name"
+    continue
+  fi
+  # -r so reference/ files and any future asset count too, and so a file present on only one side
+  # is reported; -u because the diff is the whole point of the failure message.
+  if diff -ru "$src" "$shipped"; then
+    pass ".agents/skills/$name == plugin/skills/$name"
+  else
+    fail ".agents/skills/$name and plugin/skills/$name have diverged (diff above: --- source, +++ shipped)"
+  fi
+done
+
+# A checkout with no pairs left to compare means the layout moved and this check silently stopped
+# testing anything — the exact failure mode it guards against.
+[ "$pairs" -gt 0 ] || { echo "FAIL: no skills found under $SHIPPED_ROOT" >&2; exit 1; }
+
+step "repository-only skills (no shipped copy — informational)"
+for src in "$SRC_ROOT"/*/; do
+  [ -d "$src" ] || continue
+  name="$(basename "$src")"
+  [ -d "$SHIPPED_ROOT/$name" ] || echo "  .agents/skills/$name (not in the installer bundle)"
+done
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "skill parity: $failures of $pairs shipped skill(s) differ from their source." >&2
+  echo "Fix by copying the authoritative side over the other — both must be byte-identical." >&2
+  exit 1
+fi
+echo "skill parity verification: OK ($pairs shipped skill(s) match their source)"


### PR DESCRIPTION
## Summary

Adds a CI check that diffs each `.agents/skills/<name>/` source against its shipped `plugin/skills/<name>/` copy and fails on divergence, so the drift that #1074 hit is caught mechanically instead of by an unrelated `diff -q`.

## Related Issues and Pull Requests

Fixes #1075

## Changes

- **`plugin/test/verify-skill-parity.sh`** (new) — walks the shipped set under `plugin/skills/`, resolves each back to its source, and runs a recursive byte-level `diff -ru` per pair. Prints the diff plus a `FAIL:` line naming the pair; does not exit early, so one run reports every diverged pair rather than just the first. Follows the existing script shape in this directory (`verify-codex-install.sh:1-11`): `set -u`, `ROOT="${1:-…}"` derived from `$0`, `step()/fail()/pass()` helpers.
- **`.github/workflows/plugin-test.yml`** — new `skill-parity` job, and `.agents/skills/**` added to the `pull_request` path filter. The filter previously listed only `plugin/**`, `.cursor-plugin/**` and the workflow itself, so a source-side edit would not have triggered this workflow at all. Both drift directions are now covered, including edits made through the `.claude/skills/` and `.codex/skills/` symlinks, which resolve into `.agents/skills/`.
- **`plugin/test/README.md`** — an L0 row in the layer table and the local-run line, so the index of these scripts does not itself go stale.

Three decisions grounded in the repo rather than general practice:

- **It walks the shipped set, not the source set, because the trees are deliberately not 1:1.** `rust-modern-style` is repository-local by design — `plugin/README.md:61-62` ("Regeneration must copy this explicit allowlist, never mirror all of `.agents/skills`: contributor-only guidance such as `rust-modern-style` stays repository-local"), with the same intent at `skills/README.md:62-64` and `skills/cli.mjs:16-18`. Source-only skills are listed informationally rather than failed.
- **It diffs directories recursively, not just `SKILL.md`.** `init-rag-rat` also ships three `references/*.md` files, and a per-`SKILL.md` check would miss drift in those.
- **It lives in `plugin-test.yml`, not `ci.yml`.** `ci.yml` as configured sets `paths-ignore: ['**/*.md','docs/**']` on *both* its `push` and `pull_request` triggers (`ci.yml:8-14`), and every skill file is `.md` — so a skill-only change never reaches it. Since GitHub has no per-job path filter, hosting the check there would mean relaxing the workspace gate's ignore list, which seemed the wrong trade.

## Testing

Local, since the change adds no Rust and compiles nothing — no cargo command applied.

- `bash plugin/test/verify-skill-parity.sh` on a clean tree → exit 0, `OK (4 shipped skill(s) match their source)`.
- **Proved it fails when it should**, each restored afterwards: source edited but not the copy; a trailing-space-only change; a stripped final newline; a `references/*.md` deleted from the shipped side; the whole `references/` directory deleted; an orphan `plugin/skills/<x>/` with no source; and two divergences at once (both reported in one run). All exit 1 with the offending pair named and the diff shown.
- **Checked it cannot pass vacuously.** Missing `plugin/skills/`, missing `.agents/skills/`, an empty `plugin/skills/`, a `plugin/skills/` containing only files, and a bogus root argument all exit 1 — the script has an explicit zero-pair gate rather than iterating an empty set and succeeding.
- Parity holds today: all 7 shipped files have byte-identical git blob OIDs to their sources on `main`. No skill content was edited by this PR.
- `shellcheck` on the new script → exit 0, no findings. `actionlint` 1.7.7 on the modified workflow → exit 0, and the `main` baseline of that file is also clean.
- Verified `git status --short` and `git diff HEAD --stat` are empty after every mutation test, and that the 11 committed symlinks under `.claude/skills` / `.codex/skills` are untouched.

All of the divergence and vacuity checks above were run against a disposable `git archive` copy rather than the checkout, so the committed tree was never mutated.

## Follow-ups / Known Limitations

- **A brand-new *public* skill added under `.agents/skills/` with no shipped copy still passes**, reported as repository-only. That is the same defect class this check exists to kill, and it is arguably the likelier shape in practice. The one-directional walk cannot distinguish "deliberately repo-local" from "forgot to ship it" without something recording the intent, and no manifest enumerates skills today — `plugin/.claude-plugin/plugin.json` and `plugin/.mcp.json` do not list them; the installer discovers by directory walk. Closing it would need an explicit repo-only marker (a list file, or SKILL.md frontmatter). Flagging it rather than guessing at the mechanism.
- `plugin/README.md:59` names the four public skills in prose, and `tools/sync-plugin-version.mjs:66-71` hardcodes its `PIN_FILES` pair list. Both are the same hand-maintained-list pattern and both can go stale as skills are added. `PIN_FILES` is correct today — it lists both sides of the `init-rag-rat` pair.
- Nothing guards a **direct push to `main`**: `plugin-test.yml` has no `push` trigger, and `ci.yml`'s push trigger is `.md`-ignored. Adding one felt like scope creep here, but say the word and I will.
- The issue mentions a better long-term shape — generate the shipped copy at package time so there is one source of truth. This check is a prerequisite for that either way, since it proves the two are equal before anything starts generating one from the other. Happy to follow up if that is the direction you want.

## Footer

Generated by Claude Opus 5 (brief, implementation, review, verification)