### PR TITLE
feat(distill): resolve synced symbol anchors against the peer's local index (#1143)

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -266,6 +266,10 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                         ensure_founder_table_repo_incarnations(conn)?;
                     } else if alpn.as_slice() == rag_rat_sync::CONTENT_SYNC_ALPN {
                         rag_rat_core::drain_synced_memory(conn)?;
+                    } else if alpn.as_slice() == rag_rat_sync::TABLE_SYNC_ALPN {
+                        // Synced anchors arrive without device-local resolution; derive it now so
+                        // they surface as drive-by this session rather than at the next index open.
+                        rag_rat_core::resolve_synced_distill_anchors(conn)?;
                     }
                     tracing::info!(
                         stream = %String::from_utf8_lossy(&alpn),
@@ -483,6 +487,8 @@ fn join(config: &Config, ticket: &str) -> anyhow::Result<()> {
                 true
             }
         };
+        // Resolve the anchors this restore just pulled against the local index before folding.
+        rag_rat_core::resolve_synced_distill_anchors(conn)?;
         db.fold_wal();
 
         // The inviter's node id in dial form, so the operator can add it to `[sync] server_peers`

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -481,6 +481,76 @@ fn null_call_path_references(
     Ok(())
 }
 
+/// Re-derive the device-local resolution (`logical_symbol_id` / `resolved`) of SELECTED SYMBOL
+/// distill anchors for `repo_id` from their portable `(name, file_path)` against the repo's current
+/// index at `generation`. A SYMBOL anchor's `logical_symbol_id`/`resolved` are `local_columns` — a
+/// peer never receives them — so a replicated anchor lands unresolved and surfaces through NEITHER
+/// read path (`records_for_symbol` matches the handle; `records_for_path`'s symbol branch wants
+/// `resolved = 1`). This is what lets a synced SYMBOL anchor surface as drive-by on the peer, and
+/// it mirrors the owner's mining-time `(name, file_path) → logical_symbol_id` resolution
+/// (`distill::candidates::symbols_in_file`).
+///
+/// It overwrites a handle ONLY when it is NULL or no longer NAMES the anchor's symbol. "Valid" is
+/// NAME-bound, not file-bound: a live handle whose symbol has the anchor's `name` (in any file) is
+/// kept, so a symbol that merely moved files keeps its resolution (`records_for_symbol` joins on
+/// the handle, and the whole #810 relocation posture carries handles across drift), and a genuine
+/// same-name overload anchor keeps its own precise handle rather than being collapsed onto the
+/// lowest-id sibling. A NULL is filled; a stale handle (a regeneration changed the `name` at a
+/// fixed `candidate_ordinal`, leaving the old handle) is re-derived to the lowest-`symbols.id`
+/// match.
+///
+/// The symbol subquery is pinned to `repo_id` + `generation` because this runs on the view-less
+/// bare-open path where `files`/`symbols` are the unscoped base tables holding every repo and every
+/// (until-gc) generation — the `all_symbols` #89/A3/A6 rule. Resolution is deliberately
+/// worktree-INVARIANT (repo + generation, not the active commit/worktree overlay), like
+/// `all_symbols`: a logical symbol is the repo-level identity that GROUPS a file's overlays, so
+/// overlays of one file share a handle, and the read paths (`records_for_path`'s live-file join) do
+/// the per-checkout scoping at query time. The differs-only WHERE (`derived IS NOT stored`) means
+/// `conn.changes()` counts only rows whose resolution truly changed, so the registration-gated
+/// papertrail Lens-lane bump fires exactly when drive-by output changed.
+pub(crate) fn resolve_synced_symbol_anchors(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    generation: i64,
+) -> rusqlite::Result<()> {
+    if !table_present(conn, "papertrail_distill_anchors")? {
+        return Ok(());
+    }
+    // The lowest-`symbols.id` handle for the anchor's `(name, file_path)` in this repo+generation,
+    // or NULL. Reused verbatim for the SET, the `resolved` flag, and the differs guard. The
+    // tables are `main.`-qualified (base, not the per-connection scope VIEW): the view is
+    // already repo-scoped but does NOT project `repo_id`/`generation`, so the explicit pin here
+    // must read the base tables — the `all_symbols` #89/A3/A6 rule, and what makes this correct
+    // on BOTH the view-installed (incremental/open) and view-less (bare-open) paths.
+    const DERIVED: &str = "SELECT 'sym_' || format('%x', m.logical_symbol_id)
+         FROM main.symbols s
+         JOIN main.files f ON f.id = s.file_id
+         JOIN main.logical_symbol_members m ON m.symbol_id = s.id
+         WHERE f.repo_id = ?1 AND f.generation = ?2 AND f.kind != 'deleted'
+           AND f.path = a.file_path AND s.name = a.name
+         ORDER BY s.id LIMIT 1";
+    // Name-bound validity: does the STORED handle still name a symbol called `a.name` (any file)?
+    const STORED_HANDLE_STILL_NAMES_IT: &str = "SELECT 1
+         FROM main.symbols s
+         JOIN main.files f ON f.id = s.file_id
+         JOIN main.logical_symbol_members m ON m.symbol_id = s.id
+         WHERE f.repo_id = ?1 AND f.generation = ?2 AND f.kind != 'deleted' AND s.name = a.name
+           AND 'sym_' || format('%x', m.logical_symbol_id) = a.logical_symbol_id";
+    let sql = format!(
+        "UPDATE papertrail_distill_anchors AS a
+         SET logical_symbol_id = ({DERIVED}),
+             resolved = CASE WHEN ({DERIVED}) IS NOT NULL THEN 1 ELSE 0 END
+         WHERE a.repo_id = ?1 AND a.anchor_kind = 'symbol' AND a.selected = 1
+           AND ({DERIVED}) IS NOT a.logical_symbol_id
+           AND (a.logical_symbol_id IS NULL OR NOT EXISTS ({STORED_HANDLE_STILL_NAMES_IT}))"
+    );
+    let changed = conn.execute(&sql, params![repo_id, generation])?;
+    if changed > 0 {
+        crate::distill::bump_papertrail_lens_lanes(conn, repo_id)?;
+    }
+    Ok(())
+}
+
 /// Move a drifted reference OFF an OCCUPIED id (a LIVE row now belonging to a DIFFERENT symbol)
 /// the heal could not realign (#493) — the vanished-id case needs no such move (a dead id already
 /// resolves to nothing). Call-path references are handled separately by
@@ -1776,6 +1846,23 @@ impl IndexDatabase {
     }
 
     pub(super) fn ensure_graph_index_current(&self) -> anyhow::Result<()> {
+        self.ensure_graph_index_current_inner()?;
+        // Re-resolve synced SYMBOL anchors against the now-current index. This must run OUTSIDE the
+        // inner heal's early returns: a peer that synced anchors but whose code index is unchanged
+        // hits those returns on every open, and that is exactly the case this pass exists for. It
+        // is a differs-only UPDATE (a no-op in steady state) and read-only opens skip
+        // `ensure` entirely, so there is no write-on-read hazard. Same-session immediacy
+        // after a sync is handled at the table-sync settle points; this is the safety net
+        // that resolves at the next index open.
+        resolve_synced_symbol_anchors(
+            self.storage.connection(),
+            &self.active_repo_id,
+            self.active_generation,
+        )?;
+        Ok(())
+    }
+
+    fn ensure_graph_index_current_inner(&self) -> anyhow::Result<()> {
         let graph_current =
             self.repo_meta("graph_index_version")?.as_deref() == Some(GRAPH_INDEX_VERSION);
         let active_derivation_owed = self.active_derivation_rows_owed()?;
@@ -2328,5 +2415,251 @@ mod relocation_lens_bump_tests {
             .unwrap();
         assert_eq!((token, resolved), (None, 0), "the local resolution is cleared");
         assert!(papertrail_rev(&conn, "r") > before, "the papertrail lane advances");
+    }
+}
+
+#[cfg(test)]
+mod synced_anchor_resolution_tests {
+    use rag_rat_base::serde_big_id::format_sym_handle;
+    use rusqlite::{Connection, params};
+
+    use super::resolve_synced_symbol_anchors;
+
+    fn papertrail_rev(conn: &Connection, repo_id: &str) -> i64 {
+        rag_rat_db::meta::repo_meta(conn, repo_id, rag_rat_db::meta::LENS_PAPERTRAIL_REVISION_META)
+            .unwrap()
+            .map(|value| value.parse().unwrap())
+            .unwrap_or(0)
+    }
+
+    fn scratch() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        // Hand-seed the symbol index directly (FK off), the raw-`main`-table fixture Fable's review
+        // requires: a scope view would mask a consolidated-repo / superseded-generation bug.
+        conn.execute_batch("PRAGMA foreign_keys = OFF").unwrap();
+        for repo in ["r", "s"] {
+            conn.execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+                [repo],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    fn add_file(conn: &Connection, id: i64, path: &str, repo: &str, generation: i64) {
+        conn.execute(
+            "INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               repo_id, generation)
+             VALUES (?1, ?2, 'rust', 'source', 'sha', 0, 0, ?3, ?4)",
+            params![id, path, repo, generation],
+        )
+        .unwrap();
+    }
+
+    fn add_symbol(conn: &Connection, sym_id: i64, file_id: i64, name: &str, logical: i64) {
+        conn.execute(
+            "INSERT INTO symbols(id, file_id, language, name, kind, start_byte, end_byte)
+             VALUES (?1, ?2, 'rust', ?3, 'function', 0, 0)",
+            params![sym_id, file_id, name],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, \
+             end_line)
+             VALUES (?1, ?2, 0, 0)",
+            params![logical, sym_id],
+        )
+        .unwrap();
+    }
+
+    /// A selected symbol anchor; `handle` is its stored `logical_symbol_id` (None =
+    /// synced/unresolved).
+    fn add_anchor(conn: &Connection, item_key: &str, repo: &str, name: &str, handle: Option<i64>) {
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+                  logical_symbol_id, file_path, name, resolved, selected, repo_id)
+             VALUES ('github', 'o/r', 'issue', ?1, 0, 'symbol', ?2, 'src/x.rs', ?3,
+                     ?4, 1, ?5)",
+            params![item_key, handle.map(format_sym_handle), name, handle.is_some() as i64, repo],
+        )
+        .unwrap();
+    }
+
+    fn anchor(conn: &Connection, item_key: &str) -> (Option<String>, i64) {
+        conn.query_row(
+            "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors
+             WHERE item_key = ?1 AND repo_id = 'r'",
+            [item_key],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn resolves_a_null_synced_anchor_and_bumps_the_lane() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        add_anchor(&conn, "5", "r", "Foo", None);
+        let before = papertrail_rev(&conn, "r");
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(anchor(&conn, "5"), (Some(format_sym_handle(100)), 1));
+        assert!(papertrail_rev(&conn, "r") > before, "a fresh resolution bumps the lane");
+    }
+
+    #[test]
+    fn a_second_run_changes_nothing_and_does_not_bump() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        add_anchor(&conn, "5", "r", "Foo", None);
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        let settled = papertrail_rev(&conn, "r");
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(anchor(&conn, "5"), (Some(format_sym_handle(100)), 1));
+        assert_eq!(papertrail_rev(&conn, "r"), settled, "an idempotent re-run must not bump");
+    }
+
+    #[test]
+    fn a_valid_overload_handle_is_preserved() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        // Two same-name symbols, distinct handles — the owner mined each its own precise anchor.
+        add_symbol(&conn, 30, 1, "Dup", 300);
+        add_symbol(&conn, 31, 1, "Dup", 301);
+        add_anchor(&conn, "5", "r", "Dup", Some(300));
+        add_anchor(&conn, "6", "r", "Dup", Some(301));
+        let before = papertrail_rev(&conn, "r");
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        // The second anchor keeps 301 rather than collapsing onto the lowest-id 300.
+        assert_eq!(anchor(&conn, "5"), (Some(format_sym_handle(300)), 1));
+        assert_eq!(anchor(&conn, "6"), (Some(format_sym_handle(301)), 1));
+        assert_eq!(papertrail_rev(&conn, "r"), before, "preserving valid handles does not bump");
+    }
+
+    #[test]
+    fn a_stale_handle_whose_name_moved_on_is_re_derived() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        add_symbol(&conn, 20, 1, "Bar", 200);
+        // A regeneration made candidate_ordinal 0 name "Bar", but the synced handle still names
+        // Foo.
+        add_anchor(&conn, "5", "r", "Bar", Some(100));
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(anchor(&conn, "5"), (Some(format_sym_handle(200)), 1), "re-derived to Bar");
+    }
+
+    #[test]
+    fn a_live_handle_whose_symbol_moved_files_is_kept() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_file(&conn, 2, "src/y.rs", "r", 0);
+        // The symbol now lives in y.rs, but the anchor's file_path still says x.rs. Validity is
+        // name-bound, so the live handle is kept (records_for_symbol joins on the handle).
+        add_symbol(&conn, 40, 2, "Moved", 400);
+        add_anchor(&conn, "5", "r", "Moved", Some(400));
+        let before = papertrail_rev(&conn, "r");
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(anchor(&conn, "5"), (Some(format_sym_handle(400)), 1), "the live handle stays");
+        assert_eq!(papertrail_rev(&conn, "r"), before);
+    }
+
+    #[test]
+    fn a_null_anchor_with_no_local_match_stays_unresolved_and_does_not_bump() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        add_anchor(&conn, "5", "r", "Ghost", None);
+        let before = papertrail_rev(&conn, "r");
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(anchor(&conn, "5"), (None, 0), "no local symbol → still unresolved");
+        assert_eq!(papertrail_rev(&conn, "r"), before, "a no-op must not bump");
+    }
+
+    #[test]
+    fn file_and_unselected_anchors_are_left_alone() {
+        let conn = scratch();
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        // A FILE anchor (surfaces via the synced file_path) and an UNSELECTED symbol candidate.
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, candidate_ordinal, anchor_kind,
+                  logical_symbol_id, file_path, name, resolved, selected, repo_id)
+             VALUES ('github', 'o/r', 'issue', '7', 0, 'file', NULL, 'src/x.rs', 'src/x.rs', 1, 1, \
+             'r'),
+                    ('github', 'o/r', 'issue', '8', 1, 'symbol', NULL, 'src/x.rs', 'Foo', 0, 0, \
+             'r')",
+            [],
+        )
+        .unwrap();
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(anchor(&conn, "7"), (None, 1), "the file anchor is untouched");
+        assert_eq!(anchor(&conn, "8"), (None, 0), "the unselected candidate is untouched");
+    }
+
+    #[test]
+    fn a_shared_path_resolves_only_against_the_active_repo() {
+        let conn = scratch();
+        // Both repos have a `src/x.rs` with a `Foo`; the pass must pick repo r's symbol.
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        add_file(&conn, 2, "src/x.rs", "s", 0);
+        add_symbol(&conn, 20, 2, "Foo", 999);
+        add_anchor(&conn, "5", "r", "Foo", None);
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(
+            anchor(&conn, "5"),
+            (Some(format_sym_handle(100)), 1),
+            "resolves against repo r, never the sibling repo's same-path symbol"
+        );
+    }
+
+    #[test]
+    fn overlapping_worktree_overlays_resolve_to_the_shared_logical_id() {
+        let conn = scratch();
+        // Two worktree overlays of the SAME file (same repo + generation, distinct worktree_id) —
+        // as a linked checkout produces. Both hold a `Foo` folded into ONE logical symbol (logical
+        // grouping is cross-overlay), so resolution is worktree-invariant: it yields the shared
+        // handle whichever overlay's symbol row wins the lowest-id tiebreak.
+        for (file_id, sym_id, worktree) in [(1, 10, "wt-a"), (2, 11, "wt-b")] {
+            conn.execute(
+                "INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, \
+                 indexed_at_ms,
+                                   repo_id, generation, worktree_id)
+                 VALUES (?1, 'src/x.rs', 'rust', 'source', 'sha', 0, 0, 'r', 0, ?2)",
+                params![file_id, worktree],
+            )
+            .unwrap();
+            add_symbol(&conn, sym_id, file_id, "Foo", 100);
+        }
+        add_anchor(&conn, "5", "r", "Foo", None);
+        resolve_synced_symbol_anchors(&conn, "r", 0).unwrap();
+        assert_eq!(
+            anchor(&conn, "5"),
+            (Some(format_sym_handle(100)), 1),
+            "overlays of one file share a logical id, so resolution is worktree-invariant"
+        );
+    }
+
+    #[test]
+    fn a_superseded_generation_symbol_is_excluded() {
+        let conn = scratch();
+        // A dead generation-0 `Foo` and a live generation-1 `Foo`, both at src/x.rs in repo r.
+        add_file(&conn, 1, "src/x.rs", "r", 0);
+        add_symbol(&conn, 10, 1, "Foo", 100);
+        add_file(&conn, 2, "src/x.rs", "r", 1);
+        add_symbol(&conn, 20, 2, "Foo", 500);
+        add_anchor(&conn, "5", "r", "Foo", None);
+        resolve_synced_symbol_anchors(&conn, "r", 1).unwrap();
+        assert_eq!(
+            anchor(&conn, "5"),
+            (Some(format_sym_handle(500)), 1),
+            "resolves against the live generation, never a superseded row"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -375,6 +375,13 @@ impl IndexDatabase {
     /// "database is locked" under concurrent MCP clients (#143). Unlike `open_config` it performs
     /// NO on-open heal writes (`ensure_model_manifest` / `ensure_graph_index_current`).
     ///
+    /// This also means it does NOT re-resolve synced distill anchors (a write): that runs at the
+    /// table-sync settle points as anchors are ingested — normally the same session they arrive —
+    /// and again in `open_config`'s `ensure_graph_index_current`, so a read-only reader serves
+    /// already- resolved rows. An anchor that reached the DB through neither (e.g. a copied
+    /// store) stays unresolved until the next read-write open resolves it, the same
+    /// deferred-materialization posture as the synced-memory drain.
+    ///
     /// Returns `Ok(None)` — caller falls back to the read-write `open_config`, which heals once and
     /// after which reads are lock-free again — when any of these is true:
     /// - the DB has never been opened for write (read-only open errors),

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -61,6 +61,17 @@ pub fn migration_hooks() -> rag_rat_db::MigrationHooks {
         realign_logical_symbol_ids: graph_index::realign_logical_symbol_ids,
     }
 }
+
+/// Re-resolve synced SYMBOL distill anchors for the active repo against its current local index —
+/// the table-sync settle-point entry (a peer receives an anchor's portable facts but never its
+/// device-local `logical_symbol_id`/`resolved`). Resolves the active repo at its live generation;
+/// safe on a view-less connection (both scope reads fall back to the sole-repo / live generation).
+pub(crate) fn resolve_synced_distill_anchors(conn: &rusqlite::Connection) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let generation = rag_rat_db::schema::active_generation(conn)?;
+    graph_index::resolve_synced_symbol_anchors(conn, &repo_id, generation)?;
+    Ok(())
+}
 // Only tests reach `install_scope_view` directly now: non-test code resolves the repo id
 // explicitly (`resolve_scope_repo_id`) and passes it into `install_worktree_scope_view`, which
 // writes the scope itself rather than routing through the config-blind `active_repo_id`

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
@@ -949,6 +949,77 @@ fn a_remap_heals_a_logical_id_referenced_only_by_a_distill_anchor() {
     let _ = fs::remove_dir_all(&root);
 }
 
+/// #1143: a SYMBOL anchor synced from a peer arrives with `logical_symbol_id = NULL` / `resolved =
+/// 0` (both are `local_columns`, never sent), so it surfaces through neither read path. The on-open
+/// pass must re-derive its handle from the portable `(name, file_path)` against THIS checkout's
+/// index — driven here through the real `open_config` entry point (which runs
+/// `ensure_graph_index_current`), then confirmed by `records_for_symbol` returning the record.
+#[test]
+fn an_unresolved_synced_symbol_anchor_is_resolved_on_open_and_surfaces_as_drive_by() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn drift_anchor() -> u32 { 7 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = rag_rat_db::schema::active_repo_id(db.storage.connection()).unwrap();
+    // A distilled provider-edge record plus a SELECTED symbol anchor as a peer would replicate it:
+    // portable facts only, the device-local resolution left unset.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+                  distilled_at_ms, repo_id)
+             VALUES \
+             ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+            params![repo_id],
+        )
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, file_path,
+                  name, resolved, candidate_ordinal, selected, repo_id)
+             VALUES ('github','o/r','issue','5','symbol',NULL,'src/lib.rs','drift_anchor',0,0,1,?1)",
+            params![repo_id],
+        )
+        .unwrap();
+    drop(db);
+
+    // Reopen through the sanctioned entry point — this runs `ensure_graph_index_current`, whose
+    // wrapper resolves the anchor against the current index.
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let conn = db.storage.connection();
+    let logical_id: i64 = conn
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let (token, resolved): (Option<String>, i64) = conn
+        .query_row(
+            "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors WHERE item_key = \
+             '5'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (token.as_deref(), resolved),
+        (Some(rag_rat_base::serde_big_id::format_sym_handle(logical_id).as_str()), 1),
+        "the synced anchor resolves to this checkout's symbol on open"
+    );
+    let records = rag_rat_papertrail::records_for_symbol(conn, &repo_id, logical_id, 10).unwrap();
+    assert_eq!(
+        records.iter().map(|record| record.item_key.as_str()).collect::<Vec<_>>(),
+        ["5"],
+        "the resolved anchor now surfaces the distilled record as symbol drive-by"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// The same gap, for `repo_node_edges.target_logical_symbol_id` — an INTEGER column that was simply
 /// never added to either the remap or the snapshot's reference set. Referenced only by that edge.
 #[test]

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -28,6 +28,15 @@ pub fn drain_synced_memory(conn: &rusqlite::Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Re-resolve synced SYMBOL distill anchors against the active repo's local index — call at a
+/// table-sync (`/5`) settle point so a replicated anchor surfaces as drive-by in the SAME session
+/// it arrived, without waiting for the next index open. A device never receives an anchor's
+/// device-local `logical_symbol_id`/`resolved` (they are `local_columns`); this derives them from
+/// the anchor's portable `(name, file_path)`. Idempotent — a no-op when nothing resolved anew.
+pub fn resolve_synced_distill_anchors(conn: &rusqlite::Connection) -> anyhow::Result<()> {
+    index::resolve_synced_distill_anchors(conn)
+}
+
 /// Lightweight, lock-free count of active repo memories whose anchor is `gone`/`stale` — the same
 /// population `memory_doctor` lists. Opens a BARE read-only connection (no git resolution, scope
 /// view, or schema migration), so it is cheap enough to call on every MCP tool result to nudge the

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -584,6 +584,11 @@ async fn accept_loop(
                 .await?;
                 if alpn.as_slice() == rag_rat_sync::CONTENT_SYNC_ALPN {
                     crate::drain_synced_memory(conn)?;
+                } else if alpn.as_slice() == rag_rat_sync::TABLE_SYNC_ALPN {
+                    // The resident host holds the index open, so the on-open re-resolution never
+                    // re-fires for anchors pushed here — resolve them at the session's settle
+                    // point.
+                    crate::resolve_synced_distill_anchors(conn)?;
                 }
                 anyhow::Ok(report)
             }
@@ -708,6 +713,10 @@ async fn reconcile(
             tracing::warn!(peer, %error, "device sync table reconciliation failed");
         }
     }
+    // Resolve any anchors this run's table reconciliation pulled against the local index, so they
+    // surface as drive-by without waiting for the next index open (idempotent when nothing
+    // changed).
+    crate::resolve_synced_distill_anchors(conn)?;
     let ok = reached.iter().filter(|reached| **reached).count();
     let peers = reached.len() + resolved.unresolved_configured;
     Ok((peers, ok, peers - ok))


### PR DESCRIPTION
A distilled SYMBOL anchor's `logical_symbol_id` and `resolved` are device-local (each peer resolves the symbol handle against its own code index) and are not replicated. A synced anchor arrives with only its portable facts (`anchor_kind`, `file_path`, `name`, `selected`) and previously surfaced through **neither** read path on the peer: `records_for_symbol` matches the handle, and `records_for_path`'s symbol branch requires `resolved = 1`. (FILE anchors already surface via the synced `file_path`.)

## What changes

- **Re-resolution pass** (`resolve_synced_symbol_anchors`): re-derives a selected SYMBOL anchor's `logical_symbol_id`/`resolved` from its `(name, file_path)` against the local index, mirroring the owner's mining-time resolution.
  - Overwrites a handle **only** when it is NULL or no longer names the anchor's symbol. Validity is **name-bound**, not file-bound: a symbol that moved files keeps its handle (the read paths join on the handle), and a genuine same-name overload anchor keeps its own precise handle rather than collapsing onto the lowest-id sibling.
  - The symbol lookup is pinned to the active repo + generation against the base tables, correct on both the scope-view and bare-open paths. Resolution is deliberately worktree-invariant — a logical symbol is the repo-level identity grouping a file's overlays; per-checkout scoping is a read-time concern.
  - The papertrail lens lane advances only when a resolution actually changes.
- **Hooks:** runs unconditionally after the on-open index-current check (safety net) and at each table-sync settle point (serve-accept, join, resident-accept, device sync), so an anchor resolves in the session it arrives rather than waiting for the next index open. The read-only fast path serves already-resolved rows and defers to a write path otherwise — the established deferred-materialization posture.

## Tests

Unit coverage of every case: fresh NULL resolution (+ lane bump), idempotent re-run (no bump), valid-overload preservation, stale-handle re-derivation, moved-file handle kept, no-match stays unresolved, file/unselected anchors untouched, consolidated-repo isolation, superseded-generation exclusion, and overlapping worktree overlays. Plus an end-to-end test driving the real `open_config` entry point: a synced unresolved anchor resolves on open and then surfaces through `records_for_symbol`.

Closes #1143.