### PR TITLE
feat(sync): replicate distilled anchors with device-local resolution kept off the wire (#1139)

### DIFF
--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -298,6 +298,8 @@ fn rewrite_logical_symbol_references(
     // that updated "the id columns" silently skipped this one (#810). A stale token then points at
     // whatever now occupies that id — surfacing the previous occupant's decision record on an
     // unrelated symbol, the failure mode that matters most here.
+    // Capture the anchor repos BEFORE the remap rewrites the handle they match on.
+    let anchor_repos = distill_anchor_lens_repos(conn, from)?;
     if table_present(conn, "papertrail_distill_anchors")? {
         conn.execute(
             "UPDATE papertrail_distill_anchors SET logical_symbol_id = ?1
@@ -309,6 +311,13 @@ fn rewrite_logical_symbol_references(
         )?;
     }
     bump_binding_lens_revisions(conn, &lens_repos)?;
+    // The anchor's `logical_symbol_id`/`resolved` are checkout-local and never author a sync entry;
+    // this is a local Lens-freshness bump (the papertrail-lane drive-by changed), replacing the
+    // trigger V112 dropped. `bump_papertrail_lens_lanes` advances both enrichment + papertrail and
+    // is registration-gated.
+    for repo_id in &anchor_repos {
+        crate::distill::bump_papertrail_lens_lanes(conn, repo_id)?;
+    }
     Ok(())
 }
 
@@ -380,6 +389,33 @@ fn bump_binding_lens_revisions(
     Ok(())
 }
 
+/// Registered repos that carry a distill anchor for `from`'s `sym_<hex>` handle. Captured BEFORE a
+/// relocation rewrites/nulls that handle, so the caller can advance the papertrail Lens lane for
+/// the affected repos — `papertrail_distill_anchors` sync (#1139) dropped the row triggers that
+/// used to do this. The JOIN to `repos` keeps only registered repos (an ungated
+/// `bump_lens_revisions` throws on the `repo_meta`→`repos` FK); the table-presence guard returns
+/// empty at migration-time schema states where the anchors/`repos`/`repo_meta` tables do not yet
+/// exist.
+fn distill_anchor_lens_repos(
+    conn: &rusqlite::Connection,
+    from: i64,
+) -> rusqlite::Result<Vec<String>> {
+    if !(table_present(conn, "papertrail_distill_anchors")?
+        && table_present(conn, "repos")?
+        && table_present(conn, "repo_meta")?)
+    {
+        return Ok(Vec::new());
+    }
+    let handle = rag_rat_base::serde_big_id::format_sym_handle(from);
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT a.repo_id
+         FROM papertrail_distill_anchors AS a
+         JOIN repos AS r ON r.repo_id = a.repo_id
+         WHERE a.logical_symbol_id = ?1",
+    )?;
+    stmt.query_map([handle], |row| row.get(0))?.collect()
+}
+
 /// NULL every CALL-PATH reference to a drifted id the heal could not realign (#493 review),
 /// including a persisted edge callee identity after rebuilding its derived hashes when possible.
 /// Call-path references are the exception to the self-healing ladder: `validate_call_path_binding`
@@ -427,6 +463,8 @@ fn null_call_path_references(
             params![from],
         )?;
     }
+    // Capture the anchor repos BEFORE the vacate nulls the handle they match on.
+    let anchor_repos = distill_anchor_lens_repos(conn, from)?;
     if table_present(conn, "papertrail_distill_anchors")? {
         conn.execute(
             "UPDATE papertrail_distill_anchors SET logical_symbol_id = NULL, resolved = 0
@@ -435,6 +473,11 @@ fn null_call_path_references(
         )?;
     }
     bump_binding_lens_revisions(conn, &lens_repos)?;
+    // Local-column relocation → a local Lens-freshness bump for the anchor's repos (see the sibling
+    // remap site); never authors a sync entry.
+    for repo_id in &anchor_repos {
+        crate::distill::bump_papertrail_lens_lanes(conn, repo_id)?;
+    }
     Ok(())
 }
 
@@ -2214,5 +2257,76 @@ mod chunk_path_tests {
         assert_eq!(chunk_part_suffix("docs/x.md::#context-intro#3"), "#3");
         // A bare trailing `#` marks nothing.
         assert_eq!(chunk_part_suffix("src/lib.rs::Foo#"), "");
+    }
+}
+
+#[cfg(test)]
+mod relocation_lens_bump_tests {
+    use rag_rat_base::serde_big_id::format_sym_handle;
+    use rusqlite::{Connection, params};
+
+    use super::{null_call_path_references, rewrite_logical_symbol_references};
+
+    fn papertrail_rev(conn: &Connection, repo_id: &str) -> i64 {
+        rag_rat_db::meta::repo_meta(conn, repo_id, rag_rat_db::meta::LENS_PAPERTRAIL_REVISION_META)
+            .unwrap()
+            .map(|value| value.parse().unwrap())
+            .unwrap_or(0)
+    }
+
+    fn scratch_with_anchor(handle_id: i64) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+                  logical_symbol_id, file_path, name, resolved, selected, repo_id)
+             VALUES ('github', 'o/r', 'issue', '5', 0, 'symbol', ?1, 'src/x.rs', 'Foo', 1, 1, 'r')",
+            params![format_sym_handle(handle_id)],
+        )
+        .unwrap();
+        conn
+    }
+
+    /// A logical-id remap carries the anchor's opaque handle to the new id AND advances the
+    /// papertrail Lens lane for the anchor's repo — the row triggers that used to do this were
+    /// dropped when the table became syncable, so the relocation code now owns the bump.
+    #[test]
+    fn a_remap_bumps_the_papertrail_lane_for_the_anchor_repo() {
+        let conn = scratch_with_anchor(100);
+        let before = papertrail_rev(&conn, "r");
+        rewrite_logical_symbol_references(&conn, 100, 200, true).unwrap();
+        let token: String = conn
+            .query_row(
+                "SELECT logical_symbol_id FROM papertrail_distill_anchors WHERE item_key = '5'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(token, format_sym_handle(200), "the handle follows the symbol");
+        assert!(papertrail_rev(&conn, "r") > before, "the papertrail lane advances");
+    }
+
+    /// A no-winner vacate clears the anchor's local resolution and likewise advances the lane.
+    #[test]
+    fn a_vacate_bumps_the_papertrail_lane_for_the_anchor_repo() {
+        let conn = scratch_with_anchor(100);
+        let before = papertrail_rev(&conn, "r");
+        null_call_path_references(&conn, 100, true).unwrap();
+        let (token, resolved): (Option<String>, i64) = conn
+            .query_row(
+                "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors
+                 WHERE item_key = '5'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((token, resolved), (None, 0), "the local resolution is cleared");
+        assert!(papertrail_rev(&conn, "r") > before, "the papertrail lane advances");
     }
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1839,7 +1839,7 @@ fn migration_101_file_graph_version_provenance() {
 /// V103 (#1109) makes memory bindings deterministic whole-row `anchors/1` state.
 #[test]
 fn migration_103_syncable_memory_bindings() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 111, "move this pin with the next schema migration");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 112, "move this pin with the next schema migration");
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -6669,6 +6669,76 @@ mod syncable_overlay_migration_tests {
             .unwrap();
         assert_eq!(rows, vec![(0, "first".to_string()), (1, "second".to_string())]);
     }
+
+    /// The full ladder re-keys anchors onto the natural key, drops the AUTOINCREMENT id, and is
+    /// idempotent on a second apply. V078's index names survive (non-unique) so its replay guard
+    /// and the drive-by `selected = 1` lookups stay indexed.
+    #[test]
+    fn v112_rekeys_anchors_onto_the_natural_key() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        super::super::apply(&conn, &crate::hooks::MigrationHooks::noop()).unwrap();
+        assert_eq!(primary_key_columns(&conn, "papertrail_distill_anchors").unwrap(), [
+            "repo_id",
+            "tracker",
+            "project",
+            "item_kind",
+            "item_key",
+            "candidate_ordinal"
+        ]);
+        let has_id: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('papertrail_distill_anchors')
+                 WHERE name = 'id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_id, 0, "the AUTOINCREMENT id is dropped");
+        for index in [
+            "idx_papertrail_distill_anchors_candidate",
+            "idx_papertrail_distill_anchors_selected",
+            "idx_papertrail_distill_anchors_symbol",
+        ] {
+            let present: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                    [index],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(present, 1, "V112 keeps index `{index}`");
+        }
+    }
+
+    /// The rebuild copies the device-local columns (`logical_symbol_id`, `resolved`) and the
+    /// selection state verbatim — the whole-row-LWW applier never sees these, so the migration is
+    /// the only thing that can lose them.
+    #[test]
+    fn v112_preserves_local_resolution_and_selection() {
+        let conn = Connection::open_in_memory().unwrap();
+        super::apply_distill_record_store(&conn).unwrap();
+        super::apply_distill_anchor_selection(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+                  logical_symbol_id, file_path, name, resolved, selected, repo_id)
+             VALUES ('github', 'o/r', 'issue', '9', 0, 'symbol',
+                     'sym_abc', 'src/x.rs', 'Foo', 1, 1, 'r')",
+            [],
+        )
+        .unwrap();
+        super::apply_syncable_distill_anchors(&conn).unwrap();
+        let (sym, resolved, selected): (String, i64, i64) = conn
+            .query_row(
+                "SELECT logical_symbol_id, resolved, selected FROM papertrail_distill_anchors
+                 WHERE repo_id = 'r' AND item_key = '9' AND candidate_ordinal = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!((sym.as_str(), resolved, selected), ("sym_abc", 1, 1));
+    }
 }
 
 /// V095 (#1002): per-TABLE spec versioning, plus a direct pointer from a row to its winning entry.
@@ -8090,6 +8160,83 @@ pub fn apply_syncable_distill_evidence(conn: &Connection) -> rusqlite::Result<()
          FROM papertrail_distill_evidence AS e;
          DROP TABLE papertrail_distill_evidence;
          ALTER TABLE papertrail_distill_evidence_v111 RENAME TO papertrail_distill_evidence;",
+    )
+}
+
+/// V112 (#1139): make the distill `anchors` child syncable on `distill/1`.
+///
+/// Re-key onto the existing UNIQUE natural key `(repo_id, tracker, project, item_kind, item_key,
+/// candidate_ordinal)`, drop the device-local AUTOINCREMENT `id`, and drop the six Lens-revision
+/// triggers (3 V093 `*_lens_revision_*` on the enrichment lane, 3 V102 `*_lane_revision_*` on the
+/// papertrail lane) unconditionally, before the shape short-circuit, so a full-ladder replay that
+/// recreates them still ends trigger-free. The write and apply paths advance the lanes explicitly.
+///
+/// `logical_symbol_id` and `resolved` stay as columns but are the table's checkout-local resolution
+/// state — the registry marks them `local_columns`, so they never replicate. `candidate_ordinal`'s
+/// and `selected`'s CHECKs are preserved. The `(repo_id, logical_symbol_id)` symbol index is
+/// recreated (the rebuild drops all indexes and it serves the drive-by symbol joins); the former
+/// UNIQUE candidate index is intentionally NOT recreated — the PK subsumes it.
+pub fn apply_syncable_distill_anchors(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS papertrail_distill_anchors_lens_revision_insert;
+         DROP TRIGGER IF EXISTS papertrail_distill_anchors_lens_revision_delete;
+         DROP TRIGGER IF EXISTS papertrail_distill_anchors_lens_revision_update;
+         DROP TRIGGER IF EXISTS papertrail_distill_anchors_lane_revision_insert;
+         DROP TRIGGER IF EXISTS papertrail_distill_anchors_lane_revision_delete;
+         DROP TRIGGER IF EXISTS papertrail_distill_anchors_lane_revision_update;",
+    )?;
+    if table_is_strict(conn, "papertrail_distill_anchors")?
+        && primary_key_columns(conn, "papertrail_distill_anchors")?
+            == ["repo_id", "tracker", "project", "item_kind", "item_key", "candidate_ordinal"]
+    {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS papertrail_distill_anchors_v112;
+         CREATE TABLE papertrail_distill_anchors_v112(
+             tracker TEXT NOT NULL,
+             project TEXT NOT NULL,
+             item_kind TEXT NOT NULL,
+             item_key TEXT NOT NULL,
+             candidate_ordinal INTEGER NOT NULL DEFAULT 0 CHECK(candidate_ordinal >= 0),
+             anchor_kind TEXT NOT NULL,
+             logical_symbol_id TEXT,
+             file_path TEXT,
+             name TEXT NOT NULL,
+             resolved INTEGER NOT NULL DEFAULT 0,
+             selected INTEGER NOT NULL DEFAULT 0 CHECK(selected IN (0, 1)),
+             repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+             PRIMARY KEY(repo_id, tracker, project, item_kind, item_key, candidate_ordinal)
+         ) STRICT;
+         INSERT INTO papertrail_distill_anchors_v112(
+             tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+             logical_symbol_id, file_path, name, resolved, selected, repo_id)
+         SELECT tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+             logical_symbol_id, file_path, name, resolved, selected, repo_id
+         FROM papertrail_distill_anchors;
+         DROP TABLE papertrail_distill_anchors;
+         ALTER TABLE papertrail_distill_anchors_v112 RENAME TO papertrail_distill_anchors;
+         -- `idx_papertrail_distill_anchors_thread` (repo_id, tracker, project, item_kind, \
+         item_key)
+         -- is deliberately NOT recreated: it is a strict prefix of the new PK, so the PK autoindex
+         -- serves the same thread lookups, and nothing references it by name.
+         CREATE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_symbol
+             ON papertrail_distill_anchors(repo_id, logical_symbol_id);
+         -- Recreate the candidate index as NON-UNIQUE (the PK now enforces the uniqueness the
+         -- registry lint would reject a second UNIQUE index for). It is otherwise redundant with \
+         the
+         -- PK, but V078's backfill keys its 'already applied' guard on this index's existence by
+         -- name: without it, a full-ladder replay re-runs V078's id-based backfill against this
+         -- id-less rebuilt table and errors. Keeping the name satisfies that guard.
+         CREATE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_candidate
+             ON papertrail_distill_anchors(repo_id, tracker, project, item_kind, item_key,
+                                           candidate_ordinal);
+         -- The V078 partial `selected` index (recreated identically; non-unique, so the lint is
+         -- satisfied) — keeps the drive-by `selected = 1` lookups indexed and preserves the index
+         -- inventory later migrations/tests expect.
+         CREATE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_selected
+             ON papertrail_distill_anchors(repo_id, tracker, project, item_kind, item_key,
+                                           candidate_ordinal) WHERE selected = 1;",
     )
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 111;
+pub const LATEST_SCHEMA_VERSION: u32 = 112;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -830,6 +830,13 @@ const MIGRATION_111_DESCRIPTION: &str =
     "Rebuild papertrail_distill_evidence onto its natural key (repo_id first) with a per-thread \
      ordinal, dropping the device-local AUTOINCREMENT id, so the distill evidence child \
      replicates on the distill/1 table-sync scope under whole-row LWW (#1139)";
+const MIGRATION_112_ID: &str = "112_syncable_distill_anchors";
+const MIGRATION_112_CHECKSUM: &str = "sha256:rag-rat-syncable-distill-anchors-v112";
+const MIGRATION_112_DESCRIPTION: &str =
+    "Rebuild papertrail_distill_anchors onto its natural key (repo_id first), dropping the \
+     device-local AUTOINCREMENT id and its Lens revision triggers, so the distill anchors child \
+     replicates on the distill/1 table-sync scope under whole-row LWW; logical_symbol_id and \
+     resolved stay checkout-local and never replicate (#1139)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1048,6 +1055,7 @@ const LEDGER_ATOMIC_MIGRATIONS: &[&str] = &[
     MIGRATION_109_ID,
     MIGRATION_110_ID,
     MIGRATION_111_ID,
+    MIGRATION_112_ID,
 ];
 
 /// Apply one migration and stamp its ledger row, atomically when the migration converts data an
@@ -1735,6 +1743,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_111_DESCRIPTION,
         apply: MigrationFn::Plain(migrations::apply_syncable_distill_evidence),
     },
+    Migration {
+        id: MIGRATION_112_ID,
+        checksum: MIGRATION_112_CHECKSUM,
+        description: MIGRATION_112_DESCRIPTION,
+        apply: MigrationFn::Plain(migrations::apply_syncable_distill_anchors),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1966,6 +1980,7 @@ mod ledger_atomicity {
         MIGRATION_109_ID,
         MIGRATION_110_ID,
         MIGRATION_111_ID,
+        MIGRATION_112_ID,
     ];
 
     /// Every migration whose ledger stamp must be atomic, from both statements of the set.

--- a/crates/rag-rat-oplog/src/table_sync/refold.rs
+++ b/crates/rag-rat-oplog/src/table_sync/refold.rs
@@ -57,7 +57,7 @@ use crate::op::OpMeta;
 /// registering a table or widening a spec forces an append, and an append is the bump. A widening
 /// that is not a registry change (a new row-op kind) still has to append a generation by hand,
 /// repeating the previous snapshot.
-pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 7;
+pub(crate) const TABLE_SYNC_PROJECTOR_VERSION: i64 = 8;
 
 const TABLE_SYNC_PROJECTOR_VERSION_KEY: &str = "table_sync_projector_version";
 

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -416,6 +416,40 @@ const DISTILL_EVIDENCE: TableSpec = TableSpec {
     repo_column: Some("repo_id"),
 };
 
+// An anchor candidate, keyed by the thread + its stable candidate ordinal. Portable facts (kind,
+// exact file path, name, model selection) replicate; `logical_symbol_id`/`resolved` are
+// checkout-local resolution state — a `sym_<hex>` handle valid only in the local index, remapped
+// per checkout by the relocation engine — so they are `local_columns` and never cross the wire. (A
+// synced symbol anchor therefore surfaces as drive-by only after a local re-resolution path exists;
+// a file anchor surfaces immediately via `records_for_path`.)
+const DISTILL_ANCHOR_PK: &[ColumnSpec] = &[
+    ColumnSpec::required("repo_id", ValueType::Text),
+    ColumnSpec::required("tracker", ValueType::Text),
+    ColumnSpec::required("project", ValueType::Text),
+    ColumnSpec::required("item_kind", ValueType::Text),
+    ColumnSpec::required("item_key", ValueType::Text),
+    ColumnSpec::required("candidate_ordinal", ValueType::I64),
+];
+
+const DISTILL_ANCHOR_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec::required("anchor_kind", ValueType::Text),
+    ColumnSpec::required("file_path", ValueType::Text),
+    ColumnSpec::required("name", ValueType::Text),
+    ColumnSpec::required("selected", ValueType::Bool),
+];
+
+const DISTILL_ANCHOR_LOCAL_COLUMNS: &[&str] = &["logical_symbol_id", "resolved"];
+
+const DISTILL_ANCHORS: TableSpec = TableSpec {
+    name: "papertrail_distill_anchors",
+    scope_id: "distill/1",
+    spec_version: 1,
+    pk: DISTILL_ANCHOR_PK,
+    columns: DISTILL_ANCHOR_COLUMNS,
+    local_columns: DISTILL_ANCHOR_LOCAL_COLUMNS,
+    repo_column: Some("repo_id"),
+};
+
 /// The production table registry. `anchors/1` retains durable memory-binding history in full;
 /// `overlay/1` carries regenerable dream output (verdicts, summaries) and `distill/1` the distilled
 /// papertrail record plus its enrichment children — both under a bounded retention budget.
@@ -428,6 +462,7 @@ pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[
     DISTILL_ALTERNATIVES,
     DISTILL_RECORD_COMMITS,
     DISTILL_EVIDENCE,
+    DISTILL_ANCHORS,
 ];
 
 /// The per-repo Lens lane metas a scope's applied rows advance — the aggregate enrichment clock
@@ -1145,6 +1180,202 @@ pub(crate) const PROJECTOR_GENERATIONS: &[&[TableGeneration]] = &[
                 ("author_kind", ValueType::Text, None),
                 ("author_association", ValueType::Text, None),
                 ("unit_created_at_ms", ValueType::I64, None),
+            ],
+        },
+    ],
+    // v8: the distill anchors child joins distill/1. Whole-registry snapshot: v7's eight tables
+    // plus anchors, in `SYNCABLE_TABLES` order. Anchors' local columns (logical_symbol_id,
+    // resolved) are excluded from the generation by design.
+    &[
+        TableGeneration {
+            table: "repo_memory_bindings",
+            scope_id: "anchors/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("binding_kind", ValueType::Text),
+                ("binding_id", ValueType::Text),
+            ],
+            columns: &[
+                ("path", ValueType::Text, None),
+                ("start_line", ValueType::I64, None),
+                ("end_line", ValueType::I64, None),
+                ("commit_hash", ValueType::Text, None),
+                ("tracker", ValueType::Text, None),
+                ("project", ValueType::Text, None),
+                ("item_key", ValueType::Text, None),
+                ("created_at_ms", ValueType::I64, None),
+                ("symbol_kind", ValueType::Text, None),
+                ("signature_hash", ValueType::Text, None),
+                ("moniker_tool", ValueType::Text, None),
+                ("moniker_tool_version", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_reality",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[("repo_id", ValueType::Text), ("memory_id", ValueType::Text)],
+            columns: &[
+                ("content_hash", ValueType::Text, None),
+                ("verdict", ValueType::Text, None),
+                ("direction", ValueType::Text, None),
+                ("checked_against_commit", ValueType::Text, None),
+                ("checked_inputs_hash", ValueType::Text, None),
+                ("evidence_json", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("checked_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "memory_summaries",
+            scope_id: "overlay/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("memory_id", ValueType::Text),
+                ("content_hash", ValueType::Text),
+            ],
+            columns: &[
+                ("summary", ValueType::Text, None),
+                ("model_id", ValueType::Text, None),
+                ("prompt_version", ValueType::Text, None),
+                ("generated_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+            ],
+            columns: &[
+                ("distill_input_hash", ValueType::Text, None),
+                ("pipeline_version", ValueType::I64, None),
+                ("root_issue", ValueType::Text, None),
+                ("root_cause", ValueType::Text, None),
+                ("root_cause_class", ValueType::Text, None),
+                ("decision_chosen", ValueType::Text, None),
+                ("outcome_summary", ValueType::Text, None),
+                ("outcome_status_model", ValueType::Text, None),
+                ("epistemic_status_decision", ValueType::Text, None),
+                ("epistemic_status_outcome", ValueType::Text, None),
+                ("fix_edge_source", ValueType::Text, None),
+                ("quotes_materialized", ValueType::I64, None),
+                ("anchors_qualified_count", ValueType::I64, None),
+                ("thread_shape", ValueType::Text, None),
+                ("outcome_claim_verified", ValueType::Bool, None),
+                ("decision_provenance_verified", ValueType::Bool, None),
+                ("revert_override", ValueType::Bool, None),
+                ("closing_keyword_floor", ValueType::Text, None),
+                ("distilled_at_ms", ValueType::I64, None),
+                ("prompt_version", ValueType::I64, None),
+                ("model_input_hash", ValueType::Text, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill_edges",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("src_item_kind", ValueType::Text),
+                ("src_item_key", ValueType::Text),
+                ("dst_item_kind", ValueType::Text),
+                ("dst_item_key", ValueType::Text),
+                ("edge_kind", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_alternatives",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("ordinal", ValueType::I64),
+            ],
+            columns: &[("alternative", ValueType::Text, None), ("reason", ValueType::Text, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_record_commits",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("commit_sha", ValueType::Text),
+            ],
+            columns: &[("created_at_ms", ValueType::I64, None)],
+        },
+        TableGeneration {
+            table: "papertrail_distill_evidence",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("ordinal", ValueType::I64),
+            ],
+            columns: &[
+                ("field", ValueType::Text, None),
+                ("source_kind", ValueType::Text, None),
+                ("source_part", ValueType::Text, None),
+                ("source_id", ValueType::Text, None),
+                ("byte_start", ValueType::I64, None),
+                ("byte_end", ValueType::I64, None),
+                ("quote", ValueType::Text, None),
+                ("author", ValueType::Text, None),
+                ("author_kind", ValueType::Text, None),
+                ("author_association", ValueType::Text, None),
+                ("unit_created_at_ms", ValueType::I64, None),
+            ],
+        },
+        TableGeneration {
+            table: "papertrail_distill_anchors",
+            scope_id: "distill/1",
+            spec_version: 1,
+            repo_column: Some("repo_id"),
+            pk: &[
+                ("repo_id", ValueType::Text),
+                ("tracker", ValueType::Text),
+                ("project", ValueType::Text),
+                ("item_kind", ValueType::Text),
+                ("item_key", ValueType::Text),
+                ("candidate_ordinal", ValueType::I64),
+            ],
+            columns: &[
+                ("anchor_kind", ValueType::Text, None),
+                ("file_path", ValueType::Text, None),
+                ("name", ValueType::Text, None),
+                ("selected", ValueType::Bool, None),
             ],
         },
     ],

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -1047,6 +1047,18 @@ async fn production_distill_records_replicate_and_regenerate() {
             [],
         )
         .unwrap();
+    // An anchor whose portable facts (kind/name/file_path/selected) must cross, while its
+    // device-local resolution (`logical_symbol_id`, `resolved`) must stay owner-only.
+    owner
+        .execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+                  logical_symbol_id, file_path, name, resolved, selected, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 0, 'symbol',
+                     'sym_owner_local', 'src/x.rs', 'Foo', 1, 1, 'repo-a')",
+            [],
+        )
+        .unwrap();
     owner
         .execute(
             "INSERT INTO repos(repo_id, display_name, registered_at_ms)
@@ -1132,6 +1144,34 @@ async fn production_distill_records_replicate_and_regenerate() {
         )
         .unwrap();
     assert_eq!(quote, "the exact cause quote", "the distill evidence child replicates");
+    // The anchor's portable facts cross the wire...
+    let (kind, name, path, selected): (String, String, String, i64) = joiner
+        .query_row(
+            "SELECT anchor_kind, name, file_path, selected FROM papertrail_distill_anchors
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND candidate_ordinal = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (kind.as_str(), name.as_str(), path.as_str(), selected),
+        ("symbol", "Foo", "src/x.rs", 1),
+        "the anchor's portable facts (kind/name/file_path/selected) replicate"
+    );
+    // ...but its device-local resolution does not — the peer re-resolves locally.
+    let (local_sym, resolved): (Option<String>, i64) = joiner
+        .query_row(
+            "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND candidate_ordinal = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (local_sym, resolved),
+        (None, 0),
+        "the owner's local symbol handle and resolved flag never cross the wire"
+    );
     // repo-a advertises no route for repo-b's incarnation, so repo-b's record never lands.
     let sibling: bool = joiner
         .query_row(
@@ -1162,6 +1202,41 @@ async fn production_distill_records_replicate_and_regenerate() {
         )
         .unwrap();
     assert_eq!(regenerated, "the regenerated cause", "regeneration upserts the record on the peer");
+
+    // The make-or-break case: the peer resolves the anchor in ITS OWN index (local columns set),
+    // then a winning remote Upsert changes a PORTABLE column. The whole-row-LWW applier must update
+    // the portable cell without clobbering the peer's local resolution — the columns/local_columns
+    // split is exactly what a future `INSERT OR REPLACE` refactor could silently break.
+    joiner
+        .execute(
+            "UPDATE papertrail_distill_anchors
+             SET logical_symbol_id = 'sym_joiner_local', resolved = 1
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND candidate_ordinal = 0",
+            [],
+        )
+        .unwrap();
+    owner
+        .execute(
+            "UPDATE papertrail_distill_anchors SET selected = 0
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND candidate_ordinal = 0",
+            [],
+        )
+        .unwrap();
+    reconcile().await;
+    let (selected, local_sym, resolved): (i64, Option<String>, i64) = joiner
+        .query_row(
+            "SELECT selected, logical_symbol_id, resolved FROM papertrail_distill_anchors
+             WHERE repo_id = 'repo-a' AND item_key = '7' AND candidate_ordinal = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(selected, 0, "the winning remote Upsert applies the portable column change");
+    assert_eq!(
+        (local_sym.as_deref(), resolved),
+        (Some("sym_joiner_local"), 1),
+        "the peer's own anchor resolution survives a winning whole-row update"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Makes `papertrail_distill_anchors` syncable over the table-to-log layer on the `distill/1` scope — the last child of the distilled papertrail cluster to gain replication.

## What changes

- **Migration V112** re-keys the table off its AUTOINCREMENT `id` onto the natural key `(repo_id, tracker, project, item_kind, item_key, candidate_ordinal)` and drops the `id`, matching the rest of the cluster. The rebuild is idempotent, drops the lens/lane triggers unconditionally before its shape short-circuit, and preserves every row's columns verbatim.
- **`DISTILL_ANCHORS` TableSpec** registers the table on `distill/1`. `logical_symbol_id` and `resolved` are declared as **local columns** — they are device-local (each peer resolves the symbol handle against its own index) and must never cross the wire. Only `anchor_kind`, `file_path`, `name`, and `selected` are synced. The whole-row LWW applier only ever reads/writes the synced columns, so a peer that has already resolved an anchor locally keeps that resolution when a winning remote update changes a portable column.
- **Lens-lane ownership on relocation.** The row triggers that used to advance the papertrail lens lane on anchor changes are dropped by the rebuild. The logical-id relocation path (`rewrite_logical_symbol_references`, `null_call_path_references`) now advances the lane for the affected repos itself — capturing them before it rewrites or nulls the handle it matches on, and gating the bump on repo registration.

## Tests

- V112 migration: natural-key re-key + `id` drop + index inventory, and local-column/selection preservation across the rebuild.
- Relocation: both the remap and vacate paths advance the papertrail lane for the anchor's repo.
- End-to-end replication: portable facts cross while `logical_symbol_id`/`resolved` stay at their local default on the peer; and a peer's own resolution survives a winning remote update to a portable column.

Closes #1139.