### PR TITLE
feat(sync): bound egress with a global byte rate limiter (#1157)

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -248,6 +248,11 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
         // flood BEFORE the handshake, regardless of peer id (Sybil-resistant). Loop-owned;
         // the accept is sequential so no locking.
         let mut accept_rate = rag_rat_sync::GlobalAcceptRateLimiter::new();
+        // Global egress byte cap bounding total data served — a peer cannot drain the host by
+        // re-pulling. An `Arc<Mutex>` to match the shared-handle API (the CLI accept is sequential,
+        // so there is never real contention).
+        let egress =
+            std::sync::Arc::new(std::sync::Mutex::new(rag_rat_sync::GlobalEgressLimiter::new()));
         loop {
             // One endpoint, one accept loop: a connection carries the ACCOUNT-LOG ALPN or the
             // CONTENT ALPN (or ENROLL/TABLE), and `dispatch_connection` routes it to
@@ -292,6 +297,7 @@ fn serve_with(config: &Config, once: bool, mint: Option<InviteMint>) -> anyhow::
                                     &mut content_store,
                                     policy,
                                     time::now_ms,
+                                    Some(egress.clone()),
                                 )
                                 .await,
                             )

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -618,6 +618,10 @@ async fn accept_loop(
     let mut accept_rate = rag_rat_sync::GlobalAcceptRateLimiter::new();
     // Per-peer concurrent-session fairness: one node id may not hold every session slot.
     let per_peer = PerPeerSessionLimiter::default();
+    // Global egress byte cap shared across all concurrent session tasks (an `Arc<Mutex>` — unlike
+    // the sequential accept limiter above, sessions run in parallel): bounds total data served
+    // so a peer cannot drain the host by re-pulling.
+    let egress = Arc::new(Mutex::new(rag_rat_sync::GlobalEgressLimiter::new()));
     loop {
         let connection = match rag_rat_sync::accept_connection_within_rate(
             &endpoint,
@@ -655,6 +659,7 @@ async fn accept_loop(
         };
         let database = database.clone();
         let node = *endpoint.id().as_bytes();
+        let egress = Arc::clone(&egress);
         tokio::task::spawn_local(async move {
             let _permit = permit;
             // Held to task end so this peer's slot is reserved for the whole session, then released
@@ -680,6 +685,7 @@ async fn accept_loop(
                     &mut content_store,
                     policy,
                     time::now_ms,
+                    Some(egress),
                 )
                 .await?;
                 if alpn.as_slice() == rag_rat_sync::CONTENT_SYNC_ALPN {

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -42,6 +42,7 @@ use crate::enrollment::{
 };
 use crate::session::{
     DEFAULT_IDLE_TIMEOUT, ServeScope, SessionError, SessionReport, SyncStore, run_session,
+    run_session_limited,
 };
 use crate::store::{OplogContentSyncStore, OplogSyncStore};
 use crate::table_session::{
@@ -725,7 +726,9 @@ where
 {
     let local_node = *endpoint.id().as_bytes();
     let conn = accept_connection(endpoint).await?;
-    dispatch_connection(conn, local_node, account_store, content_store, policy, now_ms).await
+    // Unmetered convenience/test wrapper — the live serve loops (resident host, `sync serve`) call
+    // `dispatch_connection` directly with the shared egress limiter.
+    dispatch_connection(conn, local_node, account_store, content_store, policy, now_ms, None).await
 }
 
 /// Accept and complete the transport handshake for one inbound connection. Kept separate from
@@ -747,6 +750,15 @@ pub async fn accept_connection(endpoint: &Endpoint) -> Result<IrohConnection, Sy
 const ACCEPT_REFILL_PER_SEC: f64 = 8.0;
 /// Maximum inbound connections admitted in one instantaneous burst.
 const ACCEPT_BURST: f64 = 32.0;
+
+/// Bytes served per second in steady state once the burst is spent — the sustained egress ceiling a
+/// public serving host allows across ALL peers. A text knowledge base is small, so a legitimate
+/// full pull clears the burst instantly; the ceiling bounds an anonymous peer that re-pulls to
+/// drain upload bandwidth. Implementation-local constants, not config (a host can be given a knob
+/// later).
+const EGRESS_REFILL_BYTES_PER_SEC: f64 = 16.0 * 1024.0 * 1024.0;
+/// Bytes servable in one instantaneous burst before the steady-state ceiling applies.
+const EGRESS_BURST_BYTES: f64 = 64.0 * 1024.0 * 1024.0;
 
 /// A GLOBAL inbound-connection rate limiter: one token bucket bounding total accept rate regardless
 /// of peer identity. Per-peer-by-node-id limiting is the wrong lever — an iroh node id is a keypair
@@ -790,6 +802,56 @@ impl GlobalAcceptRateLimiter {
         self.last_ms = Some(now_ms);
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// A GLOBAL byte-rate limiter bounding total EGRESS (data served to peers) regardless of peer
+/// identity — the anti-drain counterpart to [`GlobalAcceptRateLimiter`]. Global, not per-peer, for
+/// the same Sybil reason: a per-id budget is evaded by rotating node ids. Shared across the host's
+/// concurrent per-connection tasks (an `Arc<Mutex<_>>`), checked at each outgoing page. In-memory
+/// and transient: a restart resetting to full burst is correct for live-traffic control.
+#[derive(Debug)]
+pub struct GlobalEgressLimiter {
+    tokens: f64,
+    burst: f64,
+    refill_per_sec: f64,
+    last_ms: Option<i64>,
+}
+
+impl Default for GlobalEgressLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GlobalEgressLimiter {
+    pub fn new() -> Self {
+        Self {
+            tokens: EGRESS_BURST_BYTES,
+            burst: EGRESS_BURST_BYTES,
+            refill_per_sec: EGRESS_REFILL_BYTES_PER_SEC,
+            last_ms: None,
+        }
+    }
+
+    /// Refill by elapsed time (capped at `burst`), then, IF any credit remains, spend `bytes` (the
+    /// balance may go negative for an oversized page) and permit the page; otherwise refuse so the
+    /// sender stops after the pages already sent. Permitting on ANY positive credit guarantees
+    /// forward progress even for a page larger than the whole burst — a reader is never wedged,
+    /// only throttled, and the unsent tail is re-offered by the next session's inventory diff.
+    /// `now_ms` injected for deterministic tests.
+    pub fn allow(&mut self, bytes: usize, now_ms: i64) -> bool {
+        if let Some(last) = self.last_ms {
+            let elapsed_secs = (now_ms - last).max(0) as f64 / 1000.0;
+            self.tokens = (self.tokens + elapsed_secs * self.refill_per_sec).min(self.burst);
+        }
+        self.last_ms = Some(now_ms);
+        if self.tokens > 0.0 {
+            self.tokens -= bytes as f64;
             true
         } else {
             false
@@ -844,6 +906,7 @@ pub async fn dispatch_connection<C>(
     content_store: &mut C,
     policy: AuthPolicy,
     now_ms: impl Fn() -> i64 + Copy,
+    egress: Option<std::sync::Arc<std::sync::Mutex<GlobalEgressLimiter>>>,
 ) -> Result<(Vec<u8>, SessionReport), SyncFailure>
 where
     C: SyncStore,
@@ -931,14 +994,35 @@ where
     content_store.set_serve_scope(scope);
     // Route the session to the store the negotiated ALPN names (validated above, so the final
     // `else` is the table stream, not an unknown-ALPN fallthrough).
+    // The account log and `/3` content are the anonymous-servable paths, so their egress is metered
+    // against the shared budget. Table sync is pinned `Closed` (unreachable by an anonymous peer),
+    // so it carries no anonymous egress and is left unmetered here.
     let report = if alpn.as_slice() == SYNC_ALPN {
-        run_session(account_store, send, recv, AuthRole::Acceptor, capabilities)
-            .await
-            .map_err(SyncFailure::Session)?
+        run_session_limited(
+            account_store,
+            send,
+            recv,
+            AuthRole::Acceptor,
+            capabilities,
+            DEFAULT_IDLE_TIMEOUT,
+            egress,
+            now_ms,
+        )
+        .await
+        .map_err(SyncFailure::Session)?
     } else if alpn.as_slice() == CONTENT_SYNC_ALPN {
-        run_session(content_store, send, recv, AuthRole::Acceptor, capabilities)
-            .await
-            .map_err(SyncFailure::Session)?
+        run_session_limited(
+            content_store,
+            send,
+            recv,
+            AuthRole::Acceptor,
+            capabilities,
+            DEFAULT_IDLE_TIMEOUT,
+            egress,
+            now_ms,
+        )
+        .await
+        .map_err(SyncFailure::Session)?
     } else {
         let mut table_store = crate::store::OplogTableSyncStore::new(
             account_store.connection(),
@@ -1016,6 +1100,7 @@ pub async fn dispatch_connection_multi(
     local_node: [u8; 32],
     accounts: &mut [HostedAccount<'_>],
     now_ms: impl Fn() -> i64 + Copy,
+    egress: Option<std::sync::Arc<std::sync::Mutex<GlobalEgressLimiter>>>,
 ) -> Result<(Vec<u8>, SessionReport), SyncFailure> {
     let remote_node = *conn.remote_id().as_bytes();
     let alpn = conn.alpn().to_vec();
@@ -1078,14 +1163,34 @@ pub async fn dispatch_connection_multi(
     let scope = serve_scope_for(alpn_policy, admission);
     account.sync.set_serve_scope(scope);
     account.content.set_serve_scope(scope);
+    // As in `dispatch_connection`: the anonymous-servable account + content paths are
+    // egress-metered; table sync is pinned `Closed` (no anonymous egress) and left unmetered.
     let report = if alpn.as_slice() == SYNC_ALPN {
-        run_session(&mut account.sync, send, recv, AuthRole::Acceptor, capabilities)
-            .await
-            .map_err(SyncFailure::Session)?
+        run_session_limited(
+            &mut account.sync,
+            send,
+            recv,
+            AuthRole::Acceptor,
+            capabilities,
+            DEFAULT_IDLE_TIMEOUT,
+            egress,
+            now_ms,
+        )
+        .await
+        .map_err(SyncFailure::Session)?
     } else if alpn.as_slice() == CONTENT_SYNC_ALPN {
-        run_session(&mut account.content, send, recv, AuthRole::Acceptor, capabilities)
-            .await
-            .map_err(SyncFailure::Session)?
+        run_session_limited(
+            &mut account.content,
+            send,
+            recv,
+            AuthRole::Acceptor,
+            capabilities,
+            DEFAULT_IDLE_TIMEOUT,
+            egress,
+            now_ms,
+        )
+        .await
+        .map_err(SyncFailure::Session)?
     } else {
         let mut table_store = crate::store::OplogTableSyncStore::new(
             account.sync.connection(),
@@ -1659,6 +1764,20 @@ mod tests {
     }
 
     #[test]
+    fn egress_bounds_bytes_then_refills() {
+        let mut limiter = GlobalEgressLimiter::new();
+        // A page is permitted while any credit remains, even one larger than the whole burst
+        // (forward progress), driving the balance to zero-or-below.
+        assert!(limiter.allow(EGRESS_BURST_BYTES as usize, NOW), "the burst is servable");
+        assert!(
+            !limiter.allow(1, NOW),
+            "a further page at the same instant is refused (no credit)"
+        );
+        // One second refills `EGRESS_REFILL_BYTES_PER_SEC`, so serving resumes.
+        assert!(limiter.allow(1, NOW + 1000), "refilled credit permits serving again after 1s");
+    }
+
+    #[test]
     fn accept_rate_refills_over_time() {
         let mut limiter = GlobalAcceptRateLimiter::new();
         while limiter.allow(NOW) {} // drain the burst
@@ -2088,7 +2207,7 @@ mod tests {
         let mut dest_a_store = crate::store::OplogSyncStore::new(&dest_a, acct_a, || NOW);
         let server = async {
             let conn = accept_connection(&listener).await?;
-            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW, None).await
         };
         let client = connect_and_sync(
             &dialer,
@@ -2112,7 +2231,7 @@ mod tests {
         let mut dest_b_store = crate::store::OplogSyncStore::new(&dest_b, acct_b, || NOW);
         let server = async {
             let conn = accept_connection(&listener).await?;
-            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW, None).await
         };
         let client = connect_and_sync(
             &dialer,
@@ -2180,7 +2299,7 @@ mod tests {
         let mut dest_a_store = crate::store::OplogSyncStore::new(&dest_a, acct_a, || NOW);
         let server = async {
             let conn = accept_connection(&listener).await?;
-            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW, None).await
         };
         let client = connect_and_sync(
             &dialer,
@@ -2202,7 +2321,7 @@ mod tests {
         let mut dest_b_store = crate::store::OplogSyncStore::new(&dest_b, acct_b, || NOW);
         let server = async {
             let conn = accept_connection(&listener).await?;
-            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW).await
+            dispatch_connection_multi(conn, local_node, &mut hosts, || NOW, None).await
         };
         let client = connect_and_sync(
             &dialer,

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -33,12 +33,12 @@ pub use auth::{
     run_auth_phase_selected,
 };
 pub use endpoint::{
-    DiscoveredPeers, EndpointError, GlobalAcceptRateLimiter, HostedAccount, MAX_RECONCILE_ROUNDS,
-    ReconcileReport, SyncFailure, accept_and_dispatch, accept_and_sync, accept_connection,
-    accept_connection_within_rate, accept_enrollment, build_endpoint, connect_and_enroll,
-    connect_and_reconcile, connect_and_sync, connect_and_table_reconcile, connect_and_table_sync,
-    discover_peers, dispatch_connection, dispatch_connection_multi, endpoint_addr,
-    node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
+    DiscoveredPeers, EndpointError, GlobalAcceptRateLimiter, GlobalEgressLimiter, HostedAccount,
+    MAX_RECONCILE_ROUNDS, ReconcileReport, SyncFailure, accept_and_dispatch, accept_and_sync,
+    accept_connection, accept_connection_within_rate, accept_enrollment, build_endpoint,
+    connect_and_enroll, connect_and_reconcile, connect_and_sync, connect_and_table_reconcile,
+    connect_and_table_sync, discover_peers, dispatch_connection, dispatch_connection_multi,
+    endpoint_addr, node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,
@@ -52,7 +52,7 @@ pub use enrollment::{
 pub use iroh::EndpointAddr;
 pub use session::{
     DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES, ServeScope, SessionError, SessionReport,
-    SyncStore, run_session, run_session_with_idle_timeout,
+    SyncStore, run_session, run_session_limited, run_session_with_idle_timeout,
 };
 pub use store::{OplogContentSyncStore, OplogSyncStore, OplogTableSyncStore};
 pub use table_session::{

--- a/crates/rag-rat-sync/src/session.rs
+++ b/crates/rag-rat-sync/src/session.rs
@@ -166,8 +166,8 @@ where
 /// within `idle_timeout`. Exposed so tests can exercise the timeout without waiting the default.
 pub async fn run_session_with_idle_timeout<S, R, W>(
     store: &mut S,
-    mut send: W,
-    mut recv: R,
+    send: W,
+    recv: R,
     role: AuthRole,
     capabilities: SessionCapabilities,
     idle_timeout: Duration,
@@ -176,6 +176,32 @@ where
     S: SyncStore,
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
+{
+    run_session_limited(store, send, recv, role, capabilities, idle_timeout, None, || 0).await
+}
+
+/// [`run_session_with_idle_timeout`] plus a GLOBAL egress cap. When `egress` is `Some`, each
+/// outgoing entries page is charged against the shared [`crate::GlobalEgressLimiter`], and the
+/// sender STOPS after the last page the budget allowed (sending `Done` early) — the withheld tail
+/// is re-offered by the next session's inventory diff, so a throttled reader converges across
+/// retries. `None` leaves the session unmetered (the dialer paths and tests). `now_ms` is read only
+/// when `egress` is `Some`.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_session_limited<S, R, W, F>(
+    store: &mut S,
+    mut send: W,
+    mut recv: R,
+    role: AuthRole,
+    capabilities: SessionCapabilities,
+    idle_timeout: Duration,
+    egress: Option<std::sync::Arc<std::sync::Mutex<crate::GlobalEgressLimiter>>>,
+    now_ms: F,
+) -> Result<SessionReport, SessionError>
+where
+    S: SyncStore,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: Fn() -> i64,
 {
     let account_id = store.account_id();
     let snapshot = store.snapshot().map_err(SessionError::Store)?;
@@ -202,6 +228,21 @@ where
         } else {
             Vec::new()
         };
+        // Global egress cap: TRIM the set to the prefix the shared byte budget affords, then page
+        // it normally — the paging below is unchanged, so every `more` flag stays correct
+        // and the receiver never sees a truncated-but-`more:true` stream. The trimmed tail
+        // is re-offered by the next session's inventory diff (convergence). Charged per
+        // entry under ONE lock, held only here (never across an await); the balance may go
+        // negative on an oversized entry, and permitting while ANY credit remains
+        // guarantees forward progress. Poison-tolerant so a panic in one session task
+        // cannot wedge all future serving.
+        if let Some(limiter) = &egress {
+            let now = now_ms();
+            let mut guard = limiter.lock().unwrap_or_else(|poison| poison.into_inner());
+            let kept = to_send.iter().take_while(|entry| guard.allow(entry.len(), now)).count();
+            drop(guard);
+            to_send.truncate(kept);
+        }
         let total = to_send.len();
         // Drain into fixed pages so no single frame exceeds the per-page cap.
         let mut rest = to_send.split_off(0);
@@ -501,6 +542,124 @@ mod tests {
         assert_eq!(server.entries.len(), full.len());
         assert_eq!(reader.entries.len(), full.len() + 1);
         assert!(reader.entries.contains_key(&reader_only.0));
+    }
+
+    #[tokio::test]
+    async fn an_exhausted_egress_budget_serves_nothing_then_converges_after_refill() {
+        use std::sync::{Arc, Mutex};
+        let now = 1_700_000_000_000i64;
+        let full: Vec<_> = (0u8..5).map(entry).collect();
+
+        // A shared egress limiter overspent so its balance is negative at `now`.
+        let egress = Arc::new(Mutex::new(crate::GlobalEgressLimiter::new()));
+        egress.lock().unwrap().allow(256 * 1024 * 1024, now);
+
+        // Round 1 at `now` (no refill): an exhausted budget serves nothing.
+        {
+            let mut server = MemStore::new([0xe6; 32], &full);
+            let mut reader = MemStore::new([0xe6; 32], &[]);
+            let (server_send, reader_recv) = tokio::io::duplex(1 << 20);
+            let (reader_send, server_recv) = tokio::io::duplex(1 << 20);
+            let (s, r) = tokio::join!(
+                run_session_limited(
+                    &mut server,
+                    server_send,
+                    server_recv,
+                    AuthRole::Acceptor,
+                    SessionCapabilities::new(PeerCapability::ReadWrite, PeerCapability::ReadOnly),
+                    DEFAULT_IDLE_TIMEOUT,
+                    Some(egress.clone()),
+                    move || now,
+                ),
+                run_session(
+                    &mut reader,
+                    reader_send,
+                    reader_recv,
+                    AuthRole::Dialer,
+                    SessionCapabilities::new(PeerCapability::ReadOnly, PeerCapability::ReadWrite),
+                ),
+            );
+            s.unwrap();
+            r.unwrap();
+            assert!(reader.entries.is_empty(), "an exhausted egress budget serves nothing");
+        }
+
+        // Round 2 with the clock advanced past a full refill: the withheld set is served —
+        // convergence across retries.
+        {
+            let later = now + 60_000;
+            let mut server = MemStore::new([0xe6; 32], &full);
+            let mut reader = MemStore::new([0xe6; 32], &[]);
+            let (server_send, reader_recv) = tokio::io::duplex(1 << 20);
+            let (reader_send, server_recv) = tokio::io::duplex(1 << 20);
+            let (s, r) = tokio::join!(
+                run_session_limited(
+                    &mut server,
+                    server_send,
+                    server_recv,
+                    AuthRole::Acceptor,
+                    SessionCapabilities::new(PeerCapability::ReadWrite, PeerCapability::ReadOnly),
+                    DEFAULT_IDLE_TIMEOUT,
+                    Some(egress.clone()),
+                    move || later,
+                ),
+                run_session(
+                    &mut reader,
+                    reader_send,
+                    reader_recv,
+                    AuthRole::Dialer,
+                    SessionCapabilities::new(PeerCapability::ReadOnly, PeerCapability::ReadWrite),
+                ),
+            );
+            s.unwrap();
+            r.unwrap();
+            assert_eq!(reader.entries.len(), full.len(), "after refill the withheld set is served");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_generous_egress_budget_serves_a_multi_page_transfer_intact() {
+        use std::sync::{Arc, Mutex};
+        // Distinct 32-byte hashes so the set exceeds one page (`entry`'s u8 seed caps at 256).
+        let make = |i: usize| -> (Hash, Vec<u8>) {
+            let mut hash = [0u8; 32];
+            hash[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            let mut bytes = vec![0u8; 40];
+            bytes[..32].copy_from_slice(&hash);
+            (hash, bytes)
+        };
+        let count = MAX_ENTRIES_PER_PAGE + 10; // spans more than one page
+        let full: Vec<_> = (0..count).map(make).collect();
+        let mut server = MemStore::new([0xe7; 32], &full);
+        let mut reader = MemStore::new([0xe7; 32], &[]);
+        // A fresh (generous) budget must not disturb a normal multi-page transfer: every page's
+        // `more` flag stays correct and the receiver's truncation guard never fires.
+        let egress = Arc::new(Mutex::new(crate::GlobalEgressLimiter::new()));
+        let (server_send, reader_recv) = tokio::io::duplex(1 << 20);
+        let (reader_send, server_recv) = tokio::io::duplex(1 << 20);
+        let (s, r) = tokio::join!(
+            run_session_limited(
+                &mut server,
+                server_send,
+                server_recv,
+                AuthRole::Acceptor,
+                SessionCapabilities::new(PeerCapability::ReadWrite, PeerCapability::ReadOnly),
+                DEFAULT_IDLE_TIMEOUT,
+                Some(egress),
+                || 1_700_000_000_000,
+            ),
+            run_session(
+                &mut reader,
+                reader_send,
+                reader_recv,
+                AuthRole::Dialer,
+                SessionCapabilities::new(PeerCapability::ReadOnly, PeerCapability::ReadWrite),
+            ),
+        );
+        let server_report = s.unwrap();
+        r.unwrap();
+        assert_eq!(reader.entries.len(), count, "the whole multi-page set is served intact");
+        assert_eq!(server_report.entries_sent, count, "entries_sent reflects the full transfer");
     }
 
     #[tokio::test]


### PR DESCRIPTION
A public read-only node (#1157) serves anonymous readers, so its outbound bandwidth must be bounded or a peer can drain it by repeatedly pulling the snapshot. This adds a global egress cap — the last abuse-hardening gate before such a node is exposed.

## What changed

- **`GlobalEgressLimiter`** — a token bucket over bytes served, GLOBAL rather than per-peer (a per-id budget is evaded by rotating node ids — the same Sybil reasoning as the merged accept-rate limiter), shared across the host's concurrent session tasks via `Arc<Mutex>`. Burst 64 MiB, refill 16 MiB/s (implementation-local, tunable later).
- **Trim, don't truncate mid-stream.** The session sender trims the set it offers to the prefix the budget affords, then pages it with the unchanged paging loop — so every page's `more` flag stays correct and a throttled transfer is a valid session (not a protocol error). The withheld tail is re-offered by the next session's inventory diff, so a throttled reader converges across retries. The budget is charged per entry under one lock, released before any `.await` and poison-tolerant.
- **Metered where it matters.** Both dispatchers meter the anonymous-servable account-log and `/3` content paths; table sync is admitted only under `Closed`, so it carries no anonymous egress and is left unmetered.
- The resident host and `sync serve` each own one limiter shared across their connections.

With this, a published node authors public (#1158), serves anonymous read (#1161), and is egress-bounded — the abuse posture (global accept-rate + per-peer session caps + per-account byte ceilings + this egress cap; anonymous readers cannot push) needed to expose it.

## Tests

The bucket bounds bytes then refills; an exhausted budget serves nothing and converges after refill; a multi-page transfer (>`MAX_ENTRIES_PER_PAGE`) under a generous budget is served intact with a correct sent count.

## Verification

`cargo +nightly fmt --check`; clippy `--workspace --all-targets` under `--no-default-features` and `--all-features`, plus the `--features eval` gates — all `-D warnings` clean; `cargo nextest run --workspace` (5010) and `cargo test -p rag-rat-sync` (both CI runners).