### PR TITLE
feat(sync): register the overlay/1 table-sync scope

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -252,6 +252,13 @@ fn lens_version_tracks_binding_validation_and_in_place_enrichment_updates() {
         params![db.active_repo_id, memory.memory_id],
     )
     .unwrap();
+    // memory_summaries syncs on overlay/1 and is trigger-free; the dream write advances the
+    // memories lane explicitly, mirrored here.
+    rag_rat_db::meta::bump_lens_revisions(conn, &db.active_repo_id, &[
+        rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+        rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
+    ])
+    .unwrap();
     let after_summary_update = db.lens_version().unwrap();
     assert_ne!(
         before_summary_update.revision, after_summary_update.revision,
@@ -271,6 +278,13 @@ fn lens_version_tracks_binding_validation_and_in_place_enrichment_updates() {
          WHERE repo_id = ?1 AND memory_id = ?2",
         params![db.active_repo_id, memory.memory_id],
     )
+    .unwrap();
+    // memory_reality syncs on overlay/1 and is trigger-free; the dream write advances the memories
+    // lane explicitly, mirrored here.
+    rag_rat_db::meta::bump_lens_revisions(conn, &db.active_repo_id, &[
+        rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+        rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
+    ])
     .unwrap();
     let after_reality_update = db.lens_version().unwrap();
     assert_ne!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 106, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 107, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6352,6 +6352,62 @@ mod lens_lane_revision_migration_tests {
     }
 }
 
+#[cfg(test)]
+mod syncable_overlay_migration_tests {
+    use super::*;
+
+    fn triggers_on(conn: &Connection, table: &str) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?1",
+            [table],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// The overlay tables must carry NO triggers after the ladder, and stay that way when the whole
+    /// ladder replays (V093/V102 recreate the revision triggers ahead of V107 on every
+    /// `index --full`, so V107's drop has to be unconditional to survive the replay).
+    #[test]
+    fn v107_leaves_the_overlay_tables_trigger_free_across_a_full_replay() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        assert_eq!(triggers_on(&conn, "memory_reality"), 0);
+        assert_eq!(triggers_on(&conn, "memory_summaries"), 0);
+    }
+
+    /// With the triggers gone, a raw row write no longer advances the memories Lens lane — the
+    /// whole point of V107: under overlay/1 the lane is advanced by the dream write and the
+    /// sync apply explicitly, never as a side effect of the physical write.
+    #[test]
+    fn a_raw_overlay_write_no_longer_bumps_the_memories_lane() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        let lane = || crate::meta::repo_meta(&conn, "r", crate::meta::LENS_MEMORIES_REVISION_META);
+        let before = lane().unwrap();
+        conn.execute(
+            "INSERT INTO memory_reality(memory_id, repo_id, content_hash, checked_at_ms)
+             VALUES ('m', 'r', 'h', 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO memory_summaries(memory_id, repo_id, content_hash, summary, \
+             generated_at_ms)
+             VALUES ('m', 'r', 'h', 's', 0)",
+            [],
+        )
+        .unwrap();
+        assert_eq!(before, lane().unwrap(), "a raw overlay write must not move the lane");
+    }
+}
+
 /// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
 ///
 /// `sync_published_rows.spec_version` replaces V093's `projector_version`. The anti-echo hash
@@ -7482,6 +7538,38 @@ pub fn apply_readoption_audit_nullable_winner(conn: &Connection) -> rusqlite::Re
              RENAME TO table_sync_readoption_audit;
          CREATE INDEX IF NOT EXISTS table_sync_readoption_audit_stream
              ON table_sync_readoption_audit(account_id, stream_id);",
+    )
+}
+
+/// V107 (#1133): make `memory_reality` and `memory_summaries` syncable on the `overlay/1` scope by
+/// dropping their Lens revision triggers.
+///
+/// Both tables carry two trigger families that bump a per-repo Lens lane on every physical row
+/// write: the V093 `*_lens_revision_*` set (the aggregate enrichment clock) and the V102
+/// `*_lane_revision_*` set (the split memories lane). Under `overlay/1` a row arrives by whole-row
+/// LWW apply, and a trigger firing on a wire-applied row is a device-local side effect that also
+/// fires on redeliveries, losing writes, and refold replay — exactly what the sync apply must not
+/// do. The dream write path and the sync apply path advance the enrichment and memories lanes
+/// explicitly instead (`meta::bump_lens_revisions`), so the only remaining lane movement is the one
+/// the code chooses.
+///
+/// The DROP is UNCONDITIONAL: `schema::apply` replays the whole additive ladder, so V093/V102
+/// recreate these triggers ahead of this migration on every `index --full`; short-circuiting on
+/// table shape would let the recreated triggers survive the replay.
+pub fn apply_syncable_overlay_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS memory_reality_lens_revision_insert;
+         DROP TRIGGER IF EXISTS memory_reality_lens_revision_delete;
+         DROP TRIGGER IF EXISTS memory_reality_lens_revision_update;
+         DROP TRIGGER IF EXISTS memory_reality_lane_revision_insert;
+         DROP TRIGGER IF EXISTS memory_reality_lane_revision_delete;
+         DROP TRIGGER IF EXISTS memory_reality_lane_revision_update;
+         DROP TRIGGER IF EXISTS memory_summaries_lens_revision_insert;
+         DROP TRIGGER IF EXISTS memory_summaries_lens_revision_delete;
+         DROP TRIGGER IF EXISTS memory_summaries_lens_revision_update;
+         DROP TRIGGER IF EXISTS memory_summaries_lane_revision_insert;
+         DROP TRIGGER IF EXISTS memory_summaries_lane_revision_delete;
+         DROP TRIGGER IF EXISTS memory_summaries_lane_revision_update;",
     )
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 106;
+pub const LATEST_SCHEMA_VERSION: u32 = 107;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -798,6 +798,13 @@ const MIGRATION_106_DESCRIPTION: &str = "Make table_sync_readoption_audit.origin
                                          nullable (#1127): a winner reclaimed by accepted-entry \
                                          compaction before re-adoption ran has no hash to record; \
                                          the slot stays named by (stream, device, lamport)";
+const MIGRATION_107_ID: &str = "107_syncable_overlay_tables";
+const MIGRATION_107_CHECKSUM: &str = "sha256:rag-rat-syncable-overlay-tables-v107";
+const MIGRATION_107_DESCRIPTION: &str =
+    "Drop the Lens revision triggers on memory_reality and memory_summaries (#1133): the \
+     overlay/1 table-sync scope applies these rows under whole-row LWW, and a trigger firing on a \
+     wire-applied row is a device-local side effect; the dream write and the sync apply advance \
+     the Lens lanes explicitly instead";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1668,6 +1675,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_106_CHECKSUM,
         description: MIGRATION_106_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_readoption_audit_nullable_winner),
+    },
+    Migration {
+        id: MIGRATION_107_ID,
+        checksum: MIGRATION_107_CHECKSUM,
+        description: MIGRATION_107_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_syncable_overlay_tables),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -553,6 +553,16 @@ fn register_repo_inner(
         // normal open applies the full ladder) so this adoption never trips "no such column". Uses
         // `source_id` (not the placeholder literal) so a shallow-clone upgrade re-points periphery
         // rows off the `local:` incumbent too, exactly like the core/papertrail loop above.
+        //
+        // Lens-lane refresh for the adopted repo: `memory_reality` / `memory_summaries` are in this
+        // list, and V107 dropped their revision triggers (they sync on overlay/1). This bare UPDATE
+        // therefore does NOT bump the memories lane directly. It does not need to:
+        // `repo_memories` is ALSO in this same list (see the array), and it KEEPS its revision
+        // trigger, so re-pointing it in this loop advances the memories lane once for the
+        // adopted `repo_id` whenever it has any memory at all — the only case where a stale
+        // verdict/summary would matter. If `repo_memories`' triggers are ever removed too,
+        // add an explicit `bump_lens_revisions` here so adoption keeps refreshing the overlay
+        // rows.
         for table in A5_PERIPHERY_DIRECT_SCOPED_TABLES {
             if super::column_exists(&tx, table, "repo_id")? {
                 // `main.`-qualified for the same view-shadowing reason as the core loop above.

--- a/crates/rag-rat-dream/src/compact.rs
+++ b/crates/rag-rat-dream/src/compact.rs
@@ -321,6 +321,7 @@ fn record_summary(conn: &Connection, r: RecordSummary<'_>) -> rusqlite::Result<(
             r.now_ms,
         ],
     )?;
+    super::bump_memory_lens_lanes(conn, r.repo_id)?;
     Ok(())
 }
 
@@ -777,6 +778,34 @@ mod tests {
             rag_rat_query::memory::evidence::note_content_hash("note", "a body worth compacting")
         );
         assert_eq!(row.4, 7000);
+    }
+
+    #[test]
+    fn a_summary_write_advances_the_memories_lens_lane() {
+        // V107 dropped the memory_summaries revision triggers, so a summary write advances the
+        // memories Lens lane only via the explicit bump on the dream write path. Gated on repo
+        // registration, so the repo must exist in `repos`.
+        let c = mem_db();
+        set_repo(&c, "r");
+        c.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        seed_memory(&c, "m1", "note", "a body worth compacting", "r");
+        let lane = || -> i64 {
+            c.query_row(
+                "SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM repo_meta
+                     WHERE repo_id = 'r' AND key = 'lens_memories_revision'), 0)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        let before = lane();
+        let model = MockChatModel::new([GOOD_SUMMARY]);
+        run_compact_pass(&c, CompactPass { model: &model, budget: 10 }, 7000).unwrap();
+        assert!(lane() > before, "writing a summary advances the memories lane (trigger-free)");
     }
 
     #[test]

--- a/crates/rag-rat-dream/src/lib.rs
+++ b/crates/rag-rat-dream/src/lib.rs
@@ -258,6 +258,27 @@ pub(crate) fn removal_guarded_write_tx(
     Ok(())
 }
 
+/// Advance the per-repo Lens lanes a dream overlay write feeds — the aggregate enrichment clock and
+/// the memories lane — for a registered repo.
+///
+/// This is the explicit replacement for the `memory_reality` / `memory_summaries` revision triggers
+/// V107 dropped: those tables sync on `overlay/1`, and a trigger firing on a whole-row-LWW apply is
+/// a device-local side effect the sync apply must not have. Instead the dream write advances the
+/// lanes here and the sync apply advances them at its own site (`table_sync` transport), so the
+/// only lane movement is the one the code chooses. Call it on the SAME connection as the write
+/// (inside [`removal_guarded_write_tx`]) so Lens's same-transaction invariant holds. Gated on repo
+/// registration to match the dropped triggers (which fired only for a known repo) and to avoid
+/// phantom `repo_meta` rows under the `'__unassigned__'` sentinel.
+pub(crate) fn bump_memory_lens_lanes(conn: &Connection, repo_id: &str) -> rusqlite::Result<()> {
+    if rag_rat_db::schema::repo_id_is_registered(conn, repo_id)? {
+        rag_rat_db::meta::bump_lens_revisions(conn, repo_id, &[
+            rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+            rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
+        ])?;
+    }
+    Ok(())
+}
+
 /// Whether the model passes would call the model AT ALL this run — the zero-work guard for
 /// EPHEMERAL `[llm.dream.remote]`. A fully churn-skipped (or all-uncitable) repo returns `false`,
 /// so `rag-rat dream --verify/--compact` never cold-starts a paid GPU box that would then do zero

--- a/crates/rag-rat-dream/src/verdict.rs
+++ b/crates/rag-rat-dream/src/verdict.rs
@@ -848,6 +848,7 @@ fn record_verdict(conn: &Connection, r: RecordVerdict<'_>) -> rusqlite::Result<(
             r.now_ms,
         ],
     )?;
+    crate::bump_memory_lens_lanes(conn, r.repo_id)?;
     Ok(())
 }
 
@@ -889,6 +890,7 @@ fn record_uncitable(conn: &Connection, r: Uncitable<'_>) -> rusqlite::Result<()>
             r.now_ms,
         ],
     )?;
+    crate::bump_memory_lens_lanes(conn, r.repo_id)?;
     Ok(())
 }
 

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -170,7 +170,8 @@ pub use stream::StreamId;
 pub use table_sync::{
     TABLE_SYNC_ENTRY_MAX_BYTES, TableSyncChainEntry, TableSyncChainHead, TableSyncEntryStart,
     TableSyncFrontier, TableSyncIngestOutcome, TableSyncStream,
-    refold_stale_table_sync_projections, table_sync_author_pending, table_sync_chain_entries,
-    table_sync_chain_frontier, table_sync_chain_page_after, table_sync_compact_overdue,
-    table_sync_ingest, table_sync_supported_streams, table_sync_validate_stream,
+    refold_stale_table_sync_projections, scope_retention_budget, table_sync_author_pending,
+    table_sync_chain_entries, table_sync_chain_frontier, table_sync_chain_page_after,
+    table_sync_compact_overdue, table_sync_ingest, table_sync_supported_streams,
+    table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -41,7 +41,8 @@ pub(crate) use store::{
 };
 pub use transport::{
     TableSyncChainEntry, TableSyncChainHead, TableSyncEntryStart, TableSyncFrontier,
-    TableSyncIngestOutcome, TableSyncStream, table_sync_author_pending, table_sync_chain_entries,
-    table_sync_chain_frontier, table_sync_chain_page_after, table_sync_compact_overdue,
-    table_sync_ingest, table_sync_supported_streams, table_sync_validate_stream,
+    TableSyncIngestOutcome, TableSyncStream, scope_retention_budget, table_sync_author_pending,
+    table_sync_chain_entries, table_sync_chain_frontier, table_sync_chain_page_after,
+    table_sync_compact_overdue, table_sync_ingest, table_sync_supported_streams,
+    table_sync_validate_stream,
 };

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -38,7 +38,7 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::apply::{self, ApplyOutcome};
-use super::registry::TableSpec;
+use super::registry::{MEMORIES_LANE_TABLES, TableSpec};
 use super::row_op::{self, DecodedRowOp};
 use super::store::{self, PendingEntry, PendingReason, Worklist};
 use crate::entry;
@@ -57,7 +57,7 @@ use crate::op::OpMeta;
 /// registering a table or widening a spec forces an append, and an append is the bump. A widening
 /// that is not a registry change (a new row-op kind) still has to append a generation by hand,
 /// repeating the previous snapshot.
-pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 2;
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 3;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 
@@ -321,11 +321,30 @@ fn replay_pending_entry(
     }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
     match apply::apply_row_op_on_stream(tx, spec, &context.repo_id, pending.stream_id, &op, meta)? {
-        // Folded. `Superseded` — outranked by a newer winner, or suppressed by a tombstone — is
-        // equally a correct fold and equally not outstanding work: the entry was evaluated and
-        // lost on the merits, and no later binary changes that.
-        ApplyOutcome::Applied | ApplyOutcome::Superseded =>
-            store::clear_entry_pending(tx, &pending.entry_hash),
+        // Folded and CHANGED the projection: advance the memories Lens lanes so a row landed by
+        // replay (e.g. an entry parked as `NewerSpecVersion` by an older binary, applied here after
+        // the upgrade) surfaces in Lens without waiting for an unrelated write. Mirrors the
+        // direct-ingest bump; gated on repo registration for the same reason (no phantom
+        // `'__unassigned__'` `repo_meta` rows). Unlike the ingest site, replay holds the exact
+        // `spec`, so it gates on the applied table feeding the memories lane rather than
+        // approximating over the whole registry — a future non-memory scope replays without
+        // a spurious bump.
+        ApplyOutcome::Applied => {
+            if MEMORIES_LANE_TABLES.contains(&spec.name)
+                && rag_rat_db::schema::repo_id_is_registered(tx, &context.repo_id)?
+            {
+                rag_rat_db::meta::bump_lens_revisions(tx, &context.repo_id, &[
+                    rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+                    rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
+                ])?;
+            }
+            store::clear_entry_pending(tx, &pending.entry_hash)
+        },
+        // `Superseded` — outranked by a newer winner, or suppressed by a tombstone — is equally a
+        // correct fold and equally not outstanding work, but it did NOT change the projection, so
+        // no lane bump: the entry was evaluated and lost on the merits, and no later binary
+        // changes that.
+        ApplyOutcome::Superseded => store::clear_entry_pending(tx, &pending.entry_hash),
         // Terminal, so it stops being outstanding: a type mismatch or a constraint violation is a
         // BROKEN PRODUCER — the values do not fit the declared column types or the table's
         // constraints, and no future binary makes them fit. (A missing column is NOT this case: it
@@ -678,6 +697,166 @@ mod tests {
         assert!(b.produce(NEW_REGISTRY, "repo").is_empty());
         // The refold is one-shot: the stamp is current, so a second open does no work.
         assert!(!refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+    }
+
+    // A repo-scoped memory-lane table (the real `memory_reality`, present in the applied schema),
+    // modelled old/new the same way as t_demo: `evidence_json` is local under v1 and a synced added
+    // column under v2, so a v2 op parks on a v1 peer and lands on refold.
+    const OLD_REALITY_COLS: &[ColumnSpec] = &[
+        ColumnSpec::required("content_hash", ValueType::Text),
+        ColumnSpec::required("verdict", ValueType::Text),
+        ColumnSpec::required("direction", ValueType::Text),
+        ColumnSpec::required("checked_against_commit", ValueType::Text),
+        ColumnSpec::required("checked_inputs_hash", ValueType::Text),
+        ColumnSpec::required("model_id", ValueType::Text),
+        ColumnSpec::required("prompt_version", ValueType::Text),
+        ColumnSpec::required("checked_at_ms", ValueType::I64),
+    ];
+    const REALITY_PK: &[ColumnSpec] = &[
+        ColumnSpec::required("repo_id", ValueType::Text),
+        ColumnSpec::required("memory_id", ValueType::Text),
+    ];
+    const OLD_REALITY: TableSpec = TableSpec {
+        name: "memory_reality",
+        scope_id: "overlay/1",
+        spec_version: 1,
+        pk: REALITY_PK,
+        columns: OLD_REALITY_COLS,
+        local_columns: &["evidence_json"],
+        repo_column: Some("repo_id"),
+    };
+    const NEW_REALITY: TableSpec = TableSpec {
+        name: "memory_reality",
+        scope_id: "overlay/1",
+        spec_version: 2,
+        pk: REALITY_PK,
+        columns: &[
+            ColumnSpec::required("content_hash", ValueType::Text),
+            ColumnSpec::required("verdict", ValueType::Text),
+            ColumnSpec::required("direction", ValueType::Text),
+            ColumnSpec::required("checked_against_commit", ValueType::Text),
+            ColumnSpec::required("checked_inputs_hash", ValueType::Text),
+            ColumnSpec::required("model_id", ValueType::Text),
+            ColumnSpec::required("prompt_version", ValueType::Text),
+            ColumnSpec::required("checked_at_ms", ValueType::I64),
+            ColumnSpec::added("evidence_json", ValueType::Text, 2, DefaultValue::Null),
+        ],
+        local_columns: &[],
+        repo_column: Some("repo_id"),
+    };
+
+    fn lens_memories_revision(conn: &rusqlite::Connection) -> i64 {
+        conn.query_row(
+            "SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM repo_meta
+                 WHERE repo_id = 'repo' AND key = 'lens_memories_revision'), 0)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// The refold guard (`MEMORIES_LANE_TABLES.contains(&spec.name)`) fires for a memory-lane
+    /// table: a `memory_reality` row parked as `NewerSpecVersion` and applied on refold
+    /// advances the memories Lens lane, so a row landed by replay surfaces in Lens without an
+    /// unrelated write.
+    #[test]
+    fn refold_replay_of_a_memory_lane_row_bumps_the_memories_lens_lane() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        // The bump is registration-gated, so the repo must exist on B.
+        b.conn
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo', \
+                 'repo', 0)",
+                [],
+            )
+            .unwrap();
+        b.enroll(a.pubkey().fingerprint());
+
+        a.conn
+            .execute(
+                "INSERT INTO memory_reality(
+                     memory_id, repo_id, content_hash, verdict, direction, checked_against_commit,
+                     checked_inputs_hash, evidence_json, model_id, prompt_version, checked_at_ms)
+                 VALUES ('m1', 'repo', 'h', 'confirmed', 'note_ahead', 'c', 'i', '[]', 'model',
+                         'v1', 0)",
+                [],
+            )
+            .unwrap();
+        let entries = a.produce(&[NEW_REALITY], "repo");
+        assert_eq!(entries.len(), 1);
+
+        // B (old spec) parks the newer op without applying it — no bump yet.
+        let outcomes: Vec<IngestOutcome> = {
+            let tx = b.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account(),
+                incarnation_ref: [0x44; 32],
+                device: &b.local,
+                registry: &[OLD_REALITY],
+                now_ms: 0,
+            };
+            let out = entries
+                .iter()
+                .map(|bytes| {
+                    engine::ingest(&tx, &ctx, "overlay/1", bytes, &a.pubkey(), None)
+                        .unwrap()
+                        .outcome
+                })
+                .collect();
+            tx.commit().unwrap();
+            out
+        };
+        assert_eq!(outcomes, vec![IngestOutcome::Retained(
+            PendingReason::NewerSpecVersion.as_db_str()
+        )]);
+        assert_eq!(lens_memories_revision(&b.conn), 0, "a parked entry has not applied");
+
+        // Refold under the new spec applies it, and the guard advances the memories lane.
+        assert!(refold_stale_projections_against(&b.conn, &[NEW_REALITY]).unwrap());
+        let applied: bool = b
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM memory_reality WHERE repo_id = 'repo' AND memory_id \
+                 = 'm1')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(applied, "the parked memory_reality row lands on refold");
+        assert!(
+            lens_memories_revision(&b.conn) >= 1,
+            "replaying a memory-lane row advances the memories lane"
+        );
+    }
+
+    /// The negative half of the guard: a non-memory table (`t_demo`) applied on refold must NOT
+    /// touch the memories lane, so a future non-memory scope replays without a spurious bump.
+    #[test]
+    fn refold_replay_of_a_non_memory_row_leaves_the_memories_lens_lane_untouched() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        b.conn
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo', \
+                 'repo', 0)",
+                [],
+            )
+            .unwrap();
+        let entries = author_wide_row(&mut a);
+        b.enroll(a.pubkey().fingerprint());
+        assert_eq!(b.ingest(OLD_REGISTRY, "repo", &entries, &a.pubkey()), vec![
+            IngestOutcome::Retained(PendingReason::NewerSpecVersion.as_db_str())
+        ]);
+
+        assert!(refold_stale_projections_against(&b.conn, NEW_REGISTRY).unwrap());
+        assert_eq!(b.row(), Some(("v1".to_string(), Some("wide".to_string()))), "t_demo applied");
+        assert_eq!(
+            lens_memories_revision(&b.conn),
+            0,
+            "a non-memory table's replay must not bump the memories lane"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -198,9 +198,75 @@ const MEMORY_BINDINGS: TableSpec = TableSpec {
     repo_column: Some("repo_id"),
 };
 
+// A memory verdict is regenerable model output; every non-pk column is a portable fact about the
+// verdict or the check that produced it (`checked_against_commit`/`checked_inputs_hash` are the
+// churn-skip comparators — replicating them lets a receiver skip re-verification, which is the
+// point of the scope). Nothing here is checkout-local, so `local_columns` is empty; a NULL value
+// (an uncitable row's verdict/direction/model_id) is wire-legal under whole-row LWW.
+const MEMORY_REALITY_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("memory_id", ValueType::Text),
+];
+
+const MEMORY_REALITY_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec::required("content_hash", ValueType::Text),
+    ColumnSpec::required("verdict", ValueType::Text),
+    ColumnSpec::required("direction", ValueType::Text),
+    ColumnSpec::required("checked_against_commit", ValueType::Text),
+    ColumnSpec::required("checked_inputs_hash", ValueType::Text),
+    ColumnSpec::required("evidence_json", ValueType::Text),
+    ColumnSpec::required("model_id", ValueType::Text),
+    ColumnSpec::required("prompt_version", ValueType::Text),
+    ColumnSpec::required("checked_at_ms", ValueType::I64),
+];
+
+const MEMORY_REALITY: TableSpec = TableSpec {
+    name: "memory_reality",
+    scope_id: "overlay/1",
+    spec_version: 1,
+    pk: MEMORY_REALITY_PK,
+    columns: MEMORY_REALITY_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
+// A compacted memory summary keyed WITH `content_hash`, so a title/body edit is a new row rather
+// than an in-place overwrite. Every non-pk column is regenerable model output; nothing is local.
+const MEMORY_SUMMARIES_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("memory_id", ValueType::Text),
+    ColumnSpec::required("content_hash", ValueType::Text),
+];
+
+const MEMORY_SUMMARIES_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec::required("summary", ValueType::Text),
+    ColumnSpec::required("model_id", ValueType::Text),
+    ColumnSpec::required("prompt_version", ValueType::Text),
+    ColumnSpec::required("generated_at_ms", ValueType::I64),
+];
+
+const MEMORY_SUMMARIES: TableSpec = TableSpec {
+    name: "memory_summaries",
+    scope_id: "overlay/1",
+    spec_version: 1,
+    pk: MEMORY_SUMMARIES_PK,
+    columns: MEMORY_SUMMARIES_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
 /// The production table registry. `anchors/1` retains durable memory-binding history in full;
-/// higher-churn overlay and distill tables remain unregistered until their retention milestones.
-pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[MEMORY_BINDINGS];
+/// `overlay/1` carries regenerable dream output (verdicts, summaries) under a bounded retention
+/// budget. The `distill/1` scope remains unregistered until its retention milestone.
+pub(crate) const SYNCABLE_TABLES: &[TableSpec] =
+    &[MEMORY_BINDINGS, MEMORY_REALITY, MEMORY_SUMMARIES];
+
+/// Registered tables whose rows feed the per-repo memories Lens lane
+/// (`LENS_MEMORIES_REVISION_META`). The apply-side lane bump consults this because `IngestOutcome`
+/// does not name the applied table; keep it in sync with any memory-facing table added to
+/// [`SYNCABLE_TABLES`].
+pub(crate) const MEMORIES_LANE_TABLES: &[&str] =
+    &["repo_memory_bindings", "memory_reality", "memory_summaries"];
 
 /// One table's REPLICATED CONTRACT within a projector generation — everything that decides what
 /// this binary can project from the wire, and nothing that does not.
@@ -277,6 +343,72 @@ pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
             ("moniker_tool_version", ValueType::Text, None),
         ],
     }],
+    // v3: regenerable dream output (verdicts, summaries) replicates on the bounded overlay/1
+    // stream. A generation is a whole-registry snapshot, so this repeats the anchors table and
+    // adds the two overlay tables, in `SYNCABLE_TABLES` order.
+    &[
+        TableGeneration {
+            table: "repo_memory_bindings",
+            scope_id: "anchors/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("binding_kind", ValueType::Text),
+                ("binding_id", ValueType::Text),
+            ],
+            columns: &[
+                ("path", ValueType::Text, None),
+                ("start_line", ValueType::I64, None),
+                ("end_line", ValueType::I64, None),
+                ("commit_hash", ValueType::Text, None),
+                ("tracker", ValueType::Text, None),
+                ("project", ValueType::Text, None),
+                ("item_key", ValueType::Text, None),
+                ("created_at_ms", ValueType::I64, None),
+                ("symbol_kind", ValueType::Text, None),
+                ("signature_hash", ValueType::Text, None),
+                ("moniker_tool", ValueType::Text, None),
+                ("moniker_tool_version", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_reality",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[("repo_id", ValueType::Text), ("memory_id", ValueType::Text)],
+            columns: &[
+                ("content_hash", ValueType::Text, None),
+                ("verdict", ValueType::Text, None),
+                ("direction", ValueType::Text, None),
+                ("checked_against_commit", ValueType::Text, None),
+                ("checked_inputs_hash", ValueType::Text, None),
+                ("evidence_json", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("checked_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_summaries",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("content_hash", ValueType::Text),
+            ],
+            columns: &[
+                ("summary", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+    ],
 ];
 
 /// Assert a spec classifies EVERY physical column of its table exactly once — as pk, a synced
@@ -761,6 +893,22 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    /// Every production spec must classify its live physical schema exactly — the invariant that
+    /// stops a column being added to a registered table without a matching spec edit. Runs against
+    /// the real migration ladder, not a synthetic fixture, so a drift between the CREATE TABLE and
+    /// the `TableSpec` fails here.
+    #[test]
+    fn the_production_specs_cover_their_live_schema() {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        for spec in SYNCABLE_TABLES {
+            assert_spec_covers_schema(&conn, spec).unwrap_or_else(|err| {
+                panic!("spec for `{}` does not cover its schema: {err}", spec.name)
+            });
+        }
+        assert_registry_consistent(SYNCABLE_TABLES).unwrap();
     }
 
     /// The comparable shape of one generation: `(table, spec_version, [(column, in_version,

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::engine::{self, IngestOutcome, SyncCtx};
-use super::registry::{SYNCABLE_TABLES, TableSpec};
+use super::registry::{MEMORIES_LANE_TABLES, SYNCABLE_TABLES, TableSpec};
 use super::scope_stream::scope_stream_id;
 use super::{retention, store};
 use crate::AccountId;
@@ -200,6 +200,23 @@ pub fn table_sync_author_pending(
         tx.commit()?;
     }
     Ok(authored)
+}
+
+/// The per-(stream, device) accepted-entry budget for a scope: `None` = full retention, `Some(n)` =
+/// keep the newest `n` reclaimable entries and compact the rest. This is the production
+/// `retain` argument to [`table_sync_compact_overdue`].
+///
+/// `anchors/1` is fully retained (durable memory anchors — every entry is history worth keeping).
+/// `overlay/1` is the first bounded scope: its per-edit `Remove`+insert churn on `memory_summaries`
+/// would grow a chain without limit, so each device chain keeps [`OVERLAY_ACCEPTED_RETENTION`]
+/// accepted entries. An unknown scope defaults to full retention.
+pub const OVERLAY_ACCEPTED_RETENTION: u64 = 256;
+
+pub fn scope_retention_budget(scope_id: &str) -> Option<u64> {
+    match scope_id {
+        "overlay/1" => Some(OVERLAY_ACCEPTED_RETENTION),
+        _ => None,
+    }
 }
 
 /// Compact accepted chain prefixes for scopes whose retention policy bounds them (#1127).
@@ -726,7 +743,13 @@ fn ingest_against(
         advertised_floor
             .map(|(lamport, entry_hash)| store::AdvertisedFloor { lamport, entry_hash }),
     )?;
-    if registry.iter().any(|spec| spec.name == "repo_memory_bindings")
+    // An applied row on this stream changed derived memory state, so advance the memories Lens
+    // lanes (the explicit replacement for the row triggers overlay/1 and anchors/1 dropped). The
+    // registered-repo gate matches the dropped triggers and avoids phantom `'__unassigned__'` rows.
+    // `IngestOutcome` does not name the applied table, so this bumps whenever a memories-lane table
+    // is registered at all — correct while every registered table (bindings, memory_reality,
+    // memory_summaries) feeds this lane; revisit the gate if a non-memory table ever registers.
+    if registry.iter().any(|spec| MEMORIES_LANE_TABLES.contains(&spec.name))
         && std::iter::once(&report.outcome)
             .chain(report.promoted.iter())
             .any(|outcome| matches!(outcome, IngestOutcome::Applied))
@@ -914,6 +937,92 @@ mod tests {
             table_sync_compact_overdue(&conn, account(), 3, zero).is_err(),
             "a zero budget would drop the chain tail itself — refused"
         );
+    }
+
+    #[test]
+    fn scope_retention_budget_bounds_overlay_and_leaves_anchors_full() {
+        assert_eq!(scope_retention_budget("overlay/1"), Some(OVERLAY_ACCEPTED_RETENTION));
+        assert_eq!(scope_retention_budget("anchors/1"), None);
+        assert_eq!(scope_retention_budget("distill/1"), None);
+        assert_eq!(scope_retention_budget("unknown/1"), None);
+    }
+
+    /// Seed `count` reclaimable (non-pending) accepted entries on a single-device chain, with
+    /// globally-unique entry hashes derived from `(tag, lamport)`. Records the stream's apply
+    /// context first — compaction needs it to restamp a dropped winner's published record.
+    fn seed_reclaimable_chain(conn: &Connection, stream: &TableSyncStream, tag: u8, count: i64) {
+        conn.execute(
+            "INSERT INTO table_sync_streams(stream_id, repo_id, account_id, incarnation_ref, \
+             scope_id) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                stream.stream_id.as_slice(),
+                stream.repo_id,
+                account().to_bytes().as_slice(),
+                stream.incarnation_ref.as_slice(),
+                stream.scope_id,
+            ],
+        )
+        .unwrap();
+        for lamport in 0..count {
+            let mut entry_hash = [0u8; 32];
+            entry_hash[0] = tag;
+            entry_hash[1..9].copy_from_slice(&(lamport as u64).to_le_bytes());
+            conn.execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, signed_bytes,
+                     received_at_ms
+                 ) VALUES (?1, ?2, ?3, ?4, x'00', 0)",
+                params![
+                    entry_hash.as_slice(),
+                    stream.stream_id.as_slice(),
+                    [7u8; 32].as_slice(),
+                    lamport
+                ],
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn the_production_policy_compacts_overlay_chains_and_leaves_anchors_full() {
+        let conn = database();
+        let streams = table_sync_supported_streams(&conn, account()).unwrap();
+        let overlay = streams
+            .iter()
+            .find(|s| s.repo_id == "repo-a" && s.scope_id == "overlay/1")
+            .expect("repo-a advertises an overlay stream");
+        let anchors = streams
+            .iter()
+            .find(|s| s.repo_id == "repo-a" && s.scope_id == "anchors/1")
+            .expect("repo-a advertises an anchors stream");
+
+        // Overlay is bounded; give it more than its budget. Anchors is full-retention; a chain the
+        // same length must be left untouched.
+        let overlay_len = i64::try_from(OVERLAY_ACCEPTED_RETENTION).unwrap() + 4;
+        seed_reclaimable_chain(&conn, overlay, 0xAA, overlay_len);
+        seed_reclaimable_chain(&conn, anchors, 0xBB, overlay_len);
+
+        let dropped =
+            table_sync_compact_overdue(&conn, account(), 1, &scope_retention_budget).unwrap();
+        assert_eq!(dropped, 4, "overlay compacts to its 256-entry budget; 4 oldest are reclaimed");
+
+        let overlay_remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE stream_id = ?1",
+                [overlay.stream_id.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(overlay_remaining, i64::try_from(OVERLAY_ACCEPTED_RETENTION).unwrap());
+
+        let anchors_remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE stream_id = ?1",
+                [anchors.stream_id.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(anchors_remaining, overlay_len, "anchors is full-retention — nothing reclaimed");
     }
 
     /// A pending entry below the computed floor would survive locally yet be unreachable to
@@ -1209,13 +1318,20 @@ mod tests {
     }
 
     #[test]
-    fn production_registry_advertises_one_anchors_stream_per_current_repo() {
+    fn production_registry_advertises_anchors_and_overlay_per_current_repo() {
         let conn = database();
         let streams = table_sync_supported_streams(&conn, account()).unwrap();
-        assert_eq!(streams.len(), 2);
-        assert!(streams.iter().all(|stream| stream.scope_id == "anchors/1"));
-        assert_eq!(streams.iter().map(|stream| stream.repo_id.as_str()).collect::<Vec<_>>(), [
-            "repo-a", "repo-b"
+        // Each current repo advertises one stream per registered scope: anchors/1 and overlay/1.
+        let mut pairs: Vec<(String, String)> = streams
+            .iter()
+            .map(|stream| (stream.repo_id.clone(), stream.scope_id.clone()))
+            .collect();
+        pairs.sort();
+        assert_eq!(pairs, vec![
+            ("repo-a".to_string(), "anchors/1".to_string()),
+            ("repo-a".to_string(), "overlay/1".to_string()),
+            ("repo-b".to_string(), "anchors/1".to_string()),
+            ("repo-b".to_string(), "overlay/1".to_string()),
         ]);
     }
 

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -319,7 +319,19 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
     }
 
     fn prepare(&mut self) -> anyhow::Result<()> {
-        rag_rat_oplog::table_sync_author_pending(self.conn, self.account_id, (self.now_fn)())?;
+        // Author local edits FIRST, then compact: the retention docs require the authoring pass to
+        // have run so a winner restamp never disowns an unsent local edit. `prepare` runs only when
+        // the local device can push, so a read-only peer never compacts. Compaction is a
+        // re-runnable steady-state no-op — bounded scopes (overlay/1) trim to their budget,
+        // fully-retained scopes (anchors/1) are inert.
+        let now_ms = (self.now_fn)();
+        rag_rat_oplog::table_sync_author_pending(self.conn, self.account_id, now_ms)?;
+        rag_rat_oplog::table_sync_compact_overdue(
+            self.conn,
+            self.account_id,
+            now_ms,
+            &rag_rat_oplog::scope_retention_budget,
+        )?;
         Ok(())
     }
 

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -761,6 +761,211 @@ async fn production_anchors_replicate_through_dispatch_before_local_repo_registr
 }
 
 #[tokio::test]
+async fn production_overlay_replicates_summaries_and_verdicts() {
+    use rag_rat_sync::{
+        AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, TABLE_SYNC_ALPN,
+        accept_and_dispatch, connect_and_table_sync,
+    };
+
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let joiner = fresh_db();
+    let (owner_endpoint, joiner_endpoint) = loopback_endpoints().await;
+    enroll_member_over_endpoint(
+        &owner_endpoint,
+        &joiner_endpoint,
+        &owner,
+        &joiner,
+        account,
+        "https://relay.example",
+    )
+    .await;
+
+    owner
+        .execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+             VALUES ('repo-a', 'repo-a', 0)",
+            [],
+        )
+        .unwrap();
+    rag_rat_oplog::ensure_repo_incarnation(&owner, "repo-a", NOW + 1).unwrap().unwrap();
+    // Regenerable dream output: one verdict (memory_reality) and one summary (memory_summaries).
+    owner
+        .execute(
+            "INSERT INTO memory_reality(
+                 memory_id, repo_id, content_hash, verdict, direction, checked_inputs_hash,
+                 evidence_json, model_id, prompt_version, checked_at_ms)
+             VALUES ('memory-a', 'repo-a', 'hash-a', 'confirmed', 'note_ahead', 'inputs-a',
+                     '[]', 'model-x', 'v1', ?1)",
+            [NOW + 2],
+        )
+        .unwrap();
+    owner
+        .execute(
+            "INSERT INTO memory_summaries(
+                 memory_id, repo_id, content_hash, summary, model_id, prompt_version,
+                 generated_at_ms)
+             VALUES ('memory-a', 'repo-a', 'hash-a', 'A concise summary.', 'model-x', 'v1', ?1)",
+            [NOW + 2],
+        )
+        .unwrap();
+    for entry in account_entries_for_sync(&owner, account).unwrap() {
+        rag_rat_oplog::account_ingest(&joiner, &entry.signed_bytes, NOW + 2).unwrap();
+    }
+    // The joiner is actively working in repo-a, so the apply-side lane bump has a registered repo
+    // to advance (the bump is gated on registration to avoid phantom rows on a peer that only
+    // relays).
+    joiner
+        .execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+             VALUES ('repo-a', 'repo-a', 0)",
+            [],
+        )
+        .unwrap();
+
+    let mut account_store = OplogSyncStore::new(&owner, account, || NOW);
+    let mut content_store = OplogContentSyncStore::new(&owner, account, || NOW);
+    let mut table_store = OplogTableSyncStore::new(&joiner, account, || NOW);
+    let server = accept_and_dispatch(
+        &owner_endpoint,
+        &mut account_store,
+        &mut content_store,
+        AuthPolicy::Closed,
+        || NOW,
+    );
+    let client = connect_and_table_sync(
+        &joiner_endpoint,
+        direct_addr(&owner_endpoint),
+        &mut table_store,
+        NOW,
+    );
+    let (server, client) = tokio::join!(server, client);
+    let (alpn, server_report) = server.unwrap();
+    let client_report = client.unwrap();
+    assert_eq!(alpn, TABLE_SYNC_ALPN);
+    assert_eq!(server_report.entries_sent, 2, "one verdict and one summary");
+    assert_eq!(client_report.entries_newly_stored, 2);
+
+    let verdict: String = joiner
+        .query_row(
+            "SELECT verdict FROM memory_reality WHERE repo_id = 'repo-a' AND memory_id = \
+             'memory-a'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(verdict, "confirmed");
+    let summary: String = joiner
+        .query_row(
+            "SELECT summary FROM memory_summaries
+             WHERE repo_id = 'repo-a' AND memory_id = 'memory-a' AND content_hash = 'hash-a'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(summary, "A concise summary.");
+    // The apply advanced the memories Lens lane on the receiver, so the synced rows surface in Lens
+    // without a local dream pass.
+    let lane: i64 = joiner
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM repo_meta
+             WHERE repo_id = 'repo-a' AND key = 'lens_memories_revision'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(lane >= 1, "applying overlay rows advances the memories lane");
+}
+
+#[tokio::test]
+async fn a_pruned_overlay_summary_is_removed_on_the_peer() {
+    use rag_rat_sync::{
+        AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, accept_and_dispatch,
+        connect_and_table_sync,
+    };
+
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let joiner = fresh_db();
+    let (owner_endpoint, joiner_endpoint) = loopback_endpoints().await;
+    enroll_member_over_endpoint(
+        &owner_endpoint,
+        &joiner_endpoint,
+        &owner,
+        &joiner,
+        account,
+        "https://relay.example",
+    )
+    .await;
+
+    owner
+        .execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+             VALUES ('repo-a', 'repo-a', 0)",
+            [],
+        )
+        .unwrap();
+    rag_rat_oplog::ensure_repo_incarnation(&owner, "repo-a", NOW + 1).unwrap().unwrap();
+    owner
+        .execute(
+            "INSERT INTO memory_summaries(
+                 memory_id, repo_id, content_hash, summary, model_id, prompt_version,
+                 generated_at_ms)
+             VALUES ('memory-a', 'repo-a', 'hash-old', 'Stale summary.', 'model-x', 'v1', ?1)",
+            [NOW + 2],
+        )
+        .unwrap();
+    for entry in account_entries_for_sync(&owner, account).unwrap() {
+        rag_rat_oplog::account_ingest(&joiner, &entry.signed_bytes, NOW + 2).unwrap();
+    }
+
+    let sync_once = async |owner: &_, joiner: &_| {
+        let mut account_store = OplogSyncStore::new(owner, account, || NOW);
+        let mut content_store = OplogContentSyncStore::new(owner, account, || NOW);
+        let mut table_store = OplogTableSyncStore::new(joiner, account, || NOW);
+        let server = accept_and_dispatch(
+            &owner_endpoint,
+            &mut account_store,
+            &mut content_store,
+            AuthPolicy::Closed,
+            || NOW,
+        );
+        let client = connect_and_table_sync(
+            &joiner_endpoint,
+            direct_addr(&owner_endpoint),
+            &mut table_store,
+            NOW,
+        );
+        let (server, client) = tokio::join!(server, client);
+        server.unwrap();
+        client.unwrap();
+    };
+
+    sync_once(&owner, &joiner).await;
+    let present: bool = joiner
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM memory_summaries WHERE content_hash = 'hash-old')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(present, "the summary replicates on the first pass");
+
+    // A newer note supersedes the old summary: the producer's prune deletes the old row locally,
+    // and the next authoring pass emits a Remove that must delete it on the peer too.
+    owner.execute("DELETE FROM memory_summaries WHERE content_hash = 'hash-old'", []).unwrap();
+    sync_once(&owner, &joiner).await;
+    let gone: bool = joiner
+        .query_row(
+            "SELECT NOT EXISTS(SELECT 1 FROM memory_summaries WHERE content_hash = 'hash-old')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(gone, "the pruned summary is removed on the peer");
+}
+
+#[tokio::test]
 async fn a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_floor() {
     use rag_rat_sync::{
         AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, TABLE_SYNC_ALPN,


### PR DESCRIPTION
Registers `overlay/1` as the second production table-sync scope after the live `anchors/1`, replicating regenerable dream output across an account's device roster per project on the existing `/5` transport:

- **`memory_reality`** — memory verdicts
- **`memory_summaries`** — compacted memory summaries

`memory_model_failures` stays local (model-failure state does not replicate).

## Trigger-free Lens invalidation (migration V107)

Both tables carried `*_lens_revision` / `*_lane_revision` triggers that bumped a per-repo Lens lane on every physical row write. Under `overlay/1` a row arrives by whole-row LWW, and a trigger firing on a wire-applied row is a device-local side effect that also fires on redeliveries, losing writes, and refold replay. V107 drops those 12 triggers unconditionally (so they stay gone across a full `index --full` ladder replay), and the enrichment + memories Lens lanes are advanced explicitly instead:

- at the dream write sites (`record_verdict`, `record_uncitable`, `record_summary`), inside the same transaction as the write;
- at the table-sync apply site and in refold replay, only when a row actually changes the projection.

All bumps are gated on repo registration (matching the dropped trigger's `EXISTS(repos)` condition and avoiding phantom `repo_meta` rows).

## Bounded retention

`overlay/1` is the first high-churn scope, so it cannot launch fully retained like `anchors/1`. Each device chain retains 256 accepted entries via the existing prefix-compaction machinery, driven after the authoring pass in the sync prepare step. `anchors/1` stays fully retained.

## Tests

- registry specs cover the live schema; the projector generation matches the registry and the version is bumped;
- V107 leaves the tables trigger-free across a full ladder replay, and a raw write no longer bumps the lane;
- explicit lane advancement on the dream write, the apply path, and the refold replay path (positive + negative);
- end-to-end wire replication of a summary and a verdict, receiver-side lane bump, prune propagation, and the 256-entry retention bound.

Closes #1133. Part of #892.