### PR TITLE
feat(sync): bound the inbound accept rate to shed connection floods before the handshake (#406)

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -99,7 +99,7 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
 
 /// Owner-side pairing (`sync init`): mint a one-time invite, print the ticket, then host the
 /// enrollment exchange AND the joiner's follow-up account + content restore until interrupted. It
-/// is the same accept loop as [`serve`] — `accept_and_dispatch` already routes the enrollment ALPN
+/// is the same accept loop as [`serve`] — `dispatch_connection` already routes the enrollment ALPN
 /// against the owner's database — so `init` is simply "mint, then serve". Never `--once`: a joiner
 /// needs the enrollment connection plus two sync connections.
 fn init(config: &Config, mint: InviteMint) -> anyhow::Result<()> {
@@ -234,22 +234,47 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
         // ONE ctrl_c future for the whole loop: a fresh `ctrl_c()` per iteration would let a signal
         // delivered between iterations be swallowed by tokio's driver and missed.
         let mut shutdown = std::pin::pin!(tokio::signal::ctrl_c());
+        // `local_node` is already bound above (the roster gate); reuse it for
+        // `dispatch_connection`. Global inbound accept-rate limit: refuses a connection
+        // flood BEFORE the handshake, regardless of peer id (Sybil-resistant). Loop-owned;
+        // the accept is sequential so no locking.
+        let mut accept_rate = rag_rat_sync::GlobalAcceptRateLimiter::new();
         loop {
             // One endpoint, one accept loop: a connection carries the ACCOUNT-LOG ALPN or the
-            // CONTENT ALPN, and `accept_and_dispatch` routes it to the matching store after the
-            // (account-level) auth phase. Both stores are cheap handles reconstructed per accept.
+            // CONTENT ALPN (or ENROLL/TABLE), and `dispatch_connection` routes it to
+            // the matching store after the (account-level) auth phase. Both stores are
+            // cheap handles reconstructed per accept.
             let mut account_store = OplogSyncStore::new(conn, account_id, time::now_ms);
             let mut content_store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
+            // Accept + rate check + dispatch stay in ONE selected future so ctrl_c interrupts a
+            // peer mid-session. `Some(None)` = refused by the accept-rate limit
+            // (nothing served); `None` = shutdown. `accept_connection_within_rate`
+            // reads `now_ms` once a peer connects, so the auth timestamp never predates
+            // the connection.
             let outcome = tokio::select! {
-                // `accept_and_dispatch` reads `now_ms` once a peer connects — the server may wait
-                // here arbitrarily long, so the auth timestamp must not predate the connection.
-                result = rag_rat_sync::accept_and_dispatch(
-                    &endpoint,
-                    &mut account_store,
-                    &mut content_store,
-                    policy,
-                    time::now_ms,
-                ) => Some(result),
+                result = async {
+                    match rag_rat_sync::accept_connection_within_rate(
+                        &endpoint,
+                        &mut accept_rate,
+                        time::now_ms,
+                    )
+                    .await
+                    {
+                        Ok(Some(conn)) => Some(
+                            rag_rat_sync::dispatch_connection(
+                                conn,
+                                local_node,
+                                &mut account_store,
+                                &mut content_store,
+                                policy,
+                                time::now_ms,
+                            )
+                            .await,
+                        ),
+                        Ok(None) => None,
+                        Err(error) => Some(Err(error)),
+                    }
+                } => Some(result),
                 _ = &mut shutdown => None,
             };
             match outcome {
@@ -257,7 +282,10 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                     tracing::info!("interrupted; shutting down");
                     break;
                 },
-                Some(Ok((alpn, report))) => {
+                // Refused by the accept-rate limit before the handshake — nothing served, take the
+                // next connection (never an error, so `--once` is unaffected by a refusal).
+                Some(None) => continue,
+                Some(Some(Ok((alpn, report)))) => {
                     if alpn.as_slice() == rag_rat_sync::SYNC_ALPN
                         && report.entries_sent == 0
                         && report.entries_received == 0
@@ -282,8 +310,8 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                 // In one-shot mode the session IS the command's result, so a failed session is a
                 // failed command (scripted checks must see the non-zero exit). The long-running
                 // server logs and moves on to the next peer instead.
-                Some(Err(e)) if once => return Err(anyhow!("sync session failed: {e}")),
-                Some(Err(e)) => {
+                Some(Some(Err(e))) if once => return Err(anyhow!("sync session failed: {e}")),
+                Some(Some(Err(e))) => {
                     tracing::warn!(error = %e, "sync session failed");
                     // A closed endpoint makes `accept` fail immediately and forever, so continuing
                     // would spin the loop at 100% CPU logging the same error — exit non-zero.

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -546,9 +546,21 @@ async fn accept_loop(
     database: PathBuf,
 ) {
     let sessions = Arc::new(tokio::sync::Semaphore::new(RESIDENT_SESSION_MAX));
+    // Global inbound accept-rate limit: refuses a connection flood BEFORE the handshake, regardless
+    // of peer id (Sybil-resistant). Loop-owned, so no locking.
+    let mut accept_rate = rag_rat_sync::GlobalAcceptRateLimiter::new();
     loop {
-        let connection = match rag_rat_sync::accept_connection(&endpoint).await {
-            Ok(connection) => connection,
+        let connection = match rag_rat_sync::accept_connection_within_rate(
+            &endpoint,
+            &mut accept_rate,
+            time::now_ms,
+        )
+        .await
+        {
+            Ok(Some(connection)) => connection,
+            // Refused by the accept-rate limit before the handshake — nothing served, take the
+            // next.
+            Ok(None) => continue,
             Err(error) if endpoint.is_closed() => {
                 tracing::warn!(%error, "resident sync endpoint closed");
                 return;

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -739,6 +739,89 @@ pub async fn accept_connection(endpoint: &Endpoint) -> Result<IrohConnection, Sy
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))
 }
 
+/// Inbound connections admitted per second in steady state once the burst is spent. Sized to clear
+/// legitimate multi-peer inbound (a joiner opens ~4 rapid connections — enrollment + account log +
+/// content + table) while bounding a flood. Implementation-local constant, not config.
+const ACCEPT_REFILL_PER_SEC: f64 = 8.0;
+/// Maximum inbound connections admitted in one instantaneous burst.
+const ACCEPT_BURST: f64 = 32.0;
+
+/// A GLOBAL inbound-connection rate limiter: one token bucket bounding total accept rate regardless
+/// of peer identity. Per-peer-by-node-id limiting is the wrong lever — an iroh node id is a keypair
+/// mintable in microseconds, so a flood rotates ids and evades any per-id bucket while making the
+/// id map its own memory/eviction target. The Sybil-resistant bound is global and refused before
+/// the handshake. In-memory and transient by design: a restart resetting the window to full burst
+/// is correct for a live-traffic control (contrast the durable byte ceilings on the ingest paths).
+#[derive(Debug)]
+pub struct GlobalAcceptRateLimiter {
+    tokens: f64,
+    burst: f64,
+    refill_per_sec: f64,
+    last_ms: Option<i64>,
+}
+
+impl Default for GlobalAcceptRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GlobalAcceptRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            tokens: ACCEPT_BURST,
+            burst: ACCEPT_BURST,
+            refill_per_sec: ACCEPT_REFILL_PER_SEC,
+            last_ms: None,
+        }
+    }
+
+    /// Refill by the time elapsed since the last call (capped at `burst`, so idle time never
+    /// accrues unbounded credit), then spend one token. Returns `false` when the bucket is
+    /// empty — the connection should be refused. `now_ms` is injected so refill is
+    /// deterministically testable.
+    pub fn allow(&mut self, now_ms: i64) -> bool {
+        if let Some(last) = self.last_ms {
+            let elapsed_secs = (now_ms - last).max(0) as f64 / 1000.0;
+            self.tokens = (self.tokens + elapsed_secs * self.refill_per_sec).min(self.burst);
+        }
+        self.last_ms = Some(now_ms);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Accept one inbound connection, refusing it BEFORE the TLS handshake when the global accept-rate
+/// `limiter` is exhausted. `Ok(None)` means the connection was refused by the rate limit — the
+/// caller continues its accept loop; `Ok(Some(conn))` means admitted and handshaken. Refusing at
+/// the `Incoming` stage costs no handshake CPU and reveals nothing to the peer.
+pub async fn accept_connection_within_rate(
+    endpoint: &Endpoint,
+    limiter: &mut GlobalAcceptRateLimiter,
+    now_ms: impl Fn() -> i64,
+) -> Result<Option<IrohConnection>, SyncFailure> {
+    let incoming = endpoint
+        .accept()
+        .await
+        .ok_or_else(|| SyncFailure::Endpoint(EndpointError::Connect("endpoint closed".into())))?;
+    // Read the clock only NOW that a peer has connected — `accept()` can idle arbitrarily long, and
+    // a timestamp taken before the wait would under-credit the bucket's refill and wrongly
+    // refuse a connection arriving after a load-then-idle stretch.
+    if !limiter.allow(now_ms()) {
+        incoming.refuse();
+        return Ok(None);
+    }
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, incoming)
+        .await
+        .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("handshake timed out".into())))?
+        .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    Ok(Some(conn))
+}
+
 /// Run the ALPN-selected sync session for an already-accepted connection.
 pub async fn dispatch_connection<C>(
     conn: IrohConnection,
@@ -1507,6 +1590,102 @@ mod tests {
             .port();
         EndpointAddr::new(endpoint.id())
             .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+    }
+
+    #[test]
+    fn accept_rate_admits_a_burst_then_denies() {
+        let mut limiter = GlobalAcceptRateLimiter::new();
+        // The full burst is admitted at one instant...
+        for i in 0..ACCEPT_BURST as usize {
+            assert!(limiter.allow(NOW), "burst connection {i} within capacity");
+        }
+        // ...and the next one at the same instant is denied.
+        assert!(!limiter.allow(NOW), "the connection past the burst is refused");
+    }
+
+    #[test]
+    fn accept_rate_refills_over_time() {
+        let mut limiter = GlobalAcceptRateLimiter::new();
+        while limiter.allow(NOW) {} // drain the burst
+        assert!(!limiter.allow(NOW), "drained");
+        // One second later, exactly `ACCEPT_REFILL_PER_SEC` tokens are available again.
+        let later = NOW + 1000;
+        for i in 0..ACCEPT_REFILL_PER_SEC as usize {
+            assert!(limiter.allow(later), "refilled token {i} available after 1s");
+        }
+        assert!(!limiter.allow(later), "no more than the per-second refill accrues in 1s");
+    }
+
+    #[test]
+    fn accept_rate_refill_is_capped_at_the_burst() {
+        let mut limiter = GlobalAcceptRateLimiter::new();
+        while limiter.allow(NOW) {} // drain
+        // A long idle must not accrue unbounded credit — only up to the burst.
+        let long_idle = NOW + 1_000_000;
+        for i in 0..ACCEPT_BURST as usize {
+            assert!(limiter.allow(long_idle), "capped-refill token {i}");
+        }
+        assert!(!limiter.allow(long_idle), "idle time accrues at most one burst, not more");
+    }
+
+    #[test]
+    fn accept_rate_never_denies_traffic_under_the_rate() {
+        let mut limiter = GlobalAcceptRateLimiter::new();
+        // One connection every 250ms = 4/s, well under the 8/s refill — never denied over a long
+        // run.
+        for tick in 0..200 {
+            let now = NOW + tick * 250;
+            assert!(limiter.allow(now), "steady sub-rate traffic at tick {tick} is admitted");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_drained_accept_rate_refuses_a_connection_before_the_handshake() {
+        let (listener, dialer) = loopback_endpoints().await;
+        let mut limiter = GlobalAcceptRateLimiter::new();
+        while limiter.allow(NOW) {} // drain so the next accept is refused
+
+        let server = accept_connection_within_rate(&listener, &mut limiter, || NOW);
+        let client = async {
+            // The refused `Incoming` makes the dial fail rather than establish a session.
+            timeout(DEFAULT_IDLE_TIMEOUT, dialer.connect(direct_addr(&listener), SYNC_ALPN)).await
+        };
+        let (server_result, client_result) = tokio::join!(server, client);
+
+        assert!(
+            matches!(server_result, Ok(None)),
+            "a drained limiter refuses at the Incoming stage: {server_result:?}"
+        );
+        assert!(
+            matches!(client_result, Ok(Err(_)) | Err(_)),
+            "the dialer's connection does not establish"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_accept_rate_clock_is_read_when_the_peer_connects_not_before_the_wait() {
+        // Drain the bucket, then let the connection arrive an HOUR later. The limiter must refill
+        // against the CONNECT time — read via the closure after `accept()` resolves — not a
+        // timestamp captured before the idle wait. With an eagerly-captured clock this
+        // would wrongly refuse a legitimate connection after any load-then-idle stretch;
+        // the closure makes it admit.
+        let (listener, dialer) = loopback_endpoints().await;
+        let mut limiter = GlobalAcceptRateLimiter::new();
+        while limiter.allow(NOW) {}
+        let connect_at = NOW + 3_600_000;
+
+        let server = accept_connection_within_rate(&listener, &mut limiter, move || connect_at);
+        let client = async {
+            timeout(DEFAULT_IDLE_TIMEOUT, dialer.connect(direct_addr(&listener), SYNC_ALPN)).await
+        };
+        let (server_result, client_result) = tokio::join!(server, client);
+
+        assert!(
+            matches!(server_result, Ok(Some(_))),
+            "the bucket refilled to the connect time admits the delayed connection: \
+             {server_result:?}"
+        );
+        assert!(matches!(client_result, Ok(Ok(_))), "the dialer connects: {client_result:?}");
     }
 
     async fn accept_test_table_sync(

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -32,12 +32,12 @@ pub use auth::{
     PeerCapability, Selected, SessionCapabilities, run_auth_phase, run_auth_phase_selected,
 };
 pub use endpoint::{
-    DiscoveredPeers, EndpointError, HostedAccount, MAX_RECONCILE_ROUNDS, ReconcileReport,
-    SyncFailure, accept_and_dispatch, accept_and_sync, accept_connection, accept_enrollment,
-    build_endpoint, connect_and_enroll, connect_and_reconcile, connect_and_sync,
-    connect_and_table_reconcile, connect_and_table_sync, discover_peers, dispatch_connection,
-    dispatch_connection_multi, endpoint_addr, node_id_from_secret, node_id_to_string, peer_addr,
-    peer_addr_from_bytes,
+    DiscoveredPeers, EndpointError, GlobalAcceptRateLimiter, HostedAccount, MAX_RECONCILE_ROUNDS,
+    ReconcileReport, SyncFailure, accept_and_dispatch, accept_and_sync, accept_connection,
+    accept_connection_within_rate, accept_enrollment, build_endpoint, connect_and_enroll,
+    connect_and_reconcile, connect_and_sync, connect_and_table_reconcile, connect_and_table_sync,
+    discover_peers, dispatch_connection, dispatch_connection_multi, endpoint_addr,
+    node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,


### PR DESCRIPTION
Part of sync phase D (#406), Quotas. A sync host had no inbound connection rate limiting — a bounded concurrent-session semaphore and a pre-auth timeout cap concurrency and stalled slots, but not the RATE of connection establishment, so a flood forces a QUIC/TLS handshake per connection before any defense engages.

## What changes

- **A global accept-rate token bucket**, refused at iroh's `Incoming` stage **before** the handshake (`accept_connection_within_rate`). It is **global, not per-peer**: an iroh node id is a keypair mintable in microseconds, so a per-id limit is Sybil-evadable *and* still pays the handshake cost; a global cap bounds total inbound establishment regardless of id and refuses before any crypto. In-memory and transient by design — a restart resetting the window to full burst is correct for a live-traffic control (unlike the durable byte budgets on the ingest paths).
- **Both accept loops enforce it:** the resident host, and the CLI `sync serve` loop — the latter now accepts and dispatches explicitly (rather than through the combined helper) so the rate check sits between them, inside the one shutdown-selected future. A refused connection is a plain loop continuation, never a served session or a `--once` error.
- The limiter clock is read **when a peer actually connects**, not before the (arbitrarily long) accept wait, so a connection arriving after an idle stretch is measured against a correctly-refilled bucket. The clock is a closure parameter, so an eager evaluation cannot compile.

## Tests

Token-bucket units (injected clock): burst-then-deny, refill over time, refill capped at burst, and no denial under a sustained sub-rate. Real-loopback: a drained bucket refuses a connection at the `Incoming` stage, and a connection arriving after an idle stretch is admitted (proving the connect-time clock).

Per-peer concurrent-session fairness, per-account throttling, and global egress limits remain scoped follow-ups. Part of #406.