### PR TITLE
feat(sync): compact accepted table-sync prefixes below a retained floor

### DIFF
--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -615,6 +615,13 @@ mod tests {
             ],
         )
         .unwrap();
+        // The retained floor bounds the same accepted log (#1127) and is swept with it.
+        conn.execute(
+            "INSERT INTO table_sync_retained_floors(stream_id, device_fingerprint, lamport, \
+             entry_hash, compacted_at_ms) VALUES (?1, ?2, 1, ?3, 0)",
+            params![stream_id, vec![seed; 32], vec![seed; 32]],
+        )
+        .unwrap();
         stream_id
     }
 
@@ -667,6 +674,7 @@ mod tests {
             ("table_sync_gapped_entries", "stream_id", blob_literal(stream_id)),
             ("table_sync_readoption_work", "stream_id", blob_literal(stream_id)),
             ("table_sync_readoption_audit", "stream_id", blob_literal(stream_id)),
+            ("table_sync_retained_floors", "stream_id", blob_literal(stream_id)),
         ];
         for (table, column, in_body) in checks {
             let count: i64 = conn

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 104, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 106, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
@@ -1987,6 +1987,66 @@ fn migration_104_table_sync_readoption() {
     let recorded: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM schema_version WHERE id = '104_table_sync_readoption'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1);
+}
+
+/// V105 (#1127) adds the per-chain retained floor for accepted-entry compaction.
+#[test]
+fn migration_105_table_sync_retained_floors() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    let strict: i64 = conn
+        .query_row(
+            "SELECT strict FROM pragma_table_list
+             WHERE schema = 'main' AND name = 'table_sync_retained_floors'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(strict, 1);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '105_table_sync_retained_floors'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1);
+}
+
+/// V106 (#1127) makes the re-adoption audit's original entry hash nullable for compacted winners.
+#[test]
+fn migration_106_readoption_audit_nullable_winner() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    let nullable: i64 = conn
+        .query_row(
+            "SELECT NOT \"notnull\" FROM pragma_table_info('table_sync_readoption_audit')
+             WHERE name = 'original_entry_hash'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(nullable, 1);
+    conn.execute(
+        "INSERT INTO table_sync_readoption_audit(
+             account_id, removed_fingerprint, adopter_fingerprint, stream_id, repo_id, scope_id,
+             table_name, row_pk, original_lamport, original_entry_hash, adopted_entry_hash,
+             adopted_at_ms
+         ) VALUES (zeroblob(32), zeroblob(32), zeroblob(32), zeroblob(32), 'r', 's', 't', 'p',
+                   1, NULL, zeroblob(32), 0)",
+        [],
+    )
+    .expect("a compacted winner's audit row has no hash to record");
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '106_readoption_audit_nullable_winner'",
             [],
             |row| row.get(0),
         )

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -7420,6 +7420,71 @@ pub fn apply_table_sync_readoption(conn: &Connection) -> rusqlite::Result<()> {
     )
 }
 
+/// V105 (#1127): the per-(stream, device) retained floor.
+///
+/// Accepted-entry compaction drops a chain prefix below the floor; this table is how a peer
+/// (and the local accept path) tells an intentionally reclaimed prefix from a chain gap. It is
+/// swept with the stream directory on repository purge, NOT retained like the chain-tip
+/// witnesses: once the accepted log itself is gone, "the prefix below F was compacted" stops
+/// being true, and a surviving floor would short-circuit the re-offered prefix the restored
+/// chain then waits on forever.
+pub fn apply_table_sync_retained_floors(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS table_sync_retained_floors(
+             stream_id          BLOB    NOT NULL CHECK(length(stream_id) = 32),
+             device_fingerprint BLOB    NOT NULL CHECK(length(device_fingerprint) = 32),
+             lamport            INTEGER NOT NULL,
+             entry_hash         BLOB    NOT NULL CHECK(length(entry_hash) = 32),
+             compacted_at_ms    INTEGER NOT NULL,
+             PRIMARY KEY(stream_id, device_fingerprint)
+         ) STRICT;",
+    )
+}
+
+/// V106 (#1127): re-adoption audit provenance for a compacted winner.
+///
+/// Re-adoption candidates derive from the merge state, which survives compaction; a winning entry
+/// below the retained floor is gone, so the audit records its slot by `(stream, device, lamport)`
+/// and stores NULL for the hash. Rebuilds the just-shipped V104 table — it holds only locally
+/// authored audit rows, copied verbatim.
+pub fn apply_readoption_audit_nullable_winner(conn: &Connection) -> rusqlite::Result<()> {
+    let already_nullable: bool = conn.query_row(
+        "SELECT NOT \"notnull\" FROM pragma_table_info('table_sync_readoption_audit')
+         WHERE name = 'original_entry_hash'",
+        [],
+        |row| row.get(0),
+    )?;
+    if already_nullable {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "CREATE TABLE table_sync_readoption_audit_v106(
+             audit_id INTEGER PRIMARY KEY,
+             account_id BLOB NOT NULL CHECK(length(account_id) = 32),
+             removed_fingerprint BLOB NOT NULL CHECK(length(removed_fingerprint) = 32),
+             adopter_fingerprint BLOB NOT NULL CHECK(length(adopter_fingerprint) = 32),
+             stream_id BLOB NOT NULL CHECK(length(stream_id) = 32),
+             repo_id TEXT NOT NULL,
+             scope_id TEXT NOT NULL,
+             table_name TEXT NOT NULL,
+             row_pk TEXT NOT NULL,
+             original_lamport INTEGER NOT NULL,
+             original_entry_hash BLOB CHECK(
+                 original_entry_hash IS NULL OR length(original_entry_hash) = 32
+             ),
+             adopted_entry_hash BLOB NOT NULL CHECK(length(adopted_entry_hash) = 32),
+             adopted_at_ms INTEGER NOT NULL
+         ) STRICT;
+         INSERT INTO table_sync_readoption_audit_v106
+         SELECT * FROM table_sync_readoption_audit;
+         DROP TABLE table_sync_readoption_audit;
+         ALTER TABLE table_sync_readoption_audit_v106
+             RENAME TO table_sync_readoption_audit;
+         CREATE INDEX IF NOT EXISTS table_sync_readoption_audit_stream
+             ON table_sync_readoption_audit(account_id, stream_id);",
+    )
+}
+
 fn primary_key_columns(conn: &Connection, table: &str) -> rusqlite::Result<Vec<String>> {
     let mut stmt =
         conn.prepare("SELECT name FROM pragma_table_info(?1) WHERE pk > 0 ORDER BY pk")?;

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 104;
+pub const LATEST_SCHEMA_VERSION: u32 = 106;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -786,6 +786,18 @@ const MIGRATION_104_DESCRIPTION: &str =
     "Add the durable table-sync re-adoption worklist and audit log (#997): an effective \
      DeviceRemove enqueues one item per affected stream, which a current writer drains by \
      re-authoring the removed writer's surviving LWW state under its own chain";
+const MIGRATION_105_ID: &str = "105_table_sync_retained_floors";
+const MIGRATION_105_CHECKSUM: &str = "sha256:rag-rat-table-sync-retained-floors-v105";
+const MIGRATION_105_DESCRIPTION: &str = "Add table_sync_retained_floors (#1127): the per-(stream, \
+                                         device) chain prefix floor an accepted-entry compaction \
+                                         has reclaimed below, so peers and the accept path can \
+                                         tell an intentionally pruned prefix from a chain gap";
+const MIGRATION_106_ID: &str = "106_readoption_audit_nullable_winner";
+const MIGRATION_106_CHECKSUM: &str = "sha256:rag-rat-readoption-audit-nullable-winner-v106";
+const MIGRATION_106_DESCRIPTION: &str = "Make table_sync_readoption_audit.original_entry_hash \
+                                         nullable (#1127): a winner reclaimed by accepted-entry \
+                                         compaction before re-adoption ran has no hash to record; \
+                                         the slot stays named by (stream, device, lamport)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -999,6 +1011,7 @@ const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[
     MIGRATION_098_ID,
     MIGRATION_099_ID,
     MIGRATION_103_ID,
+    MIGRATION_106_ID,
 ];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
@@ -1644,6 +1657,18 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_104_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_table_sync_readoption),
     },
+    Migration {
+        id: MIGRATION_105_ID,
+        checksum: MIGRATION_105_CHECKSUM,
+        description: MIGRATION_105_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_table_sync_retained_floors),
+    },
+    Migration {
+        id: MIGRATION_106_ID,
+        checksum: MIGRATION_106_CHECKSUM,
+        description: MIGRATION_106_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_readoption_audit_nullable_winner),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1870,6 +1895,7 @@ mod ledger_atomicity {
         MIGRATION_098_ID,
         MIGRATION_099_ID,
         MIGRATION_103_ID,
+        MIGRATION_106_ID,
     ];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -180,6 +180,14 @@ const TRANSITIVE_SCOPED_TABLES: &[TransitiveTable] = &[
         id_column: "stream_id",
         parent_ids: purge_ids::STREAMS,
     },
+    // The per-chain retained floor an accepted-entry compaction recorded. It rides the same
+    // derived stream identity as the log it bounds, so it is swept with the directory for exactly
+    // the same reason.
+    TransitiveTable {
+        table: "table_sync_retained_floors",
+        id_column: "stream_id",
+        parent_ids: purge_ids::STREAMS,
+    },
     // Entries held awaiting a chain predecessor. Same reasoning as the accepted log above, and for
     // the same reason it must not be exempted: these are signed operations on a stream whose id is
     // derived, so retaining them across a re-registration of the repo would replay a removed

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -13,6 +13,7 @@ mod engine;
 mod produce;
 mod refold;
 mod registry;
+mod retention;
 mod row_op;
 mod schema_facts;
 mod scope_stream;

--- a/crates/rag-rat-oplog/src/table_sync/retention.rs
+++ b/crates/rag-rat-oplog/src/table_sync/retention.rs
@@ -1,0 +1,639 @@
+//! Retention for the accepted table-sync log: compact a per-(stream, device) chain prefix below
+//! a recorded floor (#1127).
+//!
+//! Anchors/1 launches fully retained; the first high-churn scope cannot. Compaction here drops
+//! accepted entries with `lamport < floor` for ONE device chain, after refreshing every row whose
+//! LWW winner is one of those entries — the hard constraint from #1020: without the refresh,
+//! every such row's next producer pass takes the stale-version winner lookup, finds the entry
+//! gone, reads `StaleRow::Unknown`, and the whole table re-authors at once.
+//!
+//! The floor is recorded durably (`table_sync_retained_floors`) so the accept path can tell an
+//! intentionally reclaimed prefix from a chain gap: a re-offered entry below the floor is
+//! idempotently ignored instead of classifying as a fork against the retained tail. What this
+//! slice deliberately does NOT do is signal the floor to a FRESH peer — a peer with no chain
+//! state whose first retained entry cites a pruned predecessor still parks as
+//! `AwaitingPredecessor`. Manifest/hello floor advertisement and peer-side floor acceptance are
+//! the follow-up slice, and the same slice wires the driver: this module is invoked by the
+//! transport's manifest/reconcile path and the first scope whose retention policy demands it
+//! (overlay), not by anchors, which stays fully retained.
+//!
+//! Two accepted horizons, named rather than hidden:
+//!
+//! - **Spec bumps un-invisibilize refreshed rows.** The refresh restamps the published record but
+//!   the row clock keeps pointing at the dropped winner, so the next table spec-version bump takes
+//!   every refreshed row stale → the winner lookup finds the entry gone → `Unknown` → the producer
+//!   re-authors it: one entry per refreshed row per spec bump. A clock can only point at a live
+//!   entry, so this churn is the accepted cost of reclaiming the prefix — bounded, and far cheaper
+//!   than the table-wide storm the refresh prevents on the uncompacted path. In the window between
+//!   a spec bump and the next producer pass, the refold reads the same `Unknown` as a possible
+//!   unsent edit and defers replay over those rows — the safe direction, and worth knowing when
+//!   diagnosing a deferred entry after an upgrade.
+//! - **Below-floor equivocations are undetectable on compacted peers.** The accept path answers
+//!   `AlreadyPresent` for any entry below the floor, so a compacted peer discards fork evidence a
+//!   non-compacted peer would still classify. Accepted: `Fork` is non-storing and a below-floor
+//!   entry can never apply, so the divergence costs evidence, never convergence — and evidence loss
+//!   is the price of reclaiming the region the evidence would describe.
+
+use rusqlite::{OptionalExtension, Transaction, params};
+
+use super::apply::{self, SyncedRow};
+use super::registry::TableSpec;
+use super::{row_op, store};
+use crate::op::DeviceFingerprint;
+use crate::stream::StreamId;
+
+/// What one prefix compaction did.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompactionReport {
+    /// Rows whose published record was restamped to the current spec before their winner dropped.
+    pub refreshed_rows: usize,
+    /// Accepted entries dropped from the chain prefix.
+    pub dropped_entries: usize,
+    /// Gapped entries swept below the floor — they can never promote once their predecessor is
+    /// reclaimed, so holding them would only burn the per-chain capacity cap.
+    pub swept_gapped: usize,
+}
+
+/// The recorded retained floor for one device chain, if any.
+pub(crate) fn retained_floor(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+) -> anyhow::Result<Option<u64>> {
+    let row: Option<i64> = tx
+        .query_row(
+            "SELECT lamport FROM table_sync_retained_floors
+             WHERE stream_id = ?1 AND device_fingerprint = ?2",
+            params![stream.to_bytes().as_slice(), device.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    row.map(u64::try_from).transpose().map_err(Into::into)
+}
+
+/// Drop every accepted entry on `device`'s chain in `stream` with `lamport < floor_lamport`.
+///
+/// The floor entry itself is RETAINED and must exist on the chain — an arbitrary lamport cannot
+/// invent a floor that no peer could ever be pointed at. Entries retained for replay
+/// (`pending_reason IS NOT NULL`) are never compacted: their payloads are owed to a later binary,
+/// and dropping them would silently lose the forward-compat contract.
+pub(crate) fn compact_chain_prefix(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+    floor_lamport: u64,
+    registry: &[TableSpec],
+    now_ms: i64,
+) -> anyhow::Result<CompactionReport> {
+    if let Some(current) = retained_floor(tx, stream, device)?
+        && floor_lamport <= current
+    {
+        anyhow::bail!(
+            "table-sync compaction floor {floor_lamport} does not advance the retained floor \
+             {current} — a retreating compaction is a caller bug, not a no-op"
+        );
+    }
+    let floor_entry: Option<(Vec<u8>,)> = tx
+        .query_row(
+            "SELECT entry_hash FROM table_sync_entries
+             WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport = ?3",
+            params![
+                stream.to_bytes().as_slice(),
+                device.to_bytes().as_slice(),
+                i64::try_from(floor_lamport)?
+            ],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?,)),
+        )
+        .optional()?;
+    let Some((floor_hash,)) = floor_entry else {
+        anyhow::bail!(
+            "table-sync compaction floor {floor_lamport} names no entry on the chain — the floor \
+             must be a retained entry a peer can be pointed at"
+        );
+    };
+
+    let Some(context) = store::stream_context(tx, stream)? else {
+        anyhow::bail!("table-sync compaction needs the stream's apply context");
+    };
+    let refreshed_rows =
+        refresh_winners_below(tx, stream, &context.repo_id, registry, device, floor_lamport)?;
+    let dropped_entries = tx.execute(
+        "DELETE FROM table_sync_entries
+         WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport < ?3
+           AND pending_reason IS NULL",
+        params![
+            stream.to_bytes().as_slice(),
+            device.to_bytes().as_slice(),
+            i64::try_from(floor_lamport)?
+        ],
+    )?;
+    // A gapped entry below the floor can never promote: its predecessor is part of the reclaimed
+    // prefix and no honest sender re-offers it. Sweeping here is what keeps a stalled chain from
+    // burning its per-chain gapped capacity forever.
+    let swept_gapped = tx.execute(
+        "DELETE FROM table_sync_gapped_entries
+         WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport < ?3",
+        params![
+            stream.to_bytes().as_slice(),
+            device.to_bytes().as_slice(),
+            i64::try_from(floor_lamport)?
+        ],
+    )?;
+    tx.execute(
+        "INSERT INTO table_sync_retained_floors(
+             stream_id, device_fingerprint, lamport, entry_hash, compacted_at_ms
+         ) VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(stream_id, device_fingerprint) DO UPDATE SET
+             lamport = excluded.lamport,
+             entry_hash = excluded.entry_hash,
+             compacted_at_ms = excluded.compacted_at_ms
+         WHERE excluded.lamport > table_sync_retained_floors.lamport",
+        params![
+            stream.to_bytes().as_slice(),
+            device.to_bytes().as_slice(),
+            i64::try_from(floor_lamport)?,
+            floor_hash.as_slice(),
+            now_ms,
+        ],
+    )?;
+    Ok(CompactionReport { refreshed_rows, dropped_entries, swept_gapped })
+}
+
+/// Restamp the published record of every UNTOUCHED row whose whole-row LWW winner is one of the
+/// entries about to drop. After the refresh such a row compares hashes at the CURRENT spec
+/// version and never consults the winner lookup, so the dropped entry is invisible to it.
+///
+/// The `registry` MUST be the full production registry, not the scope's subset: a row whose table
+/// is missing here keeps its stale published record while its winner drops anyway — the
+/// conservative direction (a later pass re-authors it), but a silent one.
+///
+/// The refresh is deliberately verdict-gated on [`apply::StaleRow::Unchanged`]: a raw local write
+/// does not advance the row clock, so restamping to the CURRENT row contents would record an
+/// unsent edit as published — the producer would then see no delta and never author it (the
+/// `StaleRow::Unknown` path it would otherwise take authors, the safe direction), and the replay
+/// guard that keys off the published record would let a remote upsert clobber the edit. A
+/// `LocallyChanged` or `Unknown` row is left alone: the producer authors it at a retained
+/// lamport, exactly as it would without compaction. An unreadable row is skipped for the same
+/// reason it always was — no comparable hash exists to restamp.
+fn refresh_winners_below(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    repo_id: &str,
+    registry: &[TableSpec],
+    device: DeviceFingerprint,
+    floor_lamport: u64,
+) -> anyhow::Result<usize> {
+    let device_hex = device.to_string();
+    let mut stmt = tx.prepare(
+        "SELECT table_name, row_pk FROM sync_row_clocks
+         WHERE stream_id = ?1 AND repo_id = ?2 AND device_fingerprint = ?3 AND lamport < ?4",
+    )?;
+    let rows = stmt
+        .query_map(
+            params![
+                stream.to_bytes().as_slice(),
+                repo_id,
+                device_hex,
+                i64::try_from(floor_lamport)?
+            ],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut refreshed = 0;
+    for (table_name, row_pk) in rows {
+        let Some(spec) = registry.iter().find(|spec| spec.name == table_name) else {
+            continue;
+        };
+        let pk = row_op::row_pk_values(&row_pk)?;
+        let SyncedRow::Cells(cells) = apply::read_synced_cells(tx, spec, &pk)? else {
+            continue;
+        };
+        // The winner still exists at this point (the refresh runs before the drop), so the
+        // disposition is settled against the entry itself — not against the published record,
+        // which is exactly what may be lying about the row being sent.
+        if apply::stale_row_disposition(tx, spec, repo_id, stream, &pk, &cells)?
+            != apply::StaleRow::Unchanged
+        {
+            continue;
+        }
+        apply::record_published(
+            tx,
+            stream,
+            repo_id,
+            spec.name,
+            &row_pk,
+            &row_op::cells_hash(&cells),
+            spec.spec_version,
+        )?;
+        refreshed += 1;
+    }
+    Ok(refreshed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::table_sync::registry::{ColumnSpec, ValueType};
+    use crate::table_sync::store::record_stream_context;
+    use crate::table_sync::{Cell, RowOp, TypedValue};
+    use crate::{AccountId, LocalDevice};
+
+    const SPEC: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        spec_version: 1,
+        pk: &[ColumnSpec::required("id", ValueType::Text)],
+        columns: &[ColumnSpec::required("title", ValueType::Text)],
+        local_columns: &[],
+        repo_column: None,
+    };
+    const REGISTRY: &[TableSpec] = &[SPEC];
+
+    fn conn() -> rusqlite::Connection {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT) STRICT;").unwrap();
+        c
+    }
+
+    fn account() -> AccountId {
+        AccountId::from_bytes([42; 32])
+    }
+
+    fn stream() -> StreamId {
+        crate::stream::StreamId::from_bytes([7; 32])
+    }
+
+    fn enroll(conn: &rusqlite::Connection, device: &LocalDevice) {
+        conn.execute(
+            "INSERT OR IGNORE INTO account_roster_history
+                 (roster_ref, account_id, device_fingerprint, role, effective_at, closed_at)
+             VALUES (?1, ?2, ?3, 'owner', 0, NULL)",
+            params![
+                device.fingerprint().to_bytes().as_slice(),
+                account().to_bytes().as_slice(),
+                device.fingerprint().to_bytes().as_slice()
+            ],
+        )
+        .unwrap();
+    }
+
+    fn upsert(id: &str, title: &str) -> RowOp {
+        RowOp::Upsert {
+            spec_version: 1,
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text(id.to_string())],
+            cells: vec![Cell {
+                column: "title".to_string(),
+                value: TypedValue::Text(title.to_string()),
+            }],
+        }
+    }
+
+    /// Author `n` entries on the device chain (r{i} = v{i}), recording the stream context.
+    fn author_chain(conn: &mut rusqlite::Connection, device: &LocalDevice, n: u64) {
+        enroll(conn, device);
+        let tx = conn.transaction().unwrap();
+        record_stream_context(&tx, stream(), "repo", account(), [0x44; 32], "demo/1").unwrap();
+        for i in 0..n {
+            let op = upsert(&format!("r{i}"), &format!("v{i}"));
+            let signed = store::author_row_entry(&tx, stream(), device.secret(), &op, 0).unwrap();
+            let meta = crate::op::OpMeta {
+                lamport: signed.entry.lamport,
+                device: signed.entry.device_fingerprint,
+            };
+            apply::apply_row_op_on_stream(&tx, &SPEC, "repo", stream(), &op, meta).unwrap();
+        }
+        tx.commit().unwrap();
+    }
+
+    fn entry_lamports(conn: &rusqlite::Connection, device: &LocalDevice) -> Vec<i64> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT lamport FROM table_sync_entries
+                 WHERE stream_id = ?1 AND device_fingerprint = ?2 ORDER BY lamport",
+            )
+            .unwrap();
+        stmt.query_map(
+            params![stream().to_bytes().as_slice(), device.fingerprint().to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
+        .unwrap()
+    }
+
+    #[test]
+    fn compaction_drops_the_prefix_and_keeps_the_rows_authorable() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 6);
+        // A second write to r1: its winner is lamport 6 (retained), r0's winner is lamport 0
+        // (about to drop below the floor).
+        {
+            let tx = c.transaction().unwrap();
+            let op = upsert("r1", "v1b");
+            let signed = store::author_row_entry(&tx, stream(), device.secret(), &op, 0).unwrap();
+            let meta = crate::op::OpMeta {
+                lamport: signed.entry.lamport,
+                device: signed.entry.device_fingerprint,
+            };
+            apply::apply_row_op_on_stream(&tx, &SPEC, "repo", stream(), &op, meta).unwrap();
+            tx.commit().unwrap();
+        }
+        // Age the published record so the producer would consult the winner lookup without the
+        // refresh: a differing spec version is exactly the stale path compaction must close.
+        c.execute("UPDATE sync_published_rows SET spec_version = 99", []).unwrap();
+
+        let report = {
+            let tx = c.transaction().unwrap();
+            let report =
+                compact_chain_prefix(&tx, stream(), device.fingerprint(), 4, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+            report
+        };
+        assert_eq!(report.dropped_entries, 4, "entries 0..4 are reclaimed");
+        assert_eq!(
+            report.refreshed_rows, 3,
+            "r0/r2/r3's winners dropped; r1 rewrote at 6 and r4/r5 are retained"
+        );
+        assert_eq!(entry_lamports(&c, &device), vec![4, 5, 6]);
+
+        let floor = {
+            let tx = c.transaction().unwrap();
+            retained_floor(&tx, stream(), device.fingerprint()).unwrap()
+        };
+        assert_eq!(floor, Some(4));
+
+        // The producer sees no delta: refreshed rows compare at the current spec version, so the
+        // dropped winners never surface as a table-wide re-authoring storm.
+        let tx = c.transaction().unwrap();
+        let ops = super::super::produce::produce_row_ops(&tx, &SPEC, "repo", stream()).unwrap();
+        assert!(ops.is_empty(), "refresh-before-drop leaves nothing to re-author");
+        tx.commit().unwrap();
+
+        // Authoring continues on the retained tail.
+        author_chain(&mut c, &device, 0);
+        let tx = c.transaction().unwrap();
+        let op = upsert("r9", "v9");
+        let signed = store::author_row_entry(&tx, stream(), device.secret(), &op, 0).unwrap();
+        assert_eq!(signed.entry.lamport, 7, "the stream clock is based on the retained tail");
+        tx.commit().unwrap();
+    }
+
+    /// A raw local edit on a row whose winner drops below the floor must NOT be restamped as
+    /// published: that would disown the edit (the producer would see no delta) and disarm the
+    /// replay guard that keys off the published record.
+    #[test]
+    fn an_unsent_local_edit_survives_compaction_and_is_authored() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 4);
+        // Raw local write: no entry, no clock advance, published record still says v0.
+        c.execute("UPDATE t_demo SET title = 'local-edit' WHERE id = 'r0'", []).unwrap();
+
+        let report = {
+            let tx = c.transaction().unwrap();
+            let report =
+                compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+            report
+        };
+        assert_eq!(report.dropped_entries, 2);
+        assert_eq!(
+            report.refreshed_rows, 1,
+            "only the untouched r1 is restamped; r0 is left for the producer"
+        );
+
+        // The edit is authored: the published record still names v0, so the producer sees the
+        // delta it must carry — the safe direction the refresh must never close.
+        let tx = c.transaction().unwrap();
+        let ops = super::super::produce::produce_row_ops(&tx, &SPEC, "repo", stream()).unwrap();
+        assert_eq!(ops.len(), 1, "the unsent edit is produced, not disowned");
+        assert!(
+            matches!(&ops[0], RowOp::Upsert { pk, .. } if pk == &vec![TypedValue::Text("r0".to_string())]),
+            "and it is r0's local edit",
+        );
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn compaction_never_drops_a_pending_entry_or_invents_a_floor() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 3);
+        c.execute(
+            "UPDATE table_sync_entries SET pending_reason = 'unknown_column' WHERE lamport = 1",
+            [],
+        )
+        .unwrap();
+
+        {
+            let tx = c.transaction().unwrap();
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 9, REGISTRY, 0)
+                .unwrap_err();
+            assert!(err.to_string().contains("names no entry"), "a floor must be a retained entry");
+            tx.commit().unwrap();
+        }
+
+        let report = {
+            let tx = c.transaction().unwrap();
+            let report =
+                compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+            report
+        };
+        assert_eq!(report.dropped_entries, 1, "only the settled genesis drops");
+        assert_eq!(entry_lamports(&c, &device), vec![1, 2], "the pending entry is retained");
+    }
+
+    #[test]
+    fn a_second_compaction_advances_the_floor_and_a_retreat_is_refused() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 6);
+
+        {
+            let tx = c.transaction().unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = c.transaction().unwrap();
+            let report =
+                compact_chain_prefix(&tx, stream(), device.fingerprint(), 4, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+            assert_eq!(report.dropped_entries, 2, "entries 2 and 3 drop in the second pass");
+        }
+        let floor = {
+            let tx = c.transaction().unwrap();
+            retained_floor(&tx, stream(), device.fingerprint()).unwrap()
+        };
+        assert_eq!(floor, Some(4), "the floor advances monotonically");
+        assert_eq!(entry_lamports(&c, &device), vec![4, 5]);
+
+        {
+            let tx = c.transaction().unwrap();
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, REGISTRY, 0)
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("does not advance"),
+                "a retreating floor is a caller bug, not a silent re-compaction: {err}",
+            );
+            tx.commit().unwrap();
+        }
+        assert_eq!(entry_lamports(&c, &device), vec![4, 5], "the refused retreat drops nothing");
+    }
+
+    /// The below-floor idempotence is strict: an equivocation AT the floor lamport is beyond the
+    /// reclaimed region and still classifies as a fork.
+    #[test]
+    fn an_equivocation_at_the_floor_lamport_is_still_a_fork() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 4);
+        let tail_hash: Vec<u8> = c
+            .query_row("SELECT entry_hash FROM table_sync_entries WHERE lamport = 1", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        {
+            let tx = c.transaction().unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+        }
+
+        // A DIFFERENT entry at lamport 2 — the floor's own slot, but not the floor entry.
+        let forged = crate::entry::sign_entry_from_op_bytes(
+            device.secret(),
+            stream(),
+            Some(<[u8; 32]>::try_from(tail_hash.as_slice()).unwrap()),
+            2,
+            super::super::row_op::encode(&upsert("rx", "forged")),
+        );
+        let tx = c.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &forged.signed_bytes,
+            &device.secret().public(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            outcome,
+            store::AcceptOutcome::Fork,
+            "lamport == floor is outside the reclaimed prefix, so equivocation still reports",
+        );
+        tx.commit().unwrap();
+    }
+
+    /// The re-adoption candidate set derives from the merge state, which survives compaction:
+    /// compact a writer's prefix, THEN remove the writer, and the drain still repairs the row —
+    /// with the audit naming the slot by lamport alone (the winning entry is gone).
+    #[test]
+    fn compaction_before_a_removal_does_not_shrink_the_repair_set() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 4);
+        {
+            let tx = c.transaction().unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+        }
+        let removed_fp = device.fingerprint();
+
+        // The writer is removed after its prefix was compacted: entries 0..3 named the winners of
+        // r0..r2, and those winners are GONE from the entry log now.
+        let work = {
+            let tx = c.transaction().unwrap();
+            store::enqueue_readoption_work(&tx, account(), removed_fp, stream(), [9; 32], 9, 10)
+                .unwrap();
+            let work =
+                store::readoption_work_for_stream(&tx, account(), stream()).unwrap().unwrap();
+            tx.commit().unwrap();
+            work
+        };
+        let candidates = {
+            let tx = c.transaction().unwrap();
+            let out = store::readoption_candidates(&tx, stream(), work.device_fingerprint).unwrap();
+            tx.commit().unwrap();
+            out
+        };
+        assert_eq!(candidates.len(), 4, "merge state names every surviving winner");
+        assert!(
+            candidates.iter().filter(|c| c.original_lamport < 3).all(|c| c.entry_hash.is_none()),
+            "compacted winners carry no hash",
+        );
+        assert!(
+            candidates.iter().find(|c| c.original_lamport == 3).unwrap().entry_hash.is_some(),
+            "the retained winner keeps its hash",
+        );
+    }
+
+    /// A gapped entry below the floor can never promote — its predecessor is part of the
+    /// reclaimed prefix — so compaction sweeps it instead of letting it burn the per-chain cap.
+    #[test]
+    fn compaction_sweeps_gapped_entries_below_the_floor() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 4);
+        c.execute(
+            "INSERT INTO table_sync_gapped_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                 gapped_at_ms
+             ) VALUES (x'99', ?1, ?2, 1, x'98', x'00', 0),
+                      (x'9a', ?1, ?2, 9, x'97', x'00', 0)",
+            params![stream().to_bytes().as_slice(), device.fingerprint().to_bytes().as_slice()],
+        )
+        .unwrap();
+
+        let report = {
+            let tx = c.transaction().unwrap();
+            let report =
+                compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+            report
+        };
+        assert_eq!(report.swept_gapped, 1, "the gapped entry below the floor is swept");
+        let remaining: i64 = c
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 1, "the one above the floor survives");
+    }
+
+    #[test]
+    fn a_reoffered_entry_below_the_floor_is_idempotent_not_a_fork() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        author_chain(&mut c, &device, 3);
+        let dropped: Vec<u8> = c
+            .query_row("SELECT signed_bytes FROM table_sync_entries WHERE lamport = 0", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        {
+            let tx = c.transaction().unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            tx.commit().unwrap();
+        }
+
+        // Redelivery of a compacted entry must not classify as a fork against the retained tail:
+        // the floor says the prefix is intentionally gone.
+        let tx = c.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &dropped,
+            &device.secret().public(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(outcome, store::AcceptOutcome::AlreadyPresent);
+        tx.commit().unwrap();
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -354,6 +354,18 @@ pub(crate) fn accept_row_entry(
     if entry_exists(tx, &verified.entry_hash)? {
         return Ok(AcceptOutcome::AlreadyPresent);
     }
+    // Below the retained floor the prefix is INTENTIONALLY reclaimed (#1127): a redelivery of a
+    // compacted entry is idempotent, not an equivocation against the retained tail. The trade is
+    // explicit: below-floor FORK DETECTION is gone on compacted peers — an equivocation in the
+    // reclaimed region reports AlreadyPresent here while a non-compacted peer still classifies it
+    // as a fork. Accepted, because Fork is non-storing and a below-floor entry can never apply;
+    // the divergence costs evidence, never convergence (see the retention module docs).
+    if let Some(floor) =
+        super::retention::retained_floor(tx, expected_stream, verified.device_fingerprint)?
+        && verified.lamport < floor
+    {
+        return Ok(AcceptOutcome::AlreadyPresent);
+    }
     // Dedupe against the gapped table HERE, beside the accepted-entry check and BEFORE the
     // authority gate, so a redelivered gapped entry reports the same way whether or not its
     // device is still roster-effective — the dedup-precedence-over-authority ordering the
@@ -1021,10 +1033,11 @@ pub(crate) struct ReadoptionWork {
 pub(crate) struct ReadoptionCandidate {
     pub(crate) table_name: String,
     pub(crate) row_pk: String,
-    /// The removed writer's own entry coordinates — what the audit row's `original_*` columns
-    /// name. Carried alongside the hash so the audit joins back by `(lamport, hash)`.
+    /// The lamport the row's merge state crowns — what the audit's `original_lamport` names.
     pub(crate) original_lamport: u64,
-    pub(crate) entry_hash: [u8; 32],
+    /// The winning entry's hash, when that entry is still retained. `None` after accepted-entry
+    /// compaction reclaimed it (#1127): `(stream, device, lamport)` still names the slot.
+    pub(crate) entry_hash: Option<[u8; 32]>,
 }
 
 /// The provenance one re-adopted row carries into the audit log.
@@ -1038,7 +1051,9 @@ pub(crate) struct ReadoptionAudit {
     pub(crate) table_name: String,
     pub(crate) row_pk: String,
     pub(crate) original_lamport: u64,
-    pub(crate) original_entry_hash: [u8; 32],
+    /// The winning entry's hash, or `None` when compaction reclaimed it before re-adoption ran —
+    /// `(stream, removed, original_lamport)` still names the slot.
+    pub(crate) original_entry_hash: Option<[u8; 32]>,
     pub(crate) adopted_entry_hash: [u8; 32],
     pub(crate) adopted_at_ms: i64,
 }
@@ -1177,88 +1192,67 @@ pub(crate) fn has_pending_readoption_work(
     )? == 1)
 }
 
-/// Every row op the removed device authored on this stream, reduced to its row identity and
-/// provenance hash. This is the bounded candidate set the #997 redesign requires: the device's own
-/// accepted history, never a scan of every clock or deletion the merge tables have ever seen.
+/// Every row whose whole-row LWW winner is the removed device on this stream, with the winning
+/// entry's provenance when that entry is still retained.
+///
+/// Derived from the MERGE STATE (`sync_row_clocks` / `sync_row_tombstones`), not the entry log:
+/// the repair verdict reads the winner from those same tables, and they are the authoritative
+/// record that survives accepted-entry compaction (#1127). Enumerating `table_sync_entries`
+/// instead would silently shrink the candidate set after a compaction dropped the removed
+/// writer's prefix, completing the removal while compacted winners are never re-authored. Bounded
+/// by the device's surviving merge-state footprint — never a scan of unrelated rows.
 pub(crate) fn readoption_candidates(
     tx: &Transaction<'_>,
     stream: StreamId,
     device_fingerprint: DeviceFingerprint,
 ) -> anyhow::Result<Vec<ReadoptionCandidate>> {
+    let device_hex = device_fingerprint.to_string();
     let mut stmt = tx.prepare(
-        "SELECT lamport, entry_hash, signed_bytes FROM table_sync_entries
-         WHERE stream_id = ?1 AND device_fingerprint = ?2
-         ORDER BY lamport",
+        "SELECT table_name, row_pk, MAX(lamport) FROM (
+             SELECT table_name, row_pk, lamport FROM sync_row_clocks
+              WHERE stream_id = ?1 AND device_fingerprint = ?2
+             UNION ALL
+             SELECT table_name, row_pk, lamport FROM sync_row_tombstones
+              WHERE stream_id = ?1 AND device_fingerprint = ?2
+         )
+         GROUP BY table_name, row_pk
+         ORDER BY MAX(lamport)",
     )?;
     let rows = stmt
-        .query_map(
-            params![stream.to_bytes().as_slice(), device_fingerprint.to_bytes().as_slice()],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?)),
-        )?
+        .query_map(params![stream.to_bytes().as_slice(), device_hex], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+        })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     let mut candidates = Vec::with_capacity(rows.len());
-    for (lamport, hash, signed_bytes) in rows {
-        let Ok(signed) = entry::decode_signed(&signed_bytes) else {
-            continue;
-        };
-        let op = match row_op::decode(&signed.entry.op_bytes) {
-            Ok(DecodedRowOp::Known(op)) => op,
-            // Retained but not understood here; its table/row identity cannot be established.
-            _ => continue,
-        };
+    for (table_name, row_pk, lamport) in rows {
+        // The winning entry may be below a compacted floor: the audit then records the slot by
+        // `(stream, device, lamport)` with no hash.
+        //
+        // Residual edge, accepted: this lookup does not re-verify the op's table/pk the way
+        // `stale_row_disposition` does, so after a scope move the coordinates could name a
+        // sibling table's entry and the audit would carry a wrong-but-plausible hash. The hash
+        // is provenance only — the repair verdict never consumes it — so the cost is a
+        // misleading audit row, not a wrong repair.
+        let entry_hash: Option<Vec<u8>> = tx
+            .query_row(
+                "SELECT entry_hash FROM table_sync_entries
+                 WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport = ?3",
+                params![
+                    stream.to_bytes().as_slice(),
+                    device_fingerprint.to_bytes().as_slice(),
+                    lamport
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
         candidates.push(ReadoptionCandidate {
-            table_name: op.table().to_string(),
-            row_pk: row_op::row_pk_string(op.pk()),
+            table_name,
+            row_pk,
             original_lamport: u64::try_from(lamport)?,
-            entry_hash: fixed32(hash)?,
+            entry_hash: entry_hash.map(fixed32).transpose()?,
         });
     }
-    // One candidate per row, and it must be the entry the row's whole-row LWW clock points AT: the
-    // audit's `original_*` columns are provenance for the winning entry, so a later entry that was
-    // quarantined and never owned the clock must not be named. Rows arrive in lamport order, so
-    // the last per row is the fallback when the clock row is gone.
-    let mut by_row: std::collections::HashMap<(String, String), Vec<ReadoptionCandidate>> =
-        std::collections::HashMap::new();
-    for candidate in candidates {
-        by_row
-            .entry((candidate.table_name.clone(), candidate.row_pk.clone()))
-            .or_default()
-            .push(candidate);
-    }
-    let mut out = Vec::with_capacity(by_row.len());
-    for ((table_name, row_pk), entries) in by_row {
-        let winner = winner_lamport_for_row(tx, stream, &table_name, &row_pk)?;
-        let chosen = entries
-            .iter()
-            .find(|candidate| Some(candidate.original_lamport) == winner)
-            .or(entries.last())
-            .expect("one entry per grouped row");
-        out.push(chosen.clone());
-    }
-    out.sort_by_key(|candidate| candidate.original_lamport);
-    Ok(out)
-}
-
-/// The lamport the row's merge state currently crowns — the live clock when present and newer, the
-/// tombstone otherwise. `None` when the row has no merge state at all.
-fn winner_lamport_for_row(
-    tx: &Transaction<'_>,
-    stream: StreamId,
-    table_name: &str,
-    row_pk: &str,
-) -> anyhow::Result<Option<u64>> {
-    let mut stmt = tx.prepare(
-        "SELECT MAX(lamport) FROM (
-             SELECT lamport FROM sync_row_clocks
-              WHERE stream_id = ?1 AND table_name = ?2 AND row_pk = ?3
-             UNION ALL
-             SELECT lamport FROM sync_row_tombstones
-              WHERE stream_id = ?1 AND table_name = ?2 AND row_pk = ?3
-         )",
-    )?;
-    let highest: Option<i64> = stmt
-        .query_row(params![stream.to_bytes().as_slice(), table_name, row_pk], |row| row.get(0))?;
-    highest.map(u64::try_from).transpose().map_err(Into::into)
+    Ok(candidates)
 }
 
 /// Record one re-authored row operation with the removed writer's original entry as provenance.
@@ -1282,7 +1276,7 @@ pub(crate) fn record_readoption_audit(
             audit.table_name,
             audit.row_pk,
             i64::try_from(audit.original_lamport)?,
-            audit.original_entry_hash.as_slice(),
+            audit.original_entry_hash.as_ref().map(<[u8; 32]>::as_slice),
             audit.adopted_entry_hash.as_slice(),
             audit.adopted_at_ms,
         ],
@@ -1572,7 +1566,7 @@ mod tests {
             table_name: "t".to_string(),
             row_pk: "aa".to_string(),
             original_lamport: 7,
-            original_entry_hash: [1; 32],
+            original_entry_hash: Some([1; 32]),
             adopted_entry_hash: [2; 32],
             adopted_at_ms: 42,
         })


### PR DESCRIPTION
Part of #1127 (slice a). Anchors/1 launches fully retained; the first high-churn scope needs bounded accepted history.

## Summary
- V105 `table_sync_retained_floors`: durable per-(stream, device) reclaimed-prefix floor, purged with the stream directory
- `compact_chain_prefix`: drops accepted entries below the floor after restamping every row whose LWW winner drops (the #1020 refresh-before-drop constraint); pending entries never compact; floor must name a retained entry
- accept path treats below-floor redelivery as idempotent, not a fork

Deliberately not here: floor signaling to fresh peers (manifest/hello advertisement + peer-side floor acceptance) and the gapped-entry horizon — the follow-up slices.

## Verification
- cargo +nightly fmt --all -- --check
- cargo clippy -p rag-rat-oplog -p rag-rat-db -p rag-rat-core --all-targets -- -D warnings
- cargo test -p rag-rat-oplog retention --lib
- cargo test -p rag-rat-db --lib
- cargo test -p rag-rat-core migration_105 / migration_103 / purge_removes_every_scoped_row --lib