### PR TITLE
feat(sync): replicate the distill edges and alternatives children

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 108, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 109, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6470,6 +6470,88 @@ mod syncable_overlay_migration_tests {
             "item_key"
         ]);
     }
+
+    /// V109 rebuilds the edges + alternatives children onto their natural keys, dropping `id`,
+    /// across a full ladder replay.
+    #[test]
+    fn v109_rebuilds_edges_and_alternatives_to_natural_keys_across_a_replay() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill_edges").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "src_item_kind",
+            "src_item_key",
+            "dst_item_kind",
+            "dst_item_key",
+            "edge_kind"
+        ]);
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill_alternatives").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "item_kind",
+            "item_key",
+            "ordinal"
+        ]);
+        for table in ["papertrail_distill_edges", "papertrail_distill_alternatives"] {
+            let has_id: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = 'id'"),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(has_id, 0, "{table} drops the AUTOINCREMENT id");
+        }
+    }
+
+    /// The rebuild copies every edge and alternative row, re-keyed by its natural key.
+    #[test]
+    fn v109_preserves_edge_and_alternative_rows_through_the_rebuild() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::apply_distill_record_store(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_edges
+                 (tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                  edge_kind, created_at_ms, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 'change_request', '8', 'coalesced', 5, 'r')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_alternatives
+                 (tracker, project, item_kind, item_key, ordinal, alternative, reason, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 0, 'do X', 'too slow', 'r')",
+            [],
+        )
+        .unwrap();
+        super::apply_syncable_distill_edges_and_alternatives(&conn).unwrap();
+        let created_at: i64 = conn
+            .query_row(
+                "SELECT created_at_ms FROM papertrail_distill_edges
+                 WHERE repo_id = 'r' AND edge_kind = 'coalesced'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(created_at, 5);
+        let (alternative, reason): (String, String) = conn
+            .query_row(
+                "SELECT alternative, reason FROM papertrail_distill_alternatives
+                 WHERE repo_id = 'r' AND item_key = '7' AND ordinal = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(alternative, "do X");
+        assert_eq!(
+            reason, "too slow",
+            "the nullable reason column is preserved through the rebuild"
+        );
+    }
 }
 
 /// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
@@ -7722,6 +7804,80 @@ pub fn apply_syncable_distill_records(conn: &Connection) -> rusqlite::Result<()>
          DROP TABLE papertrail_distill;
          ALTER TABLE papertrail_distill_v108 RENAME TO papertrail_distill;",
     )
+}
+
+/// V109 (#1137): make the distill `edges` and `alternatives` children syncable on `distill/1`.
+///
+/// Like the parent (V108), each keyed on a device-local AUTOINCREMENT `id` with its natural key
+/// only as a UNIQUE index. Rebuild each onto the natural key (repo_id first), dropping `id`;
+/// neither carries triggers, local columns, or FKs. Each block short-circuits once its table is
+/// already in the rebuilt shape, so a full-ladder replay is a no-op.
+pub fn apply_syncable_distill_edges_and_alternatives(conn: &Connection) -> rusqlite::Result<()> {
+    if !(table_is_strict(conn, "papertrail_distill_edges")?
+        && primary_key_columns(conn, "papertrail_distill_edges")?
+            == [
+                "repo_id",
+                "tracker",
+                "project",
+                "src_item_kind",
+                "src_item_key",
+                "dst_item_kind",
+                "dst_item_key",
+                "edge_kind",
+            ])
+    {
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS papertrail_distill_edges_v109;
+             CREATE TABLE papertrail_distill_edges_v109(
+                 tracker TEXT NOT NULL,
+                 project TEXT NOT NULL,
+                 src_item_kind TEXT NOT NULL,
+                 src_item_key TEXT NOT NULL,
+                 dst_item_kind TEXT NOT NULL,
+                 dst_item_key TEXT NOT NULL,
+                 edge_kind TEXT NOT NULL,
+                 created_at_ms INTEGER NOT NULL,
+                 repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+                 PRIMARY KEY(repo_id, tracker, project, src_item_kind, src_item_key,
+                             dst_item_kind, dst_item_key, edge_kind)
+             ) STRICT;
+             INSERT INTO papertrail_distill_edges_v109(
+                 tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                 edge_kind, created_at_ms, repo_id)
+             SELECT tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                 edge_kind, created_at_ms, repo_id
+             FROM papertrail_distill_edges;
+             DROP TABLE papertrail_distill_edges;
+             ALTER TABLE papertrail_distill_edges_v109 RENAME TO papertrail_distill_edges;",
+        )?;
+    }
+    if !(table_is_strict(conn, "papertrail_distill_alternatives")?
+        && primary_key_columns(conn, "papertrail_distill_alternatives")?
+            == ["repo_id", "tracker", "project", "item_kind", "item_key", "ordinal"])
+    {
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS papertrail_distill_alternatives_v109;
+             CREATE TABLE papertrail_distill_alternatives_v109(
+                 tracker TEXT NOT NULL,
+                 project TEXT NOT NULL,
+                 item_kind TEXT NOT NULL,
+                 item_key TEXT NOT NULL,
+                 ordinal INTEGER NOT NULL,
+                 alternative TEXT NOT NULL,
+                 reason TEXT,
+                 repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+                 PRIMARY KEY(repo_id, tracker, project, item_kind, item_key, ordinal)
+             ) STRICT;
+             INSERT INTO papertrail_distill_alternatives_v109(
+                 tracker, project, item_kind, item_key, ordinal, alternative, reason, repo_id)
+             SELECT tracker, project, item_kind, item_key, ordinal, alternative, reason, repo_id
+             FROM papertrail_distill_alternatives;
+             DROP TABLE papertrail_distill_alternatives;
+             ALTER TABLE papertrail_distill_alternatives_v109
+                 RENAME TO papertrail_distill_alternatives;",
+        )?;
+    }
+    Ok(())
 }
 
 fn primary_key_columns(conn: &Connection, table: &str) -> rusqlite::Result<Vec<String>> {

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 108;
+pub const LATEST_SCHEMA_VERSION: u32 = 109;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -812,6 +812,12 @@ const MIGRATION_108_DESCRIPTION: &str =
      device-local AUTOINCREMENT id, so the distill/1 table-sync scope can replicate distilled \
      records under whole-row LWW (#1135); also drops its Lens revision triggers (the sync apply \
      advances the papertrail lane explicitly)";
+const MIGRATION_109_ID: &str = "109_syncable_distill_edges_and_alternatives";
+const MIGRATION_109_CHECKSUM: &str = "sha256:rag-rat-syncable-distill-edges-and-alternatives-v109";
+const MIGRATION_109_DESCRIPTION: &str =
+    "Rebuild papertrail_distill_edges and papertrail_distill_alternatives onto their thread \
+     natural keys (repo_id first), dropping the device-local AUTOINCREMENT id, so these distill \
+     enrichment children replicate on the distill/1 table-sync scope under whole-row LWW (#1137)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1027,6 +1033,7 @@ const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[
     MIGRATION_103_ID,
     MIGRATION_106_ID,
     MIGRATION_108_ID,
+    MIGRATION_109_ID,
 ];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
@@ -1696,6 +1703,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_108_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_syncable_distill_records),
     },
+    Migration {
+        id: MIGRATION_109_ID,
+        checksum: MIGRATION_109_CHECKSUM,
+        description: MIGRATION_109_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_syncable_distill_edges_and_alternatives),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1924,6 +1937,7 @@ mod ledger_atomicity {
         MIGRATION_103_ID,
         MIGRATION_106_ID,
         MIGRATION_108_ID,
+        MIGRATION_109_ID,
     ];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -57,7 +57,7 @@ use crate::op::OpMeta;
 /// registering a table or widening a spec forces an append, and an append is the bump. A widening
 /// that is not a registry change (a new row-op kind) still has to append a generation by hand,
 /// repeating the previous snapshot.
-pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 4;
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 5;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -302,11 +302,69 @@ const DISTILL_RECORD: TableSpec = TableSpec {
     repo_column: Some("repo_id"),
 };
 
+// A distill-cluster edge (coalesced / supersedes / promoted), keyed by the full edge tuple — its
+// own natural key, distinct from the thread key its parent uses. `created_at_ms` is the only synced
+// non-key column.
+const DISTILL_EDGE_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("tracker", ValueType::Text),
+    ColumnSpec::required("project", ValueType::Text),
+    ColumnSpec::required("src_item_kind", ValueType::Text),
+    ColumnSpec::required("src_item_key", ValueType::Text),
+    ColumnSpec::required("dst_item_kind", ValueType::Text),
+    ColumnSpec::required("dst_item_key", ValueType::Text),
+    ColumnSpec::required("edge_kind", ValueType::Text),
+];
+
+const DISTILL_EDGE_COLUMNS: &[ColumnSpec] =
+    &[ColumnSpec::required("created_at_ms", ValueType::I64)];
+
+const DISTILL_EDGES: TableSpec = TableSpec {
+    name: "papertrail_distill_edges",
+    scope_id: "distill/1",
+    spec_version: 1,
+    pk: DISTILL_EDGE_PK,
+    columns: DISTILL_EDGE_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
+// A rejected alternative, an ordinal junction keyed by the thread + its stable ordinal.
+const DISTILL_ALTERNATIVE_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("tracker", ValueType::Text),
+    ColumnSpec::required("project", ValueType::Text),
+    ColumnSpec::required("item_kind", ValueType::Text),
+    ColumnSpec::required("item_key", ValueType::Text),
+    ColumnSpec::required("ordinal", ValueType::I64),
+];
+
+const DISTILL_ALTERNATIVE_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec::required("alternative", ValueType::Text),
+    ColumnSpec::required("reason", ValueType::Text),
+];
+
+const DISTILL_ALTERNATIVES: TableSpec = TableSpec {
+    name: "papertrail_distill_alternatives",
+    scope_id: "distill/1",
+    spec_version: 1,
+    pk: DISTILL_ALTERNATIVE_PK,
+    columns: DISTILL_ALTERNATIVE_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
 /// The production table registry. `anchors/1` retains durable memory-binding history in full;
 /// `overlay/1` carries regenerable dream output (verdicts, summaries) and `distill/1` the distilled
-/// papertrail records — both under a bounded retention budget.
-pub(crate) const SYNCABLE_TABLES: &[TableSpec] =
-    &[MEMORY_BINDINGS, MEMORY_REALITY, MEMORY_SUMMARIES, DISTILL_RECORD];
+/// papertrail record plus its enrichment children — both under a bounded retention budget.
+pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[
+    MEMORY_BINDINGS,
+    MEMORY_REALITY,
+    MEMORY_SUMMARIES,
+    DISTILL_RECORD,
+    DISTILL_EDGES,
+    DISTILL_ALTERNATIVES,
+];
 
 /// The per-repo Lens lane metas a scope's applied rows advance — the aggregate enrichment clock
 /// plus the scope's specific lane. Returned to the apply-side and refold bump sites, which cannot
@@ -568,6 +626,139 @@ pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
                 ("prompt_version", ValueType::I64, None),
                 ("model_input_hash", ValueType::Text, None),
             ],
+        },
+    ],
+    // v5: the distill edges + alternatives enrichment children join distill/1. Whole-registry
+    // snapshot: v4's four tables plus the two children, in `SYNCABLE_TABLES` order.
+    &[
+        TableGeneration {
+            table: "repo_memory_bindings",
+            scope_id: "anchors/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("binding_kind", ValueType::Text),
+                ("binding_id", ValueType::Text),
+            ],
+            columns: &[
+                ("path", ValueType::Text, None),
+                ("start_line", ValueType::I64, None),
+                ("end_line", ValueType::I64, None),
+                ("commit_hash", ValueType::Text, None),
+                ("tracker", ValueType::Text, None),
+                ("project", ValueType::Text, None),
+                ("item_key", ValueType::Text, None),
+                ("created_at_ms", ValueType::I64, None),
+                ("symbol_kind", ValueType::Text, None),
+                ("signature_hash", ValueType::Text, None),
+                ("moniker_tool", ValueType::Text, None),
+                ("moniker_tool_version", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_reality",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[("repo_id", ValueType::Text), ("memory_id", ValueType::Text)],
+            columns: &[
+                ("content_hash", ValueType::Text, None),
+                ("verdict", ValueType::Text, None),
+                ("direction", ValueType::Text, None),
+                ("checked_against_commit", ValueType::Text, None),
+                ("checked_inputs_hash", ValueType::Text, None),
+                ("evidence_json", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("checked_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_summaries",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("content_hash", ValueType::Text),
+            ],
+            columns: &[
+                ("summary", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+            ],
+            columns: &[
+                ("distill_input_hash", ValueType::Text, None),
+                ("pipeline_version", ValueType::I64, None),
+                ("root_issue", ValueType::Text, None),
+                ("root_cause", ValueType::Text, None),
+                ("root_cause_class", ValueType::Text, None),
+                ("decision_chosen", ValueType::Text, None),
+                ("outcome_summary", ValueType::Text, None),
+                ("outcome_status_model", ValueType::Text, None),
+                ("epistemic_status_decision", ValueType::Text, None),
+                ("epistemic_status_outcome", ValueType::Text, None),
+                ("fix_edge_source", ValueType::Text, None),
+                ("quotes_materialized", ValueType::I64, None),
+                ("anchors_qualified_count", ValueType::I64, None),
+                ("thread_shape", ValueType::Text, None),
+                ("outcome_claim_verified", ValueType::Bool, None),
+                ("decision_provenance_verified", ValueType::Bool, None),
+                ("revert_override", ValueType::Bool, None),
+                ("closing_keyword_floor", ValueType::Text, None),
+                ("distilled_at_ms", ValueType::I64, None),
+                ("prompt_version", ValueType::I64, None),
+                ("model_input_hash", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill_edges",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("src_item_kind", ValueType::Text),
+                ("src_item_key", ValueType::Text),
+                ("dst_item_kind", ValueType::Text),
+                ("dst_item_key", ValueType::Text),
+                ("edge_kind", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_alternatives",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("ordinal", ValueType::I64),
+            ],
+            columns: &[("alternative", ValueType::Text, None), ("reason", ValueType::Text, None)],
         },
     ],
 ];

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -1010,6 +1010,25 @@ async fn production_distill_records_replicate_and_regenerate() {
             .unwrap();
     };
     seed_record("7", "repo-a", "sha256:in-a", "the original cause");
+    // An enrichment edge and a rejected alternative on the same repo-a thread — the child tables.
+    owner
+        .execute(
+            "INSERT INTO papertrail_distill_edges
+                 (tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                  edge_kind, created_at_ms, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 'change_request', '8', 'coalesced', ?1,
+                     'repo-a')",
+            [NOW + 2],
+        )
+        .unwrap();
+    owner
+        .execute(
+            "INSERT INTO papertrail_distill_alternatives
+                 (tracker, project, item_kind, item_key, ordinal, alternative, reason, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 0, 'revert instead', 'loses the fix', 'repo-a')",
+            [],
+        )
+        .unwrap();
     owner
         .execute(
             "INSERT INTO repos(repo_id, display_name, registered_at_ms)
@@ -1058,6 +1077,25 @@ async fn production_distill_records_replicate_and_regenerate() {
         )
         .unwrap();
     assert_eq!(cause, "the original cause", "the distilled record replicates");
+    let edge_kind: String = joiner
+        .query_row(
+            "SELECT edge_kind FROM papertrail_distill_edges
+             WHERE repo_id = 'repo-a' AND src_item_key = '7' AND dst_item_key = '8'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(edge_kind, "coalesced", "the distill edge child replicates");
+    let (alternative, reason): (String, String) = joiner
+        .query_row(
+            "SELECT alternative, reason FROM papertrail_distill_alternatives
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND ordinal = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(alternative, "revert instead", "the distill alternative child replicates");
+    assert_eq!(reason, "loses the fix", "the alternative's nullable reason column replicates too");
     // repo-a advertises no route for repo-b's incarnation, so repo-b's record never lands.
     let sibling: bool = joiner
         .query_row(


### PR DESCRIPTION
Extends the `distill/1` table-sync scope (parent `papertrail_distill` shipped previously) with its two simplest enrichment children:

- **`papertrail_distill_edges`** — coalesced / supersedes / promoted thread edges. Replicating these lets a peer collapse a coalesced issue↔PR into one hit instead of showing two un-merged results.
- **`papertrail_distill_alternatives`** — the rejected-alternatives junction.

## Rebuild (migration V109)

Each child keyed on a device-local AUTOINCREMENT `id` with its natural key only as a UNIQUE index — incompatible with whole-row LWW. V109 rebuilds each onto its natural key (repo_id first), dropping `id`. Neither table carries triggers, local columns, or FKs, so the rebuild is a straight re-key + copy; children reference the thread by natural key, never `id`.

- `papertrail_distill_edges`: PK `(repo_id, tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key, edge_kind)`; synced `created_at_ms`.
- `papertrail_distill_alternatives`: PK `(repo_id, tracker, project, item_kind, item_key, ordinal)`; synced `alternative, reason`.

Both register on `distill/1` with a bumped projector generation. The scope's Lens-lane bump and 512-entry retention already cover them.

## Tests

- V109 rebuilds both to their natural keys and drops `id` across a full ladder replay, and preserves existing rows (including the nullable `reason`);
- the registry spec exactly covers each rebuilt table; the projector generation matches the live registry;
- loopback replication now also asserts a distill edge and an alternative reach the peer, alongside the existing parent-record transfer, cross-repo isolation, and regeneration checks.

Follow-ups (the remaining distill children): `papertrail_distill_evidence` (needs a stable ordinal), `papertrail_distill_record_commits` (key-only — needs a non-pk column), and `papertrail_distill_anchors` (checkout-local columns, its own trigger, and a local anchor re-resolution path).

Part of #892. Refs #1137.