### PR TITLE
feat(sync): register the distill/1 table-sync scope

### DIFF
--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -838,6 +838,10 @@ fn persist_success(
         params![repo_id, job.queue_id, job.enqueued_at_ms, job.attempts],
     )?;
     anyhow::ensure!(deleted == 1, "distill queue identity changed inside success transaction");
+    // The record's model output changed, so advance the papertrail Lens lane (V108 dropped the
+    // `papertrail_distill` row triggers). In this same IMMEDIATE transaction, so Lens sees the
+    // write and the lane bump atomically.
+    super::bump_papertrail_lens_lanes(conn, repo_id)?;
     Ok(true)
 }
 
@@ -1033,6 +1037,25 @@ mod tests {
         migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
         migrations::apply_distill_enriched_context(&conn).unwrap();
         migrations::apply_distill_evidence_source_part(&conn).unwrap();
+        // `persist_success` advances the papertrail Lens lane, which needs a registered repo and
+        // the `repo_meta` sink (V108 dropped the row triggers). This partial fixture
+        // predates the full schema, so create both and register the repo the seeds use.
+        conn.execute_batch(
+            "CREATE TABLE repos(
+                 repo_id TEXT NOT NULL PRIMARY KEY,
+                 display_name TEXT,
+                 registered_at_ms INTEGER NOT NULL
+             ) STRICT;
+             INSERT INTO repos(repo_id, display_name, registered_at_ms)
+                 VALUES ('repo', 'repo', 0);
+             CREATE TABLE repo_meta(
+                 repo_id TEXT NOT NULL,
+                 key TEXT NOT NULL,
+                 value TEXT,
+                 PRIMARY KEY(repo_id, key)
+             ) STRICT;",
+        )
+        .unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1518,6 +1541,14 @@ mod tests {
                  repo_id TEXT NOT NULL, PRIMARY KEY(repo_id, hash)
              ) STRICT;
              CREATE TABLE model_probe(value INTEGER NOT NULL);
+             CREATE TABLE repos(
+                 repo_id TEXT NOT NULL PRIMARY KEY, display_name TEXT,
+                 registered_at_ms INTEGER NOT NULL
+             ) STRICT;
+             INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo', 'repo', 0);
+             CREATE TABLE repo_meta(
+                 repo_id TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY(repo_id, key)
+             ) STRICT;
              PRAGMA journal_mode = WAL;",
         )
         .unwrap();

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -270,12 +270,31 @@ pub(crate) fn extract(
             })
             .collect();
 
+        // The threads this device actually mirrors. A record whose thread is ABSENT here is "no
+        // opinion, never delete" — not "delete": once `distill/1` replicates these records (#1135),
+        // `delete_record` authors a producer `Remove`, so a thin/empty-mirror device (fresh
+        // enrollment, or a roster peer without tracker credentials — exactly whom the roster-only
+        // scope serves) would otherwise reconcile its empty plan into Removes that wipe the fleet's
+        // distilled records. Only a thread STILL mirrored but no longer eligible is stale here.
+        let mirrored: BTreeSet<RecordKey> = items
+            .iter()
+            .map(|item| {
+                (
+                    item.tracker.clone(),
+                    item.project.clone(),
+                    item.kind.as_db_str().to_string(),
+                    item.key.clone(),
+                )
+            })
+            .collect();
+
         let mut report = ExtractReport { eligible: plans.len(), ..Default::default() };
-        // Reconcile against the planned set: any persisted record no longer planned — a reopened
-        // issue, an un-merged PR, or a PR now coalesced into an issue — loses its stale
-        // record/junctions/queue so consumers never see an ineligible or duplicate record.
+        // Reconcile against the planned set: a persisted record whose thread is still mirrored but no
+        // longer planned — a reopened issue, an un-merged PR, or a PR now coalesced into an issue —
+        // loses its stale record/junctions/queue so consumers never see an ineligible or duplicate
+        // record. A record whose thread the mirror no longer carries is left untouched (see above).
         for existing in load_record_keys(conn, &repo_id)? {
-            if !planned.contains(&existing) {
+            if mirrored.contains(&existing) && !planned.contains(&existing) {
                 delete_record(conn, &repo_id, &existing)?;
             }
         }
@@ -3367,6 +3386,27 @@ mod tests {
             "the ineligible record is reconciled away",
         );
         assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"), 0);
+    }
+
+    #[test]
+    fn a_record_whose_thread_is_absent_from_the_mirror_is_preserved_not_reconciled_away() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "7", "A bug.", "closed", None);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"), 1);
+
+        // The local mirror no longer carries the thread — a thin/empty-mirror device (fresh
+        // enrollment, or a roster peer without tracker credentials), or an item deleted upstream.
+        // Absent from the mirror is "no opinion", never "delete": once distill/1 replicates records,
+        // deleting here would author a `Remove` that wipes the fleet's records (#1135).
+        conn.execute("DELETE FROM papertrail_items", []).unwrap();
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.records_written, 0, "an empty mirror plans nothing");
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"),
+            1,
+            "a record whose thread the mirror no longer carries is preserved, not reconciled away",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -289,13 +289,16 @@ pub(crate) fn extract(
             .collect();
 
         let mut report = ExtractReport { eligible: plans.len(), ..Default::default() };
-        // Reconcile against the planned set: a persisted record whose thread is still mirrored but no
-        // longer planned — a reopened issue, an un-merged PR, or a PR now coalesced into an issue —
-        // loses its stale record/junctions/queue so consumers never see an ineligible or duplicate
-        // record. A record whose thread the mirror no longer carries is left untouched (see above).
+        // Reconcile against the planned set: a persisted record whose thread is still mirrored but
+        // no longer planned — a reopened issue, an un-merged PR, or a PR now coalesced into
+        // an issue — loses its stale record/junctions/queue so consumers never see an
+        // ineligible or duplicate record. A record whose thread the mirror no longer
+        // carries is left untouched (see above).
+        let mut records_deleted = 0usize;
         for existing in load_record_keys(conn, &repo_id)? {
             if mirrored.contains(&existing) && !planned.contains(&existing) {
                 delete_record(conn, &repo_id, &existing)?;
+                records_deleted += 1;
             }
         }
         // The cheap sync enqueue queues eligible PRs BEFORE extraction runs, so a thread queued but
@@ -328,6 +331,12 @@ pub(crate) fn extract(
                 OutcomeStatus::Reverted => report.mechanical_reverted += 1,
                 _ => report.mechanical_unclear += 1,
             }
+        }
+        // A pass that wrote or deleted any record changed papertrail-distill state, so advance the
+        // papertrail Lens lane (V108 dropped the row triggers). Once per pass, inside this txn; a
+        // no-op pass (no plans, no reconcile deletes) leaves the lane untouched.
+        if report.records_written > 0 || records_deleted > 0 {
+            super::bump_papertrail_lens_lanes(conn, &repo_id)?;
         }
         Ok(report)
     })
@@ -3397,8 +3406,9 @@ mod tests {
 
         // The local mirror no longer carries the thread — a thin/empty-mirror device (fresh
         // enrollment, or a roster peer without tracker credentials), or an item deleted upstream.
-        // Absent from the mirror is "no opinion", never "delete": once distill/1 replicates records,
-        // deleting here would author a `Remove` that wipes the fleet's records (#1135).
+        // Absent from the mirror is "no opinion", never "delete": once distill/1 replicates
+        // records, deleting here would author a `Remove` that wipes the fleet's records
+        // (#1135).
         conn.execute("DELETE FROM papertrail_items", []).unwrap();
         let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
         assert_eq!(report.records_written, 0, "an empty mirror plans nothing");
@@ -3407,6 +3417,33 @@ mod tests {
             1,
             "a record whose thread the mirror no longer carries is preserved, not reconciled away",
         );
+    }
+
+    #[test]
+    fn an_extraction_that_writes_a_record_advances_the_papertrail_lens_lane() {
+        let conn = scoped_conn("repoA");
+        // V108 dropped the papertrail_distill triggers, so the extract pass advances the lane
+        // explicitly — gated on repo registration.
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repoA', 'repoA', \
+             0)",
+            [],
+        )
+        .unwrap();
+        seed_item(&conn, "repoA", "issue", "7", "A bug.", "closed", None);
+        let lane = || -> i64 {
+            conn.query_row(
+                "SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM repo_meta
+                     WHERE repo_id = 'repoA' AND key = 'lens_papertrail_revision'), 0)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        let before = lane();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"), 1);
+        assert!(lane() > before, "writing a distilled record advances the papertrail lane");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/distill/mod.rs
+++ b/crates/rag-rat-core/src/distill/mod.rs
@@ -25,3 +25,26 @@ pub use drain::DistillDrainReport;
 pub(crate) use drain::{drain, pending_count};
 pub use extract::ExtractReport;
 pub(crate) use extract::{enqueue_eligible, extract};
+
+/// Advance the per-repo papertrail Lens lanes a distill write feeds — the aggregate enrichment
+/// clock and the papertrail lane.
+///
+/// This is the explicit replacement for the `papertrail_distill` revision triggers V108 dropped:
+/// the table syncs on `distill/1`, and a trigger firing on a whole-row-LWW apply is a device-local
+/// side effect the sync apply must not have. So the extract/drain writers advance the lanes here
+/// and the sync apply advances them at its own site. Call it on the SAME connection as the write,
+/// once per pass (matching the old trigger's per-write bump collapses to per-pass — the lane is a
+/// monotonic counter). Gated on repo registration: an ungated `bump_lens_revisions` throws on the
+/// `repo_meta`→`repos` foreign key, and it avoids phantom `'__unassigned__'` rows.
+pub(crate) fn bump_papertrail_lens_lanes(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+) -> rusqlite::Result<()> {
+    if rag_rat_db::schema::repo_id_is_registered(conn, repo_id)? {
+        rag_rat_db::meta::bump_lens_revisions(conn, repo_id, &[
+            rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+            rag_rat_db::meta::LENS_PAPERTRAIL_REVISION_META,
+        ])?;
+    }
+    Ok(())
+}

--- a/crates/rag-rat-core/src/index/query_api/lens/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/lens/tests.rs
@@ -308,6 +308,13 @@ fn lens_version_tracks_binding_validation_and_in_place_enrichment_updates() {
         [&db.active_repo_id],
     )
     .unwrap();
+    // papertrail_distill syncs on distill/1 and is trigger-free (V108); the extract/drain writers
+    // advance the papertrail lane explicitly, mirrored here.
+    rag_rat_db::meta::bump_lens_revisions(conn, &db.active_repo_id, &[
+        rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+        rag_rat_db::meta::LENS_PAPERTRAIL_REVISION_META,
+    ])
+    .unwrap();
     let after_distill_update = db.lens_version().unwrap();
     assert_ne!(
         before_distill_update.revision, after_distill_update.revision,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 107, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 108, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6406,6 +6406,70 @@ mod syncable_overlay_migration_tests {
         .unwrap();
         assert_eq!(before, lane().unwrap(), "a raw overlay write must not move the lane");
     }
+
+    /// V108 rebuilds `papertrail_distill` onto the thread natural key, drops the device-local `id`,
+    /// and drops its papertrail-lane triggers — and stays that way across a full ladder replay
+    /// (V093/V102 recreate the triggers ahead of V108 on every `index --full`).
+    #[test]
+    fn v108_rebuilds_distill_to_the_natural_key_and_drops_triggers_across_a_replay() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        assert_eq!(triggers_on(&conn, "papertrail_distill"), 0);
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "item_kind",
+            "item_key"
+        ]);
+        let has_id: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('papertrail_distill') WHERE name = 'id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_id, 0, "the device-local AUTOINCREMENT id is dropped");
+    }
+
+    /// The rebuild copies every row: a distilled record present in the pre-V108 shape survives,
+    /// re-keyed by its natural key.
+    #[test]
+    fn v108_preserves_distilled_records_through_the_rebuild() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::apply_distill_record_store(&conn).unwrap();
+        // V079 adds the two columns the rebuild's INSERT..SELECT reads.
+        super::apply_distill_safe_input_snapshot(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_cause, fix_edge_source, thread_shape, distilled_at_ms, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 'sha256:in', 2, 'the cause', 'provider',
+                     'investigation', 1, 'r')",
+            [],
+        )
+        .unwrap();
+        super::apply_syncable_distill_records(&conn).unwrap();
+        let (cause, pipeline): (String, i64) = conn
+            .query_row(
+                "SELECT root_cause, pipeline_version FROM papertrail_distill
+                 WHERE repo_id = 'r' AND tracker = 'github' AND project = 'o/r'
+                   AND item_kind = 'issue' AND item_key = '7'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(cause, "the cause");
+        assert_eq!(pipeline, 2);
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "item_kind",
+            "item_key"
+        ]);
+    }
 }
 
 /// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
@@ -7570,6 +7634,93 @@ pub fn apply_syncable_overlay_tables(conn: &Connection) -> rusqlite::Result<()> 
          DROP TRIGGER IF EXISTS memory_summaries_lane_revision_insert;
          DROP TRIGGER IF EXISTS memory_summaries_lane_revision_delete;
          DROP TRIGGER IF EXISTS memory_summaries_lane_revision_update;",
+    )
+}
+
+/// V108 (#1135): make `papertrail_distill` a deterministic whole-row table for `distill/1`.
+///
+/// The old shape keyed on an AUTOINCREMENT `id` (device-local, non-deterministic) with the thread
+/// natural key only as a UNIQUE index — incompatible with whole-row LWW sync. The rebuilt table
+/// keys on `(repo_id, tracker, project, item_kind, item_key)` (repo_id part of the PK, as the
+/// transport requires), drops `id`, has no FK or triggers, and adds the `CHECK(x IN (0,1))` the
+/// store lint asks for on the genuine boolean facets (NOT on `quotes_materialized`/
+/// `anchors_qualified_count`, which are counts). Children reference the thread by its natural key,
+/// never `id`, so dropping it breaks nothing.
+///
+/// The trigger DROP is UNCONDITIONAL and precedes the shape short-circuit: `schema::apply` replays
+/// the whole ladder, so V093/V102 recreate the papertrail-lane triggers ahead of this migration on
+/// every `index --full`. Under `distill/1` a row arrives by whole-row LWW, so the distill write and
+/// the sync apply advance the papertrail Lens lane explicitly instead of via a trigger.
+pub fn apply_syncable_distill_records(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS papertrail_distill_lens_revision_insert;
+         DROP TRIGGER IF EXISTS papertrail_distill_lens_revision_delete;
+         DROP TRIGGER IF EXISTS papertrail_distill_lens_revision_update;
+         DROP TRIGGER IF EXISTS papertrail_distill_lane_revision_insert;
+         DROP TRIGGER IF EXISTS papertrail_distill_lane_revision_delete;
+         DROP TRIGGER IF EXISTS papertrail_distill_lane_revision_update;",
+    )?;
+    if table_is_strict(conn, "papertrail_distill")?
+        && primary_key_columns(conn, "papertrail_distill")?
+            == ["repo_id", "tracker", "project", "item_kind", "item_key"]
+    {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS papertrail_distill_v108;
+         CREATE TABLE papertrail_distill_v108(
+             tracker TEXT NOT NULL,
+             project TEXT NOT NULL,
+             item_kind TEXT NOT NULL,
+             item_key TEXT NOT NULL,
+             distill_input_hash TEXT NOT NULL,
+             pipeline_version INTEGER NOT NULL,
+             root_issue TEXT,
+             root_cause TEXT,
+             root_cause_class TEXT,
+             decision_chosen TEXT,
+             outcome_summary TEXT,
+             outcome_status_model TEXT,
+             epistemic_status_decision TEXT,
+             epistemic_status_outcome TEXT,
+             fix_edge_source TEXT NOT NULL,
+             -- COUNTS, not booleans (quotes_materialized is the evidence-unit count) — no 0/1 \
+         CHECK.
+             quotes_materialized INTEGER NOT NULL DEFAULT 0,
+             anchors_qualified_count INTEGER NOT NULL DEFAULT 0,
+             thread_shape TEXT NOT NULL,
+             -- Genuine 0/1 facets: carry the CHECK the store lint asks for (Bool has no pragma the
+             -- lint can require it through).
+             outcome_claim_verified INTEGER NOT NULL DEFAULT 0
+                 CHECK(outcome_claim_verified IN (0, 1)),
+             decision_provenance_verified INTEGER NOT NULL DEFAULT 0
+                 CHECK(decision_provenance_verified IN (0, 1)),
+             revert_override INTEGER NOT NULL DEFAULT 0 CHECK(revert_override IN (0, 1)),
+             closing_keyword_floor TEXT,
+             distilled_at_ms INTEGER NOT NULL,
+             repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+             prompt_version INTEGER,
+             model_input_hash TEXT,
+             PRIMARY KEY(repo_id, tracker, project, item_kind, item_key)
+         ) STRICT;
+         INSERT INTO papertrail_distill_v108(
+             tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+             root_issue, root_cause, root_cause_class, decision_chosen, outcome_summary,
+             outcome_status_model, epistemic_status_decision, epistemic_status_outcome,
+             fix_edge_source, quotes_materialized, anchors_qualified_count, thread_shape,
+             outcome_claim_verified, decision_provenance_verified, revert_override,
+             closing_keyword_floor, distilled_at_ms, repo_id, prompt_version, model_input_hash)
+         SELECT
+             tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+             root_issue, root_cause, root_cause_class, decision_chosen, outcome_summary,
+             outcome_status_model, epistemic_status_decision, epistemic_status_outcome,
+             fix_edge_source, quotes_materialized, anchors_qualified_count, thread_shape,
+             outcome_claim_verified, decision_provenance_verified, revert_override,
+             closing_keyword_floor, distilled_at_ms, repo_id, prompt_version, model_input_hash
+         FROM papertrail_distill;
+         DROP TABLE papertrail_distill;
+         ALTER TABLE papertrail_distill_v108 RENAME TO papertrail_distill;",
     )
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 107;
+pub const LATEST_SCHEMA_VERSION: u32 = 108;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -805,6 +805,13 @@ const MIGRATION_107_DESCRIPTION: &str =
      overlay/1 table-sync scope applies these rows under whole-row LWW, and a trigger firing on a \
      wire-applied row is a device-local side effect; the dream write and the sync apply advance \
      the Lens lanes explicitly instead";
+const MIGRATION_108_ID: &str = "108_syncable_distill_records";
+const MIGRATION_108_CHECKSUM: &str = "sha256:rag-rat-syncable-distill-records-v108";
+const MIGRATION_108_DESCRIPTION: &str =
+    "Rebuild papertrail_distill onto the thread natural key (repo_id first), dropping the \
+     device-local AUTOINCREMENT id, so the distill/1 table-sync scope can replicate distilled \
+     records under whole-row LWW (#1135); also drops its Lens revision triggers (the sync apply \
+     advances the papertrail lane explicitly)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1019,6 +1026,7 @@ const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[
     MIGRATION_099_ID,
     MIGRATION_103_ID,
     MIGRATION_106_ID,
+    MIGRATION_108_ID,
 ];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
@@ -1682,6 +1690,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_107_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_syncable_overlay_tables),
     },
+    Migration {
+        id: MIGRATION_108_ID,
+        checksum: MIGRATION_108_CHECKSUM,
+        description: MIGRATION_108_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_syncable_distill_records),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1909,6 +1923,7 @@ mod ledger_atomicity {
         MIGRATION_099_ID,
         MIGRATION_103_ID,
         MIGRATION_106_ID,
+        MIGRATION_108_ID,
     ];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -38,7 +38,7 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::apply::{self, ApplyOutcome};
-use super::registry::{MEMORIES_LANE_TABLES, TableSpec};
+use super::registry::TableSpec;
 use super::row_op::{self, DecodedRowOp};
 use super::store::{self, PendingEntry, PendingReason, Worklist};
 use crate::entry;
@@ -57,7 +57,7 @@ use crate::op::OpMeta;
 /// registering a table or widening a spec forces an append, and an append is the bump. A widening
 /// that is not a registry change (a new row-op kind) still has to append a generation by hand,
 /// repeating the previous snapshot.
-pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 3;
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 4;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 
@@ -321,22 +321,19 @@ fn replay_pending_entry(
     }
     let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
     match apply::apply_row_op_on_stream(tx, spec, &context.repo_id, pending.stream_id, &op, meta)? {
-        // Folded and CHANGED the projection: advance the memories Lens lanes so a row landed by
-        // replay (e.g. an entry parked as `NewerSpecVersion` by an older binary, applied here after
-        // the upgrade) surfaces in Lens without waiting for an unrelated write. Mirrors the
-        // direct-ingest bump; gated on repo registration for the same reason (no phantom
-        // `'__unassigned__'` `repo_meta` rows). Unlike the ingest site, replay holds the exact
-        // `spec`, so it gates on the applied table feeding the memories lane rather than
-        // approximating over the whole registry — a future non-memory scope replays without
-        // a spurious bump.
+        // Folded and CHANGED the projection: advance the Lens lanes the applied table's scope feeds
+        // so a row landed by replay (e.g. an entry parked as `NewerSpecVersion` by an older binary,
+        // applied here after the upgrade) surfaces in Lens without waiting for an unrelated write.
+        // Mirrors the direct-ingest bump; gated on repo registration for the same reason (no
+        // phantom `'__unassigned__'` `repo_meta` rows). `scope_lens_metas` returns the
+        // exact lane set for the applied entry's scope (memories for anchors/overlay,
+        // papertrail for distill), so an unsupported scope bumps nothing.
         ApplyOutcome::Applied => {
-            if MEMORIES_LANE_TABLES.contains(&spec.name)
+            let lens_metas = super::registry::scope_lens_metas(&context.scope_id);
+            if !lens_metas.is_empty()
                 && rag_rat_db::schema::repo_id_is_registered(tx, &context.repo_id)?
             {
-                rag_rat_db::meta::bump_lens_revisions(tx, &context.repo_id, &[
-                    rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
-                    rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
-                ])?;
+                rag_rat_db::meta::bump_lens_revisions(tx, &context.repo_id, lens_metas)?;
             }
             store::clear_entry_pending(tx, &pending.entry_hash)
         },
@@ -755,7 +752,7 @@ mod tests {
         .unwrap()
     }
 
-    /// The refold guard (`MEMORIES_LANE_TABLES.contains(&spec.name)`) fires for a memory-lane
+    /// The refold guard (`scope_lens_metas` for the applied entry's scope) fires for a memory-lane
     /// table: a `memory_reality` row parked as `NewerSpecVersion` and applied on refold
     /// advances the memories Lens lane, so a row landed by replay surfaces in Lens without an
     /// unrelated write.

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -255,18 +255,77 @@ const MEMORY_SUMMARIES: TableSpec = TableSpec {
     repo_column: Some("repo_id"),
 };
 
-/// The production table registry. `anchors/1` retains durable memory-binding history in full;
-/// `overlay/1` carries regenerable dream output (verdicts, summaries) under a bounded retention
-/// budget. The `distill/1` scope remains unregistered until its retention milestone.
-pub(crate) const SYNCABLE_TABLES: &[TableSpec] =
-    &[MEMORY_BINDINGS, MEMORY_REALITY, MEMORY_SUMMARIES];
+// A distilled papertrail record — costly LLM output keyed by the thread natural key. Every non-pk
+// column is portable derived output or a mechanical facet; the parent carries no checkout-local
+// resolution state (that lives on `papertrail_distill_anchors`, a later scope stage). The 0/1
+// verified/override facets declare `Bool` (wire-validated to 0/1); `quotes_materialized` and
+// `anchors_qualified_count` are COUNTS, so `I64`, as are timestamps and versions.
+const DISTILL_RECORD_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("tracker", ValueType::Text),
+    ColumnSpec::required("project", ValueType::Text),
+    ColumnSpec::required("item_kind", ValueType::Text),
+    ColumnSpec::required("item_key", ValueType::Text),
+];
 
-/// Registered tables whose rows feed the per-repo memories Lens lane
-/// (`LENS_MEMORIES_REVISION_META`). The apply-side lane bump consults this because `IngestOutcome`
-/// does not name the applied table; keep it in sync with any memory-facing table added to
-/// [`SYNCABLE_TABLES`].
-pub(crate) const MEMORIES_LANE_TABLES: &[&str] =
-    &["repo_memory_bindings", "memory_reality", "memory_summaries"];
+const DISTILL_RECORD_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec::required("distill_input_hash", ValueType::Text),
+    ColumnSpec::required("pipeline_version", ValueType::I64),
+    ColumnSpec::required("root_issue", ValueType::Text),
+    ColumnSpec::required("root_cause", ValueType::Text),
+    ColumnSpec::required("root_cause_class", ValueType::Text),
+    ColumnSpec::required("decision_chosen", ValueType::Text),
+    ColumnSpec::required("outcome_summary", ValueType::Text),
+    ColumnSpec::required("outcome_status_model", ValueType::Text),
+    ColumnSpec::required("epistemic_status_decision", ValueType::Text),
+    ColumnSpec::required("epistemic_status_outcome", ValueType::Text),
+    ColumnSpec::required("fix_edge_source", ValueType::Text),
+    ColumnSpec::required("quotes_materialized", ValueType::I64),
+    ColumnSpec::required("anchors_qualified_count", ValueType::I64),
+    ColumnSpec::required("thread_shape", ValueType::Text),
+    ColumnSpec::required("outcome_claim_verified", ValueType::Bool),
+    ColumnSpec::required("decision_provenance_verified", ValueType::Bool),
+    ColumnSpec::required("revert_override", ValueType::Bool),
+    ColumnSpec::required("closing_keyword_floor", ValueType::Text),
+    ColumnSpec::required("distilled_at_ms", ValueType::I64),
+    ColumnSpec::required("prompt_version", ValueType::I64),
+    ColumnSpec::required("model_input_hash", ValueType::Text),
+];
+
+const DISTILL_RECORD: TableSpec = TableSpec {
+    name: "papertrail_distill",
+    scope_id: "distill/1",
+    spec_version: 1,
+    pk: DISTILL_RECORD_PK,
+    columns: DISTILL_RECORD_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
+/// The production table registry. `anchors/1` retains durable memory-binding history in full;
+/// `overlay/1` carries regenerable dream output (verdicts, summaries) and `distill/1` the distilled
+/// papertrail records — both under a bounded retention budget.
+pub(crate) const SYNCABLE_TABLES: &[TableSpec] =
+    &[MEMORY_BINDINGS, MEMORY_REALITY, MEMORY_SUMMARIES, DISTILL_RECORD];
+
+/// The per-repo Lens lane metas a scope's applied rows advance — the aggregate enrichment clock
+/// plus the scope's specific lane. Returned to the apply-side and refold bump sites, which cannot
+/// always name the applied table but always know the stream/entry's `scope_id`. An unknown scope
+/// advances nothing. Keep in sync with the scopes in [`SYNCABLE_TABLES`].
+pub(crate) fn scope_lens_metas(scope_id: &str) -> &'static [&'static str] {
+    match scope_id {
+        // anchors/1 and overlay/1 are memory-facing scopes.
+        "anchors/1" | "overlay/1" => &[
+            rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+            rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
+        ],
+        "distill/1" => &[
+            rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+            rag_rat_db::meta::LENS_PAPERTRAIL_REVISION_META,
+        ],
+        _ => &[],
+    }
+}
 
 /// One table's REPLICATED CONTRACT within a projector generation — everything that decides what
 /// this binary can project from the wire, and nothing that does not.
@@ -406,6 +465,108 @@ pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
                 ("model_id", ValueType::Text, None),
                 ("prompt_version", ValueType::Text, None),
                 ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+    ],
+    // v4: distilled papertrail records replicate on the bounded distill/1 stream. A generation is
+    // a whole-registry snapshot, so this repeats v3's three tables and adds the distill
+    // parent, in `SYNCABLE_TABLES` order.
+    &[
+        TableGeneration {
+            table: "repo_memory_bindings",
+            scope_id: "anchors/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("binding_kind", ValueType::Text),
+                ("binding_id", ValueType::Text),
+            ],
+            columns: &[
+                ("path", ValueType::Text, None),
+                ("start_line", ValueType::I64, None),
+                ("end_line", ValueType::I64, None),
+                ("commit_hash", ValueType::Text, None),
+                ("tracker", ValueType::Text, None),
+                ("project", ValueType::Text, None),
+                ("item_key", ValueType::Text, None),
+                ("created_at_ms", ValueType::I64, None),
+                ("symbol_kind", ValueType::Text, None),
+                ("signature_hash", ValueType::Text, None),
+                ("moniker_tool", ValueType::Text, None),
+                ("moniker_tool_version", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_reality",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[("repo_id", ValueType::Text), ("memory_id", ValueType::Text)],
+            columns: &[
+                ("content_hash", ValueType::Text, None),
+                ("verdict", ValueType::Text, None),
+                ("direction", ValueType::Text, None),
+                ("checked_against_commit", ValueType::Text, None),
+                ("checked_inputs_hash", ValueType::Text, None),
+                ("evidence_json", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("checked_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_summaries",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("content_hash", ValueType::Text),
+            ],
+            columns: &[
+                ("summary", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+            ],
+            columns: &[
+                ("distill_input_hash", ValueType::Text, None),
+                ("pipeline_version", ValueType::I64, None),
+                ("root_issue", ValueType::Text, None),
+                ("root_cause", ValueType::Text, None),
+                ("root_cause_class", ValueType::Text, None),
+                ("decision_chosen", ValueType::Text, None),
+                ("outcome_summary", ValueType::Text, None),
+                ("outcome_status_model", ValueType::Text, None),
+                ("epistemic_status_decision", ValueType::Text, None),
+                ("epistemic_status_outcome", ValueType::Text, None),
+                ("fix_edge_source", ValueType::Text, None),
+                ("quotes_materialized", ValueType::I64, None),
+                ("anchors_qualified_count", ValueType::I64, None),
+                ("thread_shape", ValueType::Text, None),
+                ("outcome_claim_verified", ValueType::Bool, None),
+                ("decision_provenance_verified", ValueType::Bool, None),
+                ("revert_override", ValueType::Bool, None),
+                ("closing_keyword_floor", ValueType::Text, None),
+                ("distilled_at_ms", ValueType::I64, None),
+                ("prompt_version", ValueType::I64, None),
+                ("model_input_hash", ValueType::Text, None),
             ],
         },
     ],
@@ -909,6 +1070,26 @@ mod tests {
             });
         }
         assert_registry_consistent(SYNCABLE_TABLES).unwrap();
+    }
+
+    /// Every registered scope must map to a non-empty Lens-lane set. `scope_lens_metas` is a
+    /// hand-maintained match on scope-id literals; without this a new scope silently drops Lens
+    /// invalidation (the apply/refold bump sites short-circuit cleanly on an empty set, so nothing
+    /// errors) — this test forces the match to be extended alongside `SYNCABLE_TABLES`.
+    #[test]
+    fn every_registered_scope_maps_to_a_lens_lane() {
+        for spec in SYNCABLE_TABLES {
+            assert!(
+                !scope_lens_metas(spec.scope_id).is_empty(),
+                "scope `{}` (table `{}`) has no scope_lens_metas entry",
+                spec.scope_id,
+                spec.name,
+            );
+        }
+        assert!(
+            scope_lens_metas("nonexistent/1").is_empty(),
+            "an unregistered scope bumps nothing"
+        );
     }
 
     /// The comparable shape of one generation: `(table, spec_version, [(column, in_version,

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::engine::{self, IngestOutcome, SyncCtx};
-use super::registry::{MEMORIES_LANE_TABLES, SYNCABLE_TABLES, TableSpec};
+use super::registry::{SYNCABLE_TABLES, TableSpec, scope_lens_metas};
 use super::scope_stream::scope_stream_id;
 use super::{retention, store};
 use crate::AccountId;
@@ -212,9 +212,16 @@ pub fn table_sync_author_pending(
 /// accepted entries. An unknown scope defaults to full retention.
 pub const OVERLAY_ACCEPTED_RETENTION: u64 = 256;
 
+/// `distill/1` is higher-churn than overlay: one record regeneration authors a burst of entries
+/// across the cluster, so the budget must clear several full-cluster regenerations before the
+/// retained floor advances. A large initial backfill exceeds this immediately and converges through
+/// the retained-floor/compaction path — by design, not loss.
+pub const DISTILL_ACCEPTED_RETENTION: u64 = 512;
+
 pub fn scope_retention_budget(scope_id: &str) -> Option<u64> {
     match scope_id {
         "overlay/1" => Some(OVERLAY_ACCEPTED_RETENTION),
+        "distill/1" => Some(DISTILL_ACCEPTED_RETENTION),
         _ => None,
     }
 }
@@ -743,22 +750,19 @@ fn ingest_against(
         advertised_floor
             .map(|(lamport, entry_hash)| store::AdvertisedFloor { lamport, entry_hash }),
     )?;
-    // An applied row on this stream changed derived memory state, so advance the memories Lens
-    // lanes (the explicit replacement for the row triggers overlay/1 and anchors/1 dropped). The
+    // An applied row on this stream changed derived state, so advance the Lens lanes that scope
+    // feeds (the explicit replacement for the row triggers the synced scopes dropped). All entries
+    // in one ingest belong to one stream, hence one scope, so `scope_lens_metas(stream.scope_id)`
+    // is the exact lane set even though `IngestOutcome` does not name the applied table. The
     // registered-repo gate matches the dropped triggers and avoids phantom `'__unassigned__'` rows.
-    // `IngestOutcome` does not name the applied table, so this bumps whenever a memories-lane table
-    // is registered at all — correct while every registered table (bindings, memory_reality,
-    // memory_summaries) feeds this lane; revisit the gate if a non-memory table ever registers.
-    if registry.iter().any(|spec| MEMORIES_LANE_TABLES.contains(&spec.name))
+    let lens_metas = scope_lens_metas(&stream.scope_id);
+    if !lens_metas.is_empty()
         && std::iter::once(&report.outcome)
             .chain(report.promoted.iter())
             .any(|outcome| matches!(outcome, IngestOutcome::Applied))
         && rag_rat_db::schema::repo_id_is_registered(&tx, &stream.repo_id)?
     {
-        rag_rat_db::meta::bump_lens_revisions(&tx, &stream.repo_id, &[
-            rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
-            rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
-        ])?;
+        rag_rat_db::meta::bump_lens_revisions(&tx, &stream.repo_id, lens_metas)?;
     }
     tx.commit()?;
     Ok(match report.outcome {
@@ -942,8 +946,8 @@ mod tests {
     #[test]
     fn scope_retention_budget_bounds_overlay_and_leaves_anchors_full() {
         assert_eq!(scope_retention_budget("overlay/1"), Some(OVERLAY_ACCEPTED_RETENTION));
+        assert_eq!(scope_retention_budget("distill/1"), Some(DISTILL_ACCEPTED_RETENTION));
         assert_eq!(scope_retention_budget("anchors/1"), None);
-        assert_eq!(scope_retention_budget("distill/1"), None);
         assert_eq!(scope_retention_budget("unknown/1"), None);
     }
 
@@ -1318,10 +1322,11 @@ mod tests {
     }
 
     #[test]
-    fn production_registry_advertises_anchors_and_overlay_per_current_repo() {
+    fn production_registry_advertises_every_scope_per_current_repo() {
         let conn = database();
         let streams = table_sync_supported_streams(&conn, account()).unwrap();
-        // Each current repo advertises one stream per registered scope: anchors/1 and overlay/1.
+        // Each current repo advertises one stream per registered scope: anchors/1, overlay/1,
+        // distill/1.
         let mut pairs: Vec<(String, String)> = streams
             .iter()
             .map(|stream| (stream.repo_id.clone(), stream.scope_id.clone()))
@@ -1329,8 +1334,10 @@ mod tests {
         pairs.sort();
         assert_eq!(pairs, vec![
             ("repo-a".to_string(), "anchors/1".to_string()),
+            ("repo-a".to_string(), "distill/1".to_string()),
             ("repo-a".to_string(), "overlay/1".to_string()),
             ("repo-b".to_string(), "anchors/1".to_string()),
+            ("repo-b".to_string(), "distill/1".to_string()),
             ("repo-b".to_string(), "overlay/1".to_string()),
         ]);
     }

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -966,6 +966,131 @@ async fn a_pruned_overlay_summary_is_removed_on_the_peer() {
 }
 
 #[tokio::test]
+async fn production_distill_records_replicate_and_regenerate() {
+    use rag_rat_sync::{
+        AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, TABLE_SYNC_ALPN,
+        accept_and_dispatch, connect_and_table_sync,
+    };
+
+    let owner = fresh_db();
+    let account = local_account(&owner, NOW).unwrap();
+    let joiner = fresh_db();
+    let (owner_endpoint, joiner_endpoint) = loopback_endpoints().await;
+    enroll_member_over_endpoint(
+        &owner_endpoint,
+        &joiner_endpoint,
+        &owner,
+        &joiner,
+        account,
+        "https://relay.example",
+    )
+    .await;
+
+    for db in [&owner, &joiner] {
+        db.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+             VALUES ('repo-a', 'repo-a', 0)",
+            [],
+        )
+        .unwrap();
+    }
+    rag_rat_oplog::ensure_repo_incarnation(&owner, "repo-a", NOW + 1).unwrap().unwrap();
+    // A distilled record for a closed issue thread; also seed a sibling repo's record to prove
+    // cross-repo isolation (repo-b never rides repo-a's stream).
+    let seed_record = |item_key: &str, repo: &str, hash: &str, cause: &str| {
+        owner
+            .execute(
+                "INSERT INTO papertrail_distill
+                     (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                      root_cause, fix_edge_source, thread_shape, distilled_at_ms, repo_id)
+                 VALUES ('github', 'o/r', 'issue', ?1, ?2, 2, ?3, 'provider', 'investigation',
+                         ?4, ?5)",
+                rusqlite::params![item_key, hash, cause, NOW + 2, repo],
+            )
+            .unwrap();
+    };
+    seed_record("7", "repo-a", "sha256:in-a", "the original cause");
+    owner
+        .execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms)
+             VALUES ('repo-b', 'repo-b', 0)",
+            [],
+        )
+        .unwrap();
+    seed_record("9", "repo-b", "sha256:in-b", "a sibling repo cause");
+
+    for entry in account_entries_for_sync(&owner, account).unwrap() {
+        rag_rat_oplog::account_ingest(&joiner, &entry.signed_bytes, NOW + 2).unwrap();
+    }
+
+    // Whole-row LWW resolves by lamport (authoring increments it), not wall-clock, so both passes
+    // use the same clock — the regeneration below still wins on its higher authored lamport.
+    let reconcile = async || {
+        let mut account_store = OplogSyncStore::new(&owner, account, || NOW);
+        let mut content_store = OplogContentSyncStore::new(&owner, account, || NOW);
+        let mut table_store = OplogTableSyncStore::new(&joiner, account, || NOW);
+        let server = accept_and_dispatch(
+            &owner_endpoint,
+            &mut account_store,
+            &mut content_store,
+            AuthPolicy::Closed,
+            || NOW,
+        );
+        let client = connect_and_table_sync(
+            &joiner_endpoint,
+            direct_addr(&owner_endpoint),
+            &mut table_store,
+            NOW,
+        );
+        let (server, client) = tokio::join!(server, client);
+        let (alpn, _) = server.unwrap();
+        client.unwrap();
+        assert_eq!(alpn, TABLE_SYNC_ALPN);
+    };
+
+    reconcile().await;
+    let cause: String = joiner
+        .query_row(
+            "SELECT root_cause FROM papertrail_distill
+             WHERE repo_id = 'repo-a' AND item_kind = 'issue' AND item_key = '7'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(cause, "the original cause", "the distilled record replicates");
+    // repo-a advertises no route for repo-b's incarnation, so repo-b's record never lands.
+    let sibling: bool = joiner
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM papertrail_distill WHERE repo_id = 'repo-b')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(!sibling, "a sibling repo's distilled record never crosses repo-a's stream");
+
+    // Regeneration: the record is re-distilled (new distill_input_hash + fields). A whole-row LWW
+    // upsert on the stable natural key replaces it on the peer.
+    owner
+        .execute(
+            "UPDATE papertrail_distill
+             SET distill_input_hash = 'sha256:in-a2', root_cause = 'the regenerated cause'
+             WHERE repo_id = 'repo-a' AND item_key = '7'",
+            [],
+        )
+        .unwrap();
+    reconcile().await;
+    let regenerated: String = joiner
+        .query_row(
+            "SELECT root_cause FROM papertrail_distill
+             WHERE repo_id = 'repo-a' AND item_kind = 'issue' AND item_key = '7'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(regenerated, "the regenerated cause", "regeneration upserts the record on the peer");
+}
+
+#[tokio::test]
 async fn a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_floor() {
     use rag_rat_sync::{
         AuthPolicy, OplogContentSyncStore, OplogTableSyncStore, TABLE_SYNC_ALPN,


### PR DESCRIPTION
Registers `distill/1`, the third production table-sync scope after `anchors/1` and `overlay/1`, replicating the distilled papertrail record (`papertrail_distill`) across an account's device roster per project on the `/5` transport. These are costly LLM-derived records that may carry private tracker evidence, so the scope is roster-only. Ships the parent record; the enrichment children (evidence, anchors, alternatives, commits, edges) follow.

## Reconcile safety (prerequisite)

`extract()`'s reconcile deleted every distilled record whose thread was absent from the local tracker mirror. That is safe on a single device, but once records replicate, a thin- or empty-mirror device (a fresh enrollment, or a roster peer without tracker credentials) would reconcile its empty plan into deletions that propagate as a fleet-wide wipe. Reconcile now deletes a record only when its thread is still present in the local mirror but no longer eligible; a thread the mirror no longer carries is left untouched.

## Rebuild to a syncable shape (migration V108)

`papertrail_distill` keyed on a device-local AUTOINCREMENT `id` with the thread natural key only as a UNIQUE index — incompatible with whole-row LWW. V108 rebuilds it onto the natural key `(repo_id, tracker, project, item_kind, item_key)` (repo_id part of the primary key, as the transport requires), drops `id`, adds the `CHECK(x IN (0,1))` guards on the genuine boolean facets, and drops the record's Lens revision triggers (unconditionally, replay-safe). Children reference the thread by natural key, never `id`.

## Lane-aware Lens invalidation

Distilled records feed the papertrail Lens lane rather than the memories lane, so the apply-side lane bump is now lane-aware: a single `scope`→lane map advances the aggregate enrichment clock plus the scope's lane, at the ingest, refold, and distill write sites (extract and drain).

## Retention

`distill/1` is bounded like `overlay/1` (512 accepted entries per chain). The extraction model-input snapshots (`sources`, `units`, `fix_diffs`, `xrefs`) and operational tables (`queue`, `runs`) stay local.

## Tests

- reconcile preserves records for mirror-absent threads (no mass-delete), still deletes mirror-present-but-ineligible ones;
- V108 rebuilds to the natural key, drops `id`, drops triggers across a full ladder replay, and preserves existing rows;
- the registry spec exactly covers the rebuilt schema; the projector generation matches the live registry; every registered scope maps to a Lens lane;
- extract/drain advance the papertrail lane explicitly; loopback replication of a distilled record, cross-repo isolation, and regeneration-upsert.

Part of #892. Refs #1135.