### PR TITLE
feat(sync): accept foreign content on public_read streams (#407)

### DIFF
--- a/crates/rag-rat-oplog/src/account/authoring.rs
+++ b/crates/rag-rat-oplog/src/account/authoring.rs
@@ -49,13 +49,28 @@ pub fn ensure_owned_stream_v2_in_tx(
     repo_id: &str,
     now_ms: i64,
 ) -> anyhow::Result<StreamId> {
+    ensure_owned_stream_v2_with_mode_in_tx(tx, repo_id, stream::AccessMode::Private, now_ms)
+}
+
+/// Like [`ensure_owned_stream_v2_in_tx`], but authors the `/2` owner stream under an explicit
+/// [`AccessMode`](stream::AccessMode). A `PublicRead` stream has a DISTINCT identity from the
+/// repo's private `/2` stream — the mode folds into `stream_id` — so publishing a public knowledge
+/// base is a separate stream a peer may read anonymously, never a flag flipped on the private one.
+/// Same check-fact-first idempotence and in-txn contract as the private ensure.
+pub fn ensure_owned_stream_v2_with_mode_in_tx(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    access_mode: stream::AccessMode,
+    now_ms: i64,
+) -> anyhow::Result<StreamId> {
     // The local account (author == owner of its `/2` streams) must already exist; resolve it and
     // its genesis entry hash (the founder incarnation a control op cites) WITHOUT minting.
     let LocalAccountRef { account_id, genesis_hash } = bootstrap::local_account_ref(tx)?.context(
         "cannot ensure a /2 owned stream before the store's local account is minted (call \
          local_account first)",
     )?;
-    let spec = stream::owner_stream_v2(repo_id, account_id);
+    let mut spec = stream::owner_stream_v2(repo_id, account_id);
+    spec.access_mode = access_mode;
     let stream_id = stream::derive_v2(&spec)?;
 
     // Check-fact-first. If the account already owns this stream, author NOTHING: a second

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -46,8 +46,8 @@ mod storage;
 pub use authoring::{
     EnrollingDevice, author_device_add_in_tx, author_enrollment_device_add_in_tx,
     enrollment_authoring_fits, enrollment_authoring_requirements, ensure_owned_stream_v2_in_tx,
-    established_owned_stream_v2, owned_stream_v2_id, retry_enrollment_pre_verify,
-    validate_device_add_label,
+    ensure_owned_stream_v2_with_mode_in_tx, established_owned_stream_v2, owned_stream_v2_id,
+    retry_enrollment_pre_verify, validate_device_add_label,
 };
 pub use bootstrap::{
     AuthoredDurability, ENROLLMENT_HELD_ENTRY_HASHES_MAX, EnrollmentBootstrap, EnrollmentBudget,
@@ -129,6 +129,7 @@ pub use storage::{
     account_signed_entry_exists, account_signed_hash, auth_len_freshness,
     backfill_authority_projection, grant_effective_for_device, owned_streams_for_account,
     owner_control_authority, owner_control_authority_in_snapshot, owner_secrets_authority,
-    roster_content_authority, stream_owner_effective, verify_enrollment_device_add,
+    roster_content_authority, stream_access_mode, stream_owner_account, stream_owner_effective,
+    verify_enrollment_device_add,
 };
-pub(crate) use storage::{device_is_effective_writer, stored_device_pubkeys, stream_owner_account};
+pub(crate) use storage::{device_is_effective_writer, stored_device_pubkeys};

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -20,7 +20,7 @@ use super::{AccountId, content, fold, secrets, snapshot};
 use crate::cbor;
 use crate::device::{DevicePublic, DeviceX25519Public};
 use crate::op::DeviceFingerprint;
-use crate::stream::StreamId;
+use crate::stream::{AccessMode, StreamId};
 
 type EntryHash = [u8; 32];
 type BranchKey = (u8, DeviceFingerprint, Option<EntryHash>);
@@ -1000,6 +1000,59 @@ pub fn stream_owner_account(
         )
         .optional()?;
     owner.map(|bytes| Ok(AccountId::from_bytes(fixed(&bytes)?))).transpose()
+}
+
+/// The [`AccessMode`] of `stream_id` as declared in `owner_account_id`'s effective `StreamOwn`
+/// fact.
+///
+/// Decode-on-read: `account_stream_ownership` records only the owning entry hash (`own_id`), so the
+/// mode is read back from that `StreamOwn` entry's spec bytes — no dedicated column. Returns
+/// [`AccessMode::Private`] (FAIL-CLOSED) whenever no effective ownership fact is folded locally: an
+/// unknown or not-yet-synced owner is treated as private, never public, so admission callers open
+/// nothing on a stream whose owner authority has not yet arrived. Resolve the owner FROM THE STREAM
+/// via [`stream_owner_account`] before calling — never from an attacker-settable claimed author.
+pub fn stream_access_mode(
+    conn: &Connection,
+    owner_account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<AccessMode> {
+    let own_id: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT own_id FROM account_stream_ownership
+             WHERE account_id = ?1 AND stream_id = ?2",
+            params![owner_account_id.to_bytes().as_slice(), stream_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(own_id) = own_id else {
+        return Ok(AccessMode::Private);
+    };
+    let raw: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT signed_bytes FROM account_entries
+             WHERE entry_hash = ?1 AND account_id = ?2",
+            params![own_id.as_slice(), owner_account_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(raw) = raw else {
+        // Ownership projected effective but its source entry is not present — fail closed.
+        return Ok(AccessMode::Private);
+    };
+    let entry = envelope::decode_account_signed(&raw)?;
+    let DecodedAccountOp::Known(AccountOp::StreamOwn { stream_id: owned, stream_spec_bytes }) =
+        ops::decode(entry.header.entry_type, &entry.payload)?
+    else {
+        anyhow::bail!("ownership fact does not name a StreamOwn operation");
+    };
+    let spec = crate::stream::decode_spec_v2(&stream_spec_bytes)?;
+    // The fold makes a StreamOwn effective only after checking `derive_v2(spec) == stream_id`, so
+    // this must already hold; re-assert to document the dependency this decode-on-read leans on.
+    anyhow::ensure!(
+        owned == stream_id && crate::stream::derive_v2(&spec)? == stream_id,
+        "ownership fact spec does not derive its stream id",
+    );
+    Ok(spec.access_mode)
 }
 
 /// Whether an account has folded to `contested` — a genuine owner-key-compromise / equivocation
@@ -3977,19 +4030,64 @@ mod tests {
     }
 
     fn stream_own(account_id: AccountId) -> (crate::stream::StreamId, AccountOp) {
+        stream_own_mode(account_id, crate::stream::AccessMode::Private, "repo-a")
+    }
+
+    fn stream_own_mode(
+        account_id: AccountId,
+        access_mode: crate::stream::AccessMode,
+        repo: &str,
+    ) -> (crate::stream::StreamId, AccountOp) {
         let spec = StreamSpecV2 {
             owner_account_id: account_id,
             policy: StreamSpec {
-                repo_set: vec!["repo-a".to_string()],
+                repo_set: vec![repo.to_string()],
                 kind_allow_list: None,
                 relation_policy: None,
                 node_overrides: Vec::new(),
             },
-            access_mode: crate::stream::AccessMode::Private,
+            access_mode,
         };
         let stream_id = stream::derive_v2(&spec).unwrap();
         let stream_spec_bytes = stream::canonical_spec_v2_bytes(&spec).unwrap();
         (stream_id, AccountOp::StreamOwn { stream_id, stream_spec_bytes })
+    }
+
+    #[test]
+    fn stream_access_mode_reads_public_and_private_and_fails_closed_on_unknown() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        // A public_read stream: the accessor decodes PublicRead from the folded StreamOwn spec.
+        let (public_stream, public_op) =
+            stream_own_mode(account_id, AccessMode::PublicRead, "repo-pub");
+        let (public_bytes, public_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &public_op);
+        account_ingest(&conn, &public_bytes, NOW + 1).unwrap();
+        assert_eq!(
+            stream_access_mode(&conn, account_id, public_stream).unwrap(),
+            AccessMode::PublicRead,
+        );
+
+        // A private stream on the same account resolves Private — and has a DISTINCT id, since the
+        // mode folds into the stream identity.
+        let (private_stream, private_op) =
+            stream_own_mode(account_id, AccessMode::Private, "repo-priv");
+        let (private_bytes, _) =
+            op(account_id, &founder, 2, Some(public_hash), Some(genesis_hash), &private_op);
+        account_ingest(&conn, &private_bytes, NOW + 2).unwrap();
+        assert_ne!(public_stream, private_stream);
+        assert_eq!(
+            stream_access_mode(&conn, account_id, private_stream).unwrap(),
+            AccessMode::Private,
+        );
+
+        // A stream with no folded ownership fact fails closed to Private — never public — so an
+        // unknown or not-yet-synced owner opens nothing at an admission caller.
+        let unknown = StreamId::from_bytes([0x77; 32]);
+        assert_eq!(stream_access_mode(&conn, account_id, unknown).unwrap(), AccessMode::Private);
     }
 
     fn device_remove(dev: &Dev, control_cut: super::super::cut::Cut) -> AccountOp {

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -115,16 +115,17 @@ pub use account::{
     content_stream_has_sealed_ratchet, content_stream_is_empty, current_sealing_key,
     decode_content_signed, enroll_stream_keys_for_device_in_tx, enrollment_authoring_fits,
     enrollment_authoring_requirements, enrollment_budget, ensure_owned_stream_v2_in_tx,
-    ensure_repo_incarnation, ensure_stream_key_current_in_tx, established_owned_stream_v2,
-    grant_effective_for_device, held_account_entry_hashes, historical_content_keyring,
-    live_stream_key_targets_for_device, local_account, mint_and_author_stream_key_wrap_in_tx,
-    owned_stream_v2_id, owned_streams_for_account, owner_control_authority,
-    owner_control_authority_in_snapshot, owner_secrets_authority, prepare_content_authoring,
-    prune_account_candidate_reservations_in_tx, read_local_account, read_local_account_genesis,
-    release_account_candidate_reservation_in_tx, repo_incarnation_state,
-    retry_enrollment_pre_verify, roster_content_authority, rotate_stream_key_in_tx,
-    select_current_sealing_wrap, settle_pending_content_refold_for_stream_in_tx,
-    settle_pending_content_refolds, sign_local_node_binding, stream_key_rotation_needed,
+    ensure_owned_stream_v2_with_mode_in_tx, ensure_repo_incarnation,
+    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
+    held_account_entry_hashes, historical_content_keyring, live_stream_key_targets_for_device,
+    local_account, mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id,
+    owned_streams_for_account, owner_control_authority, owner_control_authority_in_snapshot,
+    owner_secrets_authority, prepare_content_authoring, prune_account_candidate_reservations_in_tx,
+    read_local_account, read_local_account_genesis, release_account_candidate_reservation_in_tx,
+    repo_incarnation_state, retry_enrollment_pre_verify, roster_content_authority,
+    rotate_stream_key_in_tx, select_current_sealing_wrap,
+    settle_pending_content_refold_for_stream_in_tx, settle_pending_content_refolds,
+    sign_local_node_binding, stream_access_mode, stream_key_rotation_needed, stream_owner_account,
     stream_owner_effective, upsert_account_candidate_reservation_in_tx, validate_device_add_label,
     verify_enrollment_device_add, verify_node_binding,
 };
@@ -164,7 +165,7 @@ pub use op::{
 // per J1).
 pub use project::ProjectedState;
 pub use store::{author_batch, author_op, load_projection};
-pub use stream::StreamId;
+pub use stream::{AccessMode, StreamId};
 // The table-sync forward-compat seam (#1001): replay entries retained but not projected when
 // they arrived. Belongs at store open, before producing — see the module docs.
 pub use table_sync::{

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -6,11 +6,11 @@
 //! transport therefore adds no trust — a synced entry passes exactly the checks a local write does.
 
 use rag_rat_oplog::{
-    AccountId, ContentIngestOutcome, DeviceRole, IngestOutcome, NodeAuthError,
+    AccessMode, AccountId, ContentIngestOutcome, DeviceRole, IngestOutcome, NodeAuthError,
     account_effective_count, account_entries_for_sync, account_entry_ref, account_ingest,
     account_signed_entry_exists, account_signed_hash, content_entries_for_sync, content_entry_ref,
     content_ingest, content_signed_entry_exists, content_signed_hash, sign_local_node_binding,
-    verify_node_binding,
+    stream_access_mode, stream_owner_account, verify_node_binding,
 };
 use rusqlite::Connection;
 
@@ -161,10 +161,10 @@ impl SyncStore for OplogSyncStore<'_> {
 /// memories themselves, where [`OplogSyncStore`] moves the account log that authorizes them.
 ///
 /// Scoped to a single account, like the account-log store: a session restores the account's own
-/// memories onto a fresh sibling. Content authored by OTHER accounts (shared streams) is a later
-/// slice (#407) and is refused here. Received bytes go through [`content_ingest`], which
-/// re-resolves the roster key and re-verifies the signature from scratch — the transport adds no
-/// trust.
+/// memories onto a fresh sibling. Content authored by OTHER accounts is admitted only on a
+/// `public_read` stream (#407) — private foreign content is still refused here. Received bytes go
+/// through [`content_ingest`], which re-resolves the roster key and re-verifies the signature from
+/// scratch — the transport adds no trust.
 ///
 /// Run this AFTER an account-log session in the same restore: `content_ingest` needs the roster and
 /// grant material the account log carries to ACCEPT (rather than park) a candidate, so the account
@@ -201,19 +201,36 @@ impl SyncStore for OplogContentSyncStore<'_> {
     }
 
     fn ingest(&mut self, signed_bytes: &[u8]) -> anyhow::Result<Ingested> {
-        // Refuse content whose CLAIMED author is a DIFFERENT account than this session before it
-        // reaches `content_ingest`. This is a session-scope PRE-FILTER, not a trust boundary: the
-        // claimed author is attacker-settable, so `content_ingest` re-resolves the roster key and
-        // rejects anything not signed by a device in the account's roster regardless. The
-        // pre-filter keeps an honestly-labeled foreign entry from parking in this account's
-        // pre-verify table through a session that never named the other account. An
-        // undecodable entry is a peer to distrust — dropped as NoChange, not a
-        // session-fatal error.
-        let Ok((_stream, entry_account, _entry_hash)) = content_entry_ref(signed_bytes) else {
+        // Admit this account's OWN content, plus foreign content on a `public_read` stream, before
+        // it reaches `content_ingest`. This is a session-scope PRE-FILTER, not a trust boundary:
+        // the claimed author is attacker-settable, so `content_ingest` re-resolves the roster key
+        // and rejects anything not signed by a device in the author's roster regardless — the
+        // pre-filter only widens WHICH foreign candidates reach that verifier, never how they are
+        // trusted. Private (and not-yet-known-owner) foreign content is dropped so it never parks
+        // in this account's pre-verify table through a session that never named the other account.
+        // An undecodable entry is a peer to distrust — dropped as NoChange, not a session-fatal
+        // error.
+        let Ok((stream, entry_account, _entry_hash)) = content_entry_ref(signed_bytes) else {
             return Ok(Ingested::NoChange);
         };
         if entry_account != self.account_id {
-            return Ok(Ingested::NoChange);
+            // Resolve the access mode from the STREAM's owner, never from the attacker-settable
+            // claimed author — that also correctly admits grant-gated contributor content
+            // (grantee != owner) on a public stream, which `content_ingest` then gates on the
+            // grant. A dropped entry is re-offered by the next session's snapshot diff, so once the
+            // owner's account log is folded locally the admission converges (E2b orders owner log
+            // before content on delivery, so first-session convergence is the norm). ANY failure to
+            // resolve the owner/mode (owner not yet synced, a corrupt ownership fact) is treated as
+            // "not public" and drops the entry as NoChange — fail-closed AND never session-fatal,
+            // matching the undecodable-entry posture above rather than aborting the whole session.
+            let public =
+                stream_owner_account(self.conn, stream).ok().flatten().is_some_and(|owner| {
+                    stream_access_mode(self.conn, owner, stream).ok()
+                        == Some(AccessMode::PublicRead)
+                });
+            if !public {
+                return Ok(Ingested::NoChange);
+            }
         }
         // Skip content already held — matched by the EXACT signed envelope, not entry_hash: a
         // distinct signature of the same body is a different entry the peer may need, so it must

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -294,11 +294,12 @@ async fn a_fresh_peer_restores_the_accounts_content_after_the_account_log() {
     assert_eq!(accepted, 2, "the restored content folds accepted once authority is in place");
 }
 
-/// A content entry authored by a DIFFERENT account than the session is scoped to must not be stored
-/// — the account-scoped content store refuses it before ingest, so a peer cannot flood this
-/// account's pre-verify table with foreign candidates through a session that never named them.
+/// A content entry authored by a DIFFERENT account on a PRIVATE stream must not be stored — the
+/// content store refuses foreign content before ingest unless it is on a `public_read` stream, so a
+/// peer cannot flood this account's pre-verify table with private foreign candidates through a
+/// session that never named them. (The public-stream exception is covered below.)
 #[tokio::test]
-async fn foreign_account_content_is_not_stored() {
+async fn foreign_account_content_on_a_private_stream_is_not_stored() {
     use rag_rat_oplog::{
         MemoryOp, NodeContent, NodeId, SealPolicy, author_content_batch, content_entries_for_sync,
         ensure_owned_stream_v2_in_tx,
@@ -349,6 +350,142 @@ async fn foreign_account_content_is_not_stored() {
     assert!(
         content_entries_for_sync(&mine, other_account).unwrap().is_empty(),
         "the other account was not grown through my session",
+    );
+}
+
+/// Author real content on a `public_read` stream owned by `other`, returning `other`'s account id,
+/// its account-log entries (genesis + the public `StreamOwn`), and the authored content bytes. The
+/// two E2a tests below differ only in WHEN they fold `other`'s account log into the subscriber.
+fn public_stream_content_from_another_account()
+-> (Connection, rag_rat_oplog::AccountId, Vec<Vec<u8>>, Vec<u8>) {
+    use rag_rat_oplog::{
+        AccessMode, MemoryOp, NodeContent, NodeId, SealPolicy, account_entries_for_sync,
+        author_content_batch, content_entries_for_sync, ensure_owned_stream_v2_with_mode_in_tx,
+    };
+    use rusqlite::{Transaction, TransactionBehavior};
+
+    let other = fresh_db();
+    let other_account = local_account(&other, NOW).unwrap();
+    let public_stream = {
+        let tx = Transaction::new_unchecked(&other, TransactionBehavior::Immediate).unwrap();
+        let s =
+            ensure_owned_stream_v2_with_mode_in_tx(&tx, "repo-pub", AccessMode::PublicRead, NOW)
+                .unwrap();
+        tx.commit().unwrap();
+        s
+    };
+    author_content_batch(
+        &other,
+        public_stream,
+        &[MemoryOp::NodeCreate {
+            node_id: NodeId::from("n1"),
+            content: NodeContent {
+                kind: "Invariant".into(),
+                title: "t".into(),
+                body: "body".into(),
+                confidence: "high".into(),
+                source: "agent".into(),
+                tags: Vec::new(),
+                payload: None,
+            },
+        }],
+        SealPolicy::Plaintext,
+        NOW,
+    )
+    .unwrap();
+    let account_log = account_entries_for_sync(&other, other_account)
+        .unwrap()
+        .into_iter()
+        .map(|e| e.signed_bytes);
+    // seq order: genesis (seq 0) precedes the StreamOwn (seq 1), so a single in-order pass folds
+    // both; a re-pass would settle any parked tail regardless.
+    let account_log: Vec<Vec<u8>> = account_log.collect();
+    let content = content_entries_for_sync(&other, other_account).unwrap()[0].signed_bytes.clone();
+    (other, other_account, account_log, content)
+}
+
+/// Foreign content on a `public_read` stream IS admitted — and folds accepted — once the owner's
+/// account log is present locally. This is the acceptance half of anonymous pull (#407): the store
+/// no longer refuses foreign content whose stream the owner published public, and `content_ingest`
+/// verifies it against the owner's synced roster exactly as it does the account's own content.
+#[tokio::test]
+async fn foreign_content_on_a_public_stream_is_admitted_once_the_owner_log_is_present() {
+    use rag_rat_oplog::{
+        ContentRefoldBudget, account_ingest, content_entries_for_sync,
+        settle_pending_content_refolds,
+    };
+    use rag_rat_sync::{OplogContentSyncStore, SyncStore};
+
+    let (_other, other_account, account_log, content) =
+        public_stream_content_from_another_account();
+
+    // A subscriber account holds the owner's account log (roster + public StreamOwn) before ingest.
+    let mine = fresh_db();
+    let my_account = local_account(&mine, NOW).unwrap();
+    assert_ne!(my_account.to_bytes(), other_account.to_bytes());
+    for bytes in &account_log {
+        account_ingest(&mine, bytes, NOW).unwrap();
+    }
+
+    let mut store = OplogContentSyncStore::new(&mine, my_account, || NOW);
+    assert_eq!(
+        store.ingest(&content).unwrap(),
+        rag_rat_sync::Ingested::Stored,
+        "foreign content on a public_read stream is admitted to ingest",
+    );
+    assert_eq!(
+        content_entries_for_sync(&mine, other_account).unwrap().len(),
+        1,
+        "the public stream's content landed under the owner account",
+    );
+    // And it folds ACCEPTED — the subscriber recomputes authority from the synced owner log, never
+    // trusting the sender.
+    settle_pending_content_refolds(&mine, &ContentRefoldBudget::unbounded(), NOW).unwrap();
+    let accepted: i64 = mine
+        .query_row(
+            "SELECT count(*) FROM content_entries WHERE author_account_id = ?1 AND accepted = 1",
+            [other_account.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(accepted, 1, "public foreign content folds accepted against the synced owner log");
+}
+
+/// Out-of-order delivery converges without a park path: a public entry that arrives BEFORE the
+/// owner's account log drops as `NoChange` (the owner is unknown, so it fails closed to private),
+/// and the next re-offer — after the owner log is folded — is admitted. Drop-and-resync, no new
+/// parking dimension.
+#[tokio::test]
+async fn public_content_before_the_owner_log_drops_then_converges_on_re_offer() {
+    use rag_rat_oplog::account_ingest;
+    use rag_rat_sync::{OplogContentSyncStore, SyncStore};
+
+    let (_other, _other_account, account_log, content) =
+        public_stream_content_from_another_account();
+
+    let mine = fresh_db();
+    let my_account = local_account(&mine, NOW).unwrap();
+
+    // Owner log absent → the stream's owner/mode is unknown → fail closed, dropped (not parked).
+    // The scope ends the store's borrow of `mine` so the owner log can be folded next.
+    {
+        let mut store = OplogContentSyncStore::new(&mine, my_account, || NOW);
+        assert_eq!(
+            store.ingest(&content).unwrap(),
+            rag_rat_sync::Ingested::NoChange,
+            "a public entry whose owner log has not arrived is dropped, not parked",
+        );
+    }
+
+    // Owner log arrives; the re-offer is admitted — snapshot-diff convergence, no park path needed.
+    for bytes in &account_log {
+        account_ingest(&mine, bytes, NOW).unwrap();
+    }
+    let mut store = OplogContentSyncStore::new(&mine, my_account, || NOW);
+    assert_eq!(
+        store.ingest(&content).unwrap(),
+        rag_rat_sync::Ingested::Stored,
+        "once the owner log is folded, the re-offered public entry is admitted",
     );
 }
 


### PR DESCRIPTION
The content sync path previously refused every foreign-account content entry at its session-scope pre-filter, so a peer could only restore its own account's memories. This adds the acceptance half of a public knowledge base (#407): a peer now admits foreign content whose stream the owner published `public_read`, while private and unknown-owner foreign content is still dropped.

## What changed

- **`stream_access_mode`** — a decode-on-read accessor that resolves a stream's access mode from the owner's effective `StreamOwn` fact (`account_stream_ownership.own_id` → the entry's spec bytes → `decode_spec_v2`). It fails closed to `Private` on any miss (no ownership fact, missing entry, non-`StreamOwn`, derive mismatch), so an unknown or not-yet-synced owner opens nothing.
- **Relaxed content ingest pre-filter** — foreign content is admitted only on a `public_read` stream, with the mode resolved from the stream's owner rather than the attacker-settable claimed author (which also admits grant-gated contributor content, where grantee ≠ owner). This is admission scoping only: `content_ingest` remains the trust boundary, re-resolving the author's roster key and parking on missing authority exactly as before. Any error resolving the mode drops the entry rather than aborting the session.
- **`ensure_owned_stream_v2_with_mode_in_tx`** — lets a `public_read` owner stream be authored; the existing ensure delegates with `Private`. A public stream has a distinct identity from the repo's private one (the mode folds into `stream_id`), so publishing is a separate stream, never a flag flip.

Out-of-order delivery converges without a park path: a public entry arriving before the owner's account log drops as `NoChange` and, being unstored, is re-offered by the next session's snapshot diff once the owner log is folded.

## Scope

Serving public content to anonymous pullers — per-stream read admission, a stream-scoped content snapshot (today's whole-account snapshot would expose private streams), and a non-member-pullable subset of the owner's account log — is the transport slice that follows.

## Verification

`cargo +nightly fmt --check`; clippy `--workspace --all-targets` under `--no-default-features` and `--all-features`, plus the `--features eval` gates for `rag-rat-core`/`rag-rat` — all `-D warnings` clean; `cargo nextest run --workspace` (4993 passed) and `cargo test -p rag-rat-oplog -p rag-rat-sync` (both CI runners). New tests: the accessor (public/private/unknown → fail-closed), foreign private content still refused, foreign public content admitted and folding accepted once the owner log is present, and the drop-then-converge out-of-order case.