### PR TITLE
docs: pin the memory title rule and a length target, and drop the provenance carve-out

### DIFF
--- a/.agents/skills/using-rag-rat/SKILL.md
+++ b/.agents/skills/using-rag-rat/SKILL.md
@@ -109,7 +109,8 @@ for `memory_create` only when nothing does.
 
 **Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
 later change can falsify, and a record that contradicts the source on one line gets distrusted on all
-of them. State the rule and the reason, then stop.
+of them. State the rule and the reason, then stop. Aim under 900 characters; most memories land at
+300–600. Past that you are usually restating code the reader can go read.
 
 **Write the present tense, not a changelog.** A memory is read by someone about to change the code,
 so it must say **what is true now and what to do about it**. "This was fixed in #123", "the predicate
@@ -129,8 +130,12 @@ Do it well:
   commit/GitHub ref for historical rationale.
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why
   this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
-  `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
-  what, and not what changed.
+  `FFIBoundary`. The body carries the **why** + **how to apply** — not just the what, and not what
+  changed.
+- **The title states the rule, not the story.** `#407 E3a: …`, `C4.3b`, `V042 … (phase A5)` are
+  titles nobody can act on: they name the work, so the reader must open the body to learn whether it
+  concerns them. Name the constraint or the trap instead, and leave an issue number as a trailing
+  pointer only when it earns its place. Max 160 characters.
 - **After a large refactor**, `memory_doctor` flags `gone` anchors and `memory_rebind` re-anchors
   them.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,8 @@ fails to help — so correcting or retiring a wrong record is the highest-value 
 
 **Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
 later change can falsify, and a record that contradicts the source on one line gets distrusted on all
-of them. State the rule and the reason, then stop.
+of them. State the rule and the reason, then stop. Aim under 900 characters; most memories land at
+300–600. Past that you are usually restating code the reader can go read.
 
 How to do it well:
 - **Anchor to the tightest stable target.** Prefer an `id` binding (the `sym_<hex>` logical-symbol
@@ -88,7 +89,11 @@ How to do it well:
   binding for file/area-level notes, or a commit/GitHub ref for historical rationale.
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why it's
   this way / why not the other), `Risk` / `BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
-  `FFIBoundary`. Write a concrete title, and a body with the *why* and *how to apply* — not just *what*.
+  `FFIBoundary`. The body carries the *why* and *how to apply* — not just *what*.
+- **The title states the rule, not the story.** `#407 E3a: …`, `C4.3b`, `V042 … (phase A5)` are
+  titles nobody can act on: they name the work, and the reader has to open the body to find out
+  whether it concerns them. Name the constraint or the trap instead, and leave an issue number as a
+  trailing pointer only when it earns its place. Max 160 characters.
 - **Write the present tense, not a changelog.** A memory says what is true NOW and what to do about
   it. "Fixed in #123", "used to fail open", "stage 2 landed the split" are unactionable: they cost
   the reader attention, go stale on the next change, and teach them to distrust the rest of the
@@ -122,8 +127,12 @@ the process that produced them:
 
 A reviewer should not be able to tell from a PR whether one agent or twenty produced it — only what
 changed and why. Durable, checkable references are encouraged: issue/PR numbers, commit SHAs, test
-names, file paths. (This is about *public* artifacts; rag-rat memories are the internal cross-agent
-layer and may record provenance freely.)
+names, file paths.
+
+Memories are held to the same bar for a different reason. A phase code, a round number, or a review
+play-by-play inside a memory is not a privacy problem — it is the narration that goes stale first
+and buries the rule underneath it. Durable, checkable references belong there too; the story does
+not.
 
 ## Repo orientation
 

--- a/plugin/skills/using-rag-rat/SKILL.md
+++ b/plugin/skills/using-rag-rat/SKILL.md
@@ -109,7 +109,8 @@ for `memory_create` only when nothing does.
 
 **Terseness is a staleness strategy, not a style preference.** Every extra detail is one more thing a
 later change can falsify, and a record that contradicts the source on one line gets distrusted on all
-of them. State the rule and the reason, then stop.
+of them. State the rule and the reason, then stop. Aim under 900 characters; most memories land at
+300–600. Past that you are usually restating code the reader can go read.
 
 **Write the present tense, not a changelog.** A memory is read by someone about to change the code,
 so it must say **what is true now and what to do about it**. "This was fixed in #123", "the predicate
@@ -129,8 +130,12 @@ Do it well:
   commit/GitHub ref for historical rationale.
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why
   this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
-  `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
-  what, and not what changed.
+  `FFIBoundary`. The body carries the **why** + **how to apply** — not just the what, and not what
+  changed.
+- **The title states the rule, not the story.** `#407 E3a: …`, `C4.3b`, `V042 … (phase A5)` are
+  titles nobody can act on: they name the work, so the reader must open the body to learn whether it
+  concerns them. Name the constraint or the trap instead, and leave an issue number as a trailing
+  pointer only when it earns its place. Max 160 characters.
 - **After a large refactor**, `memory_doctor` flags `gone` anchors and `memory_rebind` re-anchors
   them.
 


### PR DESCRIPTION
Three gaps in the memory-writing rules, each one something the guidance did not catch in practice.

**The provenance carve-out contradicted the rest.** The public-artifacts section closed with
"(This is about *public* artifacts; rag-rat memories are the internal cross-agent layer and may
record provenance freely.)" — which explicitly licensed phase codes, round numbers, and review
play-by-play inside memories. Whatever the audience argument, that is the material that goes stale
first and buries the rule underneath it. Memories are now held to the same bar, for the staleness
reason rather than the privacy one. Durable, checkable references — issue numbers, SHAs, test names,
paths — remain welcome in both places; the story does not.

**The title rule was implied, not stated.** "Write a concrete title" is satisfied by
`#407 E3a: …`, `C4.3b`, and `V042 … (phase A5)`. Those name the work rather than the rule, so a
reader scanning attached memories has to open each body to find out whether it concerns them. The
title now has to name the constraint or the trap, with an issue number allowed only as a trailing
pointer, inside the existing 160-character cap.

**Terseness had no number.** As written it was unfalsifiable, and unfalsifiable guidance does not
hold a corpus to anything. The target is now under 900 characters, with most entries at 300–600 —
past that a memory is usually restating code the reader can go read.

`plugin/test/verify-skill-parity.sh` passes: the shipped `plugin/skills/using-rag-rat` copy matches
its `.agents/skills` source. `AGENTS.md` carries the same three changes. Documentation only.