### PR TITLE
fix(deps): bump brace-expansion to 5.0.9 for GHSA-rgw5-rvv9-x895

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tools/oracle-toolchain/package-lock.json
+++ b/tools/oracle-toolchain/package-lock.json
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/tools/oracle-toolchain/package.json
+++ b/tools/oracle-toolchain/package.json
@@ -8,6 +8,6 @@
     "@sourcegraph/scip-python": "0.6.6"
   },
   "overrides": {
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }


### PR DESCRIPTION
brace-expansion 4.0.0–5.0.8 is vulnerable to DoS via unbounded intermediate arrays (bypasses the CVE-2026-14257 mitigation). Fix is 5.0.9.

- `tools/oracle-toolchain`: override raised 5.0.8 → 5.0.9 (lockfile regenerated)
- `editors/vscode`: `npm audit fix` (lockfile follows to 5.0.9)
- `npm audit`: 0 vulnerabilities in both trees
- scip-python 0.6.6 revalidated against the pinned toolchain (--version + index a fixture project)