### PR TITLE
fix(ci): re-download onnxruntime clean so a poisoned ort-sys cache can't fail the build

### DIFF
--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -87,9 +87,14 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # rust-cache restore keys can bring back ort-sys link metadata from before ORT_CACHE_DIR was
-      # target-local. Force the build script to re-emit -L for the current cache location.
-      - run: cargo clean -p ort-sys
+      # rust-cache can restore a PARTIAL ort-sys download — a cache marker present but the native
+      # onnxruntime lib missing — so `cargo clean` alone re-emits link metadata pointing at a lib
+      # that isn't there ("could not find native static library `onnxruntime`"). Nuke the downloaded
+      # cache too so the build script re-downloads it clean and a poisoned cache can't resurface.
+      - shell: bash
+        run: |
+          cargo clean -p ort-sys
+          rm -rf "$ORT_CACHE_DIR"
       # Align the MSVC C runtime so the link succeeds. esaxx-rs (a C++ dep via
       # tokenizers <- model2vec/fastembed) hardcodes cc's .static_crt(true) => /MT, but the ort_sys
       # ONNX Runtime prebuilt is /MD; the mismatch is LNK2038/LNK1319 on Windows. cc appends env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,15 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # rust-cache restore keys can bring back ort-sys link metadata from before ORT_CACHE_DIR was
-      # target-local. Force the build script to re-emit -L for the current cache location.
-      - run: cargo clean -p ort-sys
-      # Compile the default feature set (downloads the ONNX runtime once, then cached) so the
-      # released binary's embedding paths never break silently.
+      # rust-cache can restore a PARTIAL ort-sys download — a cache marker present but the native
+      # onnxruntime lib missing — so `cargo clean` alone re-emits link metadata pointing at a lib
+      # that isn't there ("could not find native static library `onnxruntime`"). Nuke the downloaded
+      # cache too so the build script re-downloads it clean and a poisoned cache can't resurface.
+      - run: |
+          cargo clean -p ort-sys
+          rm -rf "$ORT_CACHE_DIR"
+      # Compile the default feature set (re-downloads the ONNX runtime) so the released binary's
+      # embedding paths never break silently.
       - run: cargo build --workspace --locked
 
   coverage:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -78,9 +78,13 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
-      # rust-cache restore keys can bring back ort-sys link metadata from before ORT_CACHE_DIR was
-      # target-local. Force the build script to re-emit -L for the current cache location.
-      - run: cargo clean -p ort-sys
+      # rust-cache can restore a PARTIAL ort-sys download — a cache marker present but the native
+      # onnxruntime lib missing — so `cargo clean` alone re-emits link metadata pointing at a lib
+      # that isn't there ("could not find native static library `onnxruntime`"). Nuke the downloaded
+      # cache too so the build script re-downloads it clean and a poisoned cache can't resurface.
+      - run: |
+          cargo clean -p ort-sys
+          rm -rf "$ORT_CACHE_DIR"
       # Cache the MiniLM model download (immutable → static key) so the semantic pass doesn't
       # re-fetch ~90 MB from Hugging Face every run; first run / cache-miss warms it.
       - name: cache embedding model


### PR DESCRIPTION
The `build (fastembed + model2vec)` and `eval` jobs intermittently fail with:

```
error: could not find native static library `onnxruntime`, perhaps an -L flag is missing?
error: could not compile `ort-sys`
```

## Cause

`ort-sys` downloads the ONNX Runtime into `ORT_CACHE_DIR` (`target/ort-cache`), which `Swatinem/rust-cache` saves and restores per job. A save can capture that download partially — the cache marker present but the native library missing — and on restore `cargo clean -p ort-sys` clears only the build output, so the build script re-emits its `-L` link metadata pointing at a library that isn't on disk. The failure is fast (~30s) and sticky: purging the caches fixes it until a job re-saves a partial download, then it returns on the next run.

## Fix

Remove the downloaded cache (`rm -rf "$ORT_CACHE_DIR"`) alongside the existing `cargo clean -p ort-sys` in the three ort-building jobs (`build`/`eval` in `ci.yml`/`eval.yml`, plus the cross-platform `build-full`). ort-sys then always re-downloads a complete runtime, so a poisoned cache can never resurface. The Windows/macOS leg pins `shell: bash` so the removal is portable.

Trades the download-cache hit on those jobs for a reliable build — the cache was already failing to hold a usable download.