### PR TITLE
feat(sync): replicate the distill evidence child

### DIFF
--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -791,8 +791,11 @@ fn persist_success(
         return Ok(false);
     }
     clear_model_junctions(conn, repo_id, &job.key)?;
-    for evidence in evidence {
-        insert_evidence(conn, repo_id, &job.key, &evidence)?;
+    // The per-thread `ordinal` is the whole-row-LWW key discriminator (evidence has no natural
+    // unique key); assign it in citation order — the order `collect_evidence` produced these
+    // rows.
+    for (ordinal, evidence) in evidence.iter().enumerate() {
+        insert_evidence(conn, repo_id, ordinal, &job.key, evidence)?;
     }
     for (ordinal, rejected) in output.decision.rejected.iter().enumerate() {
         conn.execute(
@@ -898,21 +901,23 @@ fn collect_evidence<'a>(
 fn insert_evidence(
     conn: &Connection,
     repo_id: &str,
+    ordinal: usize,
     key: &ThreadKey,
     evidence: &EvidenceRow<'_>,
 ) -> anyhow::Result<()> {
     let quote = &evidence.source.exact_text[evidence.unit.byte_start..evidence.unit.byte_end];
     conn.execute(
         "INSERT INTO papertrail_distill_evidence
-             (tracker, project, item_kind, item_key, field, source_kind, source_part, source_id,
-              byte_start, byte_end, quote, author, author_kind, author_association,
+             (tracker, project, item_kind, item_key, ordinal, field, source_kind, source_part,
+              source_id, byte_start, byte_end, quote, author, author_kind, author_association,
               unit_created_at_ms, repo_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         params![
             key.tracker,
             key.project,
             key.item_kind,
             key.item_key,
+            i64::try_from(ordinal)?,
             evidence.field,
             evidence.source.source_kind,
             // source_part (#801) distinguishes a title citation from a body citation on the same
@@ -1037,6 +1042,9 @@ mod tests {
         migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
         migrations::apply_distill_enriched_context(&conn).unwrap();
         migrations::apply_distill_evidence_source_part(&conn).unwrap();
+        // The evidence insert now writes the per-thread ordinal (V111), so the evidence table must
+        // be in its rebuilt shape in these partial-schema fixtures.
+        migrations::apply_syncable_distill_evidence(&conn).unwrap();
         // `persist_success` advances the papertrail Lens lane, which needs a registered repo and
         // the `repo_meta` sink (V108 dropped the row triggers). This partial fixture
         // predates the full schema, so create both and register the repo the seeds use.
@@ -1346,6 +1354,9 @@ mod tests {
         migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
         migrations::apply_distill_enriched_context(&conn).unwrap();
         migrations::apply_distill_evidence_source_part(&conn).unwrap();
+        // The evidence insert now writes the per-thread ordinal (V111), so the evidence table must
+        // be in its rebuilt shape in these partial-schema fixtures.
+        migrations::apply_syncable_distill_evidence(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1535,6 +1546,9 @@ mod tests {
         migrations::apply_distill_safe_input_snapshot(&conn).unwrap();
         migrations::apply_distill_enriched_context(&conn).unwrap();
         migrations::apply_distill_evidence_source_part(&conn).unwrap();
+        // The evidence insert now writes the per-thread ordinal (V111), so the evidence table must
+        // be in its rebuilt shape in these partial-schema fixtures.
+        migrations::apply_syncable_distill_evidence(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -3812,9 +3812,10 @@ mod tests {
         .unwrap();
         conn.execute(
             "INSERT INTO papertrail_distill_evidence
-                 (tracker, project, item_kind, item_key, field, source_kind, source_id,
+                 (tracker, project, item_kind, item_key, ordinal, field, source_kind, source_id,
                   byte_start, byte_end, quote, repo_id)
-             VALUES ('github','o/r','change_request','9','root_cause','item','9',0,3,'the','repoA')",
+             VALUES \
+             ('github','o/r','change_request','9',0,'root_cause','item','9',0,3,'the','repoA')",
             [],
         )
         .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 110, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 111, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6612,6 +6612,63 @@ mod syncable_overlay_migration_tests {
         assert_eq!(sha, "abc123");
         assert_eq!(created, 0, "a legacy row gets created_at_ms = 0 until it is re-mined");
     }
+
+    /// V111 rebuilds evidence onto its natural key with a per-thread ordinal, drops `id`, across a
+    /// full ladder replay.
+    #[test]
+    fn v111_rebuilds_evidence_to_the_natural_key_with_an_ordinal_across_a_replay() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill_evidence").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "item_kind",
+            "item_key",
+            "ordinal"
+        ]);
+        let has_id: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('papertrail_distill_evidence')
+                 WHERE name = 'id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_id, 0, "the AUTOINCREMENT id is dropped");
+    }
+
+    /// The rebuild copies every evidence row and assigns per-thread ordinals in id order.
+    #[test]
+    fn v111_backfills_per_thread_evidence_ordinals_in_id_order() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::apply_distill_record_store(&conn).unwrap();
+        super::apply_distill_evidence_source_part(&conn).unwrap();
+        // Two evidence rows on one thread, inserted in order → ordinals 0, 1.
+        for quote in ["first", "second"] {
+            conn.execute(
+                "INSERT INTO papertrail_distill_evidence
+                     (tracker, project, item_kind, item_key, field, source_kind, source_id,
+                      byte_start, byte_end, quote, repo_id)
+                 VALUES ('github', 'o/r', 'issue', '7', 'root_cause', 'item', '7', 0, 5, ?1, 'r')",
+                [quote],
+            )
+            .unwrap();
+        }
+        super::apply_syncable_distill_evidence(&conn).unwrap();
+        let rows: Vec<(i64, String)> = conn
+            .prepare(
+                "SELECT ordinal, quote FROM papertrail_distill_evidence
+                 WHERE repo_id = 'r' AND item_key = '7' ORDER BY ordinal",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(rows, vec![(0, "first".to_string()), (1, "second".to_string())]);
+    }
 }
 
 /// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
@@ -7976,6 +8033,63 @@ pub fn apply_syncable_distill_record_commits(conn: &Connection) -> rusqlite::Res
          DROP TABLE papertrail_distill_record_commits;
          ALTER TABLE papertrail_distill_record_commits_v110
              RENAME TO papertrail_distill_record_commits;",
+    )
+}
+
+/// V111 (#1139): make the distill `evidence` child syncable on `distill/1`.
+///
+/// The table had no natural unique key — a model can cite the same unit twice for one field, and
+/// title/body citations share `source_id` — so a composite discriminator is duplicate-unsafe. The
+/// rebuild adds a stable per-thread `ordinal` (assigned at insert in citation order by the drain,
+/// backfilled here by `id` order within each thread so existing rows get a deterministic sequence),
+/// keys on `(repo_id, tracker, project, item_kind, item_key, ordinal)`, and drops the device-local
+/// AUTOINCREMENT `id`. No triggers, local columns, or FKs; `source_part` keeps its CHECK.
+/// Short-circuits once the table is already in the rebuilt shape.
+pub fn apply_syncable_distill_evidence(conn: &Connection) -> rusqlite::Result<()> {
+    if table_is_strict(conn, "papertrail_distill_evidence")?
+        && primary_key_columns(conn, "papertrail_distill_evidence")?
+            == ["repo_id", "tracker", "project", "item_kind", "item_key", "ordinal"]
+    {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS papertrail_distill_evidence_v111;
+         CREATE TABLE papertrail_distill_evidence_v111(
+             tracker TEXT NOT NULL,
+             project TEXT NOT NULL,
+             item_kind TEXT NOT NULL,
+             item_key TEXT NOT NULL,
+             ordinal INTEGER NOT NULL,
+             field TEXT NOT NULL,
+             source_kind TEXT NOT NULL,
+             source_part TEXT CHECK(source_part IN ('title', 'body', 'comment')),
+             source_id TEXT NOT NULL,
+             byte_start INTEGER NOT NULL,
+             byte_end INTEGER NOT NULL,
+             quote TEXT NOT NULL,
+             author TEXT,
+             author_kind TEXT,
+             author_association TEXT,
+             unit_created_at_ms INTEGER,
+             repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+             PRIMARY KEY(repo_id, tracker, project, item_kind, item_key, ordinal)
+         ) STRICT;
+         INSERT INTO papertrail_distill_evidence_v111(
+             tracker, project, item_kind, item_key, ordinal, field, source_kind, source_part,
+             source_id, byte_start, byte_end, quote, author, author_kind, author_association,
+             unit_created_at_ms, repo_id)
+         SELECT
+             e.tracker, e.project, e.item_kind, e.item_key,
+             (SELECT COUNT(*) FROM papertrail_distill_evidence AS earlier
+              WHERE earlier.repo_id = e.repo_id AND earlier.tracker = e.tracker
+                AND earlier.project = e.project AND earlier.item_kind = e.item_kind
+                AND earlier.item_key = e.item_key AND earlier.id < e.id),
+             e.field, e.source_kind, e.source_part, e.source_id, e.byte_start, e.byte_end,
+             e.quote, e.author, e.author_kind, e.author_association, e.unit_created_at_ms, \
+         e.repo_id
+         FROM papertrail_distill_evidence AS e;
+         DROP TABLE papertrail_distill_evidence;
+         ALTER TABLE papertrail_distill_evidence_v111 RENAME TO papertrail_distill_evidence;",
     )
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 110;
+pub const LATEST_SCHEMA_VERSION: u32 = 111;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -824,6 +824,12 @@ const MIGRATION_110_DESCRIPTION: &str =
     "Rebuild papertrail_distill_record_commits onto its natural key (repo_id first), dropping the \
      device-local AUTOINCREMENT id and adding a created_at_ms non-key column so the key-only \
      table can replicate on the distill/1 table-sync scope under whole-row LWW (#1139)";
+const MIGRATION_111_ID: &str = "111_syncable_distill_evidence";
+const MIGRATION_111_CHECKSUM: &str = "sha256:rag-rat-syncable-distill-evidence-v111";
+const MIGRATION_111_DESCRIPTION: &str =
+    "Rebuild papertrail_distill_evidence onto its natural key (repo_id first) with a per-thread \
+     ordinal, dropping the device-local AUTOINCREMENT id, so the distill evidence child \
+     replicates on the distill/1 table-sync scope under whole-row LWW (#1139)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1041,6 +1047,7 @@ const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[
     MIGRATION_108_ID,
     MIGRATION_109_ID,
     MIGRATION_110_ID,
+    MIGRATION_111_ID,
 ];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
@@ -1722,6 +1729,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_110_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_syncable_distill_record_commits),
     },
+    Migration {
+        id: MIGRATION_111_ID,
+        checksum: MIGRATION_111_CHECKSUM,
+        description: MIGRATION_111_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_syncable_distill_evidence),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1952,6 +1965,7 @@ mod ledger_atomicity {
         MIGRATION_108_ID,
         MIGRATION_109_ID,
         MIGRATION_110_ID,
+        MIGRATION_111_ID,
     ];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -57,7 +57,7 @@ use crate::op::OpMeta;
 /// registering a table or widening a spec forces an append, and an append is the bump. A widening
 /// that is not a registry change (a new row-op kind) still has to append a generation by hand,
 /// repeating the previous snapshot.
-pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 6;
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 7;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -379,6 +379,43 @@ const DISTILL_RECORD_COMMITS: TableSpec = TableSpec {
     repo_column: Some("repo_id"),
 };
 
+// An evidence unit: a byte-span citation with a materialized quote. No natural unique key
+// (duplicate citations are possible), so the row is keyed by a per-thread `ordinal` the drain
+// assigns in citation order. Every non-pk column is portable evidence/provenance; nothing is
+// checkout-local.
+const DISTILL_EVIDENCE_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("tracker", ValueType::Text),
+    ColumnSpec::required("project", ValueType::Text),
+    ColumnSpec::required("item_kind", ValueType::Text),
+    ColumnSpec::required("item_key", ValueType::Text),
+    ColumnSpec::required("ordinal", ValueType::I64),
+];
+
+const DISTILL_EVIDENCE_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec::required("field", ValueType::Text),
+    ColumnSpec::required("source_kind", ValueType::Text),
+    ColumnSpec::required("source_part", ValueType::Text),
+    ColumnSpec::required("source_id", ValueType::Text),
+    ColumnSpec::required("byte_start", ValueType::I64),
+    ColumnSpec::required("byte_end", ValueType::I64),
+    ColumnSpec::required("quote", ValueType::Text),
+    ColumnSpec::required("author", ValueType::Text),
+    ColumnSpec::required("author_kind", ValueType::Text),
+    ColumnSpec::required("author_association", ValueType::Text),
+    ColumnSpec::required("unit_created_at_ms", ValueType::I64),
+];
+
+const DISTILL_EVIDENCE: TableSpec = TableSpec {
+    name: "papertrail_distill_evidence",
+    scope_id: "distill/1",
+    spec_version: 1,
+    pk: DISTILL_EVIDENCE_PK,
+    columns: DISTILL_EVIDENCE_COLUMNS,
+    local_columns: &[],
+    repo_column: Some("repo_id"),
+};
+
 /// The production table registry. `anchors/1` retains durable memory-binding history in full;
 /// `overlay/1` carries regenerable dream output (verdicts, summaries) and `distill/1` the distilled
 /// papertrail record plus its enrichment children — both under a bounded retention budget.
@@ -390,6 +427,7 @@ pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[
     DISTILL_EDGES,
     DISTILL_ALTERNATIVES,
     DISTILL_RECORD_COMMITS,
+    DISTILL_EVIDENCE,
 ];
 
 /// The per-repo Lens lane metas a scope's applied rows advance — the aggregate enrichment clock
@@ -933,6 +971,181 @@ pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
                 ("commit_sha", ValueType::Text),
             ],
             columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+    ],
+    // v7: the distill evidence child joins distill/1. Whole-registry snapshot: v6's seven tables
+    // plus evidence, in `SYNCABLE_TABLES` order.
+    &[
+        TableGeneration {
+            table: "repo_memory_bindings",
+            scope_id: "anchors/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("binding_kind", ValueType::Text),
+                ("binding_id", ValueType::Text),
+            ],
+            columns: &[
+                ("path", ValueType::Text, None),
+                ("start_line", ValueType::I64, None),
+                ("end_line", ValueType::I64, None),
+                ("commit_hash", ValueType::Text, None),
+                ("tracker", ValueType::Text, None),
+                ("project", ValueType::Text, None),
+                ("item_key", ValueType::Text, None),
+                ("created_at_ms", ValueType::I64, None),
+                ("symbol_kind", ValueType::Text, None),
+                ("signature_hash", ValueType::Text, None),
+                ("moniker_tool", ValueType::Text, None),
+                ("moniker_tool_version", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_reality",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[("repo_id", ValueType::Text), ("memory_id", ValueType::Text)],
+            columns: &[
+                ("content_hash", ValueType::Text, None),
+                ("verdict", ValueType::Text, None),
+                ("direction", ValueType::Text, None),
+                ("checked_against_commit", ValueType::Text, None),
+                ("checked_inputs_hash", ValueType::Text, None),
+                ("evidence_json", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("checked_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_summaries",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("content_hash", ValueType::Text),
+            ],
+            columns: &[
+                ("summary", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+            ],
+            columns: &[
+                ("distill_input_hash", ValueType::Text, None),
+                ("pipeline_version", ValueType::I64, None),
+                ("root_issue", ValueType::Text, None),
+                ("root_cause", ValueType::Text, None),
+                ("root_cause_class", ValueType::Text, None),
+                ("decision_chosen", ValueType::Text, None),
+                ("outcome_summary", ValueType::Text, None),
+                ("outcome_status_model", ValueType::Text, None),
+                ("epistemic_status_decision", ValueType::Text, None),
+                ("epistemic_status_outcome", ValueType::Text, None),
+                ("fix_edge_source", ValueType::Text, None),
+                ("quotes_materialized", ValueType::I64, None),
+                ("anchors_qualified_count", ValueType::I64, None),
+                ("thread_shape", ValueType::Text, None),
+                ("outcome_claim_verified", ValueType::Bool, None),
+                ("decision_provenance_verified", ValueType::Bool, None),
+                ("revert_override", ValueType::Bool, None),
+                ("closing_keyword_floor", ValueType::Text, None),
+                ("distilled_at_ms", ValueType::I64, None),
+                ("prompt_version", ValueType::I64, None),
+                ("model_input_hash", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill_edges",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("src_item_kind", ValueType::Text),
+                ("src_item_key", ValueType::Text),
+                ("dst_item_kind", ValueType::Text),
+                ("dst_item_key", ValueType::Text),
+                ("edge_kind", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_alternatives",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("ordinal", ValueType::I64),
+            ],
+            columns: &[("alternative", ValueType::Text, None), ("reason", ValueType::Text, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_record_commits",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("commit_sha", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_evidence",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("ordinal", ValueType::I64),
+            ],
+            columns: &[
+                ("field", ValueType::Text, None),
+                ("source_kind", ValueType::Text, None),
+                ("source_part", ValueType::Text, None),
+                ("source_id", ValueType::Text, None),
+                ("byte_start", ValueType::I64, None),
+                ("byte_end", ValueType::I64, None),
+                ("quote", ValueType::Text, None),
+                ("author", ValueType::Text, None),
+                ("author_kind", ValueType::Text, None),
+                ("author_association", ValueType::Text, None),
+                ("unit_created_at_ms", ValueType::I64, None),
+            ],
         },
     ],
 ];

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -1039,6 +1039,16 @@ async fn production_distill_records_replicate_and_regenerate() {
         .unwrap();
     owner
         .execute(
+            "INSERT INTO papertrail_distill_evidence
+                 (tracker, project, item_kind, item_key, ordinal, field, source_kind, source_id,
+                  byte_start, byte_end, quote, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 0, 'root_cause', 'item', '7', 0, 5,
+                     'the exact cause quote', 'repo-a')",
+            [],
+        )
+        .unwrap();
+    owner
+        .execute(
             "INSERT INTO repos(repo_id, display_name, registered_at_ms)
              VALUES ('repo-b', 'repo-b', 0)",
             [],
@@ -1113,6 +1123,15 @@ async fn production_distill_records_replicate_and_regenerate() {
         )
         .unwrap();
     assert_eq!(commit_sha, "fixsha1", "the distill record_commits child replicates");
+    let quote: String = joiner
+        .query_row(
+            "SELECT quote FROM papertrail_distill_evidence
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND ordinal = 0",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(quote, "the exact cause quote", "the distill evidence child replicates");
     // repo-a advertises no route for repo-b's incarnation, so repo-b's record never lands.
     let sibling: bool = joiner
         .query_row(


### PR DESCRIPTION
Extends the `distill/1` table-sync scope with `papertrail_distill_evidence` (the byte-span evidence units with materialized quotes), so a peer receives a distilled record's cited evidence alongside it.

## Rebuild (migration V111)

The table had no natural unique key — a model can cite the same unit twice for one field, and title/body citations share `source_id` — so a composite discriminator is duplicate-unsafe. V111 rebuilds it onto `(repo_id, tracker, project, item_kind, item_key, ordinal)` with a stable per-thread `ordinal` the drain assigns in citation order; existing rows are backfilled by `id` order within each thread. The device-local AUTOINCREMENT `id` is dropped; `source_part` keeps its CHECK.

Registered on `distill/1` with a bumped projector generation. The scope's Lens-lane bump and retention already cover it.

## Tests

- V111 rebuilds to the natural key with an ordinal, drops `id`, across a full ladder replay, and backfills per-thread ordinals in id order;
- the registry spec exactly covers the rebuilt table; the projector generation matches the live registry;
- the loopback test now also asserts an evidence quote reaches the peer, alongside the existing edge/alternative/record_commits/parent transfer, cross-repo isolation, and regeneration checks.

This leaves `papertrail_distill_anchors` as the last distill child (checkout-local resolution columns, its own trigger, and a local anchor re-resolution path before synced anchors surface as drive-by).

Part of #892. Refs #1139.