### PR TITLE
feat(sync): re-root chains whose accepted tip fell below the sender's floor

### DIFF
--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -453,8 +453,9 @@ fn drain_children(
 ) -> anyhow::Result<Option<AcceptedEntry>> {
     let mut took_the_slot = None;
     while let Some(child) = store::take_gapped_child(tx, stream, device, parent_hash)? {
-        // A promoted child can never be the advertised floor root: this drain only runs after an
-        // entry was ACCEPTED, so the local chain is non-empty and the floor branch cannot fire.
+        // The advertised floor is deliberately NOT passed here: a promoted child is chain
+        // continuation, not a candidate for adoption, and passing the floor would let an exact
+        // match re-classify as RootAdopt where a promotion belongs.
         let (outcome, stored) = ingest_one(tx, ctx, scope_id, &child.signed_bytes, pubkey, None)?;
         promoted.push(outcome);
         match stored {

--- a/crates/rag-rat-oplog/src/table_sync/retention.rs
+++ b/crates/rag-rat-oplog/src/table_sync/retention.rs
@@ -18,11 +18,12 @@
 //! non-advancing floor as the steady-state no-op, and stays inert for anchors/1 — its production
 //! caller arrives with the first scope whose retention policy bounds it (overlay).
 //!
-//! A third state needs a follow-up slice of its own: a peer whose accepted TIP fell below the
-//! sender's floor (offline while the scope churned past it) is neither fresh nor current. The
-//! sender's entries cite a compacted predecessor the receiver never held, every entry parks, and
-//! the chain stalls. Recovery — re-rooting such a chain with floor proof — is tracked in #1127
-//! and deliberately not claimed here.
+//! A peer whose accepted TIP fell below the sender's floor (offline while the scope churned
+//! past it) recovers by re-rooting: the session plans the offer AT the floor instead of a suffix
+//! the peer can never link, and the receiver adopts the floor as its new root on exact coordinate
+//! match. The old prefix stays stored (projections are unaffected), the tail advances, and
+//! below-floor re-offers read idempotent. A peer forked AT the floor lamport gets ordinary fork
+//! classification, same as at any other tip.
 //!
 //! Two accepted horizons, named rather than hidden:
 //!
@@ -800,6 +801,182 @@ mod tests {
             "lamport == witness with a different hash is the equivocation, not a root",
         );
         assert!(retained_floor(&tx, stream(), device.fingerprint()).unwrap().is_none());
+        tx.commit().unwrap();
+    }
+
+    /// The rejoin case the floor exists for: a peer whose accepted tip fell below the sender's
+    /// floor re-roots onto it instead of parking forever on a compacted predecessor.
+    #[test]
+    fn a_peer_whose_tip_fell_below_the_floor_re_roots_and_converges() {
+        let mut a = conn();
+        let device = crate::local_device(&a, 0).unwrap();
+        author_chain(&mut a, &device, 6);
+        let bytes = |lamport: i64| -> (Vec<u8>, Vec<u8>) {
+            a.query_row(
+                "SELECT entry_hash, signed_bytes FROM table_sync_entries WHERE lamport = ?1",
+                [lamport],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap()
+        };
+        let floor_hash = bytes(4).0;
+
+        // The peer holds entries 0..2 (its tip is 2), then rejoins after the sender compacted
+        // below floor 4. Entry 3 is NOT delivered — its hash is the predecessor entry 4 cites.
+        let mut b = conn();
+        enroll(&b, &device);
+        for lamport in 0..3 {
+            let (_, signed_bytes) = bytes(lamport);
+            let tx = b.transaction().unwrap();
+            store::accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t_demo"],
+                &signed_bytes,
+                &device.secret().public(),
+                0,
+                None,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+
+        // The floor entry arrives with its advertisement: adopted as the new root, not parked on
+        // the compacted predecessor it cites.
+        let tx = b.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &bytes(4).1,
+            &device.secret().public(),
+            0,
+            Some(store::AdvertisedFloor {
+                lamport: 4,
+                entry_hash: <[u8; 32]>::try_from(floor_hash.as_slice()).unwrap(),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(outcome, store::AcceptOutcome::Stored { .. }),
+            "the floor re-roots the stalled chain: {outcome:?}",
+        );
+        assert_eq!(retained_floor(&tx, stream(), device.fingerprint()).unwrap(), Some(4));
+
+        // The chain continues from the new root, and the skipped prefix is idempotent, not fork.
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &bytes(5).1,
+            &device.secret().public(),
+            0,
+            None,
+        )
+        .unwrap();
+        assert!(
+            matches!(outcome, store::AcceptOutcome::Stored { .. }),
+            "entry 5 chains: {outcome:?}"
+        );
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &bytes(3).1,
+            &device.secret().public(),
+            0,
+            None,
+        )
+        .unwrap();
+        assert_eq!(outcome, store::AcceptOutcome::AlreadyPresent, "below the floor is idempotent");
+        tx.commit().unwrap();
+    }
+
+    /// A parked gapped copy of the floor entry can never promote (its predecessor was compacted),
+    /// so AlreadyGapped must not deadlock the re-root: the copy is taken out and the entry
+    /// adopted as root.
+    #[test]
+    fn a_parked_floor_entry_does_not_deadlock_the_reroot() {
+        let mut a = conn();
+        let device = crate::local_device(&a, 0).unwrap();
+        author_chain(&mut a, &device, 6);
+        let (floor_hash, floor_bytes): (Vec<u8>, Vec<u8>) = a
+            .query_row(
+                "SELECT entry_hash, signed_bytes FROM table_sync_entries WHERE lamport = 4",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+
+        // The peer holds entries 0..2, and the floor entry ITSELF is parked in its gapped table
+        // — the rolling-upgrade shape: a new sender offered At(floor) to a pre-PR receiver,
+        // which parked it on the compacted predecessor.
+        let mut b = conn();
+        enroll(&b, &device);
+        for lamport in 0..3 {
+            let (_, signed_bytes): (Vec<u8>, Vec<u8>) = a
+                .query_row(
+                    "SELECT entry_hash, signed_bytes FROM table_sync_entries WHERE lamport = ?1",
+                    [lamport],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .unwrap();
+            let tx = b.transaction().unwrap();
+            store::accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t_demo"],
+                &signed_bytes,
+                &device.secret().public(),
+                0,
+                None,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        b.execute(
+            "INSERT INTO table_sync_gapped_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                 gapped_at_ms
+             ) VALUES (?1, ?2, ?3, 4, x'00', ?4, 0)",
+            params![
+                floor_hash.as_slice(),
+                stream().to_bytes().as_slice(),
+                device.fingerprint().to_bytes().as_slice(),
+                floor_bytes.as_slice()
+            ],
+        )
+        .unwrap();
+
+        let tx = b.transaction().unwrap();
+        let outcome = store::accept_row_entry(
+            &tx,
+            account(),
+            stream(),
+            &["t_demo"],
+            &floor_bytes,
+            &device.secret().public(),
+            0,
+            Some(store::AdvertisedFloor {
+                lamport: 4,
+                entry_hash: <[u8; 32]>::try_from(floor_hash.as_slice()).unwrap(),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(outcome, store::AcceptOutcome::Stored { .. }),
+            "the parked floor entry is adopted, not short-circuited: {outcome:?}",
+        );
+        assert_eq!(retained_floor(&tx, stream(), device.fingerprint()).unwrap(), Some(4));
+        let gapped: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(gapped, 0, "the parked copy is gone");
         tx.commit().unwrap();
     }
 

--- a/crates/rag-rat-oplog/src/table_sync/retention.rs
+++ b/crates/rag-rat-oplog/src/table_sync/retention.rs
@@ -23,7 +23,8 @@
 //! the peer can never link, and the receiver adopts the floor as its new root on exact coordinate
 //! match. The old prefix stays stored (projections are unaffected), the tail advances, and
 //! below-floor re-offers read idempotent. A peer forked AT the floor lamport gets ordinary fork
-//! classification, same as at any other tip.
+//! classification, same as at any other tip. Re-rooting also discards fork evidence in a receiver's
+//! divergent below-floor prefix, even when that receiver had not compacted it.
 //!
 //! Two accepted horizons, named rather than hidden:
 //!
@@ -36,11 +37,11 @@
 //!   a spec bump and the next producer pass, the refold reads the same `Unknown` as a possible
 //!   unsent edit and defers replay over those rows — the safe direction, and worth knowing when
 //!   diagnosing a deferred entry after an upgrade.
-//! - **Below-floor equivocations are undetectable on compacted peers.** The accept path answers
-//!   `AlreadyPresent` for any entry below the floor, so a compacted peer discards fork evidence a
-//!   non-compacted peer would still classify. Accepted: `Fork` is non-storing and a below-floor
-//!   entry can never apply, so the divergence costs evidence, never convergence — and evidence loss
-//!   is the price of reclaiming the region the evidence would describe.
+//! - **Below-floor equivocations are undetectable after a floor is recorded.** The accept path
+//!   answers `AlreadyPresent` for any entry below the floor, so the peer discards fork evidence a
+//!   peer without that floor would still classify. Accepted: `Fork` is non-storing and a
+//!   below-floor entry can never apply, so the divergence costs evidence, never convergence — and
+//!   evidence loss is the price of reclaiming the region the evidence would describe.
 
 use rusqlite::{OptionalExtension, Transaction, params};
 

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -374,7 +374,21 @@ pub(crate) fn accept_row_entry(
     // accepted path already has. In the `Gap` arm below instead, a removed device's redelivery
     // would report `Unauthorized`.
     if gapped_entry_exists(tx, &verified.entry_hash)? {
-        return Ok(AcceptOutcome::AlreadyGapped);
+        // An exactly-matching floor entry parked in the gapped table can never promote — its
+        // predecessor was compacted away (rolling upgrade parked it, or ordinary reordering) —
+        // so a plain AlreadyGapped would deadlock the re-root this slice exists to provide.
+        // Take the parked copy out and let the adoption path accept the entry.
+        let adoptable_floor_root =
+            advertised_floor.is_some_and(|floor| {
+                verified.lamport == floor.lamport && verified.entry_hash == floor.entry_hash
+            }) && chain_tail(tx, expected_stream, verified.device_fingerprint)?
+                .is_none_or(|(tip, _)| verified.lamport > tip);
+        if !adoptable_floor_root {
+            return Ok(AcceptOutcome::AlreadyGapped);
+        }
+        tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
+            verified.entry_hash.as_slice()
+        ])?;
     }
     // Authority gate (#935): the signing device must be a roster-effective WRITER of the account.
     // Placed AFTER `entry_exists` so an entry stored while the device WAS a writer still reports
@@ -393,13 +407,8 @@ pub(crate) fn accept_row_entry(
     if !device_is_effective_writer(tx, account_id, verified.device_fingerprint)? {
         return Ok(AcceptOutcome::Unauthorized);
     }
-    let (fit, chain_empty) = classify(tx, expected_stream, &verified, advertised_floor)?;
-    if matches!(fit, ChainFit::Ok)
-        && chain_empty
-        && let Some(floor) = advertised_floor
-        && verified.lamport == floor.lamport
-        && verified.entry_hash == floor.entry_hash
-    {
+    let (fit, _tail_lamport) = classify(tx, expected_stream, &verified, advertised_floor)?;
+    if let (ChainFit::RootAdopt, Some(floor)) = (fit, advertised_floor) {
         super::retention::record_adopted_floor(
             tx,
             expected_stream,
@@ -410,7 +419,7 @@ pub(crate) fn accept_row_entry(
         )?;
     }
     match fit {
-        ChainFit::Ok | ChainFit::Restore => {},
+        ChainFit::Ok | ChainFit::RootAdopt | ChainFit::Restore => {},
         ChainFit::Gap =>
             return Ok(if retain_gapped_entry(tx, &verified, signed_bytes, now_ms)? {
                 AcceptOutcome::GapRetained
@@ -453,18 +462,23 @@ pub(crate) fn accept_row_entry(
 }
 
 /// How a verified entry fits its `(stream, device)` chain tail.
+#[derive(Clone, Copy)]
 enum ChainFit {
     Ok,
+    /// The entry IS the advertised floor and the chain may adopt it as its root — fresh chain,
+    /// or a re-root past a stale tip. The caller records the adoption on this variant alone, so
+    /// the predicate lives in exactly one place.
+    RootAdopt,
     Restore,
     Gap,
     Conflict,
 }
 
-/// The retained floor a peer advertised for one chain: routing advice that lets a receiver with
-/// NO local chain accept the floor entry as its local root instead of parking on a predecessor
-/// the sender has compacted away. Honored only when the entry IS the advertised floor — the
-/// lamport and hash must match exactly, so the advice can never bless an entry the sender did not
-/// itself just produce as the root.
+/// The retained floor a peer advertised for one chain: routing advice that lets a receiver
+/// accept the floor entry as its chain root — a fresh chain, or a RE-ROOT when the receiver's
+/// accepted tip fell below the floor (offline across the churn). Honored only when the entry IS
+/// the advertised floor — the lamport and hash must match exactly, so the advice can never bless
+/// an entry the sender did not itself just produce as the root.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AdvertisedFloor {
     pub lamport: u64,
@@ -476,39 +490,44 @@ fn classify(
     stream: StreamId,
     verified: &VerifiedEntry,
     advertised_floor: Option<AdvertisedFloor>,
-) -> anyhow::Result<(ChainFit, bool)> {
+) -> anyhow::Result<(ChainFit, Option<u64>)> {
     let tail = chain_tail(tx, stream, verified.device_fingerprint)?;
-    let chain_empty = tail.is_none();
+    let tail_lamport = tail.map(|(lamport, _)| lamport);
     let witness =
-        if chain_empty { chain_witness(tx, stream, verified.device_fingerprint)? } else { None };
-    if chain_empty
-        && let Some(floor) = advertised_floor
+        if tail.is_none() { chain_witness(tx, stream, verified.device_fingerprint)? } else { None };
+    if let Some(floor) = advertised_floor
         && verified.lamport == floor.lamport
         && verified.entry_hash == floor.entry_hash
     {
         // The sender has reclaimed everything below this entry. Accepting it as the local root
         // records the floor, so this peer's own re-offers propagate the same root to third
         // parties instead of re-parking them.
-        //
-        // A retained chain-tip WITNESS is chain state even with an empty log (its accepted
-        // prefix was purged): adopting a floor BELOW the witnessed tip would regress that
-        // boundary, resurrect the purged prefix, and then wedge the chain — successors citing
-        // the witness park forever. Adoption is valid only at or past the witness: the floor
-        // entry being the witness is the compacted-sender/restored-receiver rendezvous.
-        // Ahead of the witness, the only reachable rejoin is tip-as-direct-predecessor — a
-        // receiver two or more entries behind the compacted floor is refused by the session
-        // driver before classify ever runs (that recovery is the follow-up slice in #1127).
-        let regresses_witness = witness.is_some_and(|(witness_lamport, witness_hash)| {
-            !(floor.lamport == witness_lamport && floor.entry_hash == witness_hash)
-                && floor.lamport <= witness_lamport
-        });
-        if !regresses_witness {
-            return Ok((ChainFit::Ok, chain_empty));
+        if tail.is_none() {
+            // A retained chain-tip WITNESS is chain state even with an empty log (its accepted
+            // prefix was purged): adopting a floor BELOW the witnessed tip would regress that
+            // boundary, resurrect the purged prefix, and then wedge the chain — successors
+            // citing the witness park forever. Adoption is valid only at or past the witness:
+            // the floor entry being the witness is the compacted-sender/restored-receiver
+            // rendezvous.
+            let regresses_witness = witness.is_some_and(|(witness_lamport, witness_hash)| {
+                !(floor.lamport == witness_lamport && floor.entry_hash == witness_hash)
+                    && floor.lamport <= witness_lamport
+            });
+            if !regresses_witness {
+                return Ok((ChainFit::RootAdopt, tail_lamport));
+            }
+        } else if tail_lamport.is_some_and(|tip| floor.lamport > tip) {
+            // Re-root (#1127): the chain's accepted tip fell below the advertised floor — the
+            // peer was offline while the sender churned past it and compacted. Adopting the
+            // floor as the new root is the recovery the retention docs name: the old prefix
+            // stays stored (projections are unaffected), the tail advances, and below-floor
+            // re-offers read idempotent from here on.
+            return Ok((ChainFit::RootAdopt, tail_lamport));
         }
     }
     if let Some((witness_lamport, witness_hash)) = witness {
         if verified.entry_hash == witness_hash && verified.lamport == witness_lamport {
-            return Ok((ChainFit::Restore, chain_empty));
+            return Ok((ChainFit::Restore, tail_lamport));
         }
         return Ok((
             match verified.prev_hash {
@@ -518,7 +537,7 @@ fn classify(
                 Some(_) if verified.lamport <= witness_lamport => ChainFit::Conflict,
                 Some(_) => ChainFit::Gap,
             },
-            chain_empty,
+            tail_lamport,
         ));
     }
     let fit = match (verified.prev_hash, tail) {
@@ -553,7 +572,7 @@ fn classify(
                 ChainFit::Gap // links to an UNKNOWN predecessor — a genuine missing intermediate.
             },
     };
-    Ok((fit, chain_empty))
+    Ok((fit, tail_lamport))
 }
 
 /// The `(stream, device)` chain's highest-lamport `(lamport, entry_hash)`, or `None` for an empty

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -358,37 +358,15 @@ pub(crate) fn accept_row_entry(
     }
     // Below the retained floor the prefix is INTENTIONALLY reclaimed (#1127): a redelivery of a
     // compacted entry is idempotent, not an equivocation against the retained tail. The trade is
-    // explicit: below-floor FORK DETECTION is gone on compacted peers — an equivocation in the
-    // reclaimed region reports AlreadyPresent here while a non-compacted peer still classifies it
-    // as a fork. Accepted, because Fork is non-storing and a below-floor entry can never apply;
-    // the divergence costs evidence, never convergence (see the retention module docs).
+    // explicit: below-floor FORK DETECTION is gone once a peer records a floor, whether by local
+    // compaction or re-rooting — an equivocation in the reclaimed region reports AlreadyPresent.
+    // Accepted, because Fork is non-storing and a below-floor entry can never apply; the divergence
+    // costs evidence, never convergence (see the retention module docs).
     if let Some(floor) =
         super::retention::retained_floor(tx, expected_stream, verified.device_fingerprint)?
         && verified.lamport < floor
     {
         return Ok(AcceptOutcome::AlreadyPresent);
-    }
-    // Dedupe against the gapped table HERE, beside the accepted-entry check and BEFORE the
-    // authority gate, so a redelivered gapped entry reports the same way whether or not its
-    // device is still roster-effective — the dedup-precedence-over-authority ordering the
-    // accepted path already has. In the `Gap` arm below instead, a removed device's redelivery
-    // would report `Unauthorized`.
-    if gapped_entry_exists(tx, &verified.entry_hash)? {
-        // An exactly-matching floor entry parked in the gapped table can never promote — its
-        // predecessor was compacted away (rolling upgrade parked it, or ordinary reordering) —
-        // so a plain AlreadyGapped would deadlock the re-root this slice exists to provide.
-        // Take the parked copy out and let the adoption path accept the entry.
-        let adoptable_floor_root =
-            advertised_floor.is_some_and(|floor| {
-                verified.lamport == floor.lamport && verified.entry_hash == floor.entry_hash
-            }) && chain_tail(tx, expected_stream, verified.device_fingerprint)?
-                .is_none_or(|(tip, _)| verified.lamport > tip);
-        if !adoptable_floor_root {
-            return Ok(AcceptOutcome::AlreadyGapped);
-        }
-        tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
-            verified.entry_hash.as_slice()
-        ])?;
     }
     // Authority gate (#935): the signing device must be a roster-effective WRITER of the account.
     // Placed AFTER `entry_exists` so an entry stored while the device WAS a writer still reports
@@ -407,7 +385,26 @@ pub(crate) fn accept_row_entry(
     if !device_is_effective_writer(tx, account_id, verified.device_fingerprint)? {
         return Ok(AcceptOutcome::Unauthorized);
     }
-    let (fit, _tail_lamport) = classify(tx, expected_stream, &verified, advertised_floor)?;
+    // Unlike accepted-entry deduplication, adopting a parked floor mutates storage. Keep it after
+    // the authority gate so a removed writer cannot delete a retained gapped row on redelivery.
+    if gapped_entry_exists(tx, &verified.entry_hash)? {
+        // An exactly-matching floor entry parked in the gapped table can never promote — its
+        // predecessor was compacted away (rolling upgrade parked it, or ordinary reordering) —
+        // so a plain AlreadyGapped would deadlock the re-root this slice exists to provide.
+        // Take the parked copy out and let the adoption path accept the entry.
+        let adoptable_floor_root =
+            advertised_floor.is_some_and(|floor| {
+                verified.lamport == floor.lamport && verified.entry_hash == floor.entry_hash
+            }) && chain_tail(tx, expected_stream, verified.device_fingerprint)?
+                .is_none_or(|(tip, _)| verified.lamport > tip);
+        if !adoptable_floor_root {
+            return Ok(AcceptOutcome::AlreadyGapped);
+        }
+        tx.execute("DELETE FROM table_sync_gapped_entries WHERE entry_hash = ?1", params![
+            verified.entry_hash.as_slice()
+        ])?;
+    }
+    let fit = classify(tx, expected_stream, &verified, advertised_floor)?;
     if let (ChainFit::RootAdopt, Some(floor)) = (fit, advertised_floor) {
         super::retention::record_adopted_floor(
             tx,
@@ -490,7 +487,7 @@ fn classify(
     stream: StreamId,
     verified: &VerifiedEntry,
     advertised_floor: Option<AdvertisedFloor>,
-) -> anyhow::Result<(ChainFit, Option<u64>)> {
+) -> anyhow::Result<ChainFit> {
     let tail = chain_tail(tx, stream, verified.device_fingerprint)?;
     let tail_lamport = tail.map(|(lamport, _)| lamport);
     let witness =
@@ -514,7 +511,7 @@ fn classify(
                     && floor.lamport <= witness_lamport
             });
             if !regresses_witness {
-                return Ok((ChainFit::RootAdopt, tail_lamport));
+                return Ok(ChainFit::RootAdopt);
             }
         } else if tail_lamport.is_some_and(|tip| floor.lamport > tip) {
             // Re-root (#1127): the chain's accepted tip fell below the advertised floor — the
@@ -522,23 +519,20 @@ fn classify(
             // floor as the new root is the recovery the retention docs name: the old prefix
             // stays stored (projections are unaffected), the tail advances, and below-floor
             // re-offers read idempotent from here on.
-            return Ok((ChainFit::RootAdopt, tail_lamport));
+            return Ok(ChainFit::RootAdopt);
         }
     }
     if let Some((witness_lamport, witness_hash)) = witness {
         if verified.entry_hash == witness_hash && verified.lamport == witness_lamport {
-            return Ok((ChainFit::Restore, tail_lamport));
+            return Ok(ChainFit::Restore);
         }
-        return Ok((
-            match verified.prev_hash {
-                Some(prev) if prev == witness_hash && verified.lamport > witness_lamport =>
-                    ChainFit::Ok,
-                None => ChainFit::Conflict,
-                Some(_) if verified.lamport <= witness_lamport => ChainFit::Conflict,
-                Some(_) => ChainFit::Gap,
-            },
-            tail_lamport,
-        ));
+        return Ok(match verified.prev_hash {
+            Some(prev) if prev == witness_hash && verified.lamport > witness_lamport =>
+                ChainFit::Ok,
+            None => ChainFit::Conflict,
+            Some(_) if verified.lamport <= witness_lamport => ChainFit::Conflict,
+            Some(_) => ChainFit::Gap,
+        });
     }
     let fit = match (verified.prev_hash, tail) {
         // A genesis (no predecessor) is the valid first entry of this device's chain; a genesis
@@ -572,7 +566,7 @@ fn classify(
                 ChainFit::Gap // links to an UNKNOWN predecessor — a genuine missing intermediate.
             },
     };
-    Ok((fit, tail_lamport))
+    Ok(fit)
 }
 
 /// The `(stream, device)` chain's highest-lamport `(lamport, entry_hash)`, or `None` for an empty
@@ -2623,6 +2617,51 @@ mod tests {
         remove_from_roster(&b, account(), secret.public().fingerprint());
         let tx = b.transaction().unwrap();
         assert_eq!(accept(&tx, account(), &signed, &secret.public()), AcceptOutcome::Unauthorized);
+    }
+
+    #[test]
+    fn an_unauthorized_floor_redelivery_keeps_its_gapped_copy() {
+        let secret = DeviceSecret::from_seed(&[1; 32]); // conn() enrolls it as owner
+        let signed = signed_row(&secret, "r1");
+        let mut b = conn();
+        b.execute(
+            "INSERT INTO table_sync_gapped_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+                 gapped_at_ms
+             ) VALUES (?1, ?2, ?3, 0, ?4, ?5, 0)",
+            params![
+                signed.entry.entry_hash.as_slice(),
+                stream().to_bytes().as_slice(),
+                secret.public().fingerprint().to_bytes().as_slice(),
+                [0u8; 32].as_slice(),
+                signed.signed_bytes.as_slice(),
+            ],
+        )
+        .unwrap();
+        remove_from_roster(&b, account(), secret.public().fingerprint());
+
+        let tx = b.transaction().unwrap();
+        assert_eq!(
+            accept_row_entry(
+                &tx,
+                account(),
+                stream(),
+                &["t"],
+                &signed.signed_bytes,
+                &secret.public(),
+                0,
+                Some(AdvertisedFloor {
+                    lamport: signed.entry.lamport,
+                    entry_hash: signed.entry.entry_hash,
+                }),
+            )
+            .unwrap(),
+            AcceptOutcome::Unauthorized,
+        );
+        let held: i64 = tx
+            .query_row("SELECT COUNT(*) FROM table_sync_gapped_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(held, 1, "authority rejection does not delete the parked floor");
     }
 
     #[test]

--- a/crates/rag-rat-sync/src/table_session.rs
+++ b/crates/rag-rat-sync/src/table_session.rs
@@ -547,8 +547,21 @@ fn chain_plan(local: &ChainHead, frontier: FrontierState) -> Result<ChainPlan, T
             }
             Ok(ChainPlan::Complete)
         },
-        FrontierState::Accepted { lamport, entry_hash } =>
-            Ok(ChainPlan::Send(ChainStart::After { lamport, entry_hash })),
+        FrontierState::Accepted { lamport, entry_hash } => {
+            if let Some((floor_lamport, floor_hash)) = local.floor
+                && lamport < floor_lamport
+            {
+                // The peer's accepted tip fell below our retained floor: offering the suffix
+                // after its tip parks forever — every entry's predecessor was compacted away.
+                // Offer the floor as a re-root instead; the receiver adopts it as its new chain
+                // root and converges from there (#1127).
+                return Ok(ChainPlan::Send(ChainStart::At {
+                    lamport: floor_lamport,
+                    entry_hash: floor_hash,
+                }));
+            }
+            Ok(ChainPlan::Send(ChainStart::After { lamport, entry_hash }))
+        },
         FrontierState::Restore { lamport, .. } if lamport > local.lamport => Ok(ChainPlan::Pending),
         FrontierState::Restore { lamport, entry_hash } =>
             Ok(ChainPlan::Send(ChainStart::At { lamport, entry_hash })),
@@ -1035,6 +1048,28 @@ mod tests {
         assert_eq!(
             chain_plan(&local, FrontierState::Restore { lamport: 4, entry_hash: [4; 32] }).unwrap(),
             ChainPlan::Pending
+        );
+    }
+
+    #[test]
+    fn a_tip_below_the_sender_floor_plans_a_reroot_not_a_suffix() {
+        let local = ChainHead {
+            device_fingerprint: [1; 32],
+            lamport: 8,
+            entry_hash: [8; 32],
+            floor: Some((4, [4; 32])),
+        };
+        assert_eq!(
+            chain_plan(&local, FrontierState::Accepted { lamport: 2, entry_hash: [2; 32] })
+                .unwrap(),
+            ChainPlan::Send(ChainStart::At { lamport: 4, entry_hash: [4; 32] }),
+            "the receiver re-roots onto the floor instead of parking on compacted predecessors"
+        );
+        // A tip AT or above the floor keeps the ordinary suffix plan.
+        assert_eq!(
+            chain_plan(&local, FrontierState::Accepted { lamport: 6, entry_hash: [6; 32] })
+                .unwrap(),
+            ChainPlan::Send(ChainStart::After { lamport: 6, entry_hash: [6; 32] })
         );
     }
 


### PR DESCRIPTION
Final #1127 slice. A peer offline while a bounded scope churned past its accepted tip stalled permanently: every offered entry cited a compacted predecessor, everything parked, and every session replayed the same unparkable page.

## Summary
- session driver plans a re-root (At the advertised floor) instead of a suffix when the peer''''s tip is below the floor
- receiver adopts the floor as its new root on exact coordinate match when its tip is below it; the old prefix stays stored, the tail advances, below-floor re-offers read idempotent
- witness guard unchanged

## Verification
- cargo +nightly fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rag-rat-oplog --lib table_sync (239)
- cargo test -p rag-rat-sync (163)