### PR TITLE
docs: lead the memory guidance with the recovery gate and rejected alternatives

### DIFF
--- a/.agents/skills/using-rag-rat/SKILL.md
+++ b/.agents/skills/using-rag-rat/SKILL.md
@@ -78,26 +78,45 @@ PreToolUse hook that auto-augments your `grep`/`rg` calls with symbol + memory c
 
 ## Rule 2 — Record durable learnings as rag-rat memories before you finish
 
-When you discover something **durable and non-obvious** — a load-bearing invariant, a decision + its
-rationale, a risk/footgun that cost you time, a perf or platform quirk — record it with
-`memory_create` **before finishing the task**. If you had to read several files and reason to learn
-it, the next agent should get it in one MCP call.
+**The gate, before anything else: could the next agent recover this by reading the repo?** If yes,
+don't record it. A memory that restates what the code, the types, the tests, or the history already
+say leaves the reader *worse off*, not merely no better — it costs attention and returns nothing. On
+most tasks the honest answer is **record nothing**; that is the common outcome, not a failure to try
+hard enough. What passes the gate is what you had to read several files and reason to learn, and
+that the repo states nowhere.
+
+**Rejected alternatives lead.** The approach that was *not* taken leaves no artifact anywhere — not
+in the diff, not in the types, not in the history — which makes it at once the most-asked question
+about unfamiliar code and the least-supplied answer. If your task settled a choice, record the
+alternative and why it lost (`RejectedAlternative`) before you record anything about what the code
+now does.
 
 **Why rag-rat and not your harness's own notes:** rag-rat memories live in the repo's shared index,
 so they surface for **every** agent that queries it — Claude Code, Codex, any future tool — not just
 the one that wrote them. Your harness's private memory is invisible to the others. rag-rat is the
 **cross-agent memory layer**.
 
-**Write the present tense, not a changelog.** A memory is read by someone about to change the code,
-so it must say **what is true now and what to do about it**. Narrating what shipped is unactionable:
-"this was fixed in #123", "the predicate used to fail open", "stage 2 landed the split" all cost the
-reader attention and tell them nothing they can act on. Worse, a memory written as history goes stale
-the moment the next change lands, and it teaches the reader to distrust the rest of the entry.
+**Translate; never store the trajectory.** What you did, in what order, is worth less than nothing
+to the next reader — a replayed trace scores worse than having no memory at all. Distill it to a
+situation and an action — *when X, do Y, because Z* — and quote the evidence you generalised from
+(the failing line, the error, the constraint). Situated questions are not answered by general
+advice, and the quote is what spares the reader from trusting a summary of a summary.
 
-The same applies when you **update** one. If the thing a memory warned about has been fixed, do not
-append a status section — rewrite the body to state the rule that now holds, and delete the warning.
-If nothing actionable survives, `memory_mark_obsolete` it. A memory whose top half is a list of
-completed work is one nobody finishes reading.
+**Revise before you create.** A memory that has drifted actively misleads, while a missing one
+merely fails to help — so correcting or retiring a wrong record is the highest-value write
+available. `memory_search` first: if something already covers the ground, `memory_update` it; reach
+for `memory_create` only when nothing does.
+
+**Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
+later change can falsify, and a record that contradicts the source on one line gets distrusted on all
+of them. State the rule and the reason, then stop.
+
+**Write the present tense, not a changelog.** A memory is read by someone about to change the code,
+so it must say **what is true now and what to do about it**. "This was fixed in #123", "the predicate
+used to fail open", "stage 2 landed the split" are unactionable, and history goes stale the moment
+the next change lands. The same applies when you update one: if the thing a memory warned about has
+been fixed, rewrite the body to state the rule that now holds rather than appending a status section,
+and `memory_mark_obsolete` it if nothing actionable survives.
 
 Keep: invariants, the reasoning behind a decision, traps and their failure modes, what to reach for,
 what is still unresolved. Drop: PR/stage narration, "used to be", anything whose only value is that
@@ -105,7 +124,6 @@ it happened. Referencing an issue or test *name* is fine when it is a pointer th
 it is the story that does not belong.
 
 Do it well:
-- **`memory_search` first** to avoid duplicates.
 - **Anchor to the tightest stable target:** prefer an `id` binding (the `sym_<hex>` handle —
   self-heals across cross-file moves); fall back to a `path` binding for file/area notes, or a
   commit/GitHub ref for historical rationale.
@@ -113,9 +131,8 @@ Do it well:
   this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
   `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
   what, and not what changed.
-- **`memory_update` / `memory_mark_obsolete`** when a memory is wrong or superseded — don't leave
-  stale guidance. After a large refactor, **`memory_doctor`** flags `gone` anchors and
-  **`memory_rebind`** re-anchors them.
+- **After a large refactor**, `memory_doctor` flags `gone` anchors and `memory_rebind` re-anchors
+  them.
 
 The memory layer is kept honest by **`dream`** — a maintenance worklist of load-bearing code with no
 memory (coverage gaps) and memories that have drifted from the source. The **dream-review** skill is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,17 +48,39 @@ server is read-only on source — it never edits files; it writes only its own S
 
 ## Record durable learnings as rag-rat memories
 
-**This is required, not optional.** When you discover something durable and non-obvious — a
-load-bearing invariant, a decision + its rationale, a risk/footgun that cost you time, a perf
-characteristic, a "do not do X because Y" — record it with `memory_create` **before you finish the
-task**. If you had to read three files and reason for ten minutes to learn it, the next agent should
-get it in one MCP call. Don't let hard-won context evaporate.
+**Running the gate is required, not optional — producing a record is not.** Before you finish a
+task, ask: **could the next agent recover this by reading the repo?** If yes, don't record it. A
+memory that restates the code, the types, the tests, or the history leaves the reader *worse off*
+than none at all — it costs attention and returns nothing. On most tasks the honest answer is
+**record nothing**, and that is the common outcome, not a failure to try hard enough. What passes
+the gate is what you had to read three files and reason for ten minutes to learn, and that the repo
+states nowhere — don't let that evaporate.
+
+**Rejected alternatives lead.** The approach *not* taken leaves no artifact anywhere — not in the
+diff, not in the types, not in the history — which makes it at once the most-asked question about
+unfamiliar code and the least-supplied answer. If your work settled a choice, record the alternative
+and why it lost (`RejectedAlternative`) before anything about what the code now does.
 
 **Why rag-rat and not your own notes:** rag-rat memories live in this repo's shared index, so they
 surface for **every** agent that uses the rag-rat MCP — Claude Code, Codex, and any future tool —
 not just the one that wrote them. An agent's private/session memory (e.g. Claude Code's file memory,
 Codex's own store) is invisible to the others. rag-rat is the **cross-agent memory layer**; put
 anything another agent would benefit from here.
+
+**Translate; never store the trajectory.** What you did, in what order, is worth less than nothing
+to the next reader — a replayed trace scores worse than having no memory at all. Distill it to a
+situation and an action — *when X, do Y, because Z* — and quote the evidence you generalised from
+(the failing line, the error, the constraint). Situated questions are not answered by general
+advice, and the quote is what spares the reader from trusting a summary of a summary.
+
+**Revise before you create.** A memory that has drifted actively misleads, while a missing one merely
+fails to help — so correcting or retiring a wrong record is the highest-value write available.
+`memory_search` first: if something already covers the ground, `memory_update` it; reach for
+`memory_create` only when nothing does, and `memory_mark_obsolete` when nothing actionable survives.
+
+**Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
+later change can falsify, and a record that contradicts the source on one line gets distrusted on all
+of them. State the rule and the reason, then stop.
 
 How to do it well:
 - **Anchor to the tightest stable target.** Prefer an `id` binding (the `sym_<hex>` logical-symbol
@@ -71,10 +93,8 @@ How to do it well:
   it. "Fixed in #123", "used to fail open", "stage 2 landed the split" are unactionable: they cost
   the reader attention, go stale on the next change, and teach them to distrust the rest of the
   entry. When updating a memory whose warning no longer applies, rewrite the body to state the rule
-  that now holds — do not append a status section — and `memory_mark_obsolete` it if nothing
-  actionable survives. An issue or test *name* is a fine pointer; the story is not.
-- **`memory_search` first** to avoid duplicates; **`memory_update` / `memory_mark_obsolete`** when a
-  memory is wrong or superseded (don't leave stale guidance).
+  that now holds — do not append a status section. An issue or test *name* is a fine pointer; the
+  story is not.
 - **After large refactors**, run `rag-rat memory doctor` and re-anchor anything it flags `gone`
   (`rag-rat memory rebind <id> --symbol <name>`); content-confirmed moves re-anchor automatically.
 - This works the same from any agent: Claude Code calls the MCP `memory_create` tool; the `rag-rat`

--- a/plugin/skills/using-rag-rat/SKILL.md
+++ b/plugin/skills/using-rag-rat/SKILL.md
@@ -78,26 +78,45 @@ PreToolUse hook that auto-augments your `grep`/`rg` calls with symbol + memory c
 
 ## Rule 2 — Record durable learnings as rag-rat memories before you finish
 
-When you discover something **durable and non-obvious** — a load-bearing invariant, a decision + its
-rationale, a risk/footgun that cost you time, a perf or platform quirk — record it with
-`memory_create` **before finishing the task**. If you had to read several files and reason to learn
-it, the next agent should get it in one MCP call.
+**The gate, before anything else: could the next agent recover this by reading the repo?** If yes,
+don't record it. A memory that restates what the code, the types, the tests, or the history already
+say leaves the reader *worse off*, not merely no better — it costs attention and returns nothing. On
+most tasks the honest answer is **record nothing**; that is the common outcome, not a failure to try
+hard enough. What passes the gate is what you had to read several files and reason to learn, and
+that the repo states nowhere.
+
+**Rejected alternatives lead.** The approach that was *not* taken leaves no artifact anywhere — not
+in the diff, not in the types, not in the history — which makes it at once the most-asked question
+about unfamiliar code and the least-supplied answer. If your task settled a choice, record the
+alternative and why it lost (`RejectedAlternative`) before you record anything about what the code
+now does.
 
 **Why rag-rat and not your harness's own notes:** rag-rat memories live in the repo's shared index,
 so they surface for **every** agent that queries it — Claude Code, Codex, any future tool — not just
 the one that wrote them. Your harness's private memory is invisible to the others. rag-rat is the
 **cross-agent memory layer**.
 
-**Write the present tense, not a changelog.** A memory is read by someone about to change the code,
-so it must say **what is true now and what to do about it**. Narrating what shipped is unactionable:
-"this was fixed in #123", "the predicate used to fail open", "stage 2 landed the split" all cost the
-reader attention and tell them nothing they can act on. Worse, a memory written as history goes stale
-the moment the next change lands, and it teaches the reader to distrust the rest of the entry.
+**Translate; never store the trajectory.** What you did, in what order, is worth less than nothing
+to the next reader — a replayed trace scores worse than having no memory at all. Distill it to a
+situation and an action — *when X, do Y, because Z* — and quote the evidence you generalised from
+(the failing line, the error, the constraint). Situated questions are not answered by general
+advice, and the quote is what spares the reader from trusting a summary of a summary.
 
-The same applies when you **update** one. If the thing a memory warned about has been fixed, do not
-append a status section — rewrite the body to state the rule that now holds, and delete the warning.
-If nothing actionable survives, `memory_mark_obsolete` it. A memory whose top half is a list of
-completed work is one nobody finishes reading.
+**Revise before you create.** A memory that has drifted actively misleads, while a missing one
+merely fails to help — so correcting or retiring a wrong record is the highest-value write
+available. `memory_search` first: if something already covers the ground, `memory_update` it; reach
+for `memory_create` only when nothing does.
+
+**Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
+later change can falsify, and a record that contradicts the source on one line gets distrusted on all
+of them. State the rule and the reason, then stop.
+
+**Write the present tense, not a changelog.** A memory is read by someone about to change the code,
+so it must say **what is true now and what to do about it**. "This was fixed in #123", "the predicate
+used to fail open", "stage 2 landed the split" are unactionable, and history goes stale the moment
+the next change lands. The same applies when you update one: if the thing a memory warned about has
+been fixed, rewrite the body to state the rule that now holds rather than appending a status section,
+and `memory_mark_obsolete` it if nothing actionable survives.
 
 Keep: invariants, the reasoning behind a decision, traps and their failure modes, what to reach for,
 what is still unresolved. Drop: PR/stage narration, "used to be", anything whose only value is that
@@ -105,7 +124,6 @@ it happened. Referencing an issue or test *name* is fine when it is a pointer th
 it is the story that does not belong.
 
 Do it well:
-- **`memory_search` first** to avoid duplicates.
 - **Anchor to the tightest stable target:** prefer an `id` binding (the `sym_<hex>` handle —
   self-heals across cross-file moves); fall back to a `path` binding for file/area notes, or a
   commit/GitHub ref for historical rationale.
@@ -113,9 +131,8 @@ Do it well:
   this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
   `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
   what, and not what changed.
-- **`memory_update` / `memory_mark_obsolete`** when a memory is wrong or superseded — don't leave
-  stale guidance. After a large refactor, **`memory_doctor`** flags `gone` anchors and
-  **`memory_rebind`** re-anchors them.
+- **After a large refactor**, `memory_doctor` flags `gone` anchors and `memory_rebind` re-anchors
+  them.
 
 The memory layer is kept honest by **`dream`** — a maintenance worklist of load-bearing code with no
 memory (coverage gaps) and memories that have drifted from the source. The **dream-review** skill is


### PR DESCRIPTION
The memory-recording guidance in the `using-rag-rat` skill and in `AGENTS.md` told agents what a good
memory looks like but never told them when *not* to write one, and it buried the one kind of context
the repo cannot supply on its own. Both copies now open with the decision to write at all, in the
order a writer needs it.

**The gate comes first.** "Could the next agent recover this by reading the repo?" — if yes, don't
record it. A record that restates the code, the types, the tests, or the history leaves the reader
worse off than none at all: it costs attention and returns nothing. Recording nothing is described as
the common outcome, not a fallback. `AGENTS.md` previously opened with "this is required, not
optional," which contradicts that, so it now says the required step before finishing is running the
gate, not producing a record.

**Rejected alternatives lead.** The approach not taken leaves no artifact anywhere — not in the diff,
not in the types, not in the history — so it is at once the most-asked question about unfamiliar code
and the least-supplied answer. If a task settled a choice, the alternative and why it lost goes in
before anything about what the code now does.

Three further rulings:

- **Translate; never store the trajectory.** A replayed trace is worth less than no memory at all.
  Distill to a situation and an action — when X, do Y, because Z — and quote the evidence the rule was
  generalised from, so the reader can check it instead of trusting a summary of a summary.
- **Revise before you create.** A drifted memory actively misleads where a missing one merely fails to
  help, which makes correcting or retiring a wrong record the highest-value write available.
  `memory_search` first; `memory_update` when something already covers the ground.
- **Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
  later change can falsify, and a record that contradicts the source on one line gets distrusted on all
  of them.

The present-tense/no-changelog rule survives, condensed — it overlapped the trajectory ruling.

`AGENTS.md` had drifted from the skill and now carries the same rulings in the same order, keeping its
own CLI-facing details (`rag-rat memory doctor` / `rebind`, the harness-agnostic note).

Verified: `plugin/test/verify-skill-parity.sh` passes — the shipped `plugin/skills/using-rag-rat` copy
matches its `.agents/skills` source. Documentation only; no code paths touched.