### PR TITLE
feat(sync): advertise retained floors so fresh peers converge through compaction

### DIFF
--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -1826,6 +1826,7 @@ mod tests {
                 head.device_fingerprint,
                 &entry.signed_bytes,
                 3,
+                None,
             )
             .unwrap();
         }

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -171,6 +171,6 @@ pub use table_sync::{
     TABLE_SYNC_ENTRY_MAX_BYTES, TableSyncChainEntry, TableSyncChainHead, TableSyncEntryStart,
     TableSyncFrontier, TableSyncIngestOutcome, TableSyncStream,
     refold_stale_table_sync_projections, table_sync_author_pending, table_sync_chain_entries,
-    table_sync_chain_frontier, table_sync_chain_page_after, table_sync_ingest,
-    table_sync_supported_streams, table_sync_validate_stream,
+    table_sync_chain_frontier, table_sync_chain_page_after, table_sync_compact_overdue,
+    table_sync_ingest, table_sync_supported_streams, table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -364,11 +364,13 @@ pub(crate) fn ingest(
     scope_id: &str,
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
+    advertised_floor: Option<store::AdvertisedFloor>,
 ) -> anyhow::Result<IngestReport> {
     store::assert_current_incarnation(tx, ctx.account_id, ctx.repo_id, ctx.incarnation_ref)?;
     let device = pubkey.fingerprint();
     let stream = scope_stream_id(ctx.repo_id, ctx.account_id, ctx.incarnation_ref, scope_id);
-    let (outcome, mut tail) = ingest_one(tx, ctx, scope_id, signed_bytes, pubkey)?;
+    let (outcome, mut tail) =
+        ingest_one(tx, ctx, scope_id, signed_bytes, pubkey, advertised_floor)?;
     let mut promoted = Vec::new();
     // Each accepted entry settles the held CHILDREN of two hashes, and both sets must be drained
     // or rows sit in the table forever, keyed to a hash no probe will ever revisit:
@@ -451,7 +453,9 @@ fn drain_children(
 ) -> anyhow::Result<Option<AcceptedEntry>> {
     let mut took_the_slot = None;
     while let Some(child) = store::take_gapped_child(tx, stream, device, parent_hash)? {
-        let (outcome, stored) = ingest_one(tx, ctx, scope_id, &child.signed_bytes, pubkey)?;
+        // A promoted child can never be the advertised floor root: this drain only runs after an
+        // entry was ACCEPTED, so the local chain is non-empty and the floor branch cannot fire.
+        let (outcome, stored) = ingest_one(tx, ctx, scope_id, &child.signed_bytes, pubkey, None)?;
         promoted.push(outcome);
         match stored {
             Some(entry) => took_the_slot = Some(entry),
@@ -476,6 +480,7 @@ fn ingest_one(
     scope_id: &str,
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
+    advertised_floor: Option<store::AdvertisedFloor>,
 ) -> anyhow::Result<(IngestOutcome, Option<AcceptedEntry>)> {
     // Same refusal as the producer: an older binary must not re-park, under its own version, an
     // entry a newer projector already understood and folded.
@@ -502,6 +507,7 @@ fn ingest_one(
             signed_bytes,
             pubkey,
             ctx.now_ms,
+            advertised_floor,
         )? {
             AcceptOutcome::Stored { op, meta, entry_hash, prev_hash } => {
                 let accepted = Some(AcceptedEntry { entry_hash, prev_hash });
@@ -679,7 +685,8 @@ mod tests {
                 registry: REGISTRY,
                 now_ms: 0,
             };
-            let out = entries.iter().map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from).unwrap());
+            let out =
+                entries.iter().map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from, None).unwrap());
             let out = out.collect();
             tx.commit().unwrap();
             out
@@ -707,7 +714,7 @@ mod tests {
             };
             let out = entries
                 .iter()
-                .map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from).unwrap().outcome);
+                .map(|bytes| ingest(&tx, &ctx, "demo/1", bytes, from, None).unwrap().outcome);
             let out = out.collect();
             tx.commit().unwrap();
             out
@@ -1313,7 +1320,7 @@ mod tests {
                 now_ms: 0,
             };
             for bytes in &entry {
-                ingest(&tx, &ctx, "demo/1", bytes, &a.pubkey()).unwrap();
+                ingest(&tx, &ctx, "demo/1", bytes, &a.pubkey(), None).unwrap();
             }
             tx.commit().unwrap();
         }
@@ -2045,7 +2052,7 @@ mod tests {
             registry: REGISTRY,
             now_ms: 0,
         };
-        let error = ingest(&tx, &ctx, "demo/1", &entries[0], &old.pubkey()).unwrap_err();
+        let error = ingest(&tx, &ctx, "demo/1", &entries[0], &old.pubkey(), None).unwrap_err();
         assert!(error.to_string().contains("different stream"));
         for table in ["table_sync_entries", "table_sync_gapped_entries", "sync_row_clocks"] {
             let count: i64 = tx
@@ -2253,7 +2260,9 @@ mod tests {
             };
             for bytes in &entries {
                 assert_eq!(
-                    ingest(&tx, &ctx, "multi/1", bytes, &a_dev.secret().public()).unwrap().outcome,
+                    ingest(&tx, &ctx, "multi/1", bytes, &a_dev.secret().public(), None)
+                        .unwrap()
+                        .outcome,
                     IngestOutcome::Applied,
                 );
             }

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -42,6 +42,6 @@ pub(crate) use store::{
 pub use transport::{
     TableSyncChainEntry, TableSyncChainHead, TableSyncEntryStart, TableSyncFrontier,
     TableSyncIngestOutcome, TableSyncStream, table_sync_author_pending, table_sync_chain_entries,
-    table_sync_chain_frontier, table_sync_chain_page_after, table_sync_ingest,
-    table_sync_supported_streams, table_sync_validate_stream,
+    table_sync_chain_frontier, table_sync_chain_page_after, table_sync_compact_overdue,
+    table_sync_ingest, table_sync_supported_streams, table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -586,7 +586,9 @@ mod tests {
             };
             let out = entries
                 .iter()
-                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap().outcome)
+                .map(|bytes| {
+                    engine::ingest(&tx, &ctx, "demo/1", bytes, from, None).unwrap().outcome
+                })
                 .collect();
             tx.commit().unwrap();
             out
@@ -1237,7 +1239,7 @@ mod tests {
             registry: OLD_REGISTRY,
             now_ms: 0,
         };
-        let ingested = engine::ingest(&tx, &ctx, "demo/1", &entries[0], &a.pubkey());
+        let ingested = engine::ingest(&tx, &ctx, "demo/1", &entries[0], &a.pubkey(), None);
         assert!(ingested.is_err(), "an older projector must not ingest into a newer store");
         assert!(
             ingested.unwrap_err().to_string().contains("newer rag-rat"),
@@ -2477,7 +2479,9 @@ mod tests {
             };
             let out = entries
                 .iter()
-                .map(|bytes| engine::ingest(&tx, &ctx, "demo/1", bytes, from).unwrap().outcome)
+                .map(|bytes| {
+                    engine::ingest(&tx, &ctx, "demo/1", bytes, from, None).unwrap().outcome
+                })
                 .collect();
             tx.commit().unwrap();
             out

--- a/crates/rag-rat-oplog/src/table_sync/retention.rs
+++ b/crates/rag-rat-oplog/src/table_sync/retention.rs
@@ -7,15 +7,22 @@
 //! every such row's next producer pass takes the stale-version winner lookup, finds the entry
 //! gone, reads `StaleRow::Unknown`, and the whole table re-authors at once.
 //!
-//! The floor is recorded durably (`table_sync_retained_floors`) so the accept path can tell an
-//! intentionally reclaimed prefix from a chain gap: a re-offered entry below the floor is
-//! idempotently ignored instead of classifying as a fork against the retained tail. What this
-//! slice deliberately does NOT do is signal the floor to a FRESH peer — a peer with no chain
-//! state whose first retained entry cites a pruned predecessor still parks as
-//! `AwaitingPredecessor`. Manifest/hello floor advertisement and peer-side floor acceptance are
-//! the follow-up slice, and the same slice wires the driver: this module is invoked by the
-//! transport's manifest/reconcile path and the first scope whose retention policy demands it
-//! (overlay), not by anchors, which stays fully retained.
+//! The floor is recorded durably (`table_sync_retained_floors`) and advertised on the wire: a
+//! FRESH peer (no local chain) accepts the floor entry as its local root on exact
+//! `(lamport, hash)` match and records the floor, so the signal propagates transitively. Adoption
+//! is bounded by the chain-tip witness: a purged chain's retained tip is chain state, and a floor
+//! at or below a different witness entry classifies as the equivocation it is. A re-offered entry
+//! below the floor is idempotently ignored instead of classifying as a fork against the retained
+//! tail. The driver (`table_sync_compact_overdue`) counts and floors only reclaimable entries,
+//! clamps at the lowest pending lamport so forward-compat payloads stay offerable, treats a
+//! non-advancing floor as the steady-state no-op, and stays inert for anchors/1 — its production
+//! caller arrives with the first scope whose retention policy bounds it (overlay).
+//!
+//! A third state needs a follow-up slice of its own: a peer whose accepted TIP fell below the
+//! sender's floor (offline while the scope churned past it) is neither fresh nor current. The
+//! sender's entries cite a compacted predecessor the receiver never held, every entry parks, and
+//! the chain stalls. Recovery — re-rooting such a chain with floor proof — is tracked in #1127
+//! and deliberately not claimed here.
 //!
 //! Two accepted horizons, named rather than hidden:
 //!
@@ -69,6 +76,51 @@ pub(crate) fn retained_floor(
         )
         .optional()?;
     row.map(u64::try_from).transpose().map_err(Into::into)
+}
+
+/// Record a floor a PEER advertised and this store just accepted as a chain root (#1127 slice b).
+/// Monotonic like the compaction record: an adopted floor can only advance. This is what makes
+/// the signal transitive — this peer's own re-offers present the same floor to third parties.
+///
+/// Also sweeps gapped entries below the adopted floor, mirroring the compaction-side sweep: a
+/// below-floor entry parked by in-session reordering can never promote once the floor is adopted
+/// (its predecessor reports `AlreadyPresent` via the below-floor early return, so no parent
+/// acceptance ever probes it), and without the sweep it burns per-chain gapped capacity forever.
+pub(crate) fn record_adopted_floor(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+    lamport: u64,
+    entry_hash: [u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO table_sync_retained_floors(
+             stream_id, device_fingerprint, lamport, entry_hash, compacted_at_ms
+         ) VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(stream_id, device_fingerprint) DO UPDATE SET
+             lamport = excluded.lamport,
+             entry_hash = excluded.entry_hash,
+             compacted_at_ms = excluded.compacted_at_ms
+         WHERE excluded.lamport > table_sync_retained_floors.lamport",
+        params![
+            stream.to_bytes().as_slice(),
+            device.to_bytes().as_slice(),
+            i64::try_from(lamport)?,
+            entry_hash.as_slice(),
+            now_ms,
+        ],
+    )?;
+    tx.execute(
+        "DELETE FROM table_sync_gapped_entries
+         WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport < ?3",
+        params![
+            stream.to_bytes().as_slice(),
+            device.to_bytes().as_slice(),
+            i64::try_from(lamport)?
+        ],
+    )?;
+    Ok(())
 }
 
 /// Drop every accepted entry on `device`'s chain in `stream` with `lamport < floor_lamport`.
@@ -520,6 +572,7 @@ mod tests {
             &forged.signed_bytes,
             &device.secret().public(),
             0,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -604,6 +657,152 @@ mod tests {
         assert_eq!(remaining, 1, "the one above the floor survives");
     }
 
+    /// Adopting an advertised floor sweeps gapped entries below it: a below-floor entry parked by
+    /// reordering can never promote once the floor is adopted (its predecessor reports
+    /// AlreadyPresent, so nothing ever probes it), and must not burn the per-chain cap forever.
+    #[test]
+    fn adopting_a_floor_sweeps_gapped_entries_below_it() {
+        let mut a = conn();
+        let device = crate::local_device(&a, 0).unwrap();
+        author_chain(&mut a, &device, 4);
+        let (floor_hash, floor_bytes): (Vec<u8>, Vec<u8>) = a
+            .query_row(
+                "SELECT entry_hash, signed_bytes FROM table_sync_entries WHERE lamport = 2",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+
+        // The fresh peer parked a below-floor entry before the floor entry arrived (reordered
+        // delivery), then the floor arrives and roots the chain.
+        let mut b = conn();
+        enroll(&b, &device);
+        b.execute(
+            "INSERT INTO table_sync_gapped_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                 gapped_at_ms
+             ) VALUES (x'99', ?1, ?2, 1, x'98', x'00', 0)",
+            params![stream().to_bytes().as_slice(), device.fingerprint().to_bytes().as_slice()],
+        )
+        .unwrap();
+        let tx = b.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &floor_bytes,
+            &device.secret().public(),
+            0,
+            Some(store::AdvertisedFloor {
+                lamport: 2,
+                entry_hash: <[u8; 32]>::try_from(floor_hash.as_slice()).unwrap(),
+            }),
+        )
+        .unwrap();
+        assert!(matches!(outcome, store::AcceptOutcome::Stored { .. }));
+        assert_eq!(
+            retained_floor(&tx, stream(), device.fingerprint()).unwrap(),
+            Some(2),
+            "the adopted floor is recorded",
+        );
+        let gapped: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(gapped, 0, "the below-floor parked entry is swept on adoption");
+        tx.commit().unwrap();
+    }
+
+    /// A retained chain-tip witness is chain state: adopting a floor BELOW it would regress the
+    /// purge boundary, resurrect the purged prefix, and wedge the chain behind it.
+    #[test]
+    fn floor_adoption_never_regresses_a_witnessed_tip() {
+        let mut a = conn();
+        let device = crate::local_device(&a, 0).unwrap();
+        author_chain(&mut a, &device, 4);
+        let (floor_hash, floor_bytes): (Vec<u8>, Vec<u8>) = a
+            .query_row(
+                "SELECT entry_hash, signed_bytes FROM table_sync_entries WHERE lamport = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+
+        // The receiver purged its accepted log; the chain-tip witness at lamport 3 survives.
+        let mut b = conn();
+        enroll(&b, &device);
+        let tip_hash: Vec<u8> = a
+            .query_row("SELECT entry_hash FROM table_sync_entries WHERE lamport = 3", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        b.execute(
+            "INSERT INTO table_sync_chain_tips(stream_id, device_fingerprint, lamport, entry_hash)
+             VALUES (?1, ?2, 3, ?3)",
+            params![
+                stream().to_bytes().as_slice(),
+                device.fingerprint().to_bytes().as_slice(),
+                tip_hash.as_slice()
+            ],
+        )
+        .unwrap();
+
+        let tx = b.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &floor_bytes,
+            &device.secret().public(),
+            0,
+            Some(store::AdvertisedFloor {
+                lamport: 1,
+                entry_hash: <[u8; 32]>::try_from(floor_hash.as_slice()).unwrap(),
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            outcome,
+            store::AcceptOutcome::Fork,
+            "a floor below the witnessed tip classifies as the equivocation it is, not a root",
+        );
+        assert!(
+            retained_floor(&tx, stream(), device.fingerprint()).unwrap().is_none(),
+            "and no floor is adopted",
+        );
+        tx.commit().unwrap();
+
+        // The same-lamport boundary: an equivocation AT the witnessed lamport (different hash)
+        // is equally not adoptable — the witness branch reports it as the fork it is.
+        let equivocation = crate::entry::sign_entry_from_op_bytes(
+            device.secret(),
+            stream(),
+            None,
+            3,
+            super::super::row_op::encode(&upsert("rx", "fork")),
+        );
+        let tx = b.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &equivocation.signed_bytes,
+            &device.secret().public(),
+            0,
+            Some(store::AdvertisedFloor { lamport: 3, entry_hash: equivocation.entry.entry_hash }),
+        )
+        .unwrap();
+        assert_eq!(
+            outcome,
+            store::AcceptOutcome::Fork,
+            "lamport == witness with a different hash is the equivocation, not a root",
+        );
+        assert!(retained_floor(&tx, stream(), device.fingerprint()).unwrap().is_none());
+        tx.commit().unwrap();
+    }
+
     #[test]
     fn a_reoffered_entry_below_the_floor_is_idempotent_not_a_fork() {
         let mut c = conn();
@@ -631,6 +830,7 @@ mod tests {
             &dropped,
             &device.secret().public(),
             0,
+            None,
         )
         .unwrap();
         assert_eq!(outcome, store::AcceptOutcome::AlreadyPresent);

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -312,6 +312,7 @@ fn stream_max_lamport(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<
 /// of whether its payload is applicable, so one undecodable / unknown / out-of-scope payload cannot
 /// wedge every later entry from that device — storage is gated on the CHAIN, application on the
 /// PAYLOAD.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn accept_row_entry(
     tx: &Transaction<'_>,
     account_id: AccountId,
@@ -320,6 +321,7 @@ pub(crate) fn accept_row_entry(
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
     now_ms: i64,
+    advertised_floor: Option<AdvertisedFloor>,
 ) -> anyhow::Result<AcceptOutcome> {
     anyhow::ensure!(
         signed_bytes.len() <= super::TABLE_SYNC_ENTRY_MAX_BYTES,
@@ -391,7 +393,23 @@ pub(crate) fn accept_row_entry(
     if !device_is_effective_writer(tx, account_id, verified.device_fingerprint)? {
         return Ok(AcceptOutcome::Unauthorized);
     }
-    match classify(tx, expected_stream, &verified)? {
+    let (fit, chain_empty) = classify(tx, expected_stream, &verified, advertised_floor)?;
+    if matches!(fit, ChainFit::Ok)
+        && chain_empty
+        && let Some(floor) = advertised_floor
+        && verified.lamport == floor.lamport
+        && verified.entry_hash == floor.entry_hash
+    {
+        super::retention::record_adopted_floor(
+            tx,
+            expected_stream,
+            verified.device_fingerprint,
+            floor.lamport,
+            floor.entry_hash,
+            now_ms,
+        )?;
+    }
+    match fit {
         ChainFit::Ok | ChainFit::Restore => {},
         ChainFit::Gap =>
             return Ok(if retain_gapped_entry(tx, &verified, signed_bytes, now_ms)? {
@@ -442,28 +460,68 @@ enum ChainFit {
     Conflict,
 }
 
+/// The retained floor a peer advertised for one chain: routing advice that lets a receiver with
+/// NO local chain accept the floor entry as its local root instead of parking on a predecessor
+/// the sender has compacted away. Honored only when the entry IS the advertised floor — the
+/// lamport and hash must match exactly, so the advice can never bless an entry the sender did not
+/// itself just produce as the root.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AdvertisedFloor {
+    pub lamport: u64,
+    pub entry_hash: [u8; 32],
+}
+
 fn classify(
     tx: &Transaction<'_>,
     stream: StreamId,
     verified: &VerifiedEntry,
-) -> anyhow::Result<ChainFit> {
+    advertised_floor: Option<AdvertisedFloor>,
+) -> anyhow::Result<(ChainFit, bool)> {
     let tail = chain_tail(tx, stream, verified.device_fingerprint)?;
-    if tail.is_none()
-        && let Some((witness_lamport, witness_hash)) =
-            chain_witness(tx, stream, verified.device_fingerprint)?
+    let chain_empty = tail.is_none();
+    let witness =
+        if chain_empty { chain_witness(tx, stream, verified.device_fingerprint)? } else { None };
+    if chain_empty
+        && let Some(floor) = advertised_floor
+        && verified.lamport == floor.lamport
+        && verified.entry_hash == floor.entry_hash
     {
-        if verified.entry_hash == witness_hash && verified.lamport == witness_lamport {
-            return Ok(ChainFit::Restore);
-        }
-        return Ok(match verified.prev_hash {
-            Some(prev) if prev == witness_hash && verified.lamport > witness_lamport =>
-                ChainFit::Ok,
-            None => ChainFit::Conflict,
-            Some(_) if verified.lamport <= witness_lamport => ChainFit::Conflict,
-            Some(_) => ChainFit::Gap,
+        // The sender has reclaimed everything below this entry. Accepting it as the local root
+        // records the floor, so this peer's own re-offers propagate the same root to third
+        // parties instead of re-parking them.
+        //
+        // A retained chain-tip WITNESS is chain state even with an empty log (its accepted
+        // prefix was purged): adopting a floor BELOW the witnessed tip would regress that
+        // boundary, resurrect the purged prefix, and then wedge the chain — successors citing
+        // the witness park forever. Adoption is valid only at or past the witness: the floor
+        // entry being the witness is the compacted-sender/restored-receiver rendezvous.
+        // Ahead of the witness, the only reachable rejoin is tip-as-direct-predecessor — a
+        // receiver two or more entries behind the compacted floor is refused by the session
+        // driver before classify ever runs (that recovery is the follow-up slice in #1127).
+        let regresses_witness = witness.is_some_and(|(witness_lamport, witness_hash)| {
+            !(floor.lamport == witness_lamport && floor.entry_hash == witness_hash)
+                && floor.lamport <= witness_lamport
         });
+        if !regresses_witness {
+            return Ok((ChainFit::Ok, chain_empty));
+        }
     }
-    Ok(match (verified.prev_hash, tail) {
+    if let Some((witness_lamport, witness_hash)) = witness {
+        if verified.entry_hash == witness_hash && verified.lamport == witness_lamport {
+            return Ok((ChainFit::Restore, chain_empty));
+        }
+        return Ok((
+            match verified.prev_hash {
+                Some(prev) if prev == witness_hash && verified.lamport > witness_lamport =>
+                    ChainFit::Ok,
+                None => ChainFit::Conflict,
+                Some(_) if verified.lamport <= witness_lamport => ChainFit::Conflict,
+                Some(_) => ChainFit::Gap,
+            },
+            chain_empty,
+        ));
+    }
+    let fit = match (verified.prev_hash, tail) {
         // A genesis (no predecessor) is the valid first entry of this device's chain; a genesis
         // when a chain already exists is a second head — an equivocation.
         (None, None) => ChainFit::Ok,
@@ -494,7 +552,8 @@ fn classify(
             } else {
                 ChainFit::Gap // links to an UNKNOWN predecessor — a genuine missing intermediate.
             },
-    })
+    };
+    Ok((fit, chain_empty))
 }
 
 /// The `(stream, device)` chain's highest-lamport `(lamport, entry_hash)`, or `None` for an empty
@@ -1602,6 +1661,7 @@ mod tests {
             &signed.signed_bytes,
             &secret.public(),
             0,
+            None,
         )
         .unwrap();
         assert_eq!(outcome, AcceptOutcome::Stored {
@@ -1643,6 +1703,7 @@ mod tests {
             &forged.signed_bytes,
             &secret.public(),
             0,
+            None,
         )
         .unwrap_err();
         assert!(error.to_string().contains("over the 65536-byte transport limit"));
@@ -1681,6 +1742,7 @@ mod tests {
                 &first.signed_bytes,
                 &secret.public(),
                 2,
+                None,
             )
             .unwrap(),
             AcceptOutcome::Stored { .. }
@@ -1734,6 +1796,7 @@ mod tests {
                     &candidate.signed_bytes,
                     &secret.public(),
                     0,
+                    None,
                 )
                 .unwrap(),
                 AcceptOutcome::Stored { .. }
@@ -1795,7 +1858,8 @@ mod tests {
                 &["t"],
                 &signed.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::Stored { .. }
@@ -1808,7 +1872,8 @@ mod tests {
                 &["t"],
                 &signed.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::AlreadyPresent,
@@ -1836,7 +1901,8 @@ mod tests {
                 &["t"],
                 &signed.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .is_err(),
             "an entry cannot be re-homed onto a stream it was not signed for",
@@ -1867,7 +1933,8 @@ mod tests {
                 &["other"],
                 &first.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::StoredInert {
@@ -1886,7 +1953,8 @@ mod tests {
                 &["t"],
                 &second.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::Stored { .. },
@@ -1917,7 +1985,8 @@ mod tests {
                 &["t"],
                 &garbage.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::StoredInert {
@@ -1935,7 +2004,8 @@ mod tests {
                 &["t"],
                 &valid.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::Stored { .. },
@@ -1964,7 +2034,8 @@ mod tests {
                 &["t"],
                 &poison.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .is_err(),
             "an out-of-bound lamport is rejected before it can poison the stream counter",
@@ -2004,7 +2075,8 @@ mod tests {
                     &["t"],
                     &at_bound.signed_bytes,
                     &secret.public(),
-                    0
+                    0,
+                    None,
                 )
                 .unwrap(),
                 AcceptOutcome::Stored { .. },
@@ -2022,7 +2094,8 @@ mod tests {
                 &["t"],
                 &beyond.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .is_err(),
             "a lamport one past the advance bound is refused",
@@ -2052,7 +2125,8 @@ mod tests {
                 &["t"],
                 &second.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::GapRetained,
@@ -2095,8 +2169,17 @@ mod tests {
         let tx = b.transaction().unwrap();
         for bytes in [&first.signed_bytes, &sibling.signed_bytes] {
             assert_eq!(
-                accept_row_entry(&tx, account(), stream(), &["t"], bytes, &secret.public(), 0)
-                    .unwrap(),
+                accept_row_entry(
+                    &tx,
+                    account(),
+                    stream(),
+                    &["t"],
+                    bytes,
+                    &secret.public(),
+                    0,
+                    None
+                )
+                .unwrap(),
                 AcceptOutcome::GapRetained,
             );
         }
@@ -2152,7 +2235,8 @@ mod tests {
                 &["t"],
                 &newcomer.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::GapRetained,
@@ -2197,7 +2281,8 @@ mod tests {
                 &["t"],
                 &far.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::GapChainFull,
@@ -2292,7 +2377,8 @@ mod tests {
                 &["t"],
                 &higher.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::GapChainFull,
@@ -2306,7 +2392,8 @@ mod tests {
                 &["t"],
                 &lower.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::GapRetained,
@@ -2352,6 +2439,7 @@ mod tests {
                     &e.signed_bytes,
                     &secret.public(),
                     0,
+                    None,
                 )
                 .unwrap();
             }
@@ -2396,10 +2484,28 @@ mod tests {
 
         let mut b = conn();
         let tx = b.transaction().unwrap();
-        accept_row_entry(&tx, account(), stream(), &["t"], &e1.signed_bytes, &secret.public(), 0)
-            .unwrap();
-        accept_row_entry(&tx, account(), stream(), &["t"], &e2.signed_bytes, &secret.public(), 0)
-            .unwrap();
+        accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t"],
+            &e1.signed_bytes,
+            &secret.public(),
+            0,
+            None,
+        )
+        .unwrap();
+        accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t"],
+            &e2.signed_bytes,
+            &secret.public(),
+            0,
+            None,
+        )
+        .unwrap();
         // Links past the tail to the STORED ancestor e1 (which already has a successor) → an
         // equivocation, not a missing predecessor.
         assert_eq!(
@@ -2410,7 +2516,8 @@ mod tests {
                 &["t"],
                 &fork.signed_bytes,
                 &secret.public(),
-                0
+                0,
+                None,
             )
             .unwrap(),
             AcceptOutcome::Fork,
@@ -2432,7 +2539,7 @@ mod tests {
         signed: &SignedEntry,
         pubkey: &DevicePublic,
     ) -> AcceptOutcome {
-        accept_row_entry(tx, acct, stream(), &["t"], &signed.signed_bytes, pubkey, 0).unwrap()
+        accept_row_entry(tx, acct, stream(), &["t"], &signed.signed_bytes, pubkey, 0, None).unwrap()
     }
 
     fn stream_entry_count(tx: &Transaction<'_>) -> i64 {

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -11,10 +11,11 @@ use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, 
 use super::engine::{self, IngestOutcome, SyncCtx};
 use super::registry::{SYNCABLE_TABLES, TableSpec};
 use super::scope_stream::scope_stream_id;
-use super::store;
+use super::{retention, store};
 use crate::AccountId;
 use crate::account::{self, RepoIncarnationState};
 use crate::device::DevicePublic;
+use crate::stream::StreamId;
 
 /// One locally-supported repo-scoped table stream.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -38,6 +39,10 @@ pub struct TableSyncChainHead {
     pub device_fingerprint: [u8; 32],
     pub lamport: u64,
     pub entry_hash: [u8; 32],
+    /// The retained floor this chain was compacted below, if any (#1127). Routing advice only:
+    /// a receiver with no local chain may accept the floor entry as its local root; a receiver
+    /// with chain state ignores it entirely.
+    pub floor: Option<(u64, [u8; 32])>,
 }
 
 /// Durable receiver progress for one offered device chain.
@@ -146,6 +151,106 @@ pub fn table_sync_author_pending(
     Ok(authored)
 }
 
+/// Compact accepted chain prefixes for scopes whose retention policy bounds them (#1127).
+///
+/// `retain` answers the per-chain accepted-entry budget for a scope, `None` for full retention
+/// (anchors/1 stays unbounded). A chain with more RECLAIMABLE entries than its budget compacts to
+/// keep its newest; chains within budget are untouched. Entries retained for forward-compat
+/// replay (`pending_reason IS NOT NULL`) are neither counted nor dropped — a chain pinned above
+/// budget by pending entries makes the computed floor not advance, which is a steady-state no-op,
+/// never an error, so the driver is safely re-runnable on any cadence. Each stream compacts in
+/// its own IMMEDIATE transaction, and the caller's authoring pass already ran, so a winner
+/// restamp never disowns an unsent local edit (see the retention module docs).
+///
+/// Returns the number of accepted entries reclaimed.
+pub fn table_sync_compact_overdue(
+    conn: &Connection,
+    account_id: AccountId,
+    now_ms: i64,
+    retain: &dyn Fn(&str) -> Option<u64>,
+) -> anyhow::Result<usize> {
+    let streams = supported_streams_against(conn, account_id, SYNCABLE_TABLES)?;
+    let registry = repo_registry(SYNCABLE_TABLES);
+    let mut compacted = 0;
+    for stream in streams {
+        let Some(keep) = retain(&stream.scope_id) else {
+            continue;
+        };
+        anyhow::ensure!(keep >= 1, "a retention budget of zero keeps no chain tail to build on");
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+        let chains = {
+            let mut stmt = tx.prepare(
+                "SELECT device_fingerprint, COUNT(*) FROM table_sync_entries
+                 WHERE stream_id = ?1 AND pending_reason IS NULL
+                 GROUP BY device_fingerprint",
+            )?;
+            stmt.query_map([stream.stream_id.as_slice()], |row| {
+                Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        for (device_bytes, count) in chains {
+            let count = u64::try_from(count)?;
+            if count <= keep {
+                continue;
+            }
+            // The floor is the oldest RECLAIMABLE entry to retain: the one at offset
+            // (count - keep) in lamport order. compact_chain_prefix drops strictly below it.
+            let floor_lamport: i64 = tx.query_row(
+                "SELECT lamport FROM table_sync_entries
+                 WHERE stream_id = ?1 AND device_fingerprint = ?2 AND pending_reason IS NULL
+                 ORDER BY lamport LIMIT 1 OFFSET ?3",
+                params![
+                    stream.stream_id.as_slice(),
+                    device_bytes.as_slice(),
+                    i64::try_from(count - keep)?
+                ],
+                |row| row.get(0),
+            )?;
+            let floor_lamport = u64::try_from(floor_lamport)?;
+            let device = crate::op::DeviceFingerprint::from_bytes(fixed32(device_bytes)?);
+            // A pending entry below the computed floor would survive locally yet become
+            // unreachable to floor-adopting peers (served early it parks and is swept; served
+            // late it reads as already-present) — silent loss of the forward-compat payload it
+            // exists to retain. Clamp the floor at the lowest pending lamport, so every pending
+            // entry sits AT or above the floor and stays offerable.
+            let lowest_pending: Option<i64> = tx
+                .query_row(
+                    "SELECT MIN(lamport) FROM table_sync_entries
+                     WHERE stream_id = ?1 AND device_fingerprint = ?2
+                       AND pending_reason IS NOT NULL",
+                    params![stream.stream_id.as_slice(), device.to_bytes().as_slice()],
+                    |row| row.get(0),
+                )
+                .optional()?
+                .flatten();
+            let floor_lamport = match lowest_pending {
+                Some(pending) if (pending as u64) < floor_lamport => pending as u64,
+                _ => floor_lamport,
+            };
+            // A chain pinned by pending entries (or simply already compacted past this point)
+            // computes a floor that does not advance: steady state, not the caller bug
+            // compact_chain_prefix's refusal exists to catch.
+            if retention::retained_floor(&tx, StreamId::from_bytes(stream.stream_id), device)?
+                .is_some_and(|current| floor_lamport <= current)
+            {
+                continue;
+            }
+            let report = retention::compact_chain_prefix(
+                &tx,
+                StreamId::from_bytes(stream.stream_id),
+                device,
+                floor_lamport,
+                &registry,
+                now_ms,
+            )?;
+            compacted += report.dropped_entries;
+        }
+        tx.commit()?;
+    }
+    Ok(compacted)
+}
+
 /// Recompute an advertised route from local current-incarnation authority and the production
 /// registry. The advertised stream id is routing advice only; it never creates authority.
 pub fn table_sync_validate_stream(
@@ -207,8 +312,18 @@ pub fn table_sync_ingest(
     expected_device: [u8; 32],
     signed_bytes: &[u8],
     now_ms: i64,
+    advertised_floor: Option<(u64, [u8; 32])>,
 ) -> anyhow::Result<TableSyncIngestOutcome> {
-    ingest_against(conn, account_id, stream, expected_device, signed_bytes, now_ms, SYNCABLE_TABLES)
+    ingest_against(
+        conn,
+        account_id,
+        stream,
+        expected_device,
+        signed_bytes,
+        now_ms,
+        advertised_floor,
+        SYNCABLE_TABLES,
+    )
 }
 
 fn repo_registry(registry: &[TableSpec]) -> Vec<TableSpec> {
@@ -283,8 +398,11 @@ fn accepted_chain_page(
     limit: usize,
 ) -> anyhow::Result<Vec<TableSyncChainHead>> {
     let mut stmt = conn.prepare(
-        "SELECT e.device_fingerprint, e.lamport, e.entry_hash
+        "SELECT e.device_fingerprint, e.lamport, e.entry_hash, f.lamport, f.entry_hash
            FROM table_sync_entries e
+           LEFT JOIN table_sync_retained_floors f
+             ON f.stream_id = e.stream_id
+            AND f.device_fingerprint = e.device_fingerprint
           WHERE e.stream_id = ?1
             AND (?2 IS NULL OR e.device_fingerprint > ?2)
             AND NOT EXISTS (
@@ -302,14 +420,31 @@ fn accepted_chain_page(
             after_device.map(|device| device.to_vec()),
             i64::try_from(limit)?,
         ],
-        |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?, row.get::<_, Vec<u8>>(2)?)),
+        |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+                row.get::<_, Option<Vec<u8>>>(4)?,
+            ))
+        },
     )?
     .map(|row| {
-        let (device, lamport, hash) = row?;
+        let (device, lamport, hash, floor_lamport, floor_hash) = row?;
+        let floor = floor_lamport
+            .map(|l| -> anyhow::Result<_> {
+                Ok((
+                    u64::try_from(l)?,
+                    fixed32(floor_hash.expect("floor row carries its entry hash"))?,
+                ))
+            })
+            .transpose()?;
         Ok(TableSyncChainHead {
             device_fingerprint: fixed32(device)?,
             lamport: u64::try_from(lamport)?,
             entry_hash: fixed32(hash)?,
+            floor,
         })
     })
     .collect::<anyhow::Result<_>>()
@@ -484,6 +619,7 @@ fn fixed32(bytes: Vec<u8>) -> anyhow::Result<[u8; 32]> {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ingest_against(
     conn: &Connection,
     account_id: AccountId,
@@ -491,6 +627,7 @@ fn ingest_against(
     expected_device: [u8; 32],
     signed_bytes: &[u8],
     now_ms: i64,
+    advertised_floor: Option<(u64, [u8; 32])>,
     registry: &[TableSpec],
 ) -> anyhow::Result<TableSyncIngestOutcome> {
     if !validate_stream_against(conn, account_id, stream, registry)? {
@@ -529,7 +666,15 @@ fn ingest_against(
         registry: &registry,
         now_ms,
     };
-    let report = engine::ingest(&tx, &ctx, &stream.scope_id, signed_bytes, &pubkey)?;
+    let report = engine::ingest(
+        &tx,
+        &ctx,
+        &stream.scope_id,
+        signed_bytes,
+        &pubkey,
+        advertised_floor
+            .map(|(lamport, entry_hash)| store::AdvertisedFloor { lamport, entry_hash }),
+    )?;
     if registry.iter().any(|spec| spec.name == "repo_memory_bindings")
         && std::iter::once(&report.outcome)
             .chain(report.promoted.iter())
@@ -633,7 +778,8 @@ mod tests {
         for route in [&stale, &unknown, &forged] {
             assert!(!validate_stream_against(&conn, account(), route, &[REPO_SPEC]).unwrap());
             assert_eq!(
-                ingest_against(&conn, account(), route, [0; 32], &[0], 0, &[REPO_SPEC]).unwrap(),
+                ingest_against(&conn, account(), route, [0; 32], &[0], 0, None, &[REPO_SPEC])
+                    .unwrap(),
                 TableSyncIngestOutcome::NoChange,
             );
         }
@@ -655,6 +801,122 @@ mod tests {
                 .unwrap();
             assert_eq!(count, 0, "invalid routes write no rows to {table}");
         }
+    }
+
+    #[test]
+    fn the_compaction_driver_is_idempotent_past_pending_entries() {
+        let conn = database();
+        let stream = supported_streams_against(&conn, account(), &[REPO_SPEC]).unwrap().remove(0);
+        conn.execute(
+            "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, incarnation_ref, \
+             scope_id) VALUES (?1, 'repo-a', ?2, ?3, 'anchors/1')",
+            params![
+                stream.stream_id.as_slice(),
+                account().to_bytes().as_slice(),
+                INCARNATION.as_slice()
+            ],
+        )
+        .unwrap();
+        for lamport in 0..5i64 {
+            conn.execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, signed_bytes,
+                     received_at_ms
+                 ) VALUES (?1, ?2, ?3, ?4, x'00', 0)",
+                params![
+                    [(lamport + 1) as u8; 32].as_slice(),
+                    stream.stream_id.as_slice(),
+                    [2u8; 32].as_slice(),
+                    lamport
+                ],
+            )
+            .unwrap();
+        }
+        // The tip carries a pending mark: reclaimable entries pin below it.
+        conn.execute(
+            "UPDATE table_sync_entries SET pending_reason = 'unknown_column' WHERE lamport = 4",
+            [],
+        )
+        .unwrap();
+
+        let keep_one = &|_scope: &str| Some(1);
+        let first = table_sync_compact_overdue(&conn, account(), 1, keep_one).unwrap();
+        assert_eq!(first, 3, "reclaimable entries 0..3 drop; the pending tip survives");
+        let floor: Option<i64> = conn
+            .query_row("SELECT lamport FROM table_sync_retained_floors", [], |row| row.get(0))
+            .ok();
+        assert_eq!(floor, Some(3));
+
+        let second = table_sync_compact_overdue(&conn, account(), 2, keep_one).unwrap();
+        assert_eq!(second, 0, "a chain pinned by its pending tip computes a non-advancing floor");
+        let remaining: Vec<i64> = conn
+            .prepare("SELECT lamport FROM table_sync_entries ORDER BY lamport")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(remaining, vec![3, 4], "nothing moves on the second pass");
+
+        let zero = &|_scope: &str| Some(0);
+        assert!(
+            table_sync_compact_overdue(&conn, account(), 3, zero).is_err(),
+            "a zero budget would drop the chain tail itself — refused"
+        );
+    }
+
+    /// A pending entry below the computed floor would survive locally yet be unreachable to
+    /// floor-adopting peers; the driver clamps the floor at the lowest pending lamport.
+    #[test]
+    fn the_compaction_driver_clamps_the_floor_above_pending_entries() {
+        let conn = database();
+        let stream = supported_streams_against(&conn, account(), &[REPO_SPEC]).unwrap().remove(0);
+        conn.execute(
+            "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, incarnation_ref, \
+             scope_id) VALUES (?1, 'repo-a', ?2, ?3, 'anchors/1')",
+            params![
+                stream.stream_id.as_slice(),
+                account().to_bytes().as_slice(),
+                INCARNATION.as_slice()
+            ],
+        )
+        .unwrap();
+        for lamport in 0..5i64 {
+            conn.execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, signed_bytes,
+                     received_at_ms
+                 ) VALUES (?1, ?2, ?3, ?4, x'00', 0)",
+                params![
+                    [(lamport + 1) as u8; 32].as_slice(),
+                    stream.stream_id.as_slice(),
+                    [2u8; 32].as_slice(),
+                    lamport
+                ],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "UPDATE table_sync_entries SET pending_reason = 'unknown_column' WHERE lamport = 1",
+            [],
+        )
+        .unwrap();
+
+        let keep_two = &|_scope: &str| Some(2);
+        let compacted = table_sync_compact_overdue(&conn, account(), 1, keep_two).unwrap();
+        assert_eq!(compacted, 1, "only the genesis drops: the floor clamps at the pending entry");
+        let floor: Option<i64> = conn
+            .query_row("SELECT lamport FROM table_sync_retained_floors", [], |row| row.get(0))
+            .ok();
+        assert_eq!(floor, Some(1), "the pending entry sits AT the floor and stays offerable");
+        let remaining: Vec<i64> = conn
+            .prepare("SELECT lamport FROM table_sync_entries ORDER BY lamport")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(remaining, vec![1, 2, 3, 4]);
     }
 
     #[test]
@@ -734,6 +996,7 @@ mod tests {
             device_fingerprint: [2; 32],
             lamport: 3,
             entry_hash: [13; 32],
+            floor: None,
         }]);
         let second = accepted_chain_page(&conn, stream.stream_id, Some([2; 32]), 1).unwrap();
         assert_eq!(second[0].device_fingerprint, [4; 32]);
@@ -928,6 +1191,7 @@ mod tests {
                     heads[0].device_fingerprint,
                     &entry.signed_bytes,
                     3,
+                    None,
                 )
                 .unwrap();
             }
@@ -1118,18 +1382,24 @@ mod tests {
 
         let destination = restore(false);
         assert_eq!(
-            ingest_against(&destination, account, &route, [0; 32], &authored[0], 1, &[REPO_SPEC],)
-                .unwrap(),
+            ingest_against(&destination, account, &route, [0; 32], &authored[0], 1, None, &[
+                REPO_SPEC
+            ])
+            .unwrap(),
             TableSyncIngestOutcome::NoChange,
         );
         assert_eq!(
-            ingest_against(&destination, account, &route, author, &authored[0], 1, &[REPO_SPEC],)
-                .unwrap(),
+            ingest_against(&destination, account, &route, author, &authored[0], 1, None, &[
+                REPO_SPEC
+            ])
+            .unwrap(),
             TableSyncIngestOutcome::Stored,
         );
         assert_eq!(
-            ingest_against(&destination, account, &route, author, &authored[0], 2, &[REPO_SPEC],)
-                .unwrap(),
+            ingest_against(&destination, account, &route, author, &authored[0], 2, None, &[
+                REPO_SPEC
+            ])
+            .unwrap(),
             TableSyncIngestOutcome::NoChange,
         );
         let title: String = destination
@@ -1143,7 +1413,7 @@ mod tests {
 
         let removed = restore(true);
         assert_eq!(
-            ingest_against(&removed, account, &route, author, &authored[0], 1, &[REPO_SPEC],)
+            ingest_against(&removed, account, &route, author, &authored[0], 1, None, &[REPO_SPEC])
                 .unwrap(),
             TableSyncIngestOutcome::NoChange,
         );

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -1149,6 +1149,7 @@ mod tests {
                     device_fingerprint: device,
                     lamport: 0,
                     entry_hash: device,
+                    floor: None,
                 })
                 .collect())
         }
@@ -1212,6 +1213,7 @@ mod tests {
             item: &crate::table_wire::ManifestItem,
             expected_device: [u8; 32],
             signed_bytes: &[u8],
+            _advertised_floor: Option<(u64, [u8; 32])>,
         ) -> anyhow::Result<crate::session::Ingested> {
             if !self.supported.contains(item) {
                 return Ok(crate::session::Ingested::NoChange);

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -356,6 +356,7 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
             device_fingerprint: chain.device_fingerprint,
             lamport: chain.lamport,
             entry_hash: chain.entry_hash,
+            floor: chain.floor,
         })
         .collect())
     }
@@ -413,6 +414,7 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
         item: &ManifestItem,
         expected_device: [u8; 32],
         signed_bytes: &[u8],
+        advertised_floor: Option<(u64, [u8; 32])>,
     ) -> anyhow::Result<Ingested> {
         Ok(
             match rag_rat_oplog::table_sync_ingest(
@@ -422,6 +424,7 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
                 expected_device,
                 signed_bytes,
                 (self.now_fn)(),
+                advertised_floor,
             )? {
                 rag_rat_oplog::TableSyncIngestOutcome::Stored => Ingested::Stored,
                 rag_rat_oplog::TableSyncIngestOutcome::NoChange => Ingested::NoChange,
@@ -478,6 +481,6 @@ mod tests {
         assert!(store.chain_page(&item, None, 1).unwrap().is_empty());
         assert_eq!(store.frontier(&item, [4; 32]).unwrap(), FrontierState::Empty);
         assert!(store.entries(&item, [4; 32], ChainStart::Beginning, 1).unwrap().is_empty());
-        assert_eq!(store.ingest(&item, [4; 32], &[0]).unwrap(), Ingested::NoChange);
+        assert_eq!(store.ingest(&item, [4; 32], &[0], None).unwrap(), Ingested::NoChange);
     }
 }

--- a/crates/rag-rat-sync/src/table_session.rs
+++ b/crates/rag-rat-sync/src/table_session.rs
@@ -43,6 +43,7 @@ pub trait TableSyncStore {
         item: &ManifestItem,
         expected_device: Hash,
         signed_bytes: &[u8],
+        advertised_floor: Option<(u64, Hash)>,
     ) -> anyhow::Result<Ingested>;
 }
 
@@ -481,9 +482,13 @@ where
                                         limits.entries_per_session
                                     )));
                                 }
+                                let floor = chains
+                                    .iter()
+                                    .find(|chain| chain.device_fingerprint == device_fingerprint)
+                                    .and_then(|chain| chain.floor);
                                 for bytes in entries {
                                     if store
-                                        .ingest(item, device_fingerprint, &bytes)
+                                        .ingest(item, device_fingerprint, &bytes, floor)
                                         .map_err(TableSessionError::Store)?
                                         == Ingested::Stored
                                     {
@@ -719,6 +724,7 @@ mod tests {
                 .filter(|(device, _)| after_device.is_none_or(|after| *device > after))
                 .take(limit)
                 .map(|(device, (lamport, entry_hash))| ChainHead {
+                    floor: None,
                     device_fingerprint: device,
                     lamport,
                     entry_hash,
@@ -798,6 +804,7 @@ mod tests {
             item: &ManifestItem,
             expected_device: Hash,
             bytes: &[u8],
+            _advertised_floor: Option<(u64, Hash)>,
         ) -> anyhow::Result<Ingested> {
             if !self.supported.contains(item) {
                 return Ok(Ingested::NoChange);
@@ -1009,7 +1016,8 @@ mod tests {
 
     #[test]
     fn peer_frontiers_must_be_provable_prefixes_and_restore_debt_stays_pending() {
-        let local = ChainHead { device_fingerprint: [1; 32], lamport: 3, entry_hash: [3; 32] };
+        let local =
+            ChainHead { device_fingerprint: [1; 32], lamport: 3, entry_hash: [3; 32], floor: None };
         assert!(matches!(
             chain_plan(&local, FrontierState::Accepted { lamport: 3, entry_hash: [4; 32] }),
             Err(TableSessionError::Protocol(_))
@@ -1081,6 +1089,7 @@ mod tests {
                             device_fingerprint: [*device; 32],
                             lamport: 0,
                             entry_hash: [*device; 32],
+                            floor: None,
                         }],
                     })
                     .await
@@ -1102,6 +1111,7 @@ mod tests {
                         device_fingerprint: [device; 32],
                         lamport: 0,
                         entry_hash: [device; 32],
+                        floor: None,
                     }],
                 })
                 .await
@@ -1137,6 +1147,7 @@ mod tests {
                     device_fingerprint: [1; 32],
                     lamport: 0,
                     entry_hash: [1; 32],
+                    floor: None,
                 }],
             })
             .await

--- a/crates/rag-rat-sync/src/table_wire.rs
+++ b/crates/rag-rat-sync/src/table_wire.rs
@@ -5,9 +5,9 @@ use std::collections::BTreeMap;
 use minicbor::{Decoder, Encoder};
 
 /// Dedicated ALPN for table-stream sync. Existing account/content/enrollment ALPNs do not move.
-pub const TABLE_SYNC_ALPN: &[u8] = b"rag-rat/table-sync/2";
+pub const TABLE_SYNC_ALPN: &[u8] = b"rag-rat/table-sync/3";
 
-const FRAME_DOMAIN: &str = "rag-rat/table-sync-frame/2";
+const FRAME_DOMAIN: &str = "rag-rat/table-sync-frame/3";
 pub const MAX_MANIFEST_ITEMS: usize = 1024;
 pub const MAX_REPO_ID_BYTES: usize = 1024;
 pub const MAX_SCOPE_ID_BYTES: usize = 128;
@@ -73,6 +73,9 @@ pub struct ChainHead {
     pub device_fingerprint: Hash,
     pub lamport: u64,
     pub entry_hash: Hash,
+    /// The retained floor the sender compacted this chain below, if any (#1127). Routing advice:
+    /// a receiver with no local chain may accept the floor entry as its local root.
+    pub floor: Option<(u64, Hash)>,
 }
 
 /// Durable receiver progress for one offered device chain.
@@ -155,10 +158,20 @@ impl TableFrame {
                 enc.bytes(stream_id).expect(INFALLIBLE);
                 enc.array(chains.len() as u64).expect(INFALLIBLE);
                 for chain in chains {
-                    enc.array(3).expect(INFALLIBLE);
+                    enc.array(4).expect(INFALLIBLE);
                     enc.bytes(&chain.device_fingerprint).expect(INFALLIBLE);
                     enc.u64(chain.lamport).expect(INFALLIBLE);
                     enc.bytes(&chain.entry_hash).expect(INFALLIBLE);
+                    match chain.floor {
+                        None => {
+                            enc.null().expect(INFALLIBLE);
+                        },
+                        Some((lamport, hash)) => {
+                            enc.array(2).expect(INFALLIBLE);
+                            enc.u64(lamport).expect(INFALLIBLE);
+                            enc.bytes(&hash).expect(INFALLIBLE);
+                        },
+                    }
                 }
             },
             Self::ChainFrontiers { stream_id, frontiers } => {
@@ -262,14 +275,28 @@ impl TableFrame {
                 }
                 let mut chains = Vec::with_capacity(count);
                 for _ in 0..count {
-                    if dec.array().map_err(m)? != Some(3) {
+                    if dec.array().map_err(m)? != Some(4) {
                         return Err(TableWireError::Malformed("chain head arity".into()));
                     }
-                    chains.push(ChainHead {
-                        device_fingerprint: fixed32(dec.bytes().map_err(m)?, "device_fingerprint")?,
-                        lamport: dec.u64().map_err(m)?,
-                        entry_hash: fixed32(dec.bytes().map_err(m)?, "entry_hash")?,
-                    });
+                    let device_fingerprint =
+                        fixed32(dec.bytes().map_err(m)?, "device_fingerprint")?;
+                    let lamport = dec.u64().map_err(m)?;
+                    let entry_hash = fixed32(dec.bytes().map_err(m)?, "entry_hash")?;
+                    let floor = match dec.datatype().map_err(m)? {
+                        minicbor::data::Type::Null => {
+                            dec.null().map_err(m)?;
+                            None
+                        },
+                        _ => {
+                            if dec.array().map_err(m)? != Some(2) {
+                                return Err(TableWireError::Malformed("chain floor arity".into()));
+                            }
+                            let floor_lamport = dec.u64().map_err(m)?;
+                            let floor_hash = fixed32(dec.bytes().map_err(m)?, "floor_hash")?;
+                            Some((floor_lamport, floor_hash))
+                        },
+                    };
+                    chains.push(ChainHead { device_fingerprint, lamport, entry_hash, floor });
                 }
                 validate_devices(chains.iter().map(|chain| chain.device_fingerprint))?;
                 Self::ChainInventory { stream_id, chains }
@@ -445,7 +472,7 @@ mod tests {
     }
 
     fn head(device: u8, lamport: u64, hash: u8) -> ChainHead {
-        ChainHead { device_fingerprint: [device; 32], lamport, entry_hash: [hash; 32] }
+        ChainHead { device_fingerprint: [device; 32], lamport, entry_hash: [hash; 32], floor: None }
     }
 
     #[test]
@@ -489,9 +516,9 @@ mod tests {
         assert_eq!(TableFrame::Done.encode(), [
             0x82, 0x78, 0x1a, b'r', b'a', b'g', b'-', b'r', b'a', b't', b'/', b't', b'a', b'b',
             b'l', b'e', b'-', b's', b'y', b'n', b'c', b'-', b'f', b'r', b'a', b'm', b'e', b'/',
-            b'2', 0x06,
+            b'3', 0x06,
         ]);
-        assert_eq!(TABLE_SYNC_ALPN, b"rag-rat/table-sync/2");
+        assert_eq!(TABLE_SYNC_ALPN, b"rag-rat/table-sync/3");
     }
 
     #[test]
@@ -525,8 +552,8 @@ mod tests {
             golden.extend_from_slice(&bytes);
         }
         assert_eq!(Sha256::digest(golden).as_slice(), &[
-            207, 130, 172, 222, 118, 237, 28, 115, 145, 245, 148, 105, 68, 107, 217, 78, 66, 164,
-            248, 205, 81, 83, 160, 84, 91, 124, 119, 163, 184, 98, 21, 236,
+            82, 135, 194, 249, 15, 17, 225, 24, 26, 241, 90, 71, 188, 230, 43, 81, 125, 48, 242,
+            27, 111, 243, 22, 141, 194, 9, 179, 63, 231, 202, 135, 31,
         ]);
     }
 

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -284,7 +284,7 @@ mod tests {
     fn alpn_identifiers_are_frozen() {
         assert_eq!(SYNC_ALPN, b"rag-rat/sync/4");
         assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/3");
-        assert_eq!(crate::table_wire::TABLE_SYNC_ALPN, b"rag-rat/table-sync/2");
+        assert_eq!(crate::table_wire::TABLE_SYNC_ALPN, b"rag-rat/table-sync/3");
         assert_eq!(crate::enrollment::ENROLL_ALPN, b"rag-rat/enroll/1");
         assert_ne!(SYNC_ALPN, CONTENT_SYNC_ALPN);
         assert_ne!(SYNC_ALPN, crate::enrollment::ENROLL_ALPN);

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -761,6 +761,109 @@ async fn production_anchors_replicate_through_dispatch_before_local_repo_registr
 }
 
 #[tokio::test]
+async fn a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_floor() {
+    use rag_rat_sync::{
+        AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, TABLE_SYNC_ALPN,
+        accept_and_dispatch, connect_and_table_sync,
+    };
+
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let joiner = fresh_db();
+    let (owner_endpoint, joiner_endpoint) = loopback_endpoints().await;
+    enroll_member_over_endpoint(
+        &owner_endpoint,
+        &joiner_endpoint,
+        &owner,
+        &joiner,
+        account,
+        "https://relay.example",
+    )
+    .await;
+
+    owner
+        .execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+             VALUES ('repo-a', 'repo-a', 0)",
+            [],
+        )
+        .unwrap();
+    rag_rat_oplog::ensure_repo_incarnation(&owner, "repo-a", NOW + 1).unwrap().unwrap();
+    for (memory, path) in [("memory-a", "src/a.rs"), ("memory-b", "src/b.rs")] {
+        owner
+            .execute(
+                "INSERT INTO repo_memory_bindings(
+                     repo_id, memory_id, binding_kind, binding_id, path, start_line, end_line,
+                     anchor_status, created_at_ms)
+                 VALUES ('repo-a', ?1, 'path', ?2, ?2, 4, 5, 'current', ?3)",
+                rusqlite::params![memory, path, NOW + 2],
+            )
+            .unwrap();
+        rag_rat_oplog::table_sync_author_pending(&owner, account, NOW + 2).unwrap();
+    }
+    // Compact the owner's chain below all but its last entry: the first binding's winning entry
+    // drops, and only the floor advertisement lets a fresh peer converge.
+    let compacted = rag_rat_oplog::table_sync_compact_overdue(&owner, account, NOW + 3, &|scope| {
+        (scope == "anchors/1").then_some(1)
+    })
+    .unwrap();
+    assert_eq!(compacted, 1, "the first binding's entry is reclaimed");
+    for entry in account_entries_for_sync(&owner, account).unwrap() {
+        rag_rat_oplog::account_ingest(&joiner, &entry.signed_bytes, NOW + 2).unwrap();
+    }
+
+    let mut account_store = OplogSyncStore::new(&owner, account, || NOW);
+    let mut content_store = OplogContentSyncStore::new(&owner, account, || NOW);
+    let mut table_store = OplogTableSyncStore::new(&joiner, account, || NOW);
+    let server = accept_and_dispatch(
+        &owner_endpoint,
+        &mut account_store,
+        &mut content_store,
+        AuthPolicy::Closed,
+        || NOW,
+    );
+    let client = connect_and_table_sync(
+        &joiner_endpoint,
+        direct_addr(&owner_endpoint),
+        &mut table_store,
+        NOW,
+    );
+    let (server, client) = tokio::join!(server, client);
+    let (alpn, _server_report) = server.unwrap();
+    let client_report = client.unwrap();
+    assert_eq!(alpn, TABLE_SYNC_ALPN);
+    assert_eq!(
+        client_report.entries_newly_stored, 1,
+        "only the retained suffix transfers — the floor entry roots the fresh chain",
+    );
+
+    let surviving: bool = joiner
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM repo_memory_bindings
+                 WHERE repo_id = 'repo-a' AND memory_id = 'memory-b')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(surviving, "the row whose entry is at/above the floor converges");
+    let compacted_row: bool = joiner
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM repo_memory_bindings
+                 WHERE repo_id = 'repo-a' AND memory_id = 'memory-a')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(!compacted_row, "the reclaimed prefix honestly does not arrive");
+    let floor: Option<i64> = joiner
+        .query_row("SELECT lamport FROM table_sync_retained_floors", [], |row| row.get(0))
+        .ok();
+    assert_eq!(floor, Some(1), "the adopted floor is recorded, so re-offers propagate it");
+}
+
+#[tokio::test]
 async fn closed_table_auth_refusal_reveals_no_manifest() {
     use rag_rat_sync::{AuthPolicy, Frame, OplogContentSyncStore, TABLE_SYNC_ALPN};
     use tokio::io::AsyncReadExt;


### PR DESCRIPTION
Part of #1127 (slice b). Follows #1128.

## Summary
- bump the table transport to rag-rat/table-sync/3 with an optional retained floor on advertised chain heads
- a fresh receiver accepts the floor entry as its local chain root (exact lamport+hash match only), records the floor so re-offers propagate it transitively, and a receiver with chain state ignores the field
- table_sync_compact_overdue drives compaction for scopes with a bounded retention policy; anchors/1 stays fully retained, so production compacts nothing until a bounded scope registers

## Verification
- cargo +nightly fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rag-rat-oplog --lib (917)
- cargo test -p rag-rat-sync (162) including the new loopback test: fresh peer converges through a compacted chain, stores exactly the retained suffix, and records the adopted floor