### PR TITLE
feat(sync): route inbound sessions to the account the dialer names, so one endpoint can host several (#406)

### DIFF
--- a/crates/rag-rat-sync/src/auth.rs
+++ b/crates/rag-rat-sync/src/auth.rs
@@ -54,9 +54,10 @@ pub enum AuthPolicy {
     /// Admit any dialer for reads on the account/`/3` content paths. A valid roster binding
     /// determines its capability when available; a rejected binding remains read-only. Only a
     /// dialer whose local authority is unavailable permits its explicitly selected server to
-    /// send the snapshot needed to restore roster state. Does NOT reach `/5` tables:
-    /// `accept_and_dispatch` pins `TABLE_SYNC_ALPN` to `Closed` regardless of the configured
-    /// policy, so a table manifest is never revealed to an unverified peer.
+    /// send the snapshot needed to restore roster state. Does NOT reach `/5` tables: the
+    /// dispatchers (`dispatch_connection` and the multi-account `dispatch_connection_multi`)
+    /// pin `TABLE_SYNC_ALPN` to `Closed` regardless of the configured policy, so a table
+    /// manifest is never revealed to an unverified peer.
     Open,
     /// Admit only a peer whose binding verifies against this account's roster and the connection's
     /// authenticated remote node id. The default for a private account.
@@ -200,6 +201,16 @@ impl std::fmt::Display for AuthError {
 
 impl std::error::Error for AuthError {}
 
+/// A hosted account chosen for a connection by [`run_auth_phase_selected`], from the account the
+/// dialer named in its opening auth frame. Carries that account's authorizer and its PER-ACCOUNT
+/// policy — a public (`Open`) account and a private (`Closed`) one may share one endpoint, so the
+/// mode must come from the selection, never an endpoint-wide default.
+pub struct Selected<'a> {
+    pub account_id: [u8; 32],
+    pub auth: &'a dyn NodeAuth,
+    pub policy: AuthPolicy,
+}
+
 /// Run the mutual auth handshake. On success, returns what each side may transmit in the data
 /// phase; the caller passes those capabilities to [`crate::session::run_session`] over the same
 /// stream. On `Err` the caller drops the connection without revealing any inventory.
@@ -214,25 +225,73 @@ where
     R: AsyncRead + Unpin,
     A: NodeAuth,
 {
-    let (local, peer) = match cfg.role {
-        // Acceptor verifies the dialer BEFORE revealing its own binding.
+    match cfg.role {
+        // Single-account acceptor: admit iff the dialer named OUR one account. Expressed as the
+        // degenerate one-account selector so the acceptor path is shared with multi-account
+        // hosting.
         AuthRole::Acceptor => {
-            let peer = verify_peer(recv, auth, &cfg).await?;
-            let local = send_ours(send, auth, &cfg).await?;
-            (local, peer)
+            let (_account, caps) = run_auth_phase_selected(send, recv, cfg, |peer_account| {
+                (*peer_account == cfg.account_id).then_some(Selected {
+                    account_id: cfg.account_id,
+                    auth,
+                    policy: cfg.policy,
+                })
+            })
+            .await?;
+            Ok(caps)
         },
-        // Dialer presents first (to the node it already authenticated), then verifies the acceptor
-        // before proceeding to the data phase.
+        // Dialer presents first (to the node it already authenticated, naming its own account),
+        // then verifies the acceptor before proceeding to the data phase.
         AuthRole::Dialer => {
             let local = send_ours(send, auth, &cfg).await?;
             let peer = verify_peer(recv, auth, &cfg).await?;
-            (local, peer)
+            let granted_by_peer = exchange_grants(send, recv, peer, cfg.pre_auth_timeout).await?;
+            Ok(SessionCapabilities::new(local.restricted_by(granted_by_peer), peer))
         },
+    }
+}
+
+/// The acceptor half of the handshake for a host that serves a BOUNDED SET of accounts on one
+/// endpoint. Reads the dialer's auth frame, hands the named account to `select` to choose the
+/// hosted account (its authorizer + per-account policy), verifies the dialer's binding against THAT
+/// account, then reveals the acceptor's own binding for it. Returns the selected account id so the
+/// caller can route the data phase to that account's stores.
+///
+/// An account the host does not serve is refused with the SAME uniform [`AuthError::Unauthorized`]
+/// as a rejected binding — no wire signal distinguishes "account not hosted here" from "not
+/// authorized", so a peer cannot probe which accounts a host holds. No inventory (not even the
+/// account confirmation in the acceptor's frame) is revealed before `select` and the binding check
+/// succeed.
+pub async fn run_auth_phase_selected<'sel, W, R, F>(
+    send: &mut W,
+    recv: &mut R,
+    cfg: AuthConfig,
+    select: F,
+) -> Result<([u8; 32], SessionCapabilities), AuthError>
+where
+    W: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+    F: FnOnce(&[u8; 32]) -> Option<Selected<'sel>>,
+{
+    let (peer_account, binding) = read_peer_auth(recv, cfg.pre_auth_timeout).await?;
+    let Some(selected) = select(&peer_account) else {
+        return Err(AuthError::Unauthorized);
     };
-    // A peer's view of our binding can be stricter than our own role due to stale or divergent
-    // roster state. Exchange the actual grants before any inventory, and honor both verdicts.
+    let peer = authorize_binding(
+        selected.auth,
+        &binding,
+        selected.policy,
+        AuthRole::Acceptor,
+        &cfg.remote_node,
+        cfg.now_ms,
+    )?;
+    // Mint our own frame for the SELECTED account (and under its policy), not the placeholder the
+    // caller passed. Everything else in `cfg` (nodes, clock, timeout) is connection-level.
+    let account_cfg =
+        AuthConfig { account_id: selected.account_id, policy: selected.policy, ..cfg };
+    let local = send_ours(send, selected.auth, &account_cfg).await?;
     let granted_by_peer = exchange_grants(send, recv, peer, cfg.pre_auth_timeout).await?;
-    Ok(SessionCapabilities::new(local.restricted_by(granted_by_peer), peer))
+    Ok((selected.account_id, SessionCapabilities::new(local.restricted_by(granted_by_peer), peer)))
 }
 
 async fn exchange_grants<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
@@ -297,42 +356,51 @@ async fn send_ours<W: AsyncWrite + Unpin>(
     }
 }
 
-async fn verify_peer<R: AsyncRead + Unpin>(
+/// Read the peer's opening `Frame::Auth` off the stream, returning the account it named and the
+/// binding it presented. Split out of [`verify_peer`] so the acceptor can SELECT which hosted
+/// account to authorize against (multi-account hosting) between this read and the policy check,
+/// rather than only equality-checking a pre-fixed account.
+async fn read_peer_auth<R: AsyncRead + Unpin>(
     recv: &mut R,
-    auth: &dyn NodeAuth,
-    cfg: &AuthConfig,
-) -> Result<PeerCapability, AuthError> {
+    pre_auth_timeout: Duration,
+) -> Result<([u8; 32], Vec<u8>), AuthError> {
     let read = codec::read_frame_within(recv, MAX_AUTH_FRAME_BYTES);
-    let frame = match tokio::time::timeout(cfg.pre_auth_timeout, read).await {
+    let frame = match tokio::time::timeout(pre_auth_timeout, read).await {
         Ok(Ok(frame)) => frame,
         Ok(Err(e)) => return Err(AuthError::Codec(e)),
         Err(_elapsed) => return Err(AuthError::Timeout),
     };
-    let Frame::Auth { account_id: peer_account, binding } = frame else {
+    let Frame::Auth { account_id, binding } = frame else {
         return Err(AuthError::Protocol("peer did not open with an auth frame".into()));
     };
-    // Account scope is enforced regardless of policy — even an Open endpoint must not proceed to
-    // the data phase (whose Hello reveals the hosted account id + inventory) for a peer that
-    // named a DIFFERENT account. Open relaxes the BINDING check, never the scope. Uniform error
-    // either way.
-    if peer_account != cfg.account_id {
-        return Err(AuthError::Unauthorized);
-    }
-    // Every rejection below is the SAME uniform error — no not-on-roster / bad-sig distinction on
-    // the wire.
-    match cfg.policy {
+    Ok((account_id, binding))
+}
+
+/// Policy verdict for a peer binding, against a CHOSEN account's `auth`. The account-scope decision
+/// (equality for single-account, selection for multi-account) happens in the caller BEFORE this;
+/// here only the binding is judged. Every rejection is the SAME uniform error — no
+/// not-on-roster / bad-sig distinction on the wire.
+fn authorize_binding(
+    auth: &dyn NodeAuth,
+    binding: &[u8],
+    policy: AuthPolicy,
+    role: AuthRole,
+    remote_node: &[u8; 32],
+    now_ms: i64,
+) -> Result<PeerCapability, AuthError> {
+    match policy {
         // Open admission grants an unverified dialer READ, never WRITE. A fresh dialer cannot yet
         // verify the selected server's roster binding, so it must permit that acceptor to serve the
         // requested snapshot; ingest still verifies every entry from scratch.
-        AuthPolicy::Open => match auth.authorize(&binding, &cfg.remote_node, cfg.now_ms) {
+        AuthPolicy::Open => match auth.authorize(binding, remote_node, now_ms) {
             Ok(PeerAuthorization::Granted(capability)) => Ok(capability),
-            Ok(PeerAuthorization::Unavailable) if cfg.role == AuthRole::Dialer =>
+            Ok(PeerAuthorization::Unavailable) if role == AuthRole::Dialer =>
                 Ok(PeerCapability::ReadWrite),
             Ok(PeerAuthorization::Rejected | PeerAuthorization::Unavailable) | Err(_) =>
                 Ok(PeerCapability::ReadOnly),
         },
         AuthPolicy::Closed => {
-            match auth.authorize(&binding, &cfg.remote_node, cfg.now_ms) {
+            match auth.authorize(binding, remote_node, now_ms) {
                 Ok(PeerAuthorization::Granted(capability)) => Ok(capability),
                 Ok(PeerAuthorization::Rejected | PeerAuthorization::Unavailable) =>
                     Err(AuthError::Unauthorized),
@@ -342,6 +410,22 @@ async fn verify_peer<R: AsyncRead + Unpin>(
             }
         },
     }
+}
+
+async fn verify_peer<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    auth: &dyn NodeAuth,
+    cfg: &AuthConfig,
+) -> Result<PeerCapability, AuthError> {
+    let (peer_account, binding) = read_peer_auth(recv, cfg.pre_auth_timeout).await?;
+    // Account scope is enforced regardless of policy — even an Open endpoint must not proceed to
+    // the data phase (whose Hello reveals the hosted account id + inventory) for a peer that
+    // named a DIFFERENT account. Open relaxes the BINDING check, never the scope. Uniform error
+    // either way.
+    if peer_account != cfg.account_id {
+        return Err(AuthError::Unauthorized);
+    }
+    authorize_binding(auth, &binding, cfg.policy, cfg.role, &cfg.remote_node, cfg.now_ms)
 }
 
 #[cfg(test)]
@@ -653,5 +737,102 @@ mod tests {
         ] {
             assert!(!format!("{e}").is_empty());
         }
+    }
+
+    const ACCT_B: [u8; 32] = [7u8; 32];
+
+    /// Run the acceptor via the MULTI-account `run_auth_phase_selected` against `hosted`
+    /// (account_id → its authorizer + per-account policy); the dialer names `dialer_account`.
+    async fn run_selected_pair(
+        dialer: FakeAuth,
+        dialer_account: [u8; 32],
+        hosted: Vec<([u8; 32], FakeAuth, AuthPolicy)>,
+    ) -> (Result<SessionCapabilities, AuthError>, Result<([u8; 32], SessionCapabilities), AuthError>)
+    {
+        let (mut d_send, mut a_recv) = tokio::io::duplex(1 << 16);
+        let (mut a_send, mut d_recv) = tokio::io::duplex(1 << 16);
+        let timeout = Duration::from_millis(300);
+        let dialer_side = run_auth_phase(&mut d_send, &mut d_recv, &dialer, AuthConfig {
+            role: AuthRole::Dialer,
+            account_id: dialer_account,
+            local_node: D_NODE,
+            remote_node: A_NODE,
+            policy: AuthPolicy::Open,
+            now_ms: 1,
+            pre_auth_timeout: timeout,
+        });
+        let acceptor_side = run_auth_phase_selected(
+            &mut a_send,
+            &mut a_recv,
+            AuthConfig {
+                role: AuthRole::Acceptor,
+                account_id: [0u8; 32],
+                local_node: A_NODE,
+                remote_node: D_NODE,
+                policy: AuthPolicy::Closed,
+                now_ms: 1,
+                pre_auth_timeout: timeout,
+            },
+            |peer_account| {
+                hosted
+                    .iter()
+                    .find(|(id, _, _)| id == peer_account)
+                    .map(|(id, auth, policy)| Selected { account_id: *id, auth, policy: *policy })
+            },
+        );
+        tokio::join!(dialer_side, acceptor_side)
+    }
+
+    #[tokio::test]
+    async fn selects_the_hosted_account_the_dialer_names() {
+        // A host holding both accounts admits a dialer for EACH, resolving to the one it named.
+        for named in [ACCT, ACCT_B] {
+            let (dialer, acceptor) = run_selected_pair(ok_auth(), named, vec![
+                (ACCT, ok_auth(), AuthPolicy::Closed),
+                (ACCT_B, ok_auth(), AuthPolicy::Closed),
+            ])
+            .await;
+            let (selected, _caps) = acceptor.unwrap();
+            assert_eq!(selected, named, "the session resolves to the account the dialer named");
+            assert!(dialer.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_an_unhosted_account_with_the_uniform_error() {
+        // A dialer naming an account the host does not serve gets the SAME error as a rejected
+        // binding — no signal reveals which accounts are hosted.
+        let unhosted = [0x9u8; 32];
+        let (_dialer, acceptor) =
+            run_selected_pair(ok_auth(), unhosted, vec![(ACCT, ok_auth(), AuthPolicy::Closed)])
+                .await;
+        assert!(
+            matches!(acceptor, Err(AuthError::Unauthorized)),
+            "an unhosted account is refused uniformly: {acceptor:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn honors_the_selected_accounts_policy_not_an_endpoint_wide_one() {
+        // The selected account is Open, so an unverified dialer is admitted READ-ONLY — even though
+        // the acceptor's config policy is Closed. The policy comes from the SELECTION.
+        let unverified_at_acceptor = FakeAuth {
+            binding: vec![],
+            local_capability: PeerCapability::ReadWrite,
+            authorization: PeerAuthorization::Rejected,
+        };
+        let (_dialer, acceptor) = run_selected_pair(ok_auth(), ACCT, vec![(
+            ACCT,
+            unverified_at_acceptor,
+            AuthPolicy::Open,
+        )])
+        .await;
+        let (selected, caps) = acceptor.unwrap();
+        assert_eq!(selected, ACCT);
+        assert_eq!(
+            caps.peer,
+            PeerCapability::ReadOnly,
+            "Open admits the unverified dialer read-only; a Closed selection would have refused it"
+        );
     }
 }

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -33,14 +33,15 @@ use sha2::{Digest, Sha256};
 use tokio::time::timeout;
 
 use crate::auth::{
-    AuthConfig, AuthPolicy, AuthRole, DEFAULT_PRE_AUTH_TIMEOUT, NodeAuth, run_auth_phase,
+    AuthConfig, AuthPolicy, AuthRole, DEFAULT_PRE_AUTH_TIMEOUT, NodeAuth, Selected, run_auth_phase,
+    run_auth_phase_selected,
 };
 use crate::enrollment::{
     ENROLL_ALPN, EnrollmentAcceptorOutcome, EnrollmentReceipt, EnrollmentRequest, InviteError,
     RESPONSE_ACK, RESPONSE_ACK_TIMEOUT, run_enrollment_acceptor, run_enrollment_dialer,
 };
 use crate::session::{DEFAULT_IDLE_TIMEOUT, SessionError, SessionReport, SyncStore, run_session};
-use crate::store::OplogSyncStore;
+use crate::store::{OplogContentSyncStore, OplogSyncStore};
 use crate::table_session::{
     TableSessionError, TableSessionReport, TableSyncStore, run_table_session,
 };
@@ -850,6 +851,145 @@ where
         }
     };
     // Keep the acceptor alive until the dialer reads its final acknowledgement and closes.
+    let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
+    conn.close(0u32.into(), b"done");
+    Ok((alpn, report))
+}
+
+/// One account a multi-account host serves: the account-log + content stores (BOTH for that one
+/// account) and its per-account admission [`AuthPolicy`]. A host holds a bounded slice of these; a
+/// connection selects one by the account the dialer names.
+///
+/// Constructed only through [`HostedAccount::new`], which REFUSES a `sync`/`content` pair for
+/// different accounts — the same invariant [`dispatch_connection`] enforces at runtime, lifted to
+/// construction so a misaligned pair (a content store for account B behind account A's log) is
+/// unrepresentable and can never serve one account's content to another's authenticated peer. The
+/// caller is responsible for passing DISTINCT accounts in the hosted slice; a duplicate account id
+/// is served by its first entry.
+pub struct HostedAccount<'a> {
+    sync: OplogSyncStore<'a>,
+    content: OplogContentSyncStore<'a>,
+    policy: AuthPolicy,
+}
+
+impl<'a> HostedAccount<'a> {
+    /// Bind an account's `sync` + `content` stores and its admission `policy` for hosting. Errors
+    /// if the two stores are for different accounts — the cross-account-content isolation
+    /// guard.
+    pub fn new(
+        sync: OplogSyncStore<'a>,
+        content: OplogContentSyncStore<'a>,
+        policy: AuthPolicy,
+    ) -> Result<Self, SyncFailure> {
+        if sync.account_id() != content.account_id() {
+            return Err(SyncFailure::Endpoint(EndpointError::Connect(
+                "account and content stores are for different accounts".into(),
+            )));
+        }
+        Ok(Self { sync, content, policy })
+    }
+}
+
+/// Accept ONE inbound connection and run its session for whichever of the host's BOUNDED SET of
+/// `accounts` the dialer names in its auth frame — one endpoint fronting N accounts (one store pair
+/// each). The dialer's named account selects the store pair, then the negotiated ALPN routes
+/// exactly as [`dispatch_connection`] does for the single-account case.
+///
+/// Isolation: the selected account's own stores serve the session, and every store rejects a
+/// foreign account's entries at ingest, so a session for one account never reads or writes
+/// another's. An account the host does not serve — or a peer that fails the selected account's
+/// policy — is refused with the SAME uniform [`AuthError`](crate::AuthError) as a rejected binding,
+/// so a peer cannot probe which accounts a host holds. No inventory leaves the host before
+/// selection + the binding check succeed.
+///
+/// Per-account policy is honored (a public `Open` account and a private `Closed` one may share the
+/// endpoint); table streams are always served under `Closed` regardless of the account's mode.
+/// `ENROLL_ALPN` is refused here: enrollment names its account out-of-band before any auth frame,
+/// and a host onboards accounts as the DIALER, not by accepting enrollment across its hosted set.
+pub async fn dispatch_connection_multi(
+    conn: IrohConnection,
+    local_node: [u8; 32],
+    accounts: &mut [HostedAccount<'_>],
+    now_ms: impl Fn() -> i64 + Copy,
+) -> Result<(Vec<u8>, SessionReport), SyncFailure> {
+    let remote_node = *conn.remote_id().as_bytes();
+    let alpn = conn.alpn().to_vec();
+    // The multi host serves the account-log, content, and table streams. ENROLL_ALPN (and any
+    // unbound ALPN) is refused BEFORE a stream opens — no route, no handshake.
+    if alpn.as_slice() != SYNC_ALPN
+        && alpn.as_slice() != CONTENT_SYNC_ALPN
+        && alpn.as_slice() != TABLE_SYNC_ALPN
+    {
+        conn.close(0u32.into(), b"unknown-alpn");
+        return Err(SyncFailure::Endpoint(EndpointError::Connect(format!(
+            "multi-account host does not serve ALPN {alpn:?}"
+        ))));
+    }
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.accept_bi())
+        .await
+        .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("peer opened no stream".into())))?
+        .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    // Read the clock only now that a peer has connected (see `accept_and_sync`).
+    let auth_now_ms = now_ms();
+    let table_alpn = alpn.as_slice() == TABLE_SYNC_ALPN;
+    // Authorize FIRST, selecting the account from the dialer's frame — no inventory (not even which
+    // account is served) leaves the host until selection + the binding check pass. `account_id` and
+    // `policy` in the config are placeholders the selection overrides.
+    let (selected_account, capabilities) = run_auth_phase_selected(
+        &mut send,
+        &mut recv,
+        AuthConfig {
+            role: AuthRole::Acceptor,
+            account_id: [0u8; 32],
+            local_node,
+            remote_node,
+            policy: AuthPolicy::Closed,
+            now_ms: auth_now_ms,
+            pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
+        },
+        |peer_account| {
+            accounts.iter().find(|account| account.sync.account_id() == *peer_account).map(
+                |account| Selected {
+                    account_id: *peer_account,
+                    auth: &account.sync,
+                    // Table streams are private account data — never Open, whatever the account's
+                    // mode.
+                    policy: if table_alpn { AuthPolicy::Closed } else { account.policy },
+                },
+            )
+        },
+    )
+    .await
+    .map_err(SyncFailure::Auth)?;
+    // The selector's shared borrow has ended; take the selected store pair mutably for the session.
+    let account = accounts
+        .iter_mut()
+        .find(|account| account.sync.account_id() == selected_account)
+        .expect("run_auth_phase_selected returns only an account the selector accepted");
+    let report = if alpn.as_slice() == SYNC_ALPN {
+        run_session(&mut account.sync, send, recv, AuthRole::Acceptor, capabilities)
+            .await
+            .map_err(SyncFailure::Session)?
+    } else if alpn.as_slice() == CONTENT_SYNC_ALPN {
+        run_session(&mut account.content, send, recv, AuthRole::Acceptor, capabilities)
+            .await
+            .map_err(SyncFailure::Session)?
+    } else {
+        let mut table_store = crate::store::OplogTableSyncStore::new(
+            account.sync.connection(),
+            AccountId::from_bytes(account.sync.account_id()),
+            now_ms,
+        );
+        let table =
+            run_table_session(&mut table_store, send, recv, AuthRole::Acceptor, capabilities)
+                .await
+                .map_err(SyncFailure::TableSession)?;
+        SessionReport {
+            entries_sent: table.entries_sent,
+            entries_received: table.entries_received,
+            entries_newly_stored: table.entries_newly_stored,
+        }
+    };
     let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
     conn.close(0u32.into(), b"done");
     Ok((alpn, report))
@@ -1672,6 +1812,175 @@ mod tests {
             rag_rat_oplog::account_entries_for_sync(&destination, account).unwrap().len(),
             expected.len(),
             "the anonymous dialer restored the selected server's account snapshot",
+        );
+    }
+
+    #[tokio::test]
+    async fn two_accounts_share_one_endpoint_and_route_by_the_named_account() {
+        // Two DISTINCT accounts, each in its own store, hosted on ONE endpoint via
+        // `dispatch_connection_multi`. A dialer naming account A restores A; a dialer naming
+        // account B restores B — over the SAME listener. Because each dialer's store is
+        // scoped to its own account (a foreign account's entries are rejected at ingest), a
+        // B-dialer restoring B's log proves the host SELECTED B's store, not a fixed first
+        // account — the isolation + routing guarantee together.
+        let db_a = database();
+        let acct_a = rag_rat_oplog::local_account(&db_a, NOW).unwrap();
+        let db_b = database();
+        let acct_b = rag_rat_oplog::local_account(&db_b, NOW).unwrap();
+        let a_expected = rag_rat_oplog::account_entries_for_sync(&db_a, acct_a).unwrap();
+        let b_expected = rag_rat_oplog::account_entries_for_sync(&db_b, acct_b).unwrap();
+        assert_ne!(acct_a.to_bytes(), acct_b.to_bytes(), "the two hosted accounts are distinct");
+
+        let (listener, dialer) = loopback_endpoints().await;
+        let local_node = *listener.id().as_bytes();
+        let mut hosts = vec![
+            HostedAccount::new(
+                crate::store::OplogSyncStore::new(&db_a, acct_a, || NOW),
+                crate::store::OplogContentSyncStore::new(&db_a, acct_a, || NOW),
+                AuthPolicy::Open,
+            )
+            .unwrap(),
+            HostedAccount::new(
+                crate::store::OplogSyncStore::new(&db_b, acct_b, || NOW),
+                crate::store::OplogContentSyncStore::new(&db_b, acct_b, || NOW),
+                AuthPolicy::Open,
+            )
+            .unwrap(),
+        ];
+
+        // Round 1 — a fresh peer anonymously restores account A.
+        let dest_a = database();
+        let mut dest_a_store = crate::store::OplogSyncStore::new(&dest_a, acct_a, || NOW);
+        let server = async {
+            let conn = accept_connection(&listener).await?;
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+        };
+        let client = connect_and_sync(
+            &dialer,
+            direct_addr(&listener),
+            SYNC_ALPN,
+            &mut dest_a_store,
+            AuthPolicy::Open,
+            NOW,
+        );
+        let (server_result, _client_result) = tokio::join!(server, client);
+        let (_alpn, report_a) = server_result.unwrap();
+        assert_eq!(report_a.entries_sent, a_expected.len(), "the host served account A's log");
+        assert_eq!(
+            rag_rat_oplog::account_entries_for_sync(&dest_a, acct_a).unwrap().len(),
+            a_expected.len(),
+            "the A-dialer restored account A",
+        );
+
+        // Round 2 — a fresh peer anonymously restores account B over the SAME host.
+        let dest_b = database();
+        let mut dest_b_store = crate::store::OplogSyncStore::new(&dest_b, acct_b, || NOW);
+        let server = async {
+            let conn = accept_connection(&listener).await?;
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+        };
+        let client = connect_and_sync(
+            &dialer,
+            direct_addr(&listener),
+            SYNC_ALPN,
+            &mut dest_b_store,
+            AuthPolicy::Open,
+            NOW,
+        );
+        let (server_result, _client_result) = tokio::join!(server, client);
+        let (_alpn, report_b) = server_result.unwrap();
+        assert_eq!(report_b.entries_sent, b_expected.len(), "the host served account B's log");
+        assert_eq!(
+            rag_rat_oplog::account_entries_for_sync(&dest_b, acct_b).unwrap().len(),
+            b_expected.len(),
+            "the B-dialer restored account B — selection served B's store, not a fixed first \
+             account",
+        );
+    }
+
+    #[test]
+    fn hosted_account_rejects_a_sync_content_pair_for_different_accounts() {
+        // The isolation guard lifted to construction: a content store behind another account's log
+        // is unrepresentable, so a connection authenticated for A can never reach B's content.
+        let db_a = database();
+        let acct_a = rag_rat_oplog::local_account(&db_a, NOW).unwrap();
+        let db_b = database();
+        let acct_b = rag_rat_oplog::local_account(&db_b, NOW).unwrap();
+        let mismatched = HostedAccount::new(
+            crate::store::OplogSyncStore::new(&db_a, acct_a, || NOW),
+            crate::store::OplogContentSyncStore::new(&db_b, acct_b, || NOW),
+            AuthPolicy::Open,
+        );
+        assert!(mismatched.is_err(), "a sync/content pair for different accounts is refused");
+    }
+
+    #[tokio::test]
+    async fn a_multi_host_applies_each_accounts_own_admission_policy() {
+        // One host, two accounts: A is Open, B is Closed. An anonymous dialer restores A but is
+        // refused on B — the policy is per-account (from the selection), not endpoint-wide.
+        let db_a = database();
+        let acct_a = rag_rat_oplog::local_account(&db_a, NOW).unwrap();
+        let db_b = database();
+        let acct_b = rag_rat_oplog::local_account(&db_b, NOW).unwrap();
+        let a_expected = rag_rat_oplog::account_entries_for_sync(&db_a, acct_a).unwrap();
+        let (listener, dialer) = loopback_endpoints().await;
+        let local_node = *listener.id().as_bytes();
+        let mut hosts = vec![
+            HostedAccount::new(
+                crate::store::OplogSyncStore::new(&db_a, acct_a, || NOW),
+                crate::store::OplogContentSyncStore::new(&db_a, acct_a, || NOW),
+                AuthPolicy::Open,
+            )
+            .unwrap(),
+            HostedAccount::new(
+                crate::store::OplogSyncStore::new(&db_b, acct_b, || NOW),
+                crate::store::OplogContentSyncStore::new(&db_b, acct_b, || NOW),
+                AuthPolicy::Closed,
+            )
+            .unwrap(),
+        ];
+
+        // The Open account A admits the anonymous dialer and restores its log.
+        let dest_a = database();
+        let mut dest_a_store = crate::store::OplogSyncStore::new(&dest_a, acct_a, || NOW);
+        let server = async {
+            let conn = accept_connection(&listener).await?;
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+        };
+        let client = connect_and_sync(
+            &dialer,
+            direct_addr(&listener),
+            SYNC_ALPN,
+            &mut dest_a_store,
+            AuthPolicy::Open,
+            NOW,
+        );
+        let (server_a, _client_a) = tokio::join!(server, client);
+        assert!(server_a.is_ok(), "the Open account admits the anonymous dialer: {server_a:?}");
+        assert_eq!(
+            rag_rat_oplog::account_entries_for_sync(&dest_a, acct_a).unwrap().len(),
+            a_expected.len(),
+        );
+
+        // The Closed account B refuses the same anonymous dialer — on the SAME host.
+        let dest_b = database();
+        let mut dest_b_store = crate::store::OplogSyncStore::new(&dest_b, acct_b, || NOW);
+        let server = async {
+            let conn = accept_connection(&listener).await?;
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+        };
+        let client = connect_and_sync(
+            &dialer,
+            direct_addr(&listener),
+            SYNC_ALPN,
+            &mut dest_b_store,
+            AuthPolicy::Open,
+            NOW,
+        );
+        let (server_b, _client_b) = tokio::join!(server, client);
+        assert!(
+            matches!(server_b, Err(SyncFailure::Auth(_))),
+            "the Closed account refuses the anonymous dialer: {server_b:?}"
         );
     }
 

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -29,14 +29,15 @@ pub mod wire;
 
 pub use auth::{
     AuthConfig, AuthError, AuthPolicy, AuthRole, LocalAuth, NodeAuth, PeerAuthorization,
-    PeerCapability, SessionCapabilities, run_auth_phase,
+    PeerCapability, Selected, SessionCapabilities, run_auth_phase, run_auth_phase_selected,
 };
 pub use endpoint::{
-    DiscoveredPeers, EndpointError, MAX_RECONCILE_ROUNDS, ReconcileReport, SyncFailure,
-    accept_and_dispatch, accept_and_sync, accept_connection, accept_enrollment, build_endpoint,
-    connect_and_enroll, connect_and_reconcile, connect_and_sync, connect_and_table_reconcile,
-    connect_and_table_sync, discover_peers, dispatch_connection, endpoint_addr,
-    node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
+    DiscoveredPeers, EndpointError, HostedAccount, MAX_RECONCILE_ROUNDS, ReconcileReport,
+    SyncFailure, accept_and_dispatch, accept_and_sync, accept_connection, accept_enrollment,
+    build_endpoint, connect_and_enroll, connect_and_reconcile, connect_and_sync,
+    connect_and_table_reconcile, connect_and_table_sync, discover_peers, dispatch_connection,
+    dispatch_connection_multi, endpoint_addr, node_id_from_secret, node_id_to_string, peer_addr,
+    peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,


### PR DESCRIPTION
Part of sync phase D (#406), Admission. The host was single-account by construction — the served account was fixed before a connection was accepted, and the dialer's named account was only equality-checked. This lets one endpoint front a **bounded set of accounts** (one store each), routed per connection by the account the dialer names in its auth frame.

## What changes

- **Restructured acceptor handshake.** `verify_peer`'s fused read-frame + account-scope + policy-authorize is split into a frame read and a binding authorization. A new `run_auth_phase_selected` reads the dialer's frame, hands the named account to a selector that picks the hosted account (its authorizer + **per-account** policy), authorizes the binding against that account, mints the acceptor's own frame for it, and returns the selected account so the dispatcher routes the data phase to its stores. The single-account path delegates through a one-account equality selector — its behavior is unchanged.
- **`dispatch_connection_multi`** selects a `HostedAccount` by the dialer's named account and dispatches the account-log, content, and table streams to it. An unhosted account — or a peer that fails the selected account's policy — is refused with the **same uniform error** as a rejected binding, so a peer cannot probe which accounts a host holds. Per-account policy is honored (a public `Open` account and a private `Closed` one may share the endpoint); table streams stay `Closed` regardless. `ENROLL_ALPN` is refused on the multi path (enrollment names its account out-of-band; a host onboards accounts as the dialer).
- **Isolation at both ends.** `HostedAccount` is built only through a constructor that refuses a `sync`/`content` pair for different accounts (unrepresentable misalignment), so a connection authenticated for one account can never reach another's content; and each store already rejects a foreign account's entries at ingest.

## Tests

Auth-layer: account selection resolves to the named account, an unhosted account is refused uniformly, and the selected account's own policy gates the connection. End-to-end over real loopback: two accounts share one endpoint and each dialer restores only its own account's log (a B-dialer restoring B proves B's store was selected, since a B-scoped store rejects A's entries); one host with A=`Open` and B=`Closed` admits an anonymous dialer on A but refuses it on B; and the constructor rejects a mismatched store pair.

This is the transport core. Host configuration for a bounded store set, the host-level node key, and per-account discovery advertisement are a follow-up. Part of #406.