### PR TITLE
feat(sync): serve a published account under public-read admission (#1157)

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -202,7 +202,6 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
             },
             None => None,
         };
-        let policy = AuthPolicy::Closed;
 
         // A host is advertised by the same persisted controller the resident MCP host uses. It
         // owns its timer and DB handles, so resealing never waits for (or cancels) an inbound sync.
@@ -270,17 +269,33 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                     )
                     .await
                     {
-                        Ok(Some(conn)) => Some(
-                            rag_rat_sync::dispatch_connection(
-                                conn,
-                                local_node,
-                                &mut account_store,
-                                &mut content_store,
-                                policy,
-                                time::now_ms,
+                        Ok(Some(incoming)) => {
+                            // Serve a published public-KB account PublicRead (anonymous read),
+                            // everything else Closed — derived AFTER the peer lands so a `sync
+                            // publish` while parked waiting takes effect on this very connection. A
+                            // DB read fault fails closed (Closed); the store's fully-public snapshot
+                            // guard is the backstop either way.
+                            let policy = if rag_rat_core::sync_driver::account_is_public_kb(
+                                conn, account_id,
                             )
-                            .await,
-                        ),
+                            .unwrap_or(false)
+                            {
+                                AuthPolicy::PublicRead
+                            } else {
+                                AuthPolicy::Closed
+                            };
+                            Some(
+                                rag_rat_sync::dispatch_connection(
+                                    incoming,
+                                    local_node,
+                                    &mut account_store,
+                                    &mut content_store,
+                                    policy,
+                                    time::now_ms,
+                                )
+                                .await,
+                            )
+                        },
                         Ok(None) => None,
                         Err(error) => Some(Err(error)),
                     }

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -344,6 +344,21 @@ fn refused_publication_is_due(
     )
 }
 
+/// Whether `account` is a published public knowledge base — served under `AuthPolicy::PublicRead`
+/// (anonymous read) rather than `Closed`. True iff the account is fully public (no private stream)
+/// AND owns at least one stream, so a vacuously-fully-public FRESH/empty account is NOT exposed;
+/// only a deliberate `sync publish` (which refuses a non-fully-public account and ensures the
+/// public stream) satisfies both. Evaluated PER-CONNECTION by the serve loops so a node published
+/// while the host runs starts serving public without a restart; the store's own
+/// `account_is_fully_public` snapshot guard remains the fail-closed backstop.
+pub fn account_is_public_kb(
+    conn: &Connection,
+    account: rag_rat_oplog::AccountId,
+) -> anyhow::Result<bool> {
+    Ok(rag_rat_oplog::account_is_fully_public(conn, account)?
+        && !rag_rat_oplog::owned_streams_for_account(conn, account)?.is_empty())
+}
+
 /// Maintain a serving host's discovery announcement independently of its inbound session loop.
 ///
 /// The record in `index_meta` is reused only for the same endpoint identity, account tag, and
@@ -650,12 +665,20 @@ async fn accept_loop(
                 let conn = storage.connection();
                 let mut account_store = OplogSyncStore::new(conn, account, time::now_ms);
                 let mut content_store = OplogContentSyncStore::new(conn, account, time::now_ms);
+                // A published public-KB account is served PublicRead (anonymous read); every other
+                // account stays Closed. Derived per-connection so a mid-run `sync publish` takes
+                // effect without a restart.
+                let policy = if account_is_public_kb(conn, account)? {
+                    AuthPolicy::PublicRead
+                } else {
+                    AuthPolicy::Closed
+                };
                 let (alpn, report) = rag_rat_sync::dispatch_connection(
                     connection,
                     node,
                     &mut account_store,
                     &mut content_store,
-                    AuthPolicy::Closed,
+                    policy,
                     time::now_ms,
                 )
                 .await?;
@@ -915,10 +938,45 @@ mod tests {
 
     use super::{
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PerPeerSessionLimiter, PersistedAdvertisement,
-        RESIDENT_NUDGE, RefusedPublication, can_host, can_sync, device_sync_run,
-        nudge_resident_host, read_advertisement, refused_publication_is_due, retry_is_due,
-        write_advertisement,
+        RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host, can_sync,
+        device_sync_run, nudge_resident_host, read_advertisement, refused_publication_is_due,
+        retry_is_due, write_advertisement,
     };
+
+    fn schema_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn
+    }
+
+    fn own_stream(conn: &Connection, mode: rag_rat_oplog::AccessMode) {
+        use rusqlite::{Transaction, TransactionBehavior};
+        rag_rat_oplog::local_account(conn, 1_000).unwrap();
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        rag_rat_oplog::ensure_owned_stream_v2_with_mode_in_tx(&tx, "repo-a", mode, 1_000).unwrap();
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn account_is_public_kb_only_for_a_published_fully_public_account() {
+        // A minted-but-empty account (no owned stream) is NOT served public — else a fresh node
+        // would expose itself vacuously.
+        let empty = schema_conn();
+        let empty_account = rag_rat_oplog::local_account(&empty, 1_000).unwrap();
+        assert!(!account_is_public_kb(&empty, empty_account).unwrap());
+
+        // A private stream is not fully public.
+        let private = schema_conn();
+        own_stream(&private, rag_rat_oplog::AccessMode::Private);
+        let private_account = rag_rat_oplog::local_account(&private, 1_000).unwrap();
+        assert!(!account_is_public_kb(&private, private_account).unwrap());
+
+        // A published account (public stream, fully public) IS served public.
+        let public = schema_conn();
+        own_stream(&public, rag_rat_oplog::AccessMode::PublicRead);
+        let public_account = rag_rat_oplog::local_account(&public, 1_000).unwrap();
+        assert!(account_is_public_kb(&public, public_account).unwrap());
+    }
 
     #[test]
     fn nudge_is_durable_when_no_resident_host_is_live() {


### PR DESCRIPTION
The serve loops previously admitted every peer under `AuthPolicy::Closed`. A published public knowledge base (#1157) is now served under `AuthPolicy::PublicRead`, so anonymous peers can read it end to end (the transport and the fully-public serve guard merged in #1150–#1153); every other account stays `Closed`.

## What changed

- **`account_is_public_kb(conn, account)`** — true only for a deliberately published account: fully public (no private stream) AND owning at least one `/2` stream, so a vacuously-fully-public empty account is never exposed. Only `sync publish` reaches that state (it refuses a non-fully-public account and ensures the public stream), so the predicate tracks intent.
- **Both serve paths derive the policy per connection** — the resident host in its per-connection task, and `sync serve` in the post-accept arm — so publishing while the host is already parked waiting for a peer takes effect on that very connection, no restart. A read fault fails closed to `Closed`; the store's `account_is_fully_public` snapshot guard is the backstop regardless.
- **Table-sync stays pinned `Closed`** in `dispatch_connection`, so its manifests are never exposed to anonymous peers.

With this, a published node authors public (#1158) and serves anonymous read — the core of a dedicated public read-only node. Seeding an existing index's memories (`sync publish --seed`) and global egress limits follow.

## Verification

`cargo +nightly fmt --check`; clippy `--workspace --all-targets` under `--no-default-features` and `--all-features`, plus the `--features eval` gates — all `-D warnings` clean; `cargo nextest run --workspace` (5007) and `cargo test -p rag-rat-core` (both CI runners); the new `account_is_public_kb` test covers empty/private/public.