### PR TITLE
refactor(index): unify the call-side path stripper onto the scanner

### DIFF
--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -2,43 +2,9 @@ use std::collections::BTreeSet;
 
 use super::*;
 
-/// Remove balanced `<...>` generic-argument regions from a call path — and the turbofish's leading
-/// `::` (`f::<a::B>` → `f`, `Vec::<u8>::new` → `Vec::new`) — so a generic argument's `::` /
-/// identifiers don't corrupt path-based call name / receiver / qualified-name extraction. `<`/`>`
-/// inside a `{...}` const-generic block (`Foo::<{ 1 << 2 }>`) are shift/comparison operators, not
-/// generic delimiters, so brace regions suppress angle counting.
-///
-/// A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default`), NOT a generic argument —
-/// stripping it would drop the type/receiver and mangle the qualified name (#208 review round 10),
-/// so a path that starts with `<` is returned unchanged.
-pub(crate) fn strip_generics(path: &str) -> String {
-    if path.trim_start().starts_with('<') {
-        return path.to_string();
-    }
-    let mut out = String::new();
-    let mut angle: u32 = 0;
-    let mut brace: u32 = 0;
-    for ch in path.chars() {
-        match ch {
-            '{' => brace += 1,
-            '}' => brace = brace.saturating_sub(1),
-            '<' if brace == 0 => {
-                if angle == 0 && out.ends_with("::") {
-                    out.truncate(out.len() - 2);
-                }
-                angle += 1;
-            },
-            '>' if brace == 0 => angle = angle.saturating_sub(1),
-            _ if angle == 0 => out.push(ch),
-            _ => {},
-        }
-    }
-    out
-}
-
 pub(crate) fn target_qualified_name(node: Node<'_>, text: &str) -> Option<String> {
     let function = node.child_by_field_name("function").unwrap_or(node);
-    let value = strip_generics(&node_text(function, text));
+    let value = degeneric_path(&node_text(function, text));
     (value.contains("::") || value.contains('.')).then(|| value.replace('.', "::"))
 }
 
@@ -189,7 +155,7 @@ pub(crate) fn call_target_node(node: Node<'_>) -> Option<Node<'_>> {
 }
 pub(crate) fn scoped_receiver_name(node: Node<'_>, text: &str) -> Option<String> {
     let function = node.child_by_field_name("function").unwrap_or(node);
-    let value = strip_generics(&node_text(function, text));
+    let value = degeneric_path(&node_text(function, text));
     let separator = if value.contains("::") {
         "::"
     } else if value.contains('.') {

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -153,21 +153,23 @@ pub(crate) fn call_target_node(node: Node<'_>) -> Option<Node<'_>> {
         .or_else(|| first_identifier_node(node))
         .map(final_segment_node)
 }
+/// The name a call hangs off — the head of `Type::method` / `receiver.method`.
+///
+/// The `::` split is [`scope_grammar::segments`]' TOP-LEVEL one. `degeneric_path` deliberately
+/// keeps a `::` that sits inside a `(…)`/`[…]` group, because there it is argument text rather
+/// than a path separator, so splitting on every `::` would take the head from the arguments:
+/// `conn.execute("…", rusqlite::params![…]).unwrap` hangs off `conn`, not off the `rusqlite` in
+/// its argument list, and `stmt.query_map(.., |row| row.get::<_, String>(0)).unwrap` hangs off
+/// `stmt`, not off the `get` buried in the closure.
 pub(crate) fn scoped_receiver_name(node: Node<'_>, text: &str) -> Option<String> {
     let function = node.child_by_field_name("function").unwrap_or(node);
     let value = degeneric_path(&node_text(function, text));
-    let separator = if value.contains("::") {
-        "::"
-    } else if value.contains('.') {
-        "."
-    } else {
-        return None;
+    let head = match scope_grammar::segments(&value).as_slice() {
+        [head, _, ..] => head,
+        _ if value.contains('.') => value.split('.').next()?,
+        _ => return None,
     };
-    value
-        .split(separator)
-        .next()
-        .map(|name| short_name(name.trim()).to_string())
-        .filter(|name| !name.is_empty())
+    Some(short_name(head.trim()).to_string()).filter(|name| !name.is_empty())
 }
 pub(crate) fn child_name_text(node: Node<'_>, text: &str) -> Option<String> {
     node.child_by_field_name("name")
@@ -763,5 +765,71 @@ mod containing_symbol_tests {
         let selected = locator.find_index_by(8_190, || probes += 1);
         assert_eq!(selected.map(|index| symbols[index].id), Some(4_095));
         assert!(probes <= 14, "{probes} probes for {} symbols", symbols.len());
+    }
+}
+
+#[cfg(test)]
+mod scoped_receiver_name_tests {
+    use super::*;
+
+    /// The outermost `call_expression` in a parsed snippet — the one whose `function` field spans
+    /// a whole method chain, which is where a nested `::` can appear.
+    ///
+    /// Breadth-first, so the shallowest match is the outermost one, and iterative so it is not a
+    /// recursive tree descender (#543).
+    fn outermost_call<'tree>(root: Node<'tree>) -> Option<Node<'tree>> {
+        let mut queue = std::collections::VecDeque::from([root]);
+        while let Some(node) = queue.pop_front() {
+            if node.kind() == "call_expression" {
+                return Some(node);
+            }
+            let mut cursor = node.walk();
+            queue.extend(node.children(&mut cursor));
+        }
+        None
+    }
+
+    fn receiver_of(expression: &str) -> Option<String> {
+        let source = format!("fn probe() {{ {expression}; }}");
+        let parsed = crate::index::parser::parse_file(
+            std::path::Path::new("probe.rs"),
+            Language::Rust,
+            &source,
+        )?;
+        scoped_receiver_name(outermost_call(parsed.root())?, &source)
+    }
+
+    /// A `::` inside the ARGUMENT list is not a path separator, so the head of the path — the name
+    /// the call hangs off — is never taken from the arguments.
+    #[test]
+    fn a_nested_separator_does_not_move_the_receiver_into_the_arguments() {
+        assert_eq!(
+            receiver_of(
+                r#"conn.execute("INSERT INTO t VALUES (?1)", rusqlite::params![x]).unwrap()"#
+            )
+            .as_deref(),
+            Some("conn"),
+            "a `::` path spelled in the arguments"
+        );
+        assert_eq!(
+            receiver_of("stmt.query_map([], |row| row.get::<_, String>(0)).unwrap()").as_deref(),
+            Some("stmt"),
+            "a turbofish inside a closure inside the arguments"
+        );
+        assert_eq!(
+            receiver_of("items.iter().map(|v| v.parse::<i64>()).collect::<Vec<_>>()").as_deref(),
+            Some("items"),
+            "a turbofish in the arguments AND one on the outermost callee"
+        );
+    }
+
+    /// A TOP-LEVEL `::` still separates, and still outranks a later `.`.
+    #[test]
+    fn a_top_level_separator_still_names_the_owner() {
+        assert_eq!(receiver_of("Worker::spawn(cfg).run()").as_deref(), Some("Worker"));
+        assert_eq!(receiver_of("a::b::Worker::spawn()").as_deref(), Some("a"));
+        assert_eq!(receiver_of("Vec::<u8>::new()").as_deref(), Some("Vec"));
+        assert_eq!(receiver_of("worker.run()").as_deref(), Some("worker"));
+        assert_eq!(receiver_of("bare()").as_deref(), None, "no separator at all");
     }
 }

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -558,6 +558,11 @@ impl IndexedSymbol {
 
 /// Drop generic ARGUMENTS from a path — see [`scope_grammar::degeneric`], which owns the parsing
 /// rules every consumer of these strings shares.
+///
+/// This is the ONE normalizer: the def side (a symbol's scope path) and the call side
+/// ([`target_qualified_name`], [`scoped_receiver_name`], the Rust dispatch classifier) all reach
+/// the scanner through here, so a definition and a call written the same way cannot normalize
+/// apart (#1094).
 pub(crate) fn degeneric_path(path: &str) -> String {
     scope_grammar::degeneric(path)
 }
@@ -565,11 +570,9 @@ pub(crate) fn degeneric_path(path: &str) -> String {
 #[cfg(test)]
 mod degeneric_tests {
     use super::degeneric_path;
-    use crate::index::edges::helpers::strip_generics;
 
     /// A const-generic block holds an expression, so its `<`/`>` are operators. Getting this wrong
-    /// swallows everything after the block — and the call side (`strip_generics`) already treats
-    /// braces this way, so the two must agree or the definition and the call never meet.
+    /// swallows everything after the block, on the def side and the call side alike.
     #[test]
     fn a_const_generic_block_is_not_a_generic_delimiter() {
         for path in ["Foo<{ 1 < 2 }>::run", "Foo<{ 2 > 1 }>::run", "Foo<[u8; { 1 < 2 }]>::run"] {
@@ -579,37 +582,51 @@ mod degeneric_tests {
         assert_eq!(degeneric_path("[u8; { 1 < 2 }] as Tr::f"), "[u8; { 1 < 2 }] as Tr::f");
     }
 
-    /// The def-side (`degeneric_path`, a full scan) and the call-side (`strip_generics`, a lighter
-    /// brace/angle counter) normalizer meet on the shapes a real path takes.
+    /// The shapes a real path takes normalize to the key both sides look each other up by.
     #[test]
-    fn degeneric_path_agrees_with_the_call_side_stripper() {
-        for path in ["Foo<T>::run", "Foo<{ 1 < 2 }>::run", "A<B<C>>::run", "plain::run"] {
-            assert_eq!(degeneric_path(path), strip_generics(path), "{path}");
+    fn the_normalizer_pins_the_key_a_call_and_a_definition_meet_on() {
+        for (path, want) in [
+            ("Foo<T>::run", "Foo::run"),
+            ("Foo<{ 1 < 2 }>::run", "Foo::run"),
+            ("A<B<C>>::run", "A::run"),
+            ("plain::run", "plain::run"),
+            ("Vec::<u8>::new", "Vec::new"),
+            // A LEADING `<…>` is a UFCS qualifier, not an argument list; stripping it would drop
+            // the type and the trait and leave a bare `::default` (#208 review round 10).
+            ("<Resp as Default>::default", "<Resp as Default>::default"),
+        ] {
+            assert_eq!(degeneric_path(path), want, "{path}");
         }
     }
 
-    /// Where they DIVERGE, the divergence is one-sided: the call side is string- and comment-blind,
-    /// so a `{`/`}`/`<`/`>` inside a literal unbalances its counter and it drops the whole tail —
-    /// yielding a form with no `::`, which resolution treats as a bare name and declines. The def
-    /// side keeps the real qualified key. So the two never disagree into a DIFFERENT qualified key
-    /// (which would let a call meet the wrong definition); the worst case is a missed edge that
-    /// falls back to bare-name matching. This pins that safe direction so a future change to either
-    /// side that turned a divergence into a colliding key would fail here. Full unification of the
-    /// two onto the scanner is #1094.
+    /// The shapes a brace/angle counter gets wrong, pinned to the key the definition is indexed
+    /// under — so a second parser reintroduced on the call side fails here (#1094).
+    ///
+    /// A counter blind to literals and comments reads the `{` in `"{"` or `/* { */` as structure,
+    /// never unwinds its brace stack, suppresses the closing `>` and drops the whole tail: the
+    /// call becomes a bare name and resolution declines a match the definition side had. Blind to
+    /// `->`, it reads the arrow's `>` as a closing angle and splices a generic argument's text
+    /// into the path — `Foo::<fn()->Bar>::run` becoming `FooBar::run`, a DIFFERENT `::`-bearing
+    /// key that can meet the WRONG definition, so the divergence is not merely a recall gap.
     #[test]
-    fn a_divergence_between_the_normalizers_only_ever_declines() {
+    fn literals_comments_and_arrows_do_not_derail_the_call_key() {
         for path in [
             r#"Foo<{ "{".len() }>::run"#,
             r#"Foo<{ "}".len() }>::run"#,
-            r##"Bar<{ r#"<"#.len() }>::run"##,
+            r##"Foo<{ r#"<"#.len() }>::run"##,
+            r##"Foo<{ r#"{"#.len() }>::run"##,
+            r#"Foo<{ /* { */ 1 }>::run"#,
+            "Foo<{ // {\n1 }>::run",
+            "Foo<{ '{' as u8 }>::run",
+            "Foo::<fn()->Bar>::run",
+            "Foo::<fn(&T) -> U>::run",
         ] {
-            let call = strip_generics(path);
-            let def = degeneric_path(path);
-            assert!(
-                call == def || !call.contains("::"),
-                "{path}: call `{call}` must equal def `{def}` or carry no `::`"
-            );
+            assert_eq!(degeneric_path(path), "Foo::run", "{path}");
         }
+        // A group is an expression, so an inner generic and an arrow inside it are text, not
+        // structure: they survive rather than being mangled into `[Wrapper; 4]` / `fn(&T) - U`.
+        assert_eq!(degeneric_path("[Wrapper<X>; 4]::run"), "[Wrapper<X>; 4]::run");
+        assert_eq!(degeneric_path("fn(&T) -> U::run"), "fn(&T) -> U::run");
     }
 }
 

--- a/crates/rag-rat-core/src/index/edges/scope_grammar.rs
+++ b/crates/rag-rat-core/src/index/edges/scope_grammar.rs
@@ -258,12 +258,12 @@ pub(crate) fn strip_trait_marker(segment: &str) -> &str {
 
 /// Drop generic ARGUMENTS from a path: `Foo<T>::run` → `Foo::run`, `Foo::<T>::run` → `Foo::run`.
 ///
-/// The turbofish's `::` goes with the arguments it introduces — a definition scope and a call
-/// target must normalize to the same string, and the call side has always dropped it.
+/// The turbofish's `::` goes with the arguments it introduces, so it is dropped with them: a
+/// definition scope and a call target must normalize to the same string, and only one of the two
+/// ever spells the turbofish.
 pub(crate) fn degeneric(path: &str) -> String {
     // A LEADING `<…>` is a UFCS qualifier (`<W as a::Runs>::run`), not an argument list — dropping
-    // it would erase the type and the trait and leave a bare `::run`. The call side has always
-    // returned such a path unchanged, and the whole point of this module is that the two agree.
+    // it would erase the type and the trait and leave a bare `::run` (#208 review round 10).
     if path.trim_start().starts_with('<') {
         return path.to_string();
     }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -585,7 +585,7 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     if raw.starts_with('<') {
         return CallRole::Skip;
     }
-    let stripped = strip_generics(raw);
+    let stripped = degeneric_path(raw);
     let segments: Vec<&str> =
         stripped.split("::").map(str::trim).filter(|segment| !segment.is_empty()).collect();
     let Some(tail) = segments.last() else {

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -586,8 +586,16 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
         return CallRole::Skip;
     }
     let stripped = degeneric_path(raw);
-    let segments: Vec<&str> =
-        stripped.split("::").map(str::trim).filter(|segment| !segment.is_empty()).collect();
+    // TOP-LEVEL segments only. A `::` inside a `(…)`/`[…]` group is argument text, which
+    // `degeneric_path` keeps, so splitting on every `::` would read a longer path than the source
+    // wrote and take the tail from the arguments: `Transaction::new_unchecked(&conn,
+    // TransactionBehavior::Immediate).unwrap` is a `Type::assoc(..)` constructor, not a call whose
+    // tail is the PascalCase `Immediate).unwrap`.
+    let segments: Vec<&str> = scope_grammar::segments(&stripped)
+        .into_iter()
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect();
     let Some(tail) = segments.last() else {
         return CallRole::Delegate;
     };
@@ -704,5 +712,60 @@ pub(super) fn rust_dispatch_handle_facts(
                 Some(key.clone()),
             ));
         }
+    }
+}
+
+#[cfg(test)]
+mod classify_call_tests {
+    use super::*;
+
+    /// Breadth-first, so the shallowest match is the outermost call, and iterative so it is not a
+    /// recursive tree descender (#543).
+    fn outermost_call<'tree>(root: Node<'tree>) -> Option<Node<'tree>> {
+        let mut queue = std::collections::VecDeque::from([root]);
+        while let Some(node) = queue.pop_front() {
+            if node.kind() == "call_expression" {
+                return Some(node);
+            }
+            let mut cursor = node.walk();
+            queue.extend(node.children(&mut cursor));
+        }
+        None
+    }
+
+    fn role_of(expression: &str) -> CallRole {
+        let source = format!("fn probe() {{ {expression}; }}");
+        let parsed = crate::index::parser::parse_file(
+            std::path::Path::new("probe.rs"),
+            rag_rat_base::language::Language::Rust,
+            &source,
+        )
+        .expect("probe parses");
+        classify_call(outermost_call(parsed.root()).expect("a call expression"), &source)
+    }
+
+    /// A `::` inside the ARGUMENT list is not a path separator, so the classified TAIL is the real
+    /// callee rather than the last argument fragment. `Transaction::new_unchecked(..)` is a
+    /// `Type::assoc(..)` constructor (Skip); reading its tail as the PascalCase `Immediate).unwrap`
+    /// would bill it as a transparent variant wrapper instead.
+    #[test]
+    fn a_nested_separator_does_not_move_the_callee_into_the_arguments() {
+        assert!(matches!(
+            role_of("Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap()"),
+            CallRole::Skip
+        ));
+        // The handler is `handle`; `Resp::Embedded` is its argument, not its callee.
+        assert!(matches!(role_of("handle(Resp::Embedded(payload))"), CallRole::Delegate));
+    }
+
+    /// The ordinary shapes keep their roles.
+    #[test]
+    fn top_level_paths_keep_their_roles() {
+        assert!(matches!(role_of("Resp::Embedded(body)"), CallRole::Wrapper));
+        assert!(matches!(role_of("Ok(body)"), CallRole::Wrapper));
+        assert!(matches!(role_of("Err(problem)"), CallRole::Skip));
+        assert!(matches!(role_of("Config::from_env(path)"), CallRole::Skip));
+        assert!(matches!(role_of("render_page(body)"), CallRole::Delegate));
+        assert!(matches!(role_of("<Resp as Default>::default()"), CallRole::Skip));
     }
 }


### PR DESCRIPTION
## Summary

Routes the call-side path stripper through the scanner's `degeneric`, deleting the duplicate, and makes the two consumers that split on `::` respect nesting — which the unification requires, because `degeneric` deliberately preserves a `::` that sits inside a `(…)` group.

## Related Issues and Pull Requests

Fixes #1094

## Changes

Two commits, kept separate because they are separately reviewable and revertable — squash if you'd rather.

**`53fcdf9` — unify the normalizer.** Deletes `strip_generics` from `edges/helpers.rs`; `target_qualified_name`, `scoped_receiver_name` and `classify_call` all call `degeneric_path`. The two tests that compared the two implementations become exact-value tests of the survivor, since a cross-function equality assertion is tautological once there is one function.

**`4ed2515` — split on top-level separators only.** `scoped_receiver_name` and `classify_call` now split via `scope_grammar::segments` instead of a nesting-blind `contains("::")` / split. Adds `scoped_receiver_name_tests` and `classify_call_tests`.

**Why the second commit is part of this change rather than scope creep.** With only the first, `stmt.query_map([], |row| row.get::<_, String>(0)).unwrap()` yields a receiver hint of `get` instead of `stmt` — the surviving in-group turbofish flips the separator from `.` to `::` and the head becomes a method name taken from inside a closure. That is worse than a miss, because `get` is a plausible real symbol that can mis-resolve. Any consumer that splits on `::` has to become nesting-aware for the unification to be correct.

It also repairs a case that is broken on `main` today: `conn.execute("INSERT INTO …", rusqlite::params![…])` currently yields a receiver hint of `execute("INSERT INTO …", rusqlite`.

**Two premises in the issue did not survive checking**, and I'd rather say so than inherit the framing:

- **"The divergence is always safe-direction" is false.** `Foo::<fn()->Bar>::run` gives `strip_generics` → `"FooBar::run"`, and `Box<dyn Fn(u8) -> u8>::call` → `"Box u8::call"`. It reads the `>` of a `->` as a closing angle, leaves angle-mode early, and splices the generic argument's text into the path — producing a *different* `::`-bearing key that can meet the wrong definition. So this is a narrow correctness bug, not only a recall gap, and `a_divergence_between_the_normalizers_only_ever_declines` held for the three literal shapes it listed rather than in general.
- **The recall justification is a measured wash.** Across all 564 Rust files in this repo, on the 55,526 path-shaped call targets (`identifier` + `scoped_identifier`) the two normalizers differ on **exactly zero**. Every divergence sits in expression-shaped `function` fields where the string is not a resolvable path under either normalizer. `target_qualified_name`'s Some/None decision flips on 2 of 128,396 sites, both `None → Some`, and both are junk keys that miss every lookup map. The case for this change is the duplicate parser and the `->` bug, not recall.

Also worth noting: the issue's characterisation is slightly off. It is not literals and comments that diverge, it is specifically an **unmatched `{`** inside one — a `}` or `<` leaves the counter balanced, so `Bar<{ r#"<"#.len() }>::run` never diverged at all.

## Testing

Gates on the committed tree: `cargo build --no-default-features -p rag-rat-core` → 0; `cargo clippy --no-default-features --all-targets` → 0, zero lints; `cargo +nightly fmt --check` → 0; targeted `cargo test --no-default-features -p rag-rat-core --lib -- scoped_receiver_name_tests classify_call_tests degeneric_tests` → 0, with the `running N tests` count read and checked; `cargo nextest run --no-default-features --workspace` → 0, **4897 passed, 7 skipped**.

**Not run, and not to be read as passing:** the default-feature `build (fastembed + model2vec)` and `clippy (all features)`, because default features pull ONNX which fails to link here; and `coverage`/`codecov`, which need the full-feature build and the uploader. CI covers all four.

The regression the second commit prevents is pinned directly: `a_nested_separator_does_not_move_the_receiver_into_the_arguments` asserts the `stmt.query_map(…)` case yields `Some("stmt")`, the `conn.execute(…)` case yields `Some("conn")`, and a double turbofish `items.iter().map(|v| v.parse::<i64>()).collect::<Vec<_>>()` yields `Some("items")`.

**Measurement provenance, stated because the numbers below are large.** They come from a sweep over this repo's own 564 Rust files, run on the pre-commit tree with both edits applied, using a faithful replication of the two pipelines as string functions — the shipped ones take a tree-sitter `Node`. The replication includes `classify_call`'s early `starts_with('<')` guard. It excludes `edges/mod.rs` to avoid measuring its own text. The only change between the measured tree and what shipped was making a *test helper* iterative, which touches none of the three functions.

- receiver-hint moves: **3,158**
- classification role moves: **2,252**

**2,252 is an upper bound, not a count of dispatch edges.** `classify_call` is reached only from `collect_handler_calls`, i.e. calls in the result position of a `match` arm during dispatch-edge synthesis. The sweep classified every call expression in the repo, the vast majority of which never reach it. The true dispatch-edge delta is smaller and I did not measure it.

Since neither of us can hand-validate 2,252, here is a **random sample of 20** (deterministic seed), judged individually: **18 repairs, 1 regression, 1 I could not judge.** Representative repairs — `Paragraph::new(lines).style(..).block(..)` Delegate → Skip (a builder chain off a `Type::assoc`, matching `classify_call`'s own documented rule); `conn.execute("INSERT INTO …", rusqlite::params![…])` Wrapper → Delegate; `codec::write_frame(&mut send, &Frame::Done).await.map_err(SessionError::Codec)` Wrapper → Delegate, where the old tail was `Codec)`.

The one regression is `crate::tools::TOOL_NAMES.iter().map(…)` at `rag-rat-mcp/src/server/service.rs:43`, Delegate → Wrapper. Root cause is `is_pascal_case` misreading a `SCREAMING_CONST` plus method chain; it is pre-existing and unrelated to path splitting, so I filed it separately rather than folding a second fix in. The one I could not judge is `"traits::Runs::run".to_string()` — the reasoning is repaired (a `::` inside a string literal is not a separator) but the outcome moves Skip → Delegate, and given this module's "a missed edge is fine, a false edge is a bug" contract I am not confident that is safer, so I am not counting it as a win. I judged 20 of 2,252 and make no claim about the rest.

## Bugs Discovered

- #1124 is_pascal_case treats a SCREAMING_CONST with a method chain as PascalCase, so classify_call returns Wrapper

## Follow-ups / Known Limitations

- **The `.` fallback in `scoped_receiver_name` is still nesting-blind.** Only the `::` split was made top-level-aware; `scope_grammar` has no top-level dot splitter and adding one is a larger change. Those sites behave exactly as on `main`, so this is not a regression, but the asymmetry is real.
- I did **not** re-run the receiver-hint counter on the final tree to show the flipped-separator count is literally zero. It is confirmed by the direct regression test above and structurally — `segments()` never reports a nested `::`, so with one top-level segment the code falls through to the `.` branch, i.e. the mechanism is removed rather than compensated for. Happy to produce the measured zero if you want it stated that way.
- `a_divergence_between_the_normalizers_only_ever_declines` could not survive as written — its body called the deleted function. It is replaced by `literals_comments_and_arrows_do_not_derail_the_call_key`, which asserts exact values over a superset of its inputs (its original three paths plus raw-string, block-comment, line-comment, char-literal and the two `->` shapes). Since both sides are now the same function, the old disjunction property is implied by the exact assertion. Flagging because the rename loses the "declines" vocabulary, and because the invariant it was named for is now known false.
- `evals/memory-compaction/corpus/anchors.json` still embeds a frozen text snapshot of the old `helpers.rs`, `strip_generics` included. Left untouched as a historical fixture — noting it in case that corpus is ever regenerated.

## Footer

Generated by Claude Opus 5 (brief, implementation, review, verification)
