### PR TITLE
feat(sync): replicate the distill record_commits child

### DIFF
--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -646,7 +646,7 @@ fn write_record(
         let fix_diffs = fix_diff_snapshots(repo, &plan.fix_shas, &anchors);
         replace_fix_diffs(conn, repo_id, plan, &fix_diffs)?;
     }
-    write_commits(conn, repo_id, plan, &plan.fix_shas)?;
+    write_commits(conn, repo_id, now, plan, &plan.fix_shas)?;
     write_coalesced_edges(conn, repo_id, now, plan)?;
     if rebuild_anchor_candidates {
         write_anchors(conn, repo_id, plan, &anchors)?;
@@ -1870,15 +1870,16 @@ fn replace_xrefs(
 fn write_commits(
     conn: &Connection,
     repo_id: &str,
+    now: i64,
     plan: &RecordPlan,
     shas: &[String],
 ) -> anyhow::Result<()> {
     for sha in shas {
         conn.execute(
             "INSERT OR IGNORE INTO papertrail_distill_record_commits
-                 (tracker, project, item_kind, item_key, commit_sha, repo_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![plan.tracker, plan.project, plan.kind.as_db_str(), plan.key, sha, repo_id],
+                 (tracker, project, item_kind, item_key, commit_sha, created_at_ms, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![plan.tracker, plan.project, plan.kind.as_db_str(), plan.key, sha, now, repo_id],
         )?;
     }
     Ok(())

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 109, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 110, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6552,6 +6552,66 @@ mod syncable_overlay_migration_tests {
             "the nullable reason column is preserved through the rebuild"
         );
     }
+
+    /// V110 rebuilds record_commits onto its natural key, drops `id`, and adds `created_at_ms`,
+    /// across a full ladder replay.
+    #[test]
+    fn v110_rebuilds_record_commits_to_the_natural_key_across_a_replay() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill_record_commits").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "item_kind",
+            "item_key",
+            "commit_sha"
+        ]);
+        let has_id: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('papertrail_distill_record_commits')
+                 WHERE name = 'id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_id, 0, "the AUTOINCREMENT id is dropped");
+        let has_created: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('papertrail_distill_record_commits')
+                 WHERE name = 'created_at_ms'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_created, 1, "the created_at_ms non-key column is added");
+    }
+
+    /// The rebuild copies every commit link (legacy rows get created_at_ms = 0).
+    #[test]
+    fn v110_preserves_record_commit_rows_through_the_rebuild() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::apply_distill_record_store(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_record_commits
+                 (tracker, project, item_kind, item_key, commit_sha, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 'abc123', 'r')",
+            [],
+        )
+        .unwrap();
+        super::apply_syncable_distill_record_commits(&conn).unwrap();
+        let (sha, created): (String, i64) = conn
+            .query_row(
+                "SELECT commit_sha, created_at_ms FROM papertrail_distill_record_commits
+                 WHERE repo_id = 'r' AND item_key = '7'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(sha, "abc123");
+        assert_eq!(created, 0, "a legacy row gets created_at_ms = 0 until it is re-mined");
+    }
 }
 
 /// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
@@ -7878,6 +7938,45 @@ pub fn apply_syncable_distill_edges_and_alternatives(conn: &Connection) -> rusql
         )?;
     }
     Ok(())
+}
+
+/// V110 (#1139): make the distill `record_commits` child syncable on `distill/1`.
+///
+/// The table was key-only (its only columns were the natural key + `commit_sha`), which the
+/// whole-row apply path rejects — a syncable table needs at least one non-key synced column. The
+/// rebuild keys on `(repo_id, tracker, project, item_kind, item_key, commit_sha)` (its former
+/// UNIQUE index), drops the device-local AUTOINCREMENT `id`, and adds `created_at_ms` (when the
+/// fixing-commit link was recorded) as that non-key column. Legacy rows get `0`; a record
+/// regeneration rewrites them with the real timestamp (the mechanical junctions are cleared and
+/// re-mined). No triggers, local columns, or FKs. Short-circuits once the table is already in the
+/// rebuilt shape.
+pub fn apply_syncable_distill_record_commits(conn: &Connection) -> rusqlite::Result<()> {
+    if table_is_strict(conn, "papertrail_distill_record_commits")?
+        && primary_key_columns(conn, "papertrail_distill_record_commits")?
+            == ["repo_id", "tracker", "project", "item_kind", "item_key", "commit_sha"]
+    {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS papertrail_distill_record_commits_v110;
+         CREATE TABLE papertrail_distill_record_commits_v110(
+             tracker TEXT NOT NULL,
+             project TEXT NOT NULL,
+             item_kind TEXT NOT NULL,
+             item_key TEXT NOT NULL,
+             commit_sha TEXT NOT NULL,
+             created_at_ms INTEGER NOT NULL DEFAULT 0,
+             repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+             PRIMARY KEY(repo_id, tracker, project, item_kind, item_key, commit_sha)
+         ) STRICT;
+         INSERT INTO papertrail_distill_record_commits_v110(
+             tracker, project, item_kind, item_key, commit_sha, created_at_ms, repo_id)
+         SELECT tracker, project, item_kind, item_key, commit_sha, 0, repo_id
+         FROM papertrail_distill_record_commits;
+         DROP TABLE papertrail_distill_record_commits;
+         ALTER TABLE papertrail_distill_record_commits_v110
+             RENAME TO papertrail_distill_record_commits;",
+    )
 }
 
 fn primary_key_columns(conn: &Connection, table: &str) -> rusqlite::Result<Vec<String>> {

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 109;
+pub const LATEST_SCHEMA_VERSION: u32 = 110;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -818,6 +818,12 @@ const MIGRATION_109_DESCRIPTION: &str =
     "Rebuild papertrail_distill_edges and papertrail_distill_alternatives onto their thread \
      natural keys (repo_id first), dropping the device-local AUTOINCREMENT id, so these distill \
      enrichment children replicate on the distill/1 table-sync scope under whole-row LWW (#1137)";
+const MIGRATION_110_ID: &str = "110_syncable_distill_record_commits";
+const MIGRATION_110_CHECKSUM: &str = "sha256:rag-rat-syncable-distill-record-commits-v110";
+const MIGRATION_110_DESCRIPTION: &str =
+    "Rebuild papertrail_distill_record_commits onto its natural key (repo_id first), dropping the \
+     device-local AUTOINCREMENT id and adding a created_at_ms non-key column so the key-only \
+     table can replicate on the distill/1 table-sync scope under whole-row LWW (#1139)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1034,6 +1040,7 @@ const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[
     MIGRATION_106_ID,
     MIGRATION_108_ID,
     MIGRATION_109_ID,
+    MIGRATION_110_ID,
 ];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
@@ -1709,6 +1716,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_109_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_syncable_distill_edges_and_alternatives),
     },
+    Migration {
+        id: MIGRATION_110_ID,
+        checksum: MIGRATION_110_CHECKSUM,
+        description: MIGRATION_110_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_syncable_distill_record_commits),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1938,6 +1951,7 @@ mod ledger_atomicity {
         MIGRATION_106_ID,
         MIGRATION_108_ID,
         MIGRATION_109_ID,
+        MIGRATION_110_ID,
     ];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -57,7 +57,7 @@ use crate::op::OpMeta;
 /// registering a table or widening a spec forces an append, and an append is the bump. A widening
 /// that is not a registry change (a new row-op kind) still has to append a generation by hand,
 /// repeating the previous snapshot.
-pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 5;
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 6;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -354,6 +354,31 @@ const DISTILL_ALTERNATIVES: TableSpec = TableSpec {
     repo_column: Some("repo_id"),
 };
 
+// A mechanical fixing-commit link, keyed by the thread + commit SHA. `created_at_ms` (when the link
+// was recorded) is the sole synced non-key column — it exists so the otherwise key-only table has a
+// value for the whole-row apply path to carry.
+const DISTILL_RECORD_COMMIT_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("tracker", ValueType::Text),
+    ColumnSpec::required("project", ValueType::Text),
+    ColumnSpec::required("item_kind", ValueType::Text),
+    ColumnSpec::required("item_key", ValueType::Text),
+    ColumnSpec::required("commit_sha", ValueType::Text),
+];
+
+const DISTILL_RECORD_COMMIT_COLUMNS: &[ColumnSpec] =
+    &[ColumnSpec::required("created_at_ms", ValueType::I64)];
+
+const DISTILL_RECORD_COMMITS: TableSpec = TableSpec {
+    name: "papertrail_distill_record_commits",
+    scope_id: "distill/1",
+    spec_version: 1,
+    pk: DISTILL_RECORD_COMMIT_PK,
+    columns: DISTILL_RECORD_COMMIT_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
 /// The production table registry. `anchors/1` retains durable memory-binding history in full;
 /// `overlay/1` carries regenerable dream output (verdicts, summaries) and `distill/1` the distilled
 /// papertrail record plus its enrichment children — both under a bounded retention budget.
@@ -364,6 +389,7 @@ pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[
     DISTILL_RECORD,
     DISTILL_EDGES,
     DISTILL_ALTERNATIVES,
+    DISTILL_RECORD_COMMITS,
 ];
 
 /// The per-repo Lens lane metas a scope's applied rows advance — the aggregate enrichment clock
@@ -759,6 +785,154 @@ pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
                 ("ordinal", ValueType::I64),
             ],
             columns: &[("alternative", ValueType::Text, None), ("reason", ValueType::Text, None)],
+        },
+    ],
+    // v6: the distill record_commits child joins distill/1. Whole-registry snapshot: v5's six
+    // tables plus record_commits, in `SYNCABLE_TABLES` order.
+    &[
+        TableGeneration {
+            table: "repo_memory_bindings",
+            scope_id: "anchors/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("binding_kind", ValueType::Text),
+                ("binding_id", ValueType::Text),
+            ],
+            columns: &[
+                ("path", ValueType::Text, None),
+                ("start_line", ValueType::I64, None),
+                ("end_line", ValueType::I64, None),
+                ("commit_hash", ValueType::Text, None),
+                ("tracker", ValueType::Text, None),
+                ("project", ValueType::Text, None),
+                ("item_key", ValueType::Text, None),
+                ("created_at_ms", ValueType::I64, None),
+                ("symbol_kind", ValueType::Text, None),
+                ("signature_hash", ValueType::Text, None),
+                ("moniker_tool", ValueType::Text, None),
+                ("moniker_tool_version", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_reality",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[("repo_id", ValueType::Text), ("memory_id", ValueType::Text)],
+            columns: &[
+                ("content_hash", ValueType::Text, None),
+                ("verdict", ValueType::Text, None),
+                ("direction", ValueType::Text, None),
+                ("checked_against_commit", ValueType::Text, None),
+                ("checked_inputs_hash", ValueType::Text, None),
+                ("evidence_json", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("checked_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_summaries",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("content_hash", ValueType::Text),
+            ],
+            columns: &[
+                ("summary", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+            ],
+            columns: &[
+                ("distill_input_hash", ValueType::Text, None),
+                ("pipeline_version", ValueType::I64, None),
+                ("root_issue", ValueType::Text, None),
+                ("root_cause", ValueType::Text, None),
+                ("root_cause_class", ValueType::Text, None),
+                ("decision_chosen", ValueType::Text, None),
+                ("outcome_summary", ValueType::Text, None),
+                ("outcome_status_model", ValueType::Text, None),
+                ("epistemic_status_decision", ValueType::Text, None),
+                ("epistemic_status_outcome", ValueType::Text, None),
+                ("fix_edge_source", ValueType::Text, None),
+                ("quotes_materialized", ValueType::I64, None),
+                ("anchors_qualified_count", ValueType::I64, None),
+                ("thread_shape", ValueType::Text, None),
+                ("outcome_claim_verified", ValueType::Bool, None),
+                ("decision_provenance_verified", ValueType::Bool, None),
+                ("revert_override", ValueType::Bool, None),
+                ("closing_keyword_floor", ValueType::Text, None),
+                ("distilled_at_ms", ValueType::I64, None),
+                ("prompt_version", ValueType::I64, None),
+                ("model_input_hash", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill_edges",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("src_item_kind", ValueType::Text),
+                ("src_item_key", ValueType::Text),
+                ("dst_item_kind", ValueType::Text),
+                ("dst_item_key", ValueType::Text),
+                ("edge_kind", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_alternatives",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("ordinal", ValueType::I64),
+            ],
+            columns: &[("alternative", ValueType::Text, None), ("reason", ValueType::Text, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_record_commits",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("commit_sha", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
         },
     ],
 ];

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -1031,6 +1031,14 @@ async fn production_distill_records_replicate_and_regenerate() {
         .unwrap();
     owner
         .execute(
+            "INSERT INTO papertrail_distill_record_commits
+                 (tracker, project, item_kind, item_key, commit_sha, created_at_ms, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 'fixsha1', ?1, 'repo-a')",
+            [NOW + 2],
+        )
+        .unwrap();
+    owner
+        .execute(
             "INSERT INTO repos(repo_id, display_name, registered_at_ms)
              VALUES ('repo-b', 'repo-b', 0)",
             [],
@@ -1096,6 +1104,15 @@ async fn production_distill_records_replicate_and_regenerate() {
         .unwrap();
     assert_eq!(alternative, "revert instead", "the distill alternative child replicates");
     assert_eq!(reason, "loses the fix", "the alternative's nullable reason column replicates too");
+    let commit_sha: String = joiner
+        .query_row(
+            "SELECT commit_sha FROM papertrail_distill_record_commits
+             WHERE repo_id = 'repo-a' AND item_key = '7'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(commit_sha, "fixsha1", "the distill record_commits child replicates");
     // repo-a advertises no route for repo-b's incarnation, so repo-b's record never lands.
     let sibling: bool = joiner
         .query_row(


### PR DESCRIPTION
Extends the `distill/1` table-sync scope with `papertrail_distill_record_commits` (the mechanical fixing-commit links), so a peer receives a distilled record's fixing commits alongside it.

## Rebuild (migration V110)

The table was key-only — its only columns were the thread natural key plus `commit_sha` — which the whole-row apply path rejects (a syncable table needs at least one non-key synced column). V110 rebuilds it onto `(repo_id, tracker, project, item_kind, item_key, commit_sha)` (its former UNIQUE index), drops the device-local AUTOINCREMENT `id`, and adds a `created_at_ms` non-key column (when the fixing-commit link was recorded). The extract write path now stamps it; legacy rows get `created_at_ms = 0` and are rewritten with the real timestamp when the record next regenerates (the mechanical junctions are cleared and re-mined).

Registered on `distill/1` with a bumped projector generation. The scope's Lens-lane bump and retention already cover it.

## Tests

- V110 rebuilds to the natural key, drops `id`, adds `created_at_ms` across a full ladder replay, and preserves existing rows;
- the registry spec exactly covers the rebuilt table; the projector generation matches the live registry;
- the loopback test now also asserts a record_commit reaches the peer, alongside the existing edge/alternative/parent transfer, cross-repo isolation, and regeneration checks.

The last remaining distill child is `papertrail_distill_anchors` (checkout-local resolution columns, its own trigger, and a local anchor re-resolution path before synced anchors surface as drive-by).

Part of #892. Refs #1139.