### PR TITLE
ci(lens): deploy the appliance only on release tags

### DIFF
--- a/.github/workflows/deploy-appliance.yml
+++ b/.github/workflows/deploy-appliance.yml
@@ -4,15 +4,13 @@ name: deploy-appliance
 # SSH. The host's IP/hostname lives ONLY in the `appliance-prod` environment's secrets —
 # never in this file — and the public URL is a CNAME to the Cloudflare named tunnel, so
 # no DNS record ever points at the box.
+#
+# Runs ONLY on release tags (release-plz cuts vX.Y.Z): every main push deploying to
+# production meant a ~10-minute host reindex per commit and production tracking
+# unreleased code. Manual runs stay available via workflow_dispatch.
 on:
   push:
-    branches: [main]
-    paths:
-      - editors/appliance/**
-      - editors/vscode/**
-      - crates/**
-      - Cargo.toml
-      - Cargo.lock
+    tags: ["v*"]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The appliance deploy ran on every main push (path-filtered) — a full host reindex per commit, and production tracking unreleased code. Trigger it on `v*` tags (the release-plz release points) instead; `workflow_dispatch` remains for manual deploys.