### PR TITLE
fix(dispatch): read only the leading identifier when testing for PascalCase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,6 +5149,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "unicase",
+ "unicode-ident",
  "unicode-normalization",
  "ureq 3.3.0",
  "x25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ sha2 = "0.11"
 minicbor = { version = "2.3.0", features = ["alloc"] }
 protobuf = "=3.7.2"
 scip = "0.9.0"
-# Rust identifier case classification needs the Unicode Annex #31 XID tables rather than the
-# narrower `char::is_alphanumeric` predicate.
+# Rust identifier case classification needs the Unicode Annex #31 XID tables; `char::is_alphanumeric`
+# does not implement Rust's XID_Continue semantics.
 unicode-ident = "1.0.24"
 unicode-normalization = "0.1.25"
 # On-demand stack growth for the tree-sitter descent helpers. A hostile source file (a callee that

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,9 @@ sha2 = "0.11"
 minicbor = { version = "2.3.0", features = ["alloc"] }
 protobuf = "=3.7.2"
 scip = "0.9.0"
+# Rust identifier case classification needs the Unicode Annex #31 XID tables rather than the
+# narrower `char::is_alphanumeric` predicate.
+unicode-ident = "1.0.24"
 unicode-normalization = "0.1.25"
 # On-demand stack growth for the tree-sitter descent helpers. A hostile source file (a callee that
 # is thousands of nested parens, a thousands-deep generic type) parses within budget but recursing

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -73,6 +73,7 @@ tree-sitter-rust.workspace = true
 tree-sitter-swift.workspace = true
 tree-sitter-typescript.workspace = true
 minicbor.workspace = true
+unicode-ident.workspace = true
 unicode-normalization.workspace = true
 zeroize.workspace = true
 

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -879,12 +879,55 @@ mod classify_call_tests {
     /// traces through the constant instead of recording the call as the handler.
     #[test]
     fn a_screaming_const_with_a_method_chain_is_not_a_wrapper() {
+        // A chain on a scoped constant carrying a closure transformation keeps its delegation:
+        // the closure is behavior, not a produced value, and the trailing `map` is a std adapter
+        // method that never resolves to an in-corpus symbol, so no edge is synthesized (#1124).
         assert!(matches!(
             role_of("crate::tools::TOOL_NAMES.iter().map(|name| describe(name))"),
             CallRole::Delegate
         ));
         // A single-word constant has no underscore to give it away and reads the same way.
         assert!(matches!(role_of("NOW.elapsed()"), CallRole::Delegate));
+    }
+
+    /// A method whose receiver is ANOTHER CALL'S RESULT is a chained adapter tail
+    /// (`LIMIT.min(cap).max(..)`, `list.len().saturating_sub(..)`): it adapts a value, it is
+    /// never the handler, and it is not a transparent wrapper either — its argument is adapter
+    /// input, not the response. Only a BARE callee (a free function, a path, or a method on a
+    /// plain binding/`self` receiver) may fall through to `Delegate`; otherwise the trailing
+    /// method name is recorded as the handler and bare-name fallback binds it to an unrelated
+    /// same-named repository symbol — a false persisted edge (#1124 maintainer feedback).
+    #[test]
+    fn a_chained_adapter_tail_is_neither_a_delegate_nor_a_wrapper() {
+        assert!(matches!(role_of("LIMIT.min(cap).max(1)"), CallRole::Skip));
+        assert!(matches!(role_of("BACKENDS.len().saturating_sub(1)"), CallRole::Skip));
+        assert!(matches!(role_of("items(count).len().max(1)"), CallRole::Skip));
+        assert!(matches!(role_of("make_worker().run(input)"), CallRole::Skip));
+        // Bare callees keep their delegation: a free function, and a method on a plain
+        // binding/`self`/field receiver (`worker.run` IS the handler — #208 review round 11).
+        assert!(matches!(role_of("run(input)"), CallRole::Delegate));
+        assert!(matches!(role_of("worker.run(input)"), CallRole::Delegate));
+        assert!(matches!(role_of("self.embed(input)"), CallRole::Delegate));
+        assert!(matches!(role_of("self.worker.run(input)"), CallRole::Delegate));
+    }
+
+    /// An associated-constant method chain invoked with PLAIN DATA is the dispatch itself
+    /// (`Handler::DEFAULT.run(input)` — the constant is the chained method's receiver). A chain
+    /// that WRAPS a produced value is a builder (`Resp::DEFAULT.with_body(handle(cap))`): the
+    /// nested call is the real handler, so the builder is a transparent wrapper of its payload
+    /// and the builder method itself is never recorded (#1124 maintainer feedback).
+    #[test]
+    fn an_associated_constant_builder_wraps_a_produced_payload() {
+        assert!(matches!(role_of("Resp::DEFAULT.with_body(handle(cap))"), CallRole::Wrapper));
+        assert!(matches!(
+            role_of("<Resp as Build>::DEFAULT.with_body(handle(cap))"),
+            CallRole::Wrapper
+        ));
+        assert!(matches!(role_of("Handler::DEFAULT.run(input)"), CallRole::Delegate));
+        assert!(matches!(role_of("<Handler as Runner>::DEFAULT.run(input)"), CallRole::Delegate));
+        // An intermediate builder call inside the chain still delegates when the final call is
+        // invoked with plain data.
+        assert!(matches!(role_of("Handler::DEFAULT.build().run(input)"), CallRole::Delegate));
     }
 
     /// A method chain glued onto an ASSOCIATED CONSTANT delegates to the chained method (#1124

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -932,42 +932,50 @@ mod classify_call_tests {
         assert!(matches!(role_of("<Resp as Default>::default()"), CallRole::Skip));
     }
 
-    /// A `SCREAMING_CONST` head carrying a method chain is a plain delegation, not a transparent
-    /// variant constructor (#1124). The chain's method names supply the lowercase the case test
-    /// looks for, so reading the whole segment bills `TOOL_NAMES.iter().map(..)` as a wrapper and
-    /// traces through the constant instead of recording the call as the handler.
+    /// A `SCREAMING_CONST` head carrying a method chain is not a transparent variant constructor
+    /// (#1124). The chain's method names supply the lowercase the case test looks for, so reading
+    /// the whole segment would bill `TOOL_NAMES.iter().map(..)` as a wrapper and trace through the
+    /// constant instead of classifying the call on its own shape.
     #[test]
     fn a_screaming_const_with_a_method_chain_is_not_a_wrapper() {
-        // A chain on a scoped constant carrying a closure transformation keeps its delegation:
-        // the closure is behavior, not a produced value, and the trailing `map` is a std adapter
-        // method that never resolves to an in-corpus symbol, so no edge is synthesized (#1124).
+        // A chain on a SCOPED associated constant delegates to its chained method: `TOOL_NAMES` is
+        // the receiver named by its owning module, so the call is the dispatch itself (#1124).
         assert!(matches!(
             role_of("crate::tools::TOOL_NAMES.iter().map(|name| describe(name))"),
             CallRole::Delegate
         ));
-        // A single-word constant has no underscore to give it away and reads the same way.
-        assert!(matches!(role_of("NOW.elapsed()"), CallRole::Delegate));
+        // A BARE constant receiver names no owner, so the trailing method is an adapter over the
+        // constant's value rather than a handler — neither a wrapper nor a delegate.
+        assert!(matches!(role_of("NOW.elapsed()"), CallRole::Skip));
     }
 
-    /// A method whose receiver is ANOTHER CALL'S RESULT is a chained adapter tail
-    /// (`LIMIT.min(cap).max(..)`, `list.len().saturating_sub(..)`): it adapts a value, it is
-    /// never the handler, and it is not a transparent wrapper either — its argument is adapter
-    /// input, not the response. Only a BARE callee (a free function, a path, or a method on a
-    /// plain binding/`self` receiver) may fall through to `Delegate`; otherwise the trailing
-    /// method name is recorded as the handler and bare-name fallback binds it to an unrelated
-    /// same-named repository symbol — a false persisted edge (#1124 maintainer feedback).
+    /// A method glued onto ANOTHER CALL'S RESULT (`LIMIT.min(cap).max(..)`,
+    /// `list.len().saturating_sub(..)`) or onto a BARE SCREAMING constant (`BASE.to_string()`) is
+    /// an adapter tail: it adapts a value, it is never the handler, and it is not a transparent
+    /// wrapper either — its argument is adapter input, not the response. Only a BARE callee (a
+    /// free function, a path, or a method on a plain binding/`self` receiver) may fall through to
+    /// `Delegate`; otherwise the trailing method name is recorded as the handler and bare-name
+    /// fallback binds it to an unrelated same-named repository symbol — a false persisted edge
+    /// (#1124 maintainer feedback).
     #[test]
-    fn a_chained_adapter_tail_is_neither_a_delegate_nor_a_wrapper() {
+    fn an_adapter_tail_is_neither_a_delegate_nor_a_wrapper() {
         assert!(matches!(role_of("LIMIT.min(cap).max(1)"), CallRole::Skip));
         assert!(matches!(role_of("BACKENDS.len().saturating_sub(1)"), CallRole::Skip));
         assert!(matches!(role_of("items(count).len().max(1)"), CallRole::Skip));
         assert!(matches!(role_of("make_worker().run(input)"), CallRole::Skip));
+        // A single method on a bare SCREAMING constant is the same adapter shape without the
+        // second link — `BASE.to_string()`, `SWEEP_FALLBACK_CONCURRENCY.min(cap)`.
+        assert!(matches!(role_of("BASE.to_string()"), CallRole::Skip));
+        assert!(matches!(role_of("LIMIT.min(cap)"), CallRole::Skip));
+        assert!(matches!(role_of("_BASE.to_string()"), CallRole::Skip));
         // Bare callees keep their delegation: a free function, and a method on a plain
         // binding/`self`/field receiver (`worker.run` IS the handler — #208 review round 11).
         assert!(matches!(role_of("run(input)"), CallRole::Delegate));
         assert!(matches!(role_of("worker.run(input)"), CallRole::Delegate));
         assert!(matches!(role_of("self.embed(input)"), CallRole::Delegate));
         assert!(matches!(role_of("self.worker.run(input)"), CallRole::Delegate));
+        // A PascalCase receiver is a type, not a constant, and keeps its own `Type::assoc` reading.
+        assert!(matches!(role_of("Worker.run(input)"), CallRole::Delegate));
     }
 
     /// An associated-constant method chain invoked with PLAIN DATA is the dispatch itself

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -990,22 +990,24 @@ mod classify_call_tests {
         assert!(matches!(role_of("self.worker.run(input)"), CallRole::Delegate));
     }
 
-    /// An associated-constant method chain invoked with PLAIN DATA is the dispatch itself
-    /// (`Handler::DEFAULT.run(input)` — the constant is the chained method's receiver). A chain
-    /// that WRAPS a produced value is a builder (`Resp::DEFAULT.with_body(handle(cap))`): the
-    /// nested call is the real handler, so the builder is a transparent wrapper of its payload
-    /// and the builder method itself is never recorded (#1124 maintainer feedback).
+    /// An associated-constant method chain is the dispatch itself, whatever its arguments hold
+    /// (#1124 maintainer feedback): the constant is the chained method's receiver, so the call
+    /// delegates to that method. Reading the ARGUMENT SHAPE to tell a dispatch from a builder
+    /// cannot work — `Resp::DEFAULT.with_body(handle(cap))` and
+    /// `Handler::DEFAULT.run(normalize(input))` are the same expression modulo spelling — so a
+    /// nested argument call no longer diverts the classification to `Wrapper`.
     #[test]
-    fn an_associated_constant_builder_wraps_a_produced_payload() {
-        assert!(matches!(role_of("Resp::DEFAULT.with_body(handle(cap))"), CallRole::Wrapper));
-        assert!(matches!(
-            role_of("<Resp as Build>::DEFAULT.with_body(handle(cap))"),
-            CallRole::Wrapper
-        ));
+    fn an_associated_constant_method_chain_always_delegates() {
         assert!(matches!(role_of("Handler::DEFAULT.run(input)"), CallRole::Delegate));
         assert!(matches!(role_of("<Handler as Runner>::DEFAULT.run(input)"), CallRole::Delegate));
-        // An intermediate builder call inside the chain still delegates when the final call is
-        // invoked with plain data.
+        // A nested argument call is argument shape, not classification evidence.
+        assert!(matches!(role_of("Handler::DEFAULT.run(normalize(input))"), CallRole::Delegate));
+        assert!(matches!(role_of("Resp::DEFAULT.with_body(handle(cap))"), CallRole::Delegate));
+        assert!(matches!(
+            role_of("<Resp as Build>::DEFAULT.with_body(handle(cap))"),
+            CallRole::Delegate
+        ));
+        // An intermediate call inside the chain still delegates to the final chained method.
         assert!(matches!(role_of("Handler::DEFAULT.build().run(input)"), CallRole::Delegate));
     }
 

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -653,9 +653,10 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 ///   Trace its lone payload argument.
 /// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
 ///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), a
-///   UFCS associated call (`<Resp as Default>::default()`), or a chained adapter tail glued onto
-///   another call's result (`LIMIT.min(cap).max(..)` — it adapts a value, and recording the
-///   trailing method would bind it to an unrelated same-named symbol, #1124 maintainer feedback).
+///   UFCS associated call (`<Resp as Default>::default()`), or an adapter tail glued onto another
+///   call's result or onto a bare SCREAMING constant (`LIMIT.min(cap).max(..)`,
+///   `BASE.to_string()` — it adapts a value, and recording the trailing method would bind it to an
+///   unrelated same-named symbol, #1124 maintainer feedback).
 ///
 /// Classification is by the path TAIL (constructor names are PascalCase; fns/methods are
 /// snake_case), which is receiver-agnostic — so `dto::Wrapped` and `Resp::Embedded` are both
@@ -722,23 +723,29 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     match segments.as_slice() {
         [.., receiver, _last] if is_pascal_case(receiver) => CallRole::Skip,
         // The fall-through is reserved for a BARE callee. A method glued onto ANOTHER CALL'S
-        // RESULT is a chained adapter tail (`LIMIT.min(cap).max(..)`,
-        // `list.len().saturating_sub(..)`): it adapts a value into another value — never the
-        // handler, and not a wrapper either, since its argument is adapter input rather than the
-        // response. Recording the trailing method would bind it, via bare-name fallback, to an
-        // unrelated same-named repository symbol — a false persisted edge (#1124 maintainer
-        // feedback).
-        _ if is_chained_adapter_tail(function) => CallRole::Skip,
+        // RESULT or onto a BARE SCREAMING constant is an adapter tail (`LIMIT.min(cap).max(..)`,
+        // `list.len().saturating_sub(..)`, `BASE.to_string()`): it adapts a value into another
+        // value — never the handler, and not a wrapper either, since its argument is adapter input
+        // rather than the response. Recording the trailing method would bind it, via bare-name
+        // fallback, to an unrelated same-named repository symbol — a false persisted edge (#1124
+        // maintainer feedback).
+        _ if is_adapter_tail(function, text) => CallRole::Skip,
         _ => CallRole::Delegate,
     }
 }
 
-/// Whether the call's callee is a method glued onto the RESULT of another call — the structural
-/// shape of a standard-adapter chain (`x.min(cap).max(..)`, `list.len().saturating_sub(..)`).
-/// AST-checked, never textual: the callee is a `field_expression` whose receiver is itself a
-/// `call_expression`. A method on a plain binding/`self`/field receiver (`worker.run`,
-/// `self.embed`) is a bare callee, not a chained tail.
-fn is_chained_adapter_tail(function: Node<'_>) -> bool {
+/// Whether the call's callee is an adapter tail rather than a bare callee — AST-checked, never
+/// textual. Two receiver shapes qualify, both of which adapt an already-produced value:
+/// - the RESULT of another call, the standard-adapter chain (`x.min(cap).max(..)`,
+///   `list.len().saturating_sub(..)`);
+/// - a BARE SCREAMING constant (`BASE.to_string()`, `SWEEP_FALLBACK_CONCURRENCY.min(cap)`) — a
+///   constant names no owner, so its trailing method reads the constant's value.
+///
+/// A method on a plain binding/`self`/field receiver (`worker.run`, `self.embed`) is a bare
+/// callee: that receiver holds the handler. A SCOPED constant receiver
+/// (`Handler::DEFAULT.run(..)`) never reaches here — [`is_associated_const_method_chain`] claims
+/// it earlier, because naming the owning type is what makes the chained method the dispatch.
+fn is_adapter_tail(function: Node<'_>, text: &str) -> bool {
     let function = unwrap_generic_function(function);
     if function.kind() != "field_expression" {
         return false;
@@ -746,7 +753,14 @@ fn is_chained_adapter_tail(function: Node<'_>) -> bool {
     let Some(value) = function.child_by_field_name("value") else {
         return false;
     };
-    unwrap_generic_function(value).kind() == "call_expression"
+    let value = unwrap_generic_function(value);
+    match value.kind() {
+        "call_expression" => true,
+        "identifier" => value
+            .utf8_text(text.as_bytes())
+            .is_ok_and(|name| is_screaming_const_identifier(name)),
+        _ => false,
+    }
 }
 
 /// Whether any ARGUMENT of `call` contains a nested `call_expression` outside a closure — the
@@ -974,8 +988,6 @@ mod classify_call_tests {
         assert!(matches!(role_of("worker.run(input)"), CallRole::Delegate));
         assert!(matches!(role_of("self.embed(input)"), CallRole::Delegate));
         assert!(matches!(role_of("self.worker.run(input)"), CallRole::Delegate));
-        // A PascalCase receiver is a type, not a constant, and keeps its own `Type::assoc` reading.
-        assert!(matches!(role_of("Worker.run(input)"), CallRole::Delegate));
     }
 
     /// An associated-constant method chain invoked with PLAIN DATA is the dispatch itself

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -5,6 +5,7 @@
 //! CLOSED conservative handler-call recognizer (`result_handler_calls` & friends) whose
 //! false-edge-is-a-bug contract is documented in the repo memories bound here and on the parent.
 use tree_sitter::Node;
+use unicode_ident::is_xid_continue;
 
 use crate::index::edges::extract::EdgeEmitter;
 use crate::index::edges::*;
@@ -12,6 +13,8 @@ use crate::index::edges::*;
 /// PascalCase test for the enum/variant convention (#200): the segment's LEADING IDENTIFIER starts
 /// with an uppercase char AND carries at least one lowercase — so `MlReq`/`Upsert` qualify but
 /// `new`, a SCREAMING `CONST`, and a bare `T` do not.
+/// The leading scan follows Rust's `XID_Continue` rule, so decomposed identifiers keep their
+/// combining marks instead of being truncated at the first non-alphanumeric code point.
 ///
 /// Only that leading identifier is weighed because a segment can carry a method chain glued onto
 /// its head (`TOOL_NAMES.iter().map`, `NOW.elapsed`). The appended method names supply the very
@@ -19,7 +22,7 @@ use crate::index::edges::*;
 /// constructor and bills the call as a transparent wrapper instead of the delegation it is (#1124).
 fn is_pascal_case(name: &str) -> bool {
     let mut head =
-        name.chars().take_while(|&character| character.is_alphanumeric() || character == '_');
+        name.chars().take_while(|&character| is_xid_continue(character) || character == '_');
     head.next().is_some_and(char::is_uppercase) && head.any(char::is_lowercase)
 }
 
@@ -801,8 +804,20 @@ mod classify_call_tests {
         for name in ["TOOL_NAMES", "TOOL_NAMES.iter().map", "NOW", "NOW.elapsed", "T", "run"] {
             assert!(!is_pascal_case(name), "{name}");
         }
-        for name in ["MlReq", "Upsert", "HTTPResponse", "Wrapped(payload).to_string"] {
+        for name in [
+            "MlReq",
+            "Upsert",
+            "HTTPResponse",
+            "Wrapped(payload).to_string",
+            "A\u{301}bc",
+            "A\u{301}bc.iter().map",
+        ] {
             assert!(is_pascal_case(name), "{name}");
         }
+
+        // A decomposed combining mark is a valid XID_Continue character even though it is not
+        // alphanumeric. The full call must therefore remain a transparent constructor wrapper,
+        // allowing the nested handler call to be traced.
+        assert!(matches!(role_of("A\u{301}ccent(handle())"), CallRole::Wrapper));
     }
 }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -43,22 +43,26 @@ fn is_screaming_const_identifier(name: &str) -> bool {
         })
 }
 
-/// A method identifier must start lowercase and otherwise remain within Rust's identifier
-/// boundaries. The field token comes directly from tree-sitter, so comments/whitespace around the
-/// member-access dot never affect this check.
+/// A method identifier may carry leading underscores, but its first non-underscore character must
+/// be lowercase and the rest must remain within Rust's identifier boundaries. The field token
+/// comes directly from tree-sitter, so comments/whitespace around the member-access dot never
+/// affect this check.
 fn is_lowercase_method_identifier(name: &str) -> bool {
-    let name = name.strip_prefix("r#").unwrap_or(name);
+    let name = name.strip_prefix("r#").unwrap_or(name).trim_start_matches('_');
     let mut characters = name.chars();
     characters.next().is_some_and(char::is_lowercase)
         && characters.all(|character| is_xid_continue(character) || character == '_')
 }
 
 /// Associated-constant method-chain test (#1124 held feedback). Walk the Rust AST's nested
-/// `field_expression` nodes from the call's callee inward, requiring every field to be a
-/// lowercase method and the innermost receiver to be a scoped identifier whose final name is a
+/// `field_expression` nodes from the call's callee inward, following an intermediate
+/// `call_expression` only when its own callee is another field expression. Every field must be a
+/// lowercase method and the final receiver must be a scoped identifier whose name is a
 /// SCREAMING_SNAKE associated constant. This preserves the distinction between a constant receiver
 /// (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::_DEFAULT.run(..)`) and a constructor or a
-/// PascalCase method, while remaining insensitive to trivia and turbofish wrappers.
+/// PascalCase method, while remaining insensitive to trivia and turbofish wrappers. In particular,
+/// a constructor/function-call root is never treated as an associated-constant receiver, and
+/// associated constants appearing only in arguments are not traversed.
 fn is_associated_const_method_chain(function: Node<'_>, text: &str) -> bool {
     let mut current = unwrap_generic_function(function);
     let mut saw_method = false;
@@ -77,7 +81,21 @@ fn is_associated_const_method_chain(function: Node<'_>, text: &str) -> bool {
         let Some(value) = current.child_by_field_name("value") else {
             return false;
         };
-        current = unwrap_generic_function(value);
+        let value = unwrap_generic_function(value);
+        current = if value.kind() == "call_expression" {
+            let Some(inner_function) = value.child_by_field_name("function") else {
+                return false;
+            };
+            let inner_function = unwrap_generic_function(inner_function);
+            // Only another method field can continue the associated-constant chain. A scoped
+            // constructor/function call here is a separate root, even when its name is screaming.
+            if inner_function.kind() != "field_expression" {
+                return false;
+            }
+            inner_function
+        } else {
+            value
+        };
     }
 
     if !saw_method || current.kind() != "scoped_identifier" {
@@ -925,6 +943,7 @@ mod classify_call_tests {
             "Handler::DEFAULT.build.Run(input)",
             "Handler::DEFAULT._Run(input)",
             "Handler::DEFAULT(input)",
+            "Handler::DEFAULT(input).run(input)",
             "Handler::new(input).run(input)",
             "Handler::new(input).configure().run(input)",
             "Err(problem)",

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -914,7 +914,7 @@ mod classify_call_tests {
              run::<u8>(input)"
                 .to_string(),
             "Handler::r#DEFAULT.r#build::<u8>().r#run(input)".to_string(),
-            format!("Handler::A\u{203F}DEFAULT.build().r\u{203F}un::<u8>(input)"),
+            "Handler::A\u{203F}DEFAULT.build().r\u{203F}un::<u8>(input)".to_string(),
         ]);
 
         let skip_forms = [

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -26,6 +26,24 @@ fn is_pascal_case(name: &str) -> bool {
     head.next().is_some_and(char::is_uppercase) && head.any(char::is_lowercase)
 }
 
+/// Associated-constant method-chain test (#1124 held feedback): the segment is a SCREAMING_CASE
+/// constant head glued to at least one chained method call — `DEFAULT.run`, `DEFAULT.build.ship`.
+/// The constant is the RECEIVER of the chained method, never a constructor, so the call delegates
+/// however the constant was qualified (`Handler::DEFAULT.run(..)`,
+/// `<Handler as Runner>::DEFAULT.run(..)`). The head must be ONE whole identifier (uppercase
+/// start, no lowercase, every char an `XID_Continue` identifier char — the same scan rule as
+/// [`is_pascal_case`]), and the chained call must start lowercase (a method, not a tuple index or
+/// a UPPERCASE field/const segment).
+fn is_associated_const_method_chain(segment: &str) -> bool {
+    let Some((head, chained)) = segment.split_once('.') else {
+        return false;
+    };
+    let screaming_const_head = head.chars().next().is_some_and(char::is_uppercase)
+        && head.chars().all(|character| is_xid_continue(character) || character == '_')
+        && !head.chars().any(char::is_lowercase);
+    screaming_const_head && chained.chars().next().is_some_and(char::is_lowercase)
+}
+
 /// The `Enum::Variant` dispatch key from a scoped path node — its last two `::`-segments when BOTH
 /// are PascalCase, else `None`. Robust to longer paths (`crate::ml::MlReq::Upsert` →
 /// `MlReq::Upsert`) so a construction site and a handler arm produce the SAME key regardless of
@@ -563,7 +581,8 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 /// How `result_handler_calls` treats a `call_expression` (#200/#208 — one classifier so the
 /// delegate/wrapper decision can't disagree with itself, as it did across review rounds):
 /// - `Delegate`: RECORD it as the handler (a free fn `run`, a method `self.embed`, a module-pathed
-///   fn `crate::ml::embed::embed_text`).
+///   fn `crate::ml::embed::embed_text`, or an associated-constant method chain
+///   `Handler::DEFAULT.run(..)` — the constant is the chained method's receiver).
 /// - `Wrapper`: a TRANSPARENT wrapper / variant constructor whose single argument IS the response —
 ///   `Ok`/`Some` and ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`).
 ///   Trace its lone payload argument.
@@ -591,11 +610,6 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
         return CallRole::Delegate;
     };
     let raw = raw.trim();
-    // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
-    // associated/constructor call — never a handler, and its arg (if any) isn't the response.
-    if raw.starts_with('<') {
-        return CallRole::Skip;
-    }
     let stripped = degeneric_path(raw);
     // TOP-LEVEL segments only. A `::` inside a `(…)`/`[…]` group is argument text, which
     // `degeneric_path` keeps, so splitting on every `::` would read a longer path than the source
@@ -610,6 +624,19 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     let Some(tail) = segments.last() else {
         return CallRole::Delegate;
     };
+    // An associated-constant method chain calls the chained METHOD with the constant as its
+    // receiver, so it delegates like any method call. Consulted before BOTH qualifier fallbacks:
+    // the leading-`<` UFCS early return and the PascalCase-receiver `Skip` below would otherwise
+    // bill `Handler::DEFAULT.run(..)` / `<Handler as Runner>::DEFAULT.run(..)` as an
+    // associated/constructor call (#1124 held feedback).
+    if is_associated_const_method_chain(tail) {
+        return CallRole::Delegate;
+    }
+    // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
+    // associated/constructor call — never a handler, and its arg (if any) isn't the response.
+    if raw.starts_with('<') {
+        return CallRole::Skip;
+    }
     if matches!(*tail, "Err" | "None") {
         return CallRole::Skip;
     }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -794,6 +794,30 @@ mod classify_call_tests {
         assert!(matches!(role_of("NOW.elapsed()"), CallRole::Delegate));
     }
 
+    /// A method chain glued onto an ASSOCIATED CONSTANT delegates to the chained method (#1124
+    /// held feedback): `Handler::DEFAULT.run(input)` calls `run` on the `DEFAULT` constant — the
+    /// constant is the receiver, not a constructor — so neither the PascalCase receiver (`Handler`)
+    /// nor a UFCS qualifier (`<Handler as Runner>`) may bill the call as an associated/constructor
+    /// call. The guards stay: an associated FN (`Handler::new`) configures rather than responds,
+    /// and a bare UFCS associated call (`<Resp as Default>::default()`) is a constructor. The
+    /// verdicts are collected before asserting, so one failure names EVERY misclassified form.
+    #[test]
+    fn an_associated_constant_method_chain_delegates_to_the_chained_method() {
+        let delegate_forms =
+            ["Handler::DEFAULT.run(input)", "<Handler as Runner>::DEFAULT.run(input)"];
+        let skip_forms = ["Handler::new(input)", "<Resp as Default>::default()"];
+        let misclassified: Vec<&str> = delegate_forms
+            .into_iter()
+            .filter(|expression| !matches!(role_of(expression), CallRole::Delegate))
+            .chain(
+                skip_forms
+                    .into_iter()
+                    .filter(|expression| !matches!(role_of(expression), CallRole::Skip)),
+            )
+            .collect();
+        assert!(misclassified.is_empty(), "misclassified forms: {misclassified:?}");
+    }
+
     /// The case test reads the segment's leading IDENTIFIER, so a glued-on method chain cannot lend
     /// its lowercase to a constant head, while an acronym-led type keeps its leading uppercase run.
     /// A head that is genuinely PascalCase stays a constructor however the rest of the segment is

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -918,14 +918,14 @@ mod classify_call_tests {
     /// constant instead of classifying the call on its own shape.
     #[test]
     fn a_screaming_const_with_a_method_chain_is_not_a_wrapper() {
-        // A chain on a SCOPED associated constant delegates to its chained method: `TOOL_NAMES` is
-        // the receiver named by its owning module, so the call is the dispatch itself (#1124).
+        // A MODULE path names where the constant lives, not an owner that could receive the
+        // dispatch, so the chain adapts the constant's value exactly as the bare spelling does.
         assert!(matches!(
             role_of("crate::tools::TOOL_NAMES.iter().map(|name| describe(name))"),
-            CallRole::Delegate
+            CallRole::Skip
         ));
-        // A BARE constant receiver names no owner, so the trailing method is an adapter over the
-        // constant's value rather than a handler — neither a wrapper nor a delegate.
+        // A BARE constant receiver names no owner either — the trailing method is an adapter over
+        // the constant's value rather than a handler, so neither a wrapper nor a delegate.
         assert!(matches!(role_of("NOW.elapsed()"), CallRole::Skip));
     }
 
@@ -954,6 +954,58 @@ mod classify_call_tests {
         assert!(matches!(role_of("worker.run(input)"), CallRole::Delegate));
         assert!(matches!(role_of("self.embed(input)"), CallRole::Delegate));
         assert!(matches!(role_of("self.worker.run(input)"), CallRole::Delegate));
+    }
+
+    /// The role of a chained adapter tail is fixed by the chain's ROOT, never by how that root is
+    /// SPELLED (#1124 maintainer feedback). A constant reached through a module path is the same
+    /// receiver as the bare identifier — `crate::config::LIMIT`, `self::LIMIT`, `super::LIMIT`, an
+    /// aliased `cfg::LIMIT` and an arbitrarily long `crate::a::b::c::LIMIT` all adapt a value, so
+    /// every one of them skips. Only a qualifier that names the OWNING TYPE makes the chained
+    /// method the dispatch, and that stays true however long the path to the type is. The verdicts
+    /// are collected before asserting, so one failure names EVERY misclassified spelling rather
+    /// than stopping at the first.
+    #[test]
+    fn a_chained_adapter_tail_skips_however_its_root_is_spelled() {
+        let skip_forms = [
+            // The maintainer's reproduction: bare and crate-qualified spellings of one expression.
+            "LIMIT.min(cap).max(1)",
+            "crate::config::LIMIT.min(cap).max(1)",
+            // `self::`/`super::`-relative and aliased module paths are the same receiver again.
+            "self::LIMIT.min(cap).max(1)",
+            "super::LIMIT.min(cap).max(1)",
+            "super::config::LIMIT.min(cap).max(1)",
+            "cfg::LIMIT.min(cap).max(1)",
+            "crate::a::b::c::LIMIT.min(cap).max(1)",
+            // A single method glued onto the constant is the same shape without the second link.
+            "BASE.to_string()",
+            "crate::config::BASE.to_string()",
+            "self::BASE.to_string()",
+            "super::consolidate::BASE.to_string()",
+            "crate::a::b::c::BASE.to_string()",
+            "crate::config::_BASE.to_string()",
+            // The iterator-adapter chain the classifier was first written for.
+            "TOOL_NAMES.iter().map(|name| describe(name))",
+            "crate::tools::TOOL_NAMES.iter().map(|name| describe(name))",
+        ];
+        let delegate_forms = [
+            // A qualifier that names the OWNING TYPE is not a module path: the chained method is
+            // the dispatch, at any path depth and through a UFCS qualifier.
+            "Handler::DEFAULT.run(input)",
+            "crate::ml::Handler::DEFAULT.run(input)",
+            "crate::a::b::Handler::DEFAULT.build().run(input)",
+            "<Handler as Runner>::DEFAULT.run(input)",
+            // A bare callee keeps delegating whatever the receiver is called.
+            "worker.run(input)",
+            "self.embed(input)",
+        ];
+        let mut misclassified = Vec::new();
+        misclassified.extend(
+            skip_forms.into_iter().filter(|form| !matches!(role_of(form), CallRole::Skip)),
+        );
+        misclassified.extend(
+            delegate_forms.into_iter().filter(|form| !matches!(role_of(form), CallRole::Delegate)),
+        );
+        assert!(misclassified.is_empty(), "misclassified root spellings: {misclassified:?}");
     }
 
     /// An associated-constant method chain is the dispatch itself, whatever its arguments hold

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -820,4 +820,40 @@ mod classify_call_tests {
         // allowing the nested handler call to be traced.
         assert!(matches!(role_of("A\u{301}ccent(handle())"), CallRole::Wrapper));
     }
+
+    #[test]
+    fn the_case_test_distinguishes_unicode_identifier_boundaries() {
+        // U+203F UNDERTIE is XID_Continue but not alphanumeric: connector punctuation must stay
+        // in the leading identifier so its lowercase suffix still makes this PascalCase.
+        assert!(is_pascal_case("A\u{203F}bc"));
+
+        // U+00B2 SUPERSCRIPT TWO is alphanumeric but not XID_Continue: the Rust identifier rule
+        // must stop before it rather than inheriting the old alphanumeric predicate's suffix.
+        assert!(!is_pascal_case("A\u{00B2}bc"));
+
+        // U+05B0 HEBREW POINT SHEVA is both alphanumeric and XID_Continue: retain the ordinary
+        // alphanumeric case as a no-regression anchor while using the XID_Continue scan.
+        assert!(is_pascal_case("A\u{05B0}bc"));
+    }
+
+    #[test]
+    fn enum_variant_key_keeps_decomposed_xid_identifiers() {
+        for (expression, expected) in [
+            ("A\u{301}bc::Upsert(payload)", "A\u{301}bc::Upsert"),
+            ("Msg::A\u{301}bc(payload)", "Msg::A\u{301}bc"),
+        ] {
+            let source = format!("fn probe() {{ {expression}; }}");
+            let parsed = crate::index::parser::parse_file(
+                std::path::Path::new("probe.rs"),
+                rag_rat_base::language::Language::Rust,
+                &source,
+            )
+            .expect("probe parses");
+            let function = outermost_call(parsed.root())
+                .and_then(|call| call.child_by_field_name("function"))
+                .expect("the expression has a callable path");
+
+            assert_eq!(enum_variant_key(function, &source).as_deref(), Some(expected));
+        }
+    }
 }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -647,9 +647,7 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 ///   fn `crate::ml::embed::embed_text`, or an associated-constant method chain
 ///   `Handler::DEFAULT.run(..)` — the constant is the chained method's receiver).
 /// - `Wrapper`: a TRANSPARENT wrapper / variant constructor whose single argument IS the response —
-///   `Ok`/`Some`, ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`), or
-///   an associated-constant BUILDER whose argument nests the producing call
-///   (`Resp::DEFAULT.with_body(handle(cap))` — `handle` is the real handler, not `with_body`).
+///   `Ok`/`Some`, or ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`).
 ///   Trace its lone payload argument.
 /// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
 ///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), a
@@ -693,17 +691,16 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
         return CallRole::Delegate;
     };
     // An associated-constant method chain calls the chained METHOD with the constant as its
-    // receiver, so it delegates like any method call — but ONLY when the call consumes plain
-    // data (`Handler::DEFAULT.run(input)`) or a closure transformation
-    // (`TOOL_NAMES.iter().map(|name| ..)`). A chain that WRAPS a produced value is a builder
-    // (`Resp::DEFAULT.with_body(handle(cap))`): the nested argument call is the real handler,
-    // so the builder classifies as a transparent wrapper of its payload and the builder method
-    // itself is never recorded (#1124 maintainer feedback). Consulted before BOTH qualifier
-    // fallbacks: the leading-`<` UFCS early return and the PascalCase-receiver `Skip` below
-    // would otherwise bill `Handler::DEFAULT.run(..)` / `<Handler as Runner>::DEFAULT.run(..)`
-    // as an associated/constructor call (#1124 held feedback).
+    // receiver, so it delegates like any method call — UNCONDITIONALLY. The argument shape says
+    // nothing: `Resp::DEFAULT.with_body(handle(cap))` and `Handler::DEFAULT.run(normalize(input))`
+    // are the same expression modulo identifier spelling, so a nested-argument test cannot tell a
+    // builder from a dispatch and only picks which of the two loses its handler (#1124 maintainer
+    // feedback). Consulted before BOTH qualifier fallbacks: the leading-`<` UFCS early return and
+    // the PascalCase-receiver `Skip` below would otherwise bill `Handler::DEFAULT.run(..)` /
+    // `<Handler as Runner>::DEFAULT.run(..)` as an associated/constructor call (#1124 held
+    // feedback).
     if is_associated_const_method_chain(function, text) {
-        return if call_carries_nested_call(call) { CallRole::Wrapper } else { CallRole::Delegate };
+        return CallRole::Delegate;
     }
     // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
     // associated/constructor call — never a handler, and its arg (if any) isn't the response.
@@ -760,35 +757,6 @@ fn is_adapter_tail(function: Node<'_>, text: &str) -> bool {
             .utf8_text(text.as_bytes())
             .is_ok_and(|name| is_screaming_const_identifier(name)),
         _ => false,
-    }
-}
-
-/// Whether any ARGUMENT of `call` contains a nested `call_expression` outside a closure — the
-/// structural signal that the call wraps a produced value (`with_body(handle(cap))`) rather than
-/// consuming plain data (`run(input)`) or a transformation (`map(|name| describe(name))`: a
-/// closure is deferred behavior, not a produced response). The call's own callee chain is never
-/// inspected.
-fn call_carries_nested_call(call: Node<'_>) -> bool {
-    let Some(arguments) = call.child_by_field_name("arguments") else {
-        return false;
-    };
-    let mut cursor = arguments.walk();
-    arguments.named_children(&mut cursor).any(subtree_has_nested_call)
-}
-
-/// Whether `node`'s subtree contains a `call_expression`, never descending into a closure — used
-/// to tell a value-WRAPPING call from a data- or behavior-consuming one (see
-/// [`call_carries_nested_call`]).
-fn subtree_has_nested_call(node: Node<'_>) -> bool {
-    match node.kind() {
-        "call_expression" => true,
-        "closure_expression" => false,
-        // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep
-        // argument (#543).
-        _ => rag_rat_base::stack::grow_stack(|| {
-            let mut cursor = node.walk();
-            node.named_children(&mut cursor).any(subtree_has_nested_call)
-        }),
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -899,6 +899,22 @@ mod classify_call_tests {
         delegate_forms.extend([
             "Handler::DEFAULT . build.ship(input)".to_string(),
             "<Handler as Runner>::_DEFAULT /* receiver */ . run::<u8>(input)".to_string(),
+            // A leading underscore is valid on a lowercase method as well as on the associated
+            // constant.  Ordinary and qualified UFCS forms must both retain delegation.
+            "Handler::DEFAULT._run(input)".to_string(),
+            "<Handler as Runner>::_DEFAULT._run::<u8>(input)".to_string(),
+            // Actual method calls interrupt the field-expression chain.  The final method still
+            // delegates through the associated-constant receiver, including turbofish calls,
+            // another associated constant in an argument, comments/trivia, and multiple levels.
+            "Handler::DEFAULT.build().run(input)".to_string(),
+            "Handler::DEFAULT.build::<u8>().run::<u8>(input)".to_string(),
+            "Handler::DEFAULT.combine(Other::DEFAULT).run(input)".to_string(),
+            "<Handler as Runner>::DEFAULT.build().configure()._run::<u8>(input)".to_string(),
+            "<Handler as Runner>::_DEFAULT /* receiver */ . build /* call */ () /* between */ . \
+             run::<u8>(input)"
+                .to_string(),
+            "Handler::r#DEFAULT.r#build::<u8>().r#run(input)".to_string(),
+            format!("Handler::A\u{203F}DEFAULT.build().r\u{203F}un::<u8>(input)"),
         ]);
 
         let skip_forms = [
@@ -907,7 +923,10 @@ mod classify_call_tests {
             "Handler::default.run(input)",
             "Handler::DEFAULT.Run(input)",
             "Handler::DEFAULT.build.Run(input)",
+            "Handler::DEFAULT._Run(input)",
             "Handler::DEFAULT(input)",
+            "Handler::new(input).run(input)",
+            "Handler::new(input).configure().run(input)",
             "Err(problem)",
             "None()",
         ];

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -652,9 +652,9 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 /// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
 ///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), a
 ///   UFCS associated call (`<Resp as Default>::default()`), or an adapter tail glued onto another
-///   call's result or onto a bare SCREAMING constant (`LIMIT.min(cap).max(..)`,
-///   `BASE.to_string()` — it adapts a value, and recording the trailing method would bind it to an
-///   unrelated same-named symbol, #1124 maintainer feedback).
+///   call's result or onto a bare SCREAMING constant (`LIMIT.min(cap).max(..)`, `BASE.to_string()`
+///   — it adapts a value, and recording the trailing method would bind it to an unrelated
+///   same-named symbol, #1124 maintainer feedback).
 ///
 /// Classification is by the path TAIL (constructor names are PascalCase; fns/methods are
 /// snake_case), which is receiver-agnostic — so `dto::Wrapped` and `Resp::Embedded` are both
@@ -753,9 +753,8 @@ fn is_adapter_tail(function: Node<'_>, text: &str) -> bool {
     let value = unwrap_generic_function(value);
     match value.kind() {
         "call_expression" => true,
-        "identifier" => value
-            .utf8_text(text.as_bytes())
-            .is_ok_and(|name| is_screaming_const_identifier(name)),
+        "identifier" =>
+            value.utf8_text(text.as_bytes()).is_ok_and(|name| is_screaming_const_identifier(name)),
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -26,22 +26,70 @@ fn is_pascal_case(name: &str) -> bool {
     head.next().is_some_and(char::is_uppercase) && head.any(char::is_lowercase)
 }
 
-/// Associated-constant method-chain test (#1124 held feedback): the segment is a SCREAMING_CASE
-/// constant head glued to at least one chained method call — `DEFAULT.run`, `DEFAULT.build.ship`.
-/// The constant is the RECEIVER of the chained method, never a constructor, so the call delegates
-/// however the constant was qualified (`Handler::DEFAULT.run(..)`,
-/// `<Handler as Runner>::DEFAULT.run(..)`). The head must be ONE whole identifier (uppercase
-/// start, no lowercase, every char an `XID_Continue` identifier char — the same scan rule as
-/// [`is_pascal_case`]), and the chained call must start lowercase (a method, not a tuple index or
-/// a UPPERCASE field/const segment).
-fn is_associated_const_method_chain(segment: &str) -> bool {
-    let Some((head, chained)) = segment.split_once('.') else {
+/// A whole Rust identifier is SCREAMING_SNAKE_CASE when its non-underscore portion starts with an
+/// uppercase character, contains no lowercase characters, and every character follows the same
+/// `XID_Continue` boundary used by [`is_pascal_case`]. Leading underscores are permitted: names
+/// such as `_DEFAULT` are conventional associated constants too.
+fn is_screaming_const_identifier(name: &str) -> bool {
+    let name = name.strip_prefix("r#").unwrap_or(name).trim_start_matches('_');
+    let mut characters = name.chars();
+    let Some(first) = characters.next() else {
         return false;
     };
-    let screaming_const_head = head.chars().next().is_some_and(char::is_uppercase)
-        && head.chars().all(|character| is_xid_continue(character) || character == '_')
-        && !head.chars().any(char::is_lowercase);
-    screaming_const_head && chained.chars().next().is_some_and(char::is_lowercase)
+    first.is_uppercase()
+        && is_xid_continue(first)
+        && characters.all(|character| {
+            (is_xid_continue(character) || character == '_') && !character.is_lowercase()
+        })
+}
+
+/// A method identifier must start lowercase and otherwise remain within Rust's identifier
+/// boundaries. The field token comes directly from tree-sitter, so comments/whitespace around the
+/// member-access dot never affect this check.
+fn is_lowercase_method_identifier(name: &str) -> bool {
+    let name = name.strip_prefix("r#").unwrap_or(name);
+    let mut characters = name.chars();
+    characters.next().is_some_and(char::is_lowercase)
+        && characters.all(|character| is_xid_continue(character) || character == '_')
+}
+
+/// Associated-constant method-chain test (#1124 held feedback). Walk the Rust AST's nested
+/// `field_expression` nodes from the call's callee inward, requiring every field to be a
+/// lowercase method and the innermost receiver to be a scoped identifier whose final name is a
+/// SCREAMING_SNAKE associated constant. This preserves the distinction between a constant receiver
+/// (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::_DEFAULT.run(..)`) and a constructor or a
+/// PascalCase method, while remaining insensitive to trivia and turbofish wrappers.
+fn is_associated_const_method_chain(function: Node<'_>, text: &str) -> bool {
+    let mut current = unwrap_generic_function(function);
+    let mut saw_method = false;
+
+    while current.kind() == "field_expression" {
+        let Some(field) = current.child_by_field_name("field") else {
+            return false;
+        };
+        let Ok(field_name) = field.utf8_text(text.as_bytes()) else {
+            return false;
+        };
+        if !is_lowercase_method_identifier(field_name) {
+            return false;
+        }
+        saw_method = true;
+        let Some(value) = current.child_by_field_name("value") else {
+            return false;
+        };
+        current = unwrap_generic_function(value);
+    }
+
+    if !saw_method || current.kind() != "scoped_identifier" {
+        return false;
+    }
+    let Some(name) = current.child_by_field_name("name") else {
+        return false;
+    };
+    let Ok(name) = name.utf8_text(text.as_bytes()) else {
+        return false;
+    };
+    is_screaming_const_identifier(name)
 }
 
 /// The `Enum::Variant` dispatch key from a scoped path node — its last two `::`-segments when BOTH
@@ -629,7 +677,7 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     // the leading-`<` UFCS early return and the PascalCase-receiver `Skip` below would otherwise
     // bill `Handler::DEFAULT.run(..)` / `<Handler as Runner>::DEFAULT.run(..)` as an
     // associated/constructor call (#1124 held feedback).
-    if is_associated_const_method_chain(tail) {
+    if is_associated_const_method_chain(function, text) {
         return CallRole::Delegate;
     }
     // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
@@ -858,6 +906,7 @@ mod classify_call_tests {
             "<Resp as Default>::default()",
             "Handler::default.run(input)",
             "Handler::DEFAULT.Run(input)",
+            "Handler::DEFAULT.build.Run(input)",
             "Handler::DEFAULT(input)",
             "Err(problem)",
             "None()",

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -9,10 +9,18 @@ use tree_sitter::Node;
 use crate::index::edges::extract::EdgeEmitter;
 use crate::index::edges::*;
 
-/// PascalCase test for the enum/variant convention (#200): first char uppercase AND at least one
-/// lowercase — so `MlReq`/`Upsert` qualify but `new`, a SCREAMING `CONST`, and a bare `T` do not.
+/// PascalCase test for the enum/variant convention (#200): the segment's LEADING IDENTIFIER starts
+/// with an uppercase char AND carries at least one lowercase — so `MlReq`/`Upsert` qualify but
+/// `new`, a SCREAMING `CONST`, and a bare `T` do not.
+///
+/// Only that leading identifier is weighed because a segment can carry a method chain glued onto
+/// its head (`TOOL_NAMES.iter().map`, `NOW.elapsed`). The appended method names supply the very
+/// lowercase the test looks for, so reading the whole segment takes a constant for a variant
+/// constructor and bills the call as a transparent wrapper instead of the delegation it is (#1124).
 fn is_pascal_case(name: &str) -> bool {
-    name.chars().next().is_some_and(char::is_uppercase) && name.chars().any(char::is_lowercase)
+    let mut head =
+        name.chars().take_while(|&character| character.is_alphanumeric() || character == '_');
+    head.next().is_some_and(char::is_uppercase) && head.any(char::is_lowercase)
 }
 
 /// The `Enum::Variant` dispatch key from a scoped path node — its last two `::`-segments when BOTH
@@ -767,5 +775,34 @@ mod classify_call_tests {
         assert!(matches!(role_of("Config::from_env(path)"), CallRole::Skip));
         assert!(matches!(role_of("render_page(body)"), CallRole::Delegate));
         assert!(matches!(role_of("<Resp as Default>::default()"), CallRole::Skip));
+    }
+
+    /// A `SCREAMING_CONST` head carrying a method chain is a plain delegation, not a transparent
+    /// variant constructor (#1124). The chain's method names supply the lowercase the case test
+    /// looks for, so reading the whole segment bills `TOOL_NAMES.iter().map(..)` as a wrapper and
+    /// traces through the constant instead of recording the call as the handler.
+    #[test]
+    fn a_screaming_const_with_a_method_chain_is_not_a_wrapper() {
+        assert!(matches!(
+            role_of("crate::tools::TOOL_NAMES.iter().map(|name| describe(name))"),
+            CallRole::Delegate
+        ));
+        // A single-word constant has no underscore to give it away and reads the same way.
+        assert!(matches!(role_of("NOW.elapsed()"), CallRole::Delegate));
+    }
+
+    /// The case test reads the segment's leading IDENTIFIER, so a glued-on method chain cannot lend
+    /// its lowercase to a constant head, while an acronym-led type keeps its leading uppercase run.
+    /// A head that is genuinely PascalCase stays a constructor however the rest of the segment is
+    /// spelled — including a trailing method name carrying an underscore, which is the conservative
+    /// reading for the false-edge contract.
+    #[test]
+    fn the_case_test_reads_the_segments_leading_identifier() {
+        for name in ["TOOL_NAMES", "TOOL_NAMES.iter().map", "NOW", "NOW.elapsed", "T", "run"] {
+            assert!(!is_pascal_case(name), "{name}");
+        }
+        for name in ["MlReq", "Upsert", "HTTPResponse", "Wrapped(payload).to_string"] {
+            assert!(is_pascal_case(name), "{name}");
+        }
     }
 }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -51,60 +51,123 @@ fn is_lowercase_method_identifier(name: &str) -> bool {
     characters.next().is_some_and(char::is_lowercase) && characters.all(is_xid_continue)
 }
 
-/// Associated-constant method-chain test (#1124 held feedback). Walk the Rust AST's nested
-/// `field_expression` nodes from the call's callee inward, following an intermediate
-/// `call_expression` only when its own callee is another field expression. Every field must be a
-/// lowercase method and the final receiver must be a scoped identifier whose name is a
-/// SCREAMING_SNAKE associated constant. This preserves the distinction between a constant receiver
-/// (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::_DEFAULT.run(..)`) and a constructor or a
-/// PascalCase method, while remaining insensitive to trivia and turbofish wrappers. In particular,
-/// a constructor/function-call root is never treated as an associated-constant receiver, and
-/// associated constants appearing only in arguments are not traversed.
-fn is_associated_const_method_chain(function: Node<'_>, text: &str) -> bool {
+/// The innermost receiver of a method chain glued onto a call's callee — what the whole chain
+/// ultimately reads — plus whether every field crossed on the way was a lowercase METHOD. Both
+/// halves of the constant-chain decision need the same walk, and doing it once is what keeps them
+/// from disagreeing about the same expression (#1124 maintainer feedback).
+struct MethodChainRoot<'tree> {
+    receiver: Node<'tree>,
+    all_methods: bool,
+}
+
+/// Walk the Rust AST's nested `field_expression` nodes from the call's callee inward, following an
+/// intermediate `call_expression` only when its own callee is another field expression — a
+/// constructor/function-call root ends the walk there, because that call's RESULT is the value the
+/// rest of the chain adapts. `None` when the callee is not a method chain at all (a bare name, a
+/// path, a `Type::assoc` call). Insensitive to trivia and turbofish wrappers, so comments and
+/// generic arguments around the member-access dot cannot move a verdict.
+fn method_chain_root<'tree>(function: Node<'tree>, text: &str) -> Option<MethodChainRoot<'tree>> {
     let mut current = unwrap_generic_function(function);
-    let mut saw_method = false;
-
+    if current.kind() != "field_expression" {
+        return None;
+    }
+    let mut all_methods = true;
     while current.kind() == "field_expression" {
-        let Some(field) = current.child_by_field_name("field") else {
-            return false;
-        };
-        let Ok(field_name) = field.utf8_text(text.as_bytes()) else {
-            return false;
-        };
-        if !is_lowercase_method_identifier(field_name) {
-            return false;
+        let field = current.child_by_field_name("field")?;
+        all_methods &= is_lowercase_method_identifier(field.utf8_text(text.as_bytes()).ok()?);
+        let value = unwrap_generic_function(current.child_by_field_name("value")?);
+        if value.kind() != "call_expression" {
+            current = value;
+            continue;
         }
-        saw_method = true;
-        let Some(value) = current.child_by_field_name("value") else {
-            return false;
-        };
-        let value = unwrap_generic_function(value);
-        current = if value.kind() == "call_expression" {
-            let Some(inner_function) = value.child_by_field_name("function") else {
-                return false;
-            };
-            let inner_function = unwrap_generic_function(inner_function);
-            // Only another method field can continue the associated-constant chain. A scoped
-            // constructor/function call here is a separate root, even when its name is screaming.
-            if inner_function.kind() != "field_expression" {
-                return false;
-            }
-            inner_function
-        } else {
-            value
-        };
+        let inner_function = unwrap_generic_function(value.child_by_field_name("function")?);
+        current = if inner_function.kind() == "field_expression" { inner_function } else { value };
     }
+    Some(MethodChainRoot { receiver: current, all_methods })
+}
 
-    if !saw_method || current.kind() != "scoped_identifier" {
-        return false;
+/// What a method chain's root receiver is, when it is a SCREAMING_SNAKE constant.
+enum ConstantReceiver {
+    /// Owned by a named TYPE — `Handler::DEFAULT`, `crate::ml::Handler::DEFAULT`,
+    /// `<Handler as Runner>::_DEFAULT`. Naming the owner is what makes the chained method the
+    /// dispatch, so the call delegates to that method.
+    TypeOwned,
+    /// Named on its own or through the MODULE it lives in — `LIMIT`, `crate::config::LIMIT`,
+    /// `self::LIMIT`, `super::config::LIMIT`, an aliased `cfg::LIMIT`. A module is not a receiver,
+    /// so the chained method adapts the constant's VALUE and is never the handler.
+    Unowned,
+}
+
+fn constant_receiver(receiver: Node<'_>, text: &str) -> Option<ConstantReceiver> {
+    match receiver.kind() {
+        "identifier" => is_screaming_const_identifier(receiver.utf8_text(text.as_bytes()).ok()?)
+            .then_some(ConstantReceiver::Unowned),
+        "scoped_identifier" => {
+            let name = receiver.child_by_field_name("name")?;
+            if !is_screaming_const_identifier(name.utf8_text(text.as_bytes()).ok()?) {
+                return None;
+            }
+            // A leading `::` names the crate root — a module, and never a type.
+            let Some(path) = receiver.child_by_field_name("path") else {
+                return Some(ConstantReceiver::Unowned);
+            };
+            Some(if qualifier_names_a_type(path, text) {
+                ConstantReceiver::TypeOwned
+            } else {
+                ConstantReceiver::Unowned
+            })
+        },
+        _ => None,
     }
-    let Some(name) = current.child_by_field_name("name") else {
+}
+
+/// Whether a constant's qualifier names the TYPE that owns it rather than the MODULE it lives in.
+/// Rust's naming convention is the only extraction-time signal there is — type names begin with an
+/// uppercase character, module names do not, and `crate`/`self`/`super` are modules by definition —
+/// so the test is on the qualifier's LAST segment, which keeps the verdict independent of how long
+/// the path to it is (`Handler::DEFAULT` and `crate::a::b::Handler::DEFAULT` agree, as do `LIMIT`
+/// and `crate::a::b::LIMIT`). A bracketed UFCS qualifier (`<Handler as Runner>::DEFAULT`) names its
+/// type outright.
+fn qualifier_names_a_type(path: Node<'_>, text: &str) -> bool {
+    let Ok(raw) = path.utf8_text(text.as_bytes()) else {
         return false;
     };
-    let Ok(name) = name.utf8_text(text.as_bytes()) else {
-        return false;
-    };
-    is_screaming_const_identifier(name)
+    let raw = raw.trim();
+    if raw.starts_with('<') {
+        return true;
+    }
+    let stripped = degeneric_path(raw);
+    scope_grammar::segments(&stripped)
+        .into_iter()
+        .map(str::trim)
+        .rfind(|segment| !segment.is_empty())
+        .is_some_and(|segment| {
+            let segment = segment.strip_prefix("r#").unwrap_or(segment);
+            segment.chars().next().is_some_and(char::is_uppercase)
+        })
+}
+
+/// Where a method chain glued onto a SCREAMING constant lands, or `None` when the callee is not
+/// such a chain.
+enum ConstantChain {
+    /// The chain adapts the constant's value — emit nothing.
+    AdapterTail,
+    /// The chain calls a method ON the constant — record that method.
+    Dispatch,
+}
+
+/// The ONE decision about a constant-rooted method chain, taken on the chain's ROOT (#1124
+/// maintainer feedback). The adapter verdict is read off the same root as the dispatch verdict, so
+/// there is no order in which one can claim an expression before the other, and no spelling of the
+/// root can route otherwise identical expressions to different verdicts.
+fn constant_method_chain(function: Node<'_>, text: &str) -> Option<ConstantChain> {
+    let root = method_chain_root(function, text)?;
+    match constant_receiver(root.receiver, text)? {
+        ConstantReceiver::Unowned => Some(ConstantChain::AdapterTail),
+        // A PascalCase field is a variant/constructor spelling, not a method call, so it is left to
+        // the qualifier fallbacks below rather than billed as a dispatch.
+        ConstantReceiver::TypeOwned => root.all_methods.then_some(ConstantChain::Dispatch),
+    }
 }
 
 /// The `Enum::Variant` dispatch key from a scoped path node — its last two `::`-segments when BOTH
@@ -644,17 +707,18 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 /// How `result_handler_calls` treats a `call_expression` (#200/#208 — one classifier so the
 /// delegate/wrapper decision can't disagree with itself, as it did across review rounds):
 /// - `Delegate`: RECORD it as the handler (a free fn `run`, a method `self.embed`, a module-pathed
-///   fn `crate::ml::embed::embed_text`, or an associated-constant method chain
-///   `Handler::DEFAULT.run(..)` — the constant is the chained method's receiver).
+///   fn `crate::ml::embed::embed_text`, or a method chain on a constant a TYPE owns
+///   (`Handler::DEFAULT.run(..)`) — the constant is the chained method's receiver).
 /// - `Wrapper`: a TRANSPARENT wrapper / variant constructor whose single argument IS the response —
 ///   `Ok`/`Some`, or ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`).
 ///   Trace its lone payload argument.
 /// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
 ///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), a
 ///   UFCS associated call (`<Resp as Default>::default()`), or an adapter tail glued onto another
-///   call's result or onto a bare SCREAMING constant (`LIMIT.min(cap).max(..)`, `BASE.to_string()`
-///   — it adapts a value, and recording the trailing method would bind it to an unrelated
-///   same-named symbol, #1124 maintainer feedback).
+///   call's result or onto a SCREAMING constant no type owns — `LIMIT.min(cap).max(..)`,
+///   `crate::config::BASE.to_string()`, and every other spelling of that root — since it adapts a
+///   value, and recording the trailing method would bind it to an unrelated same-named symbol
+///   (#1124 maintainer feedback).
 ///
 /// Classification is by the path TAIL (constructor names are PascalCase; fns/methods are
 /// snake_case), which is receiver-agnostic — so `dto::Wrapped` and `Resp::Embedded` are both
@@ -690,17 +754,22 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     let Some(tail) = segments.last() else {
         return CallRole::Delegate;
     };
-    // An associated-constant method chain calls the chained METHOD with the constant as its
-    // receiver, so it delegates like any method call — UNCONDITIONALLY. The argument shape says
-    // nothing: `Resp::DEFAULT.with_body(handle(cap))` and `Handler::DEFAULT.run(normalize(input))`
-    // are the same expression modulo identifier spelling, so a nested-argument test cannot tell a
-    // builder from a dispatch and only picks which of the two loses its handler (#1124 maintainer
-    // feedback). Consulted before BOTH qualifier fallbacks: the leading-`<` UFCS early return and
-    // the PascalCase-receiver `Skip` below would otherwise bill `Handler::DEFAULT.run(..)` /
+    // A method chain rooted at a SCREAMING constant is decided by that ROOT, in one place, before
+    // BOTH qualifier fallbacks: the leading-`<` UFCS early return and the PascalCase-receiver
+    // `Skip` below would otherwise bill `Handler::DEFAULT.run(..)` /
     // `<Handler as Runner>::DEFAULT.run(..)` as an associated/constructor call (#1124 held
-    // feedback).
-    if is_associated_const_method_chain(function, text) {
-        return CallRole::Delegate;
+    // feedback), and a separate later adapter guard let the module-pathed spelling of an adapter
+    // tail reach a different verdict than the bare one (#1124 maintainer feedback).
+    //
+    // When a TYPE owns the constant, the chained method is called ON it and delegates
+    // UNCONDITIONALLY: the argument shape says nothing, since
+    // `Resp::DEFAULT.with_body(handle(cap))` and `Handler::DEFAULT.run(normalize(input))` are the
+    // same expression modulo identifier spelling, so a nested-argument test cannot tell a builder
+    // from a dispatch and only picks which of the two loses its handler.
+    match constant_method_chain(function, text) {
+        Some(ConstantChain::AdapterTail) => return CallRole::Skip,
+        Some(ConstantChain::Dispatch) => return CallRole::Delegate,
+        None => {},
     }
     // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
     // associated/constructor call — never a handler, and its arg (if any) isn't the response.
@@ -720,29 +789,26 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     match segments.as_slice() {
         [.., receiver, _last] if is_pascal_case(receiver) => CallRole::Skip,
         // The fall-through is reserved for a BARE callee. A method glued onto ANOTHER CALL'S
-        // RESULT or onto a BARE SCREAMING constant is an adapter tail (`LIMIT.min(cap).max(..)`,
-        // `list.len().saturating_sub(..)`, `BASE.to_string()`): it adapts a value into another
-        // value — never the handler, and not a wrapper either, since its argument is adapter input
-        // rather than the response. Recording the trailing method would bind it, via bare-name
-        // fallback, to an unrelated same-named repository symbol — a false persisted edge (#1124
-        // maintainer feedback).
-        _ if is_adapter_tail(function, text) => CallRole::Skip,
+        // RESULT is an adapter tail (`list.len().saturating_sub(..)`,
+        // `make_worker().run(input)`): it adapts a value into another value — never the handler,
+        // and not a wrapper either, since its argument is adapter input rather than the response.
+        // Recording the trailing method would bind it, via bare-name fallback, to an unrelated
+        // same-named repository symbol — a false persisted edge (#1124 maintainer feedback). A
+        // CONSTANT-rooted chain is already decided above, whatever its root's spelling.
+        _ if is_chained_adapter_tail(function) => CallRole::Skip,
         _ => CallRole::Delegate,
     }
 }
 
-/// Whether the call's callee is an adapter tail rather than a bare callee — AST-checked, never
-/// textual. Two receiver shapes qualify, both of which adapt an already-produced value:
-/// - the RESULT of another call, the standard-adapter chain (`x.min(cap).max(..)`,
-///   `list.len().saturating_sub(..)`);
-/// - a BARE SCREAMING constant (`BASE.to_string()`, `SWEEP_FALLBACK_CONCURRENCY.min(cap)`) — a
-///   constant names no owner, so its trailing method reads the constant's value.
+/// Whether the call's callee is a method glued onto ANOTHER CALL'S RESULT — AST-checked, never
+/// textual. That receiver holds an already-produced value, so the trailing method adapts it rather
+/// than handling anything.
 ///
-/// A method on a plain binding/`self`/field receiver (`worker.run`, `self.embed`) is a bare
-/// callee: that receiver holds the handler. A SCOPED constant receiver
-/// (`Handler::DEFAULT.run(..)`) never reaches here — [`is_associated_const_method_chain`] claims
-/// it earlier, because naming the owning type is what makes the chained method the dispatch.
-fn is_adapter_tail(function: Node<'_>, text: &str) -> bool {
+/// A method on a plain binding/`self`/field receiver (`worker.run`, `self.embed`) is a bare callee:
+/// that receiver holds the handler. A chain rooted at a SCREAMING constant never reaches here —
+/// [`constant_method_chain`] decides it earlier, on the root, so that `LIMIT.min(cap).max(..)` and
+/// `crate::config::LIMIT.min(cap).max(..)` cannot be answered differently.
+fn is_chained_adapter_tail(function: Node<'_>) -> bool {
     let function = unwrap_generic_function(function);
     if function.kind() != "field_expression" {
         return false;
@@ -750,12 +816,7 @@ fn is_adapter_tail(function: Node<'_>, text: &str) -> bool {
     let Some(value) = function.child_by_field_name("value") else {
         return false;
     };
-    let value = unwrap_generic_function(value);
-    match value.kind() {
-        "call_expression" => true,
-        "identifier" => value.utf8_text(text.as_bytes()).is_ok_and(is_screaming_const_identifier),
-        _ => false,
-    }
+    unwrap_generic_function(value).kind() == "call_expression"
 }
 
 /// Whether a `scoped_identifier` sits in an expression VALUE position where a unit enum-variant is
@@ -999,9 +1060,8 @@ mod classify_call_tests {
             "self.embed(input)",
         ];
         let mut misclassified = Vec::new();
-        misclassified.extend(
-            skip_forms.into_iter().filter(|form| !matches!(role_of(form), CallRole::Skip)),
-        );
+        misclassified
+            .extend(skip_forms.into_iter().filter(|form| !matches!(role_of(form), CallRole::Skip)));
         misclassified.extend(
             delegate_forms.into_iter().filter(|form| !matches!(role_of(form), CallRole::Delegate)),
         );

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -14,15 +14,15 @@ use crate::index::edges::*;
 /// with an uppercase char AND carries at least one lowercase — so `MlReq`/`Upsert` qualify but
 /// `new`, a SCREAMING `CONST`, and a bare `T` do not.
 /// The leading scan follows Rust's `XID_Continue` rule, so decomposed identifiers keep their
-/// combining marks instead of being truncated at the first non-alphanumeric code point.
+/// combining marks instead of being truncated at the first non-alphanumeric code point. `_`
+/// needs no special case: it is connector punctuation (Pc), already part of `XID_Continue`.
 ///
 /// Only that leading identifier is weighed because a segment can carry a method chain glued onto
 /// its head (`TOOL_NAMES.iter().map`, `NOW.elapsed`). The appended method names supply the very
 /// lowercase the test looks for, so reading the whole segment takes a constant for a variant
-/// constructor and bills the call as a transparent wrapper instead of the delegation it is (#1124).
+/// constructor and bills the call as a transparent wrapper it is not (#1124).
 fn is_pascal_case(name: &str) -> bool {
-    let mut head =
-        name.chars().take_while(|&character| is_xid_continue(character) || character == '_');
+    let mut head = name.chars().take_while(|&character| is_xid_continue(character));
     head.next().is_some_and(char::is_uppercase) && head.any(char::is_lowercase)
 }
 
@@ -38,9 +38,7 @@ fn is_screaming_const_identifier(name: &str) -> bool {
     };
     first.is_uppercase()
         && is_xid_continue(first)
-        && characters.all(|character| {
-            (is_xid_continue(character) || character == '_') && !character.is_lowercase()
-        })
+        && characters.all(|character| is_xid_continue(character) && !character.is_lowercase())
 }
 
 /// A method identifier may carry leading underscores, but its first non-underscore character must
@@ -50,8 +48,7 @@ fn is_screaming_const_identifier(name: &str) -> bool {
 fn is_lowercase_method_identifier(name: &str) -> bool {
     let name = name.strip_prefix("r#").unwrap_or(name).trim_start_matches('_');
     let mut characters = name.chars();
-    characters.next().is_some_and(char::is_lowercase)
-        && characters.all(|character| is_xid_continue(character) || character == '_')
+    characters.next().is_some_and(char::is_lowercase) && characters.all(is_xid_continue)
 }
 
 /// Associated-constant method-chain test (#1124 held feedback). Walk the Rust AST's nested
@@ -650,11 +647,15 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 ///   fn `crate::ml::embed::embed_text`, or an associated-constant method chain
 ///   `Handler::DEFAULT.run(..)` — the constant is the chained method's receiver).
 /// - `Wrapper`: a TRANSPARENT wrapper / variant constructor whose single argument IS the response —
-///   `Ok`/`Some` and ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`).
+///   `Ok`/`Some`, ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`), or
+///   an associated-constant BUILDER whose argument nests the producing call
+///   (`Resp::DEFAULT.with_body(handle(cap))` — `handle` is the real handler, not `with_body`).
 ///   Trace its lone payload argument.
 /// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
-///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), or
-///   a UFCS associated call (`<Resp as Default>::default()`).
+///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), a
+///   UFCS associated call (`<Resp as Default>::default()`), or a chained adapter tail glued onto
+///   another call's result (`LIMIT.min(cap).max(..)` — it adapts a value, and recording the
+///   trailing method would bind it to an unrelated same-named symbol, #1124 maintainer feedback).
 ///
 /// Classification is by the path TAIL (constructor names are PascalCase; fns/methods are
 /// snake_case), which is receiver-agnostic — so `dto::Wrapped` and `Resp::Embedded` are both
@@ -691,12 +692,17 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
         return CallRole::Delegate;
     };
     // An associated-constant method chain calls the chained METHOD with the constant as its
-    // receiver, so it delegates like any method call. Consulted before BOTH qualifier fallbacks:
-    // the leading-`<` UFCS early return and the PascalCase-receiver `Skip` below would otherwise
-    // bill `Handler::DEFAULT.run(..)` / `<Handler as Runner>::DEFAULT.run(..)` as an
-    // associated/constructor call (#1124 held feedback).
+    // receiver, so it delegates like any method call — but ONLY when the call consumes plain
+    // data (`Handler::DEFAULT.run(input)`) or a closure transformation
+    // (`TOOL_NAMES.iter().map(|name| ..)`). A chain that WRAPS a produced value is a builder
+    // (`Resp::DEFAULT.with_body(handle(cap))`): the nested argument call is the real handler,
+    // so the builder classifies as a transparent wrapper of its payload and the builder method
+    // itself is never recorded (#1124 maintainer feedback). Consulted before BOTH qualifier
+    // fallbacks: the leading-`<` UFCS early return and the PascalCase-receiver `Skip` below
+    // would otherwise bill `Handler::DEFAULT.run(..)` / `<Handler as Runner>::DEFAULT.run(..)`
+    // as an associated/constructor call (#1124 held feedback).
     if is_associated_const_method_chain(function, text) {
-        return CallRole::Delegate;
+        return if call_carries_nested_call(call) { CallRole::Wrapper } else { CallRole::Delegate };
     }
     // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
     // associated/constructor call — never a handler, and its arg (if any) isn't the response.
@@ -715,7 +721,60 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     // a bare fn / method / module-pathed fn is the handler.
     match segments.as_slice() {
         [.., receiver, _last] if is_pascal_case(receiver) => CallRole::Skip,
+        // The fall-through is reserved for a BARE callee. A method glued onto ANOTHER CALL'S
+        // RESULT is a chained adapter tail (`LIMIT.min(cap).max(..)`,
+        // `list.len().saturating_sub(..)`): it adapts a value into another value — never the
+        // handler, and not a wrapper either, since its argument is adapter input rather than the
+        // response. Recording the trailing method would bind it, via bare-name fallback, to an
+        // unrelated same-named repository symbol — a false persisted edge (#1124 maintainer
+        // feedback).
+        _ if is_chained_adapter_tail(function) => CallRole::Skip,
         _ => CallRole::Delegate,
+    }
+}
+
+/// Whether the call's callee is a method glued onto the RESULT of another call — the structural
+/// shape of a standard-adapter chain (`x.min(cap).max(..)`, `list.len().saturating_sub(..)`).
+/// AST-checked, never textual: the callee is a `field_expression` whose receiver is itself a
+/// `call_expression`. A method on a plain binding/`self`/field receiver (`worker.run`,
+/// `self.embed`) is a bare callee, not a chained tail.
+fn is_chained_adapter_tail(function: Node<'_>) -> bool {
+    let function = unwrap_generic_function(function);
+    if function.kind() != "field_expression" {
+        return false;
+    }
+    let Some(value) = function.child_by_field_name("value") else {
+        return false;
+    };
+    unwrap_generic_function(value).kind() == "call_expression"
+}
+
+/// Whether any ARGUMENT of `call` contains a nested `call_expression` outside a closure — the
+/// structural signal that the call wraps a produced value (`with_body(handle(cap))`) rather than
+/// consuming plain data (`run(input)`) or a transformation (`map(|name| describe(name))`: a
+/// closure is deferred behavior, not a produced response). The call's own callee chain is never
+/// inspected.
+fn call_carries_nested_call(call: Node<'_>) -> bool {
+    let Some(arguments) = call.child_by_field_name("arguments") else {
+        return false;
+    };
+    let mut cursor = arguments.walk();
+    arguments.named_children(&mut cursor).any(subtree_has_nested_call)
+}
+
+/// Whether `node`'s subtree contains a `call_expression`, never descending into a closure — used
+/// to tell a value-WRAPPING call from a data- or behavior-consuming one (see
+/// [`call_carries_nested_call`]).
+fn subtree_has_nested_call(node: Node<'_>) -> bool {
+    match node.kind() {
+        "call_expression" => true,
+        "closure_expression" => false,
+        // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep
+        // argument (#543).
+        _ => rag_rat_base::stack::grow_stack(|| {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor).any(subtree_has_nested_call)
+        }),
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -753,8 +753,7 @@ fn is_adapter_tail(function: Node<'_>, text: &str) -> bool {
     let value = unwrap_generic_function(value);
     match value.kind() {
         "call_expression" => true,
-        "identifier" =>
-            value.utf8_text(text.as_bytes()).is_ok_and(|name| is_screaming_const_identifier(name)),
+        "identifier" => value.utf8_text(text.as_bytes()).is_ok_and(is_screaming_const_identifier),
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -859,11 +859,10 @@ mod classify_call_tests {
             "Handler::default.run(input)",
             "Handler::DEFAULT.Run(input)",
             "Handler::DEFAULT(input)",
-            "Ok(body)",
-            "Some(body)",
             "Err(problem)",
             "None()",
         ];
+        let wrapper_forms = ["Ok(body)", "Some(body)"];
         let mut misclassified = Vec::new();
         misclassified.extend(
             delegate_forms
@@ -875,6 +874,11 @@ mod classify_call_tests {
             skip_forms
                 .into_iter()
                 .filter(|expression| !matches!(role_of(expression), CallRole::Skip)),
+        );
+        misclassified.extend(
+            wrapper_forms
+                .into_iter()
+                .filter(|expression| !matches!(role_of(expression), CallRole::Wrapper)),
         );
         assert!(misclassified.is_empty(), "misclassified forms: {misclassified:?}");
     }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -830,18 +830,52 @@ mod classify_call_tests {
     /// verdicts are collected before asserting, so one failure names EVERY misclassified form.
     #[test]
     fn an_associated_constant_method_chain_delegates_to_the_chained_method() {
-        let delegate_forms =
-            ["Handler::DEFAULT.run(input)", "<Handler as Runner>::DEFAULT.run(input)"];
-        let skip_forms = ["Handler::new(input)", "<Resp as Default>::default()"];
-        let misclassified: Vec<&str> = delegate_forms
-            .into_iter()
-            .filter(|expression| !matches!(role_of(expression), CallRole::Delegate))
-            .chain(
-                skip_forms
-                    .into_iter()
-                    .filter(|expression| !matches!(role_of(expression), CallRole::Skip)),
-            )
-            .collect();
+        // Trivia is not part of Rust's token identity. Generate the same four semantic forms
+        // through several legal spellings around the member-access dot, including comments and a
+        // line break. The leading underscore is part of the SCREAMING_SNAKE convention, not a
+        // reason to fall back to the PascalCase receiver guard.
+        let qualifiers = [
+            "Handler::DEFAULT",
+            "Handler::_DEFAULT",
+            "<Handler as Runner>::DEFAULT",
+            "<Handler as Runner>::_DEFAULT",
+        ];
+        let trivia = [".", " . ", "\n .\n", " /* receiver */ . ", "\n /* receiver */\n .\t"];
+        let mut delegate_forms = Vec::new();
+        for qualifier in qualifiers {
+            for separator in trivia {
+                delegate_forms.push(format!("{qualifier}{separator}run(input)"));
+            }
+        }
+        // A nested field chain and a turbofish must use the same token structure, too.
+        delegate_forms.extend([
+            "Handler::DEFAULT . build.ship(input)".to_string(),
+            "<Handler as Runner>::_DEFAULT /* receiver */ . run::<u8>(input)".to_string(),
+        ]);
+
+        let skip_forms = [
+            "Handler::new(input)",
+            "<Resp as Default>::default()",
+            "Handler::default.run(input)",
+            "Handler::DEFAULT.Run(input)",
+            "Handler::DEFAULT(input)",
+            "Ok(body)",
+            "Some(body)",
+            "Err(problem)",
+            "None()",
+        ];
+        let mut misclassified = Vec::new();
+        misclassified.extend(
+            delegate_forms
+                .iter()
+                .filter(|expression| !matches!(role_of(expression), CallRole::Delegate))
+                .map(String::as_str),
+        );
+        misclassified.extend(
+            skip_forms
+                .into_iter()
+                .filter(|expression| !matches!(role_of(expression), CallRole::Skip)),
+        );
         assert!(misclassified.is_empty(), "misclassified forms: {misclassified:?}");
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -407,6 +407,9 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // 17: a same-file declared return types a `let` binding under ANY callee name, not only
 // `new`/`default`, and a declared return carrying generic arguments declines instead of naming
 // itself; re-extract `receiver_type_hint_id` so deployed indexes gain the one and drop the other.
+// Also #1124 — dispatch handler classification reads only a segment's leading identifier with
+// Unicode XID continuation semantics; re-extract facts so existing indexes do not retain the old
+// wrapper/delegate decision.
 const GRAPH_INDEX_VERSION: &str = "17";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -408,9 +408,11 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // `new`/`default`, and a declared return carrying generic arguments declines instead of naming
 // itself; re-extract `receiver_type_hint_id` so deployed indexes gain the one and drop the other.
 // Also #1124 — dispatch handler classification reads only a segment's leading identifier with
-// Unicode XID continuation semantics, and an associated-constant method chain
+// Unicode XID continuation semantics, an associated-constant method chain
 // (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::DEFAULT.run(..)`) delegates to its chained
-// method; re-extract facts so existing indexes do not retain the old wrapper/delegate decision.
+// method, and an adapter tail glued onto another call's result or onto a bare constant
+// (`LIMIT.min(cap).max(1)`, `BASE.to_string()`) records no handler at all; re-extract facts so
+// existing indexes do not retain the old wrapper/delegate decision.
 const GRAPH_INDEX_VERSION: &str = "17";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -408,11 +408,12 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // `new`/`default`, and a declared return carrying generic arguments declines instead of naming
 // itself; re-extract `receiver_type_hint_id` so deployed indexes gain the one and drop the other.
 // Also #1124 — dispatch handler classification reads only a segment's leading identifier with
-// Unicode XID continuation semantics, an associated-constant method chain
+// Unicode XID continuation semantics, a method chain on a constant a TYPE owns
 // (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::DEFAULT.run(..)`) delegates to its chained
-// method, and an adapter tail glued onto another call's result or onto a bare constant
-// (`LIMIT.min(cap).max(1)`, `BASE.to_string()`) records no handler at all; re-extract facts so
-// existing indexes do not retain the old wrapper/delegate decision.
+// method, and an adapter tail glued onto another call's result or onto a constant no type owns
+// records no handler at all — `LIMIT.min(cap).max(1)` and `crate::config::BASE.to_string()` alike,
+// since the chain's ROOT decides and its spelling does not; re-extract facts so existing indexes do
+// not retain the old wrapper/delegate decision.
 const GRAPH_INDEX_VERSION: &str = "17";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -408,8 +408,9 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // `new`/`default`, and a declared return carrying generic arguments declines instead of naming
 // itself; re-extract `receiver_type_hint_id` so deployed indexes gain the one and drop the other.
 // Also #1124 — dispatch handler classification reads only a segment's leading identifier with
-// Unicode XID continuation semantics; re-extract facts so existing indexes do not retain the old
-// wrapper/delegate decision.
+// Unicode XID continuation semantics, and an associated-constant method chain
+// (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::DEFAULT.run(..)`) delegates to its chained
+// method; re-extract facts so existing indexes do not retain the old wrapper/delegate decision.
 const GRAPH_INDEX_VERSION: &str = "17";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1471,23 +1471,57 @@ fn dispatch_persists_handle_facts_for_associated_constant_method_chains() {
     fs::write(
         root.join("src/lib.rs"),
         r#"
-pub enum Msg { AssocConst { input: u8 }, UfcsConst { input: u8 } }
+pub enum Msg {
+    AssocConst { input: u8 },
+    AssocConstSpaced { input: u8 },
+    AssocConstCommented { input: u8 },
+    AssocConstUnderscore { input: u8 },
+    UfcsConst { input: u8 },
+    UfcsConstCommented { input: u8 },
+    UfcsConstUnderscore { input: u8 },
+}
 
 pub struct Handler;
-pub trait Runner { fn run(&self, input: u8); }
-impl Runner for Handler { fn run(&self, _input: u8) {} }
-impl Handler { pub const DEFAULT: Handler = Handler; }
+pub trait Runner {
+    const DEFAULT: Handler;
+    const _DEFAULT: Handler;
+    fn run(&self, input: u8);
+}
+impl Runner for Handler {
+    const DEFAULT: Handler = Handler;
+    const _DEFAULT: Handler = Handler;
+    fn run(&self, _input: u8) {}
+}
+impl Handler {
+    pub const DEFAULT: Handler = Handler;
+    pub const _DEFAULT: Handler = Handler;
+}
 
 pub fn enqueue() {
     send(Msg::AssocConst { input: 1 });
-    send(Msg::UfcsConst { input: 2 });
+    send(Msg::AssocConstSpaced { input: 2 });
+    send(Msg::AssocConstCommented { input: 3 });
+    send(Msg::AssocConstUnderscore { input: 4 });
+    send(Msg::UfcsConst { input: 5 });
+    send(Msg::UfcsConstCommented { input: 6 });
+    send(Msg::UfcsConstUnderscore { input: 7 });
 }
 fn send(_m: Msg) {}
 
 pub fn handle(m: Msg) {
     match m {
         Msg::AssocConst { input } => Handler::DEFAULT.run(input),
+        Msg::AssocConstSpaced { input } => Handler::DEFAULT
+            .run(input),
+        Msg::AssocConstCommented { input } => Handler::DEFAULT /* receiver */
+            .run(input),
+        Msg::AssocConstUnderscore { input } => Handler::_DEFAULT
+            .run(input),
         Msg::UfcsConst { input } => <Handler as Runner>::DEFAULT.run(input),
+        Msg::UfcsConstCommented { input } => <Handler as Runner>::DEFAULT /* receiver */
+            .run(input),
+        Msg::UfcsConstUnderscore { input } => <Handler as Runner>::_DEFAULT /* receiver */
+            .run(input),
     }
 }
 "#,
@@ -1513,7 +1547,15 @@ pub fn handle(m: Msg) {
 
     // Each associated-constant method-chain form persists a `dispatch_handle` edge to `run`,
     // keyed by its own variant.
-    for variant in ["Msg::AssocConst", "Msg::UfcsConst"] {
+    for variant in [
+        "Msg::AssocConst",
+        "Msg::AssocConstSpaced",
+        "Msg::AssocConstCommented",
+        "Msg::AssocConstUnderscore",
+        "Msg::UfcsConst",
+        "Msg::UfcsConstCommented",
+        "Msg::UfcsConstUnderscore",
+    ] {
         assert!(
             handle_facts
                 .iter()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1560,30 +1560,32 @@ pub fn handle(m: Msg) {
     // Each associated-constant method-chain form persists a `dispatch_handle` edge to `run`,
     // keyed by its own variant. Keep the row count independent from the per-variant assertions so
     // deleting one assertion cannot make the regression test vacuously pass.
-    let expected_variants = [
-        "Msg::AssocConst",
-        "Msg::AssocConstSpaced",
-        "Msg::AssocConstCommented",
-        "Msg::AssocConstUnderscore",
-        "Msg::AssocConstLeadingMethod",
-        "Msg::AssocConstCallInterrupted",
-        "Msg::UfcsConst",
-        "Msg::UfcsConstCommented",
-        "Msg::UfcsConstUnderscore",
+    let expected_facts = [
+        ("Msg::AssocConst", "run"),
+        ("Msg::AssocConstSpaced", "run"),
+        ("Msg::AssocConstCommented", "run"),
+        ("Msg::AssocConstUnderscore", "run"),
+        ("Msg::AssocConstLeadingMethod", "_run"),
+        ("Msg::AssocConstCallInterrupted", "run"),
+        ("Msg::UfcsConst", "run"),
+        ("Msg::UfcsConstCommented", "run"),
+        ("Msg::UfcsConstUnderscore", "run"),
     ];
-    let run_facts = handle_facts.iter().filter(|(target, _)| target == "run").count();
+    let associated_chain_facts = handle_facts
+        .iter()
+        .filter(|(target, _)| expected_facts.iter().any(|(_, expected)| target == expected))
+        .count();
     assert_eq!(
-        run_facts,
-        expected_variants.len(),
+        associated_chain_facts,
+        expected_facts.len(),
         "every associated-constant form must persist exactly one dispatch_handle edge: \
          {handle_facts:?}"
     );
-    for variant in expected_variants {
+    for (variant, target) in expected_facts {
         assert!(
-            handle_facts
-                .iter()
-                .any(|(target, evidence)| target == "run" && evidence.as_deref() == Some(variant)),
-            "{variant} must persist a dispatch_handle edge to `run`: {handle_facts:?}"
+            handle_facts.iter().any(|(actual_target, evidence)| actual_target == target
+                && evidence.as_deref() == Some(variant)),
+            "{variant} must persist a dispatch_handle edge to `{target}`: {handle_facts:?}"
         );
     }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1596,31 +1596,71 @@ pub fn handle(m: Msg) {
 fn dispatch_suppresses_adapter_tails_end_to_end() {
     // #1124 maintainer feedback (HIGH): a standard-adapter tail computes a value — it is never the
     // dispatch handler. That covers a method glued onto ANOTHER CALL'S RESULT
-    // (`LIMIT.min(cap).max(1)`, `items(count).len().max(1)`) and a method glued onto a BARE
-    // SCREAMING constant (`BASE.to_string()`). Recording the trailing method name lets bare-name
-    // fallback bind it to an unrelated same-named in-repo symbol, synthesizing a FALSE
-    // `dispatches` edge. The three arms mirror the shapes that exist in this repo today
+    // (`LIMIT.min(cap).max(1)`, `items(count).len().max(1)`) and a method glued onto a SCREAMING
+    // constant (`BASE.to_string()`). Recording the trailing method name lets bare-name fallback
+    // bind it to an unrelated same-named in-repo symbol, synthesizing a FALSE `dispatches` edge.
+    // The first three arms mirror the shapes that exist in this repo today
     // (`rag-rat-llm/src/throughput_tune.rs`, `rag-rat-cli/src/init/wizard/steps/embedding.rs`,
-    // `rag-rat-core/src/index/consolidate.rs`). This fixture defines exactly such same-named
-    // helpers (`fn max`, `fn to_string`), so a false edge cannot hide behind an unresolved name,
-    // and a plain delegate arm proves the fixture CAN synthesize edges — the negative assertions
-    // are not vacuous.
+    // `rag-rat-core/src/index/consolidate.rs`).
+    //
+    // The role is fixed by the chain's ROOT, so every SPELLING of that root behaves the same: bare,
+    // `crate::`-qualified, `self::`/`super::`-relative, aliased, and an arbitrarily long module
+    // path each get their own arm and their own trailing method. A qualifier that names the OWNING
+    // TYPE is not a module path — `Handler::DEFAULT.run_handler(input)` is a real dispatch and is
+    // the second positive control, so a fix cannot pass by skipping everything.
+    //
+    // This fixture defines a same-named in-repo helper for EVERY adapter method, so a false edge
+    // cannot hide behind an unresolved name, and the two delegate arms prove the fixture CAN
+    // synthesize edges — the negative assertions are not vacuous.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(
         root.join("src/lib.rs"),
         r#"
-pub enum Msg { Clamp { cap: usize }, Batch { count: usize }, Legacy, Direct }
+pub enum Msg {
+    Clamp { cap: usize },
+    Batch { count: usize },
+    Legacy,
+    Direct,
+    CrateQualified { cap: usize },
+    LongPath,
+    SelfRelative { cap: usize },
+    Aliased { cap: usize },
+    SuperRelative { cap: usize },
+    RelativeDirect,
+    TypeOwned { input: u8 },
+}
 pub enum Resp { Wrap(usize), Text(String), Empty }
 const LIMIT: usize = 8;
 const BASE: &str = "SELECT id FROM repo_memories";
+
+pub mod config {
+    pub const LIMIT: usize = 8;
+    pub mod deep {
+        pub const BASE: &str = "SELECT id FROM repo_memories";
+    }
+}
+use crate::config as cfg;
+
+pub struct Handler;
+impl Handler {
+    pub const DEFAULT: Handler = Handler;
+    fn run_handler(&self, _input: u8) -> usize { 0 }
+}
 
 pub fn enqueue() {
     send(Msg::Clamp { cap: 3 });
     send(Msg::Batch { count: 2 });
     send(Msg::Legacy);
     send(Msg::Direct);
+    send(Msg::CrateQualified { cap: 4 });
+    send(Msg::LongPath);
+    send(Msg::SelfRelative { cap: 5 });
+    send(Msg::Aliased { cap: 6 });
+    send(Msg::SuperRelative { cap: 7 });
+    send(Msg::RelativeDirect);
+    send(Msg::TypeOwned { input: 8 });
 }
 fn send(_m: Msg) {}
 
@@ -1630,14 +1670,39 @@ pub fn handle(m: Msg) {
         Msg::Batch { count } => Ok(Resp::Wrap(batch_items(count).len().max(1))),
         Msg::Legacy => Ok(Resp::Text(BASE.to_string())),
         Msg::Direct => Ok(Resp::Wrap(run_direct())),
+        Msg::CrateQualified { cap } => {
+            Ok(Resp::Wrap(crate::config::LIMIT.min(cap).saturating_add(1)))
+        }
+        Msg::LongPath => Ok(Resp::Text(crate::config::deep::BASE.repeat(2))),
+        Msg::SelfRelative { cap } => Ok(Resp::Wrap(self::LIMIT.wrapping_mul(cap))),
+        Msg::Aliased { cap } => Ok(Resp::Wrap(cfg::LIMIT.pow(cap))),
+        Msg::TypeOwned { input } => Ok(Resp::Wrap(Handler::DEFAULT.run_handler(input))),
+        _ => Ok(Resp::Empty),
     }
 }
+
+pub mod inner {
+    use super::{Msg, Resp};
+    pub fn handle_relative(m: Msg) {
+        match m {
+            Msg::SuperRelative { cap } => Ok(Resp::Wrap(super::LIMIT.rotate_left(cap))),
+            Msg::RelativeDirect => Ok(Resp::Wrap(super::run_relative())),
+            _ => Ok(Resp::Empty),
+        }
+    }
+}
+
 fn batch_items(_count: usize) -> Vec<usize> { Vec::new() }
 fn run_direct() -> usize { 0 }
-// Same-named in-repo helpers: an adapter-tail fall-through would bind the recorded `max` /
-// `to_string` here.
+fn run_relative() -> usize { 0 }
+// Same-named in-repo helpers: an adapter-tail fall-through would bind the recorded method here.
 fn max(_a: usize, _b: usize) -> usize { 0 }
 fn to_string(_value: &str) -> String { String::new() }
+fn saturating_add(_a: usize, _b: usize) -> usize { 0 }
+fn repeat(_value: &str, _times: usize) -> String { String::new() }
+fn wrapping_mul(_a: usize, _b: usize) -> usize { 0 }
+fn pow(_a: usize, _b: usize) -> usize { 0 }
+fn rotate_left(_a: usize, _b: usize) -> usize { 0 }
 "#,
     )
     .unwrap();
@@ -1654,13 +1719,33 @@ fn to_string(_value: &str) -> String { String::new() }
             .any(|from| from.ends_with("enqueue"))
     };
 
-    // Positive control: the plain delegate arm synthesizes its resolved edge, so the negative
-    // assertions below exercise a working synthesis pipeline.
+    // Positive controls: a plain delegate and a TYPE-owned associated-constant chain both
+    // synthesize their resolved edge, so the negative assertions below exercise a working
+    // synthesis pipeline and cannot be satisfied by suppressing every edge.
     assert!(dispatches_from_enqueue("run_direct"), "the plain delegate arm must dispatch");
+    assert!(
+        dispatches_from_enqueue("run_handler"),
+        "a type-owned associated-constant chain must still dispatch"
+    );
+    // The `super::`-relative arm lives in a submodule, so its own match must be proven extracted —
+    // otherwise its negative assertion below would pass vacuously.
+    assert!(
+        dispatches_from_enqueue("run_relative"),
+        "the submodule's delegate arm must dispatch (the super::-relative arm is not vacuous)"
+    );
 
     // Resolved-edge level: the same-named helpers and the chain's producer must gain NO
-    // synthesized `dispatches` edge from the adapter arms.
-    for non_handler in ["max", "to_string", "batch_items"] {
+    // synthesized `dispatches` edge from the adapter arms, whatever spells their root.
+    for non_handler in [
+        "max",
+        "to_string",
+        "batch_items",
+        "saturating_add",
+        "repeat",
+        "wrapping_mul",
+        "pow",
+        "rotate_left",
+    ] {
         assert!(
             !dispatches_from_enqueue(non_handler),
             "{non_handler} must NOT be a dispatch handler (false edge from an adapter tail)"
@@ -1682,14 +1767,33 @@ fn to_string(_value: &str) -> String { String::new() }
         .unwrap()
         .collect::<Result<_, _>>()
         .unwrap();
-    for chained_method in ["max", "min", "len", "to_string"] {
+    for chained_method in [
+        "max",
+        "min",
+        "len",
+        "to_string",
+        "saturating_add",
+        "repeat",
+        "wrapping_mul",
+        "pow",
+        "rotate_left",
+    ] {
         assert!(
             handle_facts.iter().all(|(target, _)| target != chained_method),
             "no dispatch_handle fact may name the adapter method `{chained_method}`: \
              {handle_facts:?}"
         );
     }
-    for adapter_variant in ["Msg::Clamp", "Msg::Batch", "Msg::Legacy"] {
+    for adapter_variant in [
+        "Msg::Clamp",
+        "Msg::Batch",
+        "Msg::Legacy",
+        "Msg::CrateQualified",
+        "Msg::LongPath",
+        "Msg::SelfRelative",
+        "Msg::Aliased",
+        "Msg::SuperRelative",
+    ] {
         assert!(
             handle_facts.iter().all(|(_, evidence)| evidence.as_deref() != Some(adapter_variant)),
             "the adapter arm {adapter_variant} must persist no dispatch_handle fact: \

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1557,14 +1557,12 @@ pub fn handle(m: Msg) {
         "Msg::UfcsConstCommented",
         "Msg::UfcsConstUnderscore",
     ];
-    let run_facts = handle_facts
-        .iter()
-        .filter(|(target, _)| target == "run")
-        .count();
+    let run_facts = handle_facts.iter().filter(|(target, _)| target == "run").count();
     assert_eq!(
         run_facts,
         expected_variants.len(),
-        "every associated-constant form must persist exactly one dispatch_handle edge: {handle_facts:?}"
+        "every associated-constant form must persist exactly one dispatch_handle edge: \
+         {handle_facts:?}"
     );
     for variant in expected_variants {
         assert!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1459,6 +1459,73 @@ pub mod b {
 }
 
 #[test]
+fn dispatch_persists_handle_facts_for_associated_constant_method_chains() {
+    // #1124 held feedback: a match arm delegating through an ASSOCIATED CONSTANT's method chain —
+    // `Handler::DEFAULT.run(input)` or the UFCS `<Handler as Runner>::DEFAULT.run(input)` — calls
+    // the chained METHOD: the constant is the receiver, not a constructor. Each form must persist
+    // a `dispatch_handle` fact to `run`; previously the first read as a PascalCase-receiver
+    // constructor and the second as a UFCS associated call, so neither fact existed.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { AssocConst { input: u8 }, UfcsConst { input: u8 } }
+
+pub struct Handler;
+pub trait Runner { fn run(&self, input: u8); }
+impl Runner for Handler { fn run(&self, _input: u8) {} }
+impl Handler { pub const DEFAULT: Handler = Handler; }
+
+pub fn enqueue() {
+    send(Msg::AssocConst { input: 1 });
+    send(Msg::UfcsConst { input: 2 });
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        Msg::AssocConst { input } => Handler::DEFAULT.run(input),
+        Msg::UfcsConst { input } => <Handler as Runner>::DEFAULT.run(input),
+    }
+}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let mut statement = conn
+        .prepare(
+            "SELECT tn.value, d.evidence FROM edges_data d
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
+             JOIN name_strings tn ON tn.id = d.to_name_id
+             WHERE ek.value = 'dispatch_handle'",
+        )
+        .unwrap();
+    let handle_facts: Vec<(String, Option<String>)> = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+
+    // Each associated-constant method-chain form persists a `dispatch_handle` edge to `run`,
+    // keyed by its own variant.
+    for variant in ["Msg::AssocConst", "Msg::UfcsConst"] {
+        assert!(
+            handle_facts
+                .iter()
+                .any(|(target, evidence)| target == "run" && evidence.as_deref() == Some(variant)),
+            "{variant} must persist a dispatch_handle edge to `run`: {handle_facts:?}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn symbol_search_excludes_generated_bindings_unless_opted_in() {
     // #202: a name/symbol_path search drowns in generated bindings (ubrn FFI output, codegen) that
     // shadow the hand-written source symbol. The real-world case is codegen living UNDER a source

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1546,8 +1546,9 @@ pub fn handle(m: Msg) {
         .unwrap();
 
     // Each associated-constant method-chain form persists a `dispatch_handle` edge to `run`,
-    // keyed by its own variant.
-    for variant in [
+    // keyed by its own variant. Keep the row count independent from the per-variant assertions so
+    // deleting one assertion cannot make the regression test vacuously pass.
+    let expected_variants = [
         "Msg::AssocConst",
         "Msg::AssocConstSpaced",
         "Msg::AssocConstCommented",
@@ -1555,7 +1556,17 @@ pub fn handle(m: Msg) {
         "Msg::UfcsConst",
         "Msg::UfcsConstCommented",
         "Msg::UfcsConstUnderscore",
-    ] {
+    ];
+    let run_facts = handle_facts
+        .iter()
+        .filter(|(target, _)| target == "run")
+        .count();
+    assert_eq!(
+        run_facts,
+        expected_variants.len(),
+        "every associated-constant form must persist exactly one dispatch_handle edge: {handle_facts:?}"
+    );
+    for variant in expected_variants {
         assert!(
             handle_facts
                 .iter()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1701,19 +1701,21 @@ fn to_string(_value: &str) -> String { String::new() }
 }
 
 #[test]
-fn dispatch_records_the_real_handler_behind_an_associated_constant_builder() {
-    // #1124 maintainer feedback (MEDIUM): `Resp::DEFAULT.with_body(make_body(cap))` is a BUILDER
-    // wrapper — the nested argument call is the real handler — while
-    // `Handler::DEFAULT.run(input)` is the dispatch itself. The builder method (`with_body`,
-    // present in-repo as the impl method) must gain no edge, the payload producer must be traced
-    // through the wrapper, and the true dispatch shape must keep delegating.
+fn dispatch_records_the_chained_method_of_an_associated_constant_chain() {
+    // #1124 maintainer feedback (MEDIUM): `Resp::DEFAULT.with_body(make_body(cap))` and
+    // `Handler::DEFAULT.run(normalize(input))` are the same expression modulo identifier spelling,
+    // so no argument-shape heuristic can tell a builder from a dispatch. An associated-constant
+    // method chain therefore delegates to its chained method unconditionally: the chained method
+    // is recorded even when an argument nests a produced value, and the nested producer is NOT
+    // traced through. Both methods and the nested producer exist in-repo, so every assertion is
+    // about a resolvable name rather than a name that could never bind.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(
         root.join("src/lib.rs"),
         r#"
-pub enum Msg { Build { cap: usize }, Run { input: u8 } }
+pub enum Msg { Build { cap: usize }, Run { input: u8 }, Plain { input: u8 } }
 pub struct Resp;
 impl Resp {
     pub const DEFAULT: Resp = Resp;
@@ -1728,16 +1730,19 @@ impl Handler {
 pub fn enqueue() {
     send(Msg::Build { cap: 1 });
     send(Msg::Run { input: 2 });
+    send(Msg::Plain { input: 3 });
 }
 fn send(_m: Msg) {}
 
 pub fn handle(m: Msg) {
     match m {
         Msg::Build { cap } => Resp::DEFAULT.with_body(make_body(cap)),
-        Msg::Run { input } => Handler::DEFAULT.run(input),
+        Msg::Run { input } => Handler::DEFAULT.run(normalize(input)),
+        Msg::Plain { input } => Handler::DEFAULT.run(input),
     }
 }
 fn make_body(_cap: usize) -> usize { 0 }
+fn normalize(_input: u8) -> u8 { 0 }
 "#,
     )
     .unwrap();
@@ -1754,21 +1759,23 @@ fn make_body(_cap: usize) -> usize { 0 }
             .any(|from| from.ends_with("enqueue"))
     };
 
-    // The wrapper retains nested-argument tracing: the REAL handler is the payload producer.
-    assert!(
-        dispatches_from_enqueue("make_body"),
-        "the builder's payload producer must be the dispatch handler"
-    );
-    // The true dispatch shape still delegates to the chained method.
-    assert!(dispatches_from_enqueue("run"), "the associated-constant dispatch must reach `run`");
-    // The builder METHOD is never the handler — the same-named in-repo impl method must gain no
-    // synthesized edge.
-    assert!(
-        !dispatches_from_enqueue("with_body"),
-        "the builder method must NOT be a dispatch handler (false edge)"
-    );
+    // Every associated-constant chain reaches its chained method, whether or not an argument
+    // nests a produced value.
+    for chained_method in ["with_body", "run"] {
+        assert!(
+            dispatches_from_enqueue(chained_method),
+            "the associated-constant dispatch must reach `{chained_method}`"
+        );
+    }
+    // A nested argument call is not descended into, so the producer gains no edge of its own.
+    for nested_producer in ["make_body", "normalize"] {
+        assert!(
+            !dispatches_from_enqueue(nested_producer),
+            "{nested_producer} must NOT be a dispatch handler (an argument is not the dispatch)"
+        );
+    }
 
-    // Fact level: the builder arm's fact names the payload producer, never the builder method.
+    // Fact level: each arm's fact names the chained method, never the nested argument call.
     let mut statement = conn
         .prepare(
             "SELECT tn.value, d.evidence FROM edges_data d
@@ -1782,17 +1789,22 @@ fn make_body(_cap: usize) -> usize { 0 }
         .unwrap()
         .collect::<Result<_, _>>()
         .unwrap();
-    assert!(
-        handle_facts
-            .iter()
-            .any(|(target, evidence)| target == "make_body"
-                && evidence.as_deref() == Some("Msg::Build")),
-        "Msg::Build must persist a dispatch_handle fact to `make_body`: {handle_facts:?}"
-    );
-    assert!(
-        handle_facts.iter().all(|(target, _)| target != "with_body"),
-        "no dispatch_handle fact may name the builder method `with_body`: {handle_facts:?}"
-    );
+    for (variant, chained_method) in
+        [("Msg::Build", "with_body"), ("Msg::Run", "run"), ("Msg::Plain", "run")]
+    {
+        assert!(
+            handle_facts.iter().any(|(target, evidence)| target == chained_method
+                && evidence.as_deref() == Some(variant)),
+            "{variant} must persist a dispatch_handle fact to `{chained_method}`: {handle_facts:?}"
+        );
+    }
+    for nested_producer in ["make_body", "normalize"] {
+        assert!(
+            handle_facts.iter().all(|(target, _)| target != nested_producer),
+            "no dispatch_handle fact may name the nested argument call `{nested_producer}`: \
+             {handle_facts:?}"
+        );
+    }
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1593,6 +1593,202 @@ pub fn handle(m: Msg) {
 }
 
 #[test]
+fn dispatch_suppresses_chained_adapter_tails_end_to_end() {
+    // #1124 maintainer feedback (HIGH): a standard-adapter chain whose trailing method is glued
+    // onto ANOTHER CALL'S RESULT (`LIMIT.min(cap).max(1)`, `items(count).len().max(1)`) computes a
+    // value — it is never the dispatch handler. Recording the trailing method name lets bare-name
+    // fallback bind it to an unrelated same-named in-repo symbol, synthesizing a FALSE
+    // `dispatches` edge. This fixture defines exactly such a helper (`fn max`), so a false edge
+    // cannot hide behind an unresolved name, and a plain delegate arm proves the fixture CAN
+    // synthesize edges — the negative assertions are not vacuous.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Clamp { cap: usize }, Batch { count: usize }, Direct }
+pub enum Resp { Wrap(usize), Empty }
+const LIMIT: usize = 8;
+
+pub fn enqueue() {
+    send(Msg::Clamp { cap: 3 });
+    send(Msg::Batch { count: 2 });
+    send(Msg::Direct);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        Msg::Clamp { cap } => Ok(Resp::Wrap(LIMIT.min(cap).max(1))),
+        Msg::Batch { count } => Ok(Resp::Wrap(batch_items(count).len().max(1))),
+        Msg::Direct => Ok(Resp::Wrap(run_direct())),
+    }
+}
+fn batch_items(_count: usize) -> Vec<usize> { Vec::new() }
+fn run_direct() -> usize { 0 }
+// A same-named in-repo helper: a chained-tail fall-through would bind the recorded `max` here.
+fn max(_a: usize, _b: usize) -> usize { 0 }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let dispatches_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Positive control: the plain delegate arm synthesizes its resolved edge, so the negative
+    // assertions below exercise a working synthesis pipeline.
+    assert!(dispatches_from_enqueue("run_direct"), "the plain delegate arm must dispatch");
+
+    // Resolved-edge level: the same-named helper and the chain's producer must gain NO
+    // synthesized `dispatches` edge from the adapter arms.
+    for non_handler in ["max", "batch_items"] {
+        assert!(
+            !dispatches_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler (false edge from a chained adapter tail)"
+        );
+    }
+
+    // Fact level: no `dispatch_handle` fact may name a chained adapter method or carry the
+    // adapter arms' variants as evidence.
+    let mut statement = conn
+        .prepare(
+            "SELECT tn.value, d.evidence FROM edges_data d
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
+             JOIN name_strings tn ON tn.id = d.to_name_id
+             WHERE ek.value = 'dispatch_handle'",
+        )
+        .unwrap();
+    let handle_facts: Vec<(String, Option<String>)> = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    for chained_method in ["max", "min", "len"] {
+        assert!(
+            handle_facts.iter().all(|(target, _)| target != chained_method),
+            "no dispatch_handle fact may name the chained adapter method `{chained_method}`: \
+             {handle_facts:?}"
+        );
+    }
+    for adapter_variant in ["Msg::Clamp", "Msg::Batch"] {
+        assert!(
+            handle_facts.iter().all(|(_, evidence)| evidence.as_deref() != Some(adapter_variant)),
+            "the adapter arm {adapter_variant} must persist no dispatch_handle fact: \
+             {handle_facts:?}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn dispatch_records_the_real_handler_behind_an_associated_constant_builder() {
+    // #1124 maintainer feedback (MEDIUM): `Resp::DEFAULT.with_body(make_body(cap))` is a BUILDER
+    // wrapper — the nested argument call is the real handler — while
+    // `Handler::DEFAULT.run(input)` is the dispatch itself. The builder method (`with_body`,
+    // present in-repo as the impl method) must gain no edge, the payload producer must be traced
+    // through the wrapper, and the true dispatch shape must keep delegating.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Build { cap: usize }, Run { input: u8 } }
+pub struct Resp;
+impl Resp {
+    pub const DEFAULT: Resp = Resp;
+    fn with_body(&self, _body: usize) -> Resp { Resp }
+}
+pub struct Handler;
+impl Handler {
+    pub const DEFAULT: Handler = Handler;
+    fn run(&self, _input: u8) {}
+}
+
+pub fn enqueue() {
+    send(Msg::Build { cap: 1 });
+    send(Msg::Run { input: 2 });
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        Msg::Build { cap } => Resp::DEFAULT.with_body(make_body(cap)),
+        Msg::Run { input } => Handler::DEFAULT.run(input),
+    }
+}
+fn make_body(_cap: usize) -> usize { 0 }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let dispatches_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // The wrapper retains nested-argument tracing: the REAL handler is the payload producer.
+    assert!(
+        dispatches_from_enqueue("make_body"),
+        "the builder's payload producer must be the dispatch handler"
+    );
+    // The true dispatch shape still delegates to the chained method.
+    assert!(dispatches_from_enqueue("run"), "the associated-constant dispatch must reach `run`");
+    // The builder METHOD is never the handler — the same-named in-repo impl method must gain no
+    // synthesized edge.
+    assert!(
+        !dispatches_from_enqueue("with_body"),
+        "the builder method must NOT be a dispatch handler (false edge)"
+    );
+
+    // Fact level: the builder arm's fact names the payload producer, never the builder method.
+    let mut statement = conn
+        .prepare(
+            "SELECT tn.value, d.evidence FROM edges_data d
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
+             JOIN name_strings tn ON tn.id = d.to_name_id
+             WHERE ek.value = 'dispatch_handle'",
+        )
+        .unwrap();
+    let handle_facts: Vec<(String, Option<String>)> = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert!(
+        handle_facts
+            .iter()
+            .any(|(target, evidence)| target == "make_body"
+                && evidence.as_deref() == Some("Msg::Build")),
+        "Msg::Build must persist a dispatch_handle fact to `make_body`: {handle_facts:?}"
+    );
+    assert!(
+        handle_facts.iter().all(|(target, _)| target != "with_body"),
+        "no dispatch_handle fact may name the builder method `with_body`: {handle_facts:?}"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn symbol_search_excludes_generated_bindings_unless_opted_in() {
     // #202: a name/symbol_path search drowns in generated bindings (ubrn FFI output, codegen) that
     // shadow the hand-written source symbol. The real-world case is codegen living UNDER a source

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1593,27 +1593,33 @@ pub fn handle(m: Msg) {
 }
 
 #[test]
-fn dispatch_suppresses_chained_adapter_tails_end_to_end() {
-    // #1124 maintainer feedback (HIGH): a standard-adapter chain whose trailing method is glued
-    // onto ANOTHER CALL'S RESULT (`LIMIT.min(cap).max(1)`, `items(count).len().max(1)`) computes a
-    // value — it is never the dispatch handler. Recording the trailing method name lets bare-name
+fn dispatch_suppresses_adapter_tails_end_to_end() {
+    // #1124 maintainer feedback (HIGH): a standard-adapter tail computes a value — it is never the
+    // dispatch handler. That covers a method glued onto ANOTHER CALL'S RESULT
+    // (`LIMIT.min(cap).max(1)`, `items(count).len().max(1)`) and a method glued onto a BARE
+    // SCREAMING constant (`BASE.to_string()`). Recording the trailing method name lets bare-name
     // fallback bind it to an unrelated same-named in-repo symbol, synthesizing a FALSE
-    // `dispatches` edge. This fixture defines exactly such a helper (`fn max`), so a false edge
-    // cannot hide behind an unresolved name, and a plain delegate arm proves the fixture CAN
-    // synthesize edges — the negative assertions are not vacuous.
+    // `dispatches` edge. The three arms mirror the shapes that exist in this repo today
+    // (`rag-rat-llm/src/throughput_tune.rs`, `rag-rat-cli/src/init/wizard/steps/embedding.rs`,
+    // `rag-rat-core/src/index/consolidate.rs`). This fixture defines exactly such same-named
+    // helpers (`fn max`, `fn to_string`), so a false edge cannot hide behind an unresolved name,
+    // and a plain delegate arm proves the fixture CAN synthesize edges — the negative assertions
+    // are not vacuous.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(
         root.join("src/lib.rs"),
         r#"
-pub enum Msg { Clamp { cap: usize }, Batch { count: usize }, Direct }
-pub enum Resp { Wrap(usize), Empty }
+pub enum Msg { Clamp { cap: usize }, Batch { count: usize }, Legacy, Direct }
+pub enum Resp { Wrap(usize), Text(String), Empty }
 const LIMIT: usize = 8;
+const BASE: &str = "SELECT id FROM repo_memories";
 
 pub fn enqueue() {
     send(Msg::Clamp { cap: 3 });
     send(Msg::Batch { count: 2 });
+    send(Msg::Legacy);
     send(Msg::Direct);
 }
 fn send(_m: Msg) {}
@@ -1622,13 +1628,16 @@ pub fn handle(m: Msg) {
     match m {
         Msg::Clamp { cap } => Ok(Resp::Wrap(LIMIT.min(cap).max(1))),
         Msg::Batch { count } => Ok(Resp::Wrap(batch_items(count).len().max(1))),
+        Msg::Legacy => Ok(Resp::Text(BASE.to_string())),
         Msg::Direct => Ok(Resp::Wrap(run_direct())),
     }
 }
 fn batch_items(_count: usize) -> Vec<usize> { Vec::new() }
 fn run_direct() -> usize { 0 }
-// A same-named in-repo helper: a chained-tail fall-through would bind the recorded `max` here.
+// Same-named in-repo helpers: an adapter-tail fall-through would bind the recorded `max` /
+// `to_string` here.
 fn max(_a: usize, _b: usize) -> usize { 0 }
+fn to_string(_value: &str) -> String { String::new() }
 "#,
     )
     .unwrap();
@@ -1649,12 +1658,12 @@ fn max(_a: usize, _b: usize) -> usize { 0 }
     // assertions below exercise a working synthesis pipeline.
     assert!(dispatches_from_enqueue("run_direct"), "the plain delegate arm must dispatch");
 
-    // Resolved-edge level: the same-named helper and the chain's producer must gain NO
+    // Resolved-edge level: the same-named helpers and the chain's producer must gain NO
     // synthesized `dispatches` edge from the adapter arms.
-    for non_handler in ["max", "batch_items"] {
+    for non_handler in ["max", "to_string", "batch_items"] {
         assert!(
             !dispatches_from_enqueue(non_handler),
-            "{non_handler} must NOT be a dispatch handler (false edge from a chained adapter tail)"
+            "{non_handler} must NOT be a dispatch handler (false edge from an adapter tail)"
         );
     }
 
@@ -1673,14 +1682,14 @@ fn max(_a: usize, _b: usize) -> usize { 0 }
         .unwrap()
         .collect::<Result<_, _>>()
         .unwrap();
-    for chained_method in ["max", "min", "len"] {
+    for chained_method in ["max", "min", "len", "to_string"] {
         assert!(
             handle_facts.iter().all(|(target, _)| target != chained_method),
-            "no dispatch_handle fact may name the chained adapter method `{chained_method}`: \
+            "no dispatch_handle fact may name the adapter method `{chained_method}`: \
              {handle_facts:?}"
         );
     }
-    for adapter_variant in ["Msg::Clamp", "Msg::Batch"] {
+    for adapter_variant in ["Msg::Clamp", "Msg::Batch", "Msg::Legacy"] {
         assert!(
             handle_facts.iter().all(|(_, evidence)| evidence.as_deref() != Some(adapter_variant)),
             "the adapter arm {adapter_variant} must persist no dispatch_handle fact: \

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1476,6 +1476,8 @@ pub enum Msg {
     AssocConstSpaced { input: u8 },
     AssocConstCommented { input: u8 },
     AssocConstUnderscore { input: u8 },
+    AssocConstLeadingMethod { input: u8 },
+    AssocConstCallInterrupted { input: u8 },
     UfcsConst { input: u8 },
     UfcsConstCommented { input: u8 },
     UfcsConstUnderscore { input: u8 },
@@ -1486,15 +1488,19 @@ pub trait Runner {
     const DEFAULT: Handler;
     const _DEFAULT: Handler;
     fn run(&self, input: u8);
+    fn _run(&self, input: u8);
 }
 impl Runner for Handler {
     const DEFAULT: Handler = Handler;
     const _DEFAULT: Handler = Handler;
     fn run(&self, _input: u8) {}
+    fn _run(&self, _input: u8) {}
 }
 impl Handler {
     pub const DEFAULT: Handler = Handler;
     pub const _DEFAULT: Handler = Handler;
+    fn build(&self) -> Self { Self }
+    fn combine(&self, _other: Handler) -> Self { Self }
 }
 
 pub fn enqueue() {
@@ -1502,9 +1508,11 @@ pub fn enqueue() {
     send(Msg::AssocConstSpaced { input: 2 });
     send(Msg::AssocConstCommented { input: 3 });
     send(Msg::AssocConstUnderscore { input: 4 });
+    send(Msg::AssocConstLeadingMethod { input: 5 });
+    send(Msg::AssocConstCallInterrupted { input: 6 });
     send(Msg::UfcsConst { input: 5 });
-    send(Msg::UfcsConstCommented { input: 6 });
-    send(Msg::UfcsConstUnderscore { input: 7 });
+    send(Msg::UfcsConstCommented { input: 7 });
+    send(Msg::UfcsConstUnderscore { input: 8 });
 }
 fn send(_m: Msg) {}
 
@@ -1516,6 +1524,10 @@ pub fn handle(m: Msg) {
         Msg::AssocConstCommented { input } => Handler::DEFAULT /* receiver */
             .run(input),
         Msg::AssocConstUnderscore { input } => Handler::_DEFAULT
+            .run(input),
+        Msg::AssocConstLeadingMethod { input } => Handler::DEFAULT._run(input),
+        Msg::AssocConstCallInterrupted { input } => Handler::DEFAULT
+            .build()
             .run(input),
         Msg::UfcsConst { input } => <Handler as Runner>::DEFAULT.run(input),
         Msg::UfcsConstCommented { input } => <Handler as Runner>::DEFAULT /* receiver */
@@ -1553,6 +1565,8 @@ pub fn handle(m: Msg) {
         "Msg::AssocConstSpaced",
         "Msg::AssocConstCommented",
         "Msg::AssocConstUnderscore",
+        "Msg::AssocConstLeadingMethod",
+        "Msg::AssocConstCallInterrupted",
         "Msg::UfcsConst",
         "Msg::UfcsConstCommented",
         "Msg::UfcsConstUnderscore",

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -236,8 +236,8 @@ pub fn handle(msg: Msg) {{
 fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
     // The handler vehicle is a SCOPED constant chain: it still delegates (and so still persists
     // the `map` handle fact) under the bare-callee fall-through gate, which now classifies the
-    // BARE form `TOOL_NAMES.iter().map(..)` as a chained adapter tail with no fact (#1124
-    // maintainer feedback).
+    // BARE form `TOOL_NAMES.iter().map(..)` as an adapter tail with no fact (#1124 maintainer
+    // feedback).
     let (root, config) = indexed_root(&[(
         "lib.rs",
         &dispatch_fixture_body("tools::TOOL_NAMES.iter().map(|name| name.len())"),
@@ -291,7 +291,10 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let linked = unique_temp_root();
     let _ = fs::remove_dir_all(&linked);
     run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
-    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("NOW.elapsed()")).unwrap();
+    // A SCOPED constant chain, like the active checkout's — a BARE one (`NOW.elapsed()`) is an
+    // adapter tail that records no handler at all (#1124 maintainer feedback), which would leave
+    // the sibling with no fact for the isolation assertions to watch.
+    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("crate::NOW.elapsed()")).unwrap();
     run_git(&linked, &["add", "."]);
     run_git(&linked, &["commit", "-q", "-m", "branch body"]);
     db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -209,16 +209,24 @@ fn stage_graph_version_16(db: &IndexDatabase) {
     *db.drift_snapshot.lock().expect("drift snapshot lock") = None;
 }
 
+/// The handler vehicle is an associated-constant method chain owned by a TYPE, which is the shape
+/// that delegates to its chained method. A constant reached through a MODULE path
+/// (`tools::TOOL_NAMES.iter().map(..)`) is an adapter tail and records no handler at all, so it
+/// cannot carry a dispatch fact for these upgrade assertions to watch (#1124 maintainer feedback).
 fn dispatch_fixture_body(handler_expression: &str) -> String {
     format!(
         r#"
 pub enum Msg {{ Work }}
-pub mod tools {{
-    pub const TOOL_NAMES: [&str; 1] = ["tool"];
+pub struct Handler;
+impl Handler {{
+    pub const DEFAULT: Handler = Handler;
+    fn run(&self, _input: usize) -> usize {{ 0 }}
 }}
-pub static NOW: Now = Now;
-pub struct Now;
-impl Now {{ fn elapsed(&self) -> usize {{ 0 }} }}
+pub struct Clock;
+impl Clock {{
+    pub const NOW: Clock = Clock;
+    fn elapsed(&self) -> usize {{ 0 }}
+}}
 
 pub fn enqueue() {{ send(Msg::Work); }}
 fn send(_msg: Msg) {{}}
@@ -234,14 +242,8 @@ pub fn handle(msg: Msg) {{
 
 #[test]
 fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
-    // The handler vehicle is a SCOPED constant chain: it still delegates (and so still persists
-    // the `map` handle fact) under the bare-callee fall-through gate, which now classifies the
-    // BARE form `TOOL_NAMES.iter().map(..)` as an adapter tail with no fact (#1124 maintainer
-    // feedback).
-    let (root, config) = indexed_root(&[(
-        "lib.rs",
-        &dispatch_fixture_body("tools::TOOL_NAMES.iter().map(|name| name.len())"),
-    )]);
+    let (root, config) =
+        indexed_root(&[("lib.rs", &dispatch_fixture_body("Handler::DEFAULT.run(1)"))]);
     let db = IndexDatabase::rebuild(&config).unwrap();
     let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id);
 
@@ -249,7 +251,7 @@ fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
     let initial_handles = edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle");
     assert!(
         initial_handles.iter().any(|(name, _, evidence)| {
-            name == "map" && evidence.as_deref() == Some("Msg::Work")
+            name == "run" && evidence.as_deref() == Some("Msg::Work")
         }),
         "the fixture must initially persist the corrected dispatch fact: {initial_handles:?}"
     );
@@ -260,9 +262,13 @@ fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
     db.ensure_graph_index_current().unwrap();
 
     let handles = edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle");
+    // The re-extracted candidate binds to the chained method defined in the same file, so the
+    // upgrade restores a RESOLVED handler rather than a dangling name.
     assert!(
         handles.iter().any(|(name, resolution, evidence)| {
-            name == "map" && resolution == "unresolved" && evidence.as_deref() == Some("Msg::Work")
+            name == "run"
+                && resolution == "target_name_fallback"
+                && evidence.as_deref() == Some("Msg::Work")
         }),
         "the v16 row must be re-extracted with the corrected handle fact: {handles:?}"
     );
@@ -277,11 +283,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let main = unique_temp_root();
     let _ = fs::remove_dir_all(&main);
     fs::create_dir_all(main.join("src")).unwrap();
-    fs::write(
-        main.join("src/lib.rs"),
-        dispatch_fixture_body("tools::TOOL_NAMES.iter().map(|name| name.len())"),
-    )
-    .unwrap();
+    fs::write(main.join("src/lib.rs"), dispatch_fixture_body("Handler::DEFAULT.run(1)")).unwrap();
     init_git_repo(&main);
     run_git(&main, &["add", "."]);
     run_git(&main, &["commit", "-q", "-m", "base"]);
@@ -291,10 +293,9 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let linked = unique_temp_root();
     let _ = fs::remove_dir_all(&linked);
     run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
-    // A SCOPED constant chain, like the active checkout's — a BARE one (`NOW.elapsed()`) is an
-    // adapter tail that records no handler at all (#1124 maintainer feedback), which would leave
-    // the sibling with no fact for the isolation assertions to watch.
-    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("crate::NOW.elapsed()")).unwrap();
+    // A TYPE-owned constant chain like the active checkout's, naming a different method so the
+    // sibling's fact is distinguishable from the active checkout's.
+    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("Clock::NOW.elapsed()")).unwrap();
     run_git(&linked, &["add", "."]);
     run_git(&linked, &["commit", "-q", "-m", "branch body"]);
     db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
@@ -333,7 +334,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let base_handles = edge_kind_rows_with_resolution(&db, base_id, "dispatch_handle");
     assert!(
         base_handles.iter().any(|(name, _, evidence)| {
-            name == "map" && evidence.as_deref() == Some("Msg::Work")
+            name == "run" && evidence.as_deref() == Some("Msg::Work")
         }),
         "the active checkout receives the corrected dispatch fact: {base_handles:?}"
     );
@@ -357,7 +358,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     );
     assert_eq!(file_graph_version(&linked_db, base_id), 17);
     assert_eq!(file_graph_version(&linked_db, overlay_id), 17);
-    assert_eq!(edge_kind_rows_with_resolution(&linked_db, base_id, "dispatch_handle")[0].0, "map");
+    assert_eq!(edge_kind_rows_with_resolution(&linked_db, base_id, "dispatch_handle")[0].0, "run");
     assert_eq!(linked_db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
 
     let _ = fs::remove_dir_all(&main);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -419,11 +419,17 @@ fn an_older_binary_does_not_downgrade_future_row_provenance() {
         )
         .unwrap();
     let future_edges = edge_targets_with_resolution(&db, future_id);
+    // Stamp the row with a genuinely FUTURE graph version — the current `GRAPH_INDEX_VERSION`
+    // plus one — so the fixture stays ahead of the constant however often it moves (#1124 held
+    // feedback: a hard-coded stamp silently became equal to the current version and the test
+    // stopped proving anything).
+    let future_graph_version = GRAPH_INDEX_VERSION.parse::<i64>().unwrap() + 1;
     db.storage
         .connection()
-        .execute("UPDATE main.files SET graph_version = 17, scope_version = 4 WHERE id = ?1", [
-            future_id,
-        ])
+        .execute(
+            "UPDATE main.files SET graph_version = ?2, scope_version = 4 WHERE id = ?1",
+            params![future_id, future_graph_version],
+        )
         .unwrap();
     db.storage
         .connection()
@@ -436,7 +442,7 @@ fn an_older_binary_does_not_downgrade_future_row_provenance() {
 
     db.ensure_graph_index_current().unwrap();
 
-    assert_eq!(file_graph_version(&db, future_id), 17);
+    assert_eq!(file_graph_version(&db, future_id), future_graph_version);
     assert_eq!(file_scope_version(&db, future_id), 4);
     assert_eq!(
         edge_targets_with_resolution(&db, future_id),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -295,7 +295,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let overlay_worktree = worktree_id_of(&linked);
     let overlay_id = scoped_file_id(&db, "src/lib.rs", &overlay_worktree);
     let sibling_resolution =
-        edges::intern_edge_string(&db.storage.connection(), "sibling_resolution").unwrap();
+        edges::intern_edge_string(db.storage.connection(), "sibling_resolution").unwrap();
     db.storage
         .connection()
         .execute(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -213,7 +213,9 @@ fn dispatch_fixture_body(handler_expression: &str) -> String {
     format!(
         r#"
 pub enum Msg {{ Work }}
-pub const TOOL_NAMES: [&str; 1] = ["tool"];
+pub mod tools {{
+    pub const TOOL_NAMES: [&str; 1] = ["tool"];
+}}
 pub static NOW: Now = Now;
 pub struct Now;
 impl Now {{ fn elapsed(&self) -> usize {{ 0 }} }}
@@ -232,9 +234,13 @@ pub fn handle(msg: Msg) {{
 
 #[test]
 fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
+    // The handler vehicle is a SCOPED constant chain: it still delegates (and so still persists
+    // the `map` handle fact) under the bare-callee fall-through gate, which now classifies the
+    // BARE form `TOOL_NAMES.iter().map(..)` as a chained adapter tail with no fact (#1124
+    // maintainer feedback).
     let (root, config) = indexed_root(&[(
         "lib.rs",
-        &dispatch_fixture_body("TOOL_NAMES.iter().map(|name| name.len())"),
+        &dispatch_fixture_body("tools::TOOL_NAMES.iter().map(|name| name.len())"),
     )]);
     let db = IndexDatabase::rebuild(&config).unwrap();
     let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id);
@@ -273,7 +279,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     fs::create_dir_all(main.join("src")).unwrap();
     fs::write(
         main.join("src/lib.rs"),
-        dispatch_fixture_body("TOOL_NAMES.iter().map(|name| name.len())"),
+        dispatch_fixture_body("tools::TOOL_NAMES.iter().map(|name| name.len())"),
     )
     .unwrap();
     init_git_repo(&main);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -194,8 +194,8 @@ fn delete_dispatch_handle_facts(db: &IndexDatabase, file_id: i64) {
 }
 
 /// Stage the graph-only part of the version upgrade while leaving the logical-key derivation at
-/// its current value. Version 16 is the stamp carried by the commit under test; version 17 is the
-/// first build that must re-extract the changed dispatch classifier.
+/// its current value. Version 16 is the persisted stamp immediately before this classifier change;
+/// version 17 is the first graph version that must re-extract it.
 fn stage_graph_version_16(db: &IndexDatabase) {
     db.set_repo_meta("graph_index_version", "16").unwrap();
     db.storage
@@ -237,7 +237,7 @@ fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
         &dispatch_fixture_body("TOOL_NAMES.iter().map(|name| name.len())"),
     )]);
     let db = IndexDatabase::rebuild(&config).unwrap();
-    let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id.clone());
+    let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id);
 
     // Simulate the deployed v16 row after the old classifier omitted this handle fact.
     let initial_handles = edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -155,6 +155,206 @@ fn edge_targets_with_resolution(db: &IndexDatabase, file_id: i64) -> Vec<(String
     rows.map(Result::unwrap).collect()
 }
 
+/// The persisted dispatch facts for one file, including the resolution assigned by the graph
+/// resolver. Keeping the kind/evidence in this probe makes an upgrade test assert the actual
+/// hidden fact row rather than only a user-facing synthesized edge.
+fn edge_kind_rows_with_resolution(
+    db: &IndexDatabase,
+    file_id: i64,
+    edge_kind: &str,
+) -> Vec<(String, String, Option<String>)> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT n.value, r.value, d.evidence
+             FROM main.edges_data d
+             JOIN main.name_strings n ON n.id = d.to_name_id
+             JOIN main.name_strings r ON r.id = d.resolution_id
+             JOIN main.name_strings k ON k.id = d.edge_kind_id
+             WHERE d.source_file_id = ?1 AND k.value = ?2
+             ORDER BY d.id",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map(params![file_id, edge_kind], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .unwrap();
+    rows.map(Result::unwrap).collect()
+}
+
+fn delete_dispatch_handle_facts(db: &IndexDatabase, file_id: i64) {
+    db.storage
+        .connection()
+        .execute(
+            r#"DELETE FROM main.edges_data
+             WHERE source_file_id = ?1
+               AND edge_kind_id = (SELECT id FROM main.name_strings WHERE value = 'dispatch_handle')"#,
+            [file_id],
+        )
+        .unwrap();
+}
+
+/// Stage the graph-only part of the version upgrade while leaving the logical-key derivation at
+/// its current value. Version 16 is the stamp carried by the commit under test; version 17 is the
+/// first build that must re-extract the changed dispatch classifier.
+fn stage_graph_version_16(db: &IndexDatabase) {
+    db.set_repo_meta("graph_index_version", "16").unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET graph_version = 16
+             WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'",
+            params![&db.active_repo_id, db.active_generation],
+        )
+        .unwrap();
+    *db.drift_snapshot.lock().expect("drift snapshot lock") = None;
+}
+
+fn dispatch_fixture_body(handler_expression: &str) -> String {
+    format!(
+        r#"
+pub enum Msg {{ Work }}
+pub const TOOL_NAMES: [&str; 1] = ["tool"];
+pub static NOW: Now = Now;
+pub struct Now;
+impl Now {{ fn elapsed(&self) -> usize {{ 0 }} }}
+
+pub fn enqueue() {{ send(Msg::Work); }}
+fn send(_msg: Msg) {{}}
+
+pub fn handle(msg: Msg) {{
+    match msg {{
+        Msg::Work => {handler_expression},
+    }}
+}}
+"#
+    )
+}
+
+#[test]
+fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
+    let (root, config) = indexed_root(&[(
+        "lib.rs",
+        &dispatch_fixture_body("TOOL_NAMES.iter().map(|name| name.len())"),
+    )]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id.clone());
+
+    // Simulate the deployed v16 row after the old classifier omitted this handle fact.
+    let initial_handles = edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle");
+    assert!(
+        initial_handles.iter().any(|(name, _, evidence)| {
+            name == "map" && evidence.as_deref() == Some("Msg::Work")
+        }),
+        "the fixture must initially persist the corrected dispatch fact: {initial_handles:?}"
+    );
+    delete_dispatch_handle_facts(&db, file_id);
+    assert!(edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle").is_empty());
+    stage_graph_version_16(&db);
+
+    db.ensure_graph_index_current().unwrap();
+
+    let handles = edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle");
+    assert!(
+        handles.iter().any(|(name, resolution, evidence)| {
+            name == "map" && resolution == "unresolved" && evidence.as_deref() == Some("Msg::Work")
+        }),
+        "the v16 row must be re-extracted with the corrected handle fact: {handles:?}"
+    );
+    assert_eq!(file_graph_version(&db, file_id), 17);
+    assert_eq!(db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(
+        main.join("src/lib.rs"),
+        dispatch_fixture_body("TOOL_NAMES.iter().map(|name| name.len())"),
+    )
+    .unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("NOW.elapsed()")).unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch body"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    set_base_scope(&mut db, &main);
+    let base_id = scoped_file_id(&db, "src/lib.rs", "");
+    let overlay_worktree = worktree_id_of(&linked);
+    let overlay_id = scoped_file_id(&db, "src/lib.rs", &overlay_worktree);
+    let sibling_resolution =
+        edges::intern_edge_string(&db.storage.connection(), "sibling_resolution").unwrap();
+    db.storage
+        .connection()
+        .execute(
+            r#"UPDATE main.edges_data
+             SET resolution_id = ?1
+             WHERE source_file_id = ?2
+               AND edge_kind_id = (SELECT id FROM main.name_strings WHERE value = 'dispatch_handle')"#,
+            params![sibling_resolution, overlay_id],
+        )
+        .unwrap();
+    let overlay_before = edge_kind_rows_with_resolution(&db, overlay_id, "dispatch_handle");
+    assert!(
+        overlay_before.iter().any(|(name, _, evidence)| {
+            name == "elapsed" && evidence.as_deref() == Some("Msg::Work")
+        }),
+        "the linked checkout starts with its own dispatch fact: {overlay_before:?}"
+    );
+    let overlay_all_before = edge_targets_with_resolution(&db, overlay_id);
+    let overlay_edge_ids_before = edge_ids(&db, overlay_id);
+
+    // Remove only the active checkout's corrected fact, then present both rows as v16 data.
+    delete_dispatch_handle_facts(&db, base_id);
+    stage_graph_version_16(&db);
+    db.ensure_graph_index_current().unwrap();
+
+    let base_handles = edge_kind_rows_with_resolution(&db, base_id, "dispatch_handle");
+    assert!(
+        base_handles.iter().any(|(name, _, evidence)| {
+            name == "map" && evidence.as_deref() == Some("Msg::Work")
+        }),
+        "the active checkout receives the corrected dispatch fact: {base_handles:?}"
+    );
+    assert_eq!(file_graph_version(&db, base_id), 17);
+    assert_eq!(file_graph_version(&db, overlay_id), 16);
+    assert_eq!(edge_ids(&db, overlay_id), overlay_edge_ids_before);
+    assert_eq!(edge_targets_with_resolution(&db, overlay_id), overlay_all_before);
+    assert_eq!(edge_kind_rows_with_resolution(&db, overlay_id, "dispatch_handle"), overlay_before);
+    assert_ne!(db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
+
+    let mut linked_config = source_config(linked.to_path_buf(), Language::Rust);
+    linked_config.database = config.database.clone();
+    drop(db);
+    let linked_db = IndexDatabase::open_config(&linked_config).unwrap();
+    let overlay_handles = edge_kind_rows_with_resolution(&linked_db, overlay_id, "dispatch_handle");
+    assert!(
+        overlay_handles.iter().any(|(name, _, evidence)| {
+            name == "elapsed" && evidence.as_deref() == Some("Msg::Work")
+        }),
+        "the sibling later re-extracts its own fact: {overlay_handles:?}"
+    );
+    assert_eq!(file_graph_version(&linked_db, base_id), 17);
+    assert_eq!(file_graph_version(&linked_db, overlay_id), 17);
+    assert_eq!(edge_kind_rows_with_resolution(&linked_db, base_id, "dispatch_handle")[0].0, "map");
+    assert_eq!(linked_db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 /// Every `to_name` on `file_id`'s edges — the file's outgoing graph as EXTRACTED, independent of
 /// which scope is active (edge rows are keyed by `source_file_id`, and base and overlay hold
 /// separate rows for a shadowed path).


### PR DESCRIPTION
## Summary

`classify_call` was returning `Wrapper` for a dispatch arm whose tail is a `SCREAMING_CONST` head with a method chain, so the `dispatch_handle` fact for that arm was dropped rather than emitted. `is_pascal_case` now weighs only a segment's leading identifier, which classifies the arm as `Delegate`.

## Related Issues and Pull Requests

Fixes #1124

## Changes

- `crates/rag-rat-core/src/index/languages/rust/dispatch.rs`: `is_pascal_case` reads only the leading identifier of a path segment — everything up to the first character that cannot continue an identifier — leaving the existing "starts uppercase, carries a lowercase" test untouched. The head scan follows Rust's `XID_Continue` rule rather than `char::is_alphanumeric`, so a decomposed identifier such as `A\u{301}ccent` keeps its combining mark instead of being truncated at `A`. Without that, `A\u{301}ccent(handle())` classifies as `Delegate` and emits the constructor itself as the dispatch handler.
- `crates/rag-rat-core/src/index/mod.rs`: `GRAPH_INDEX_VERSION` 16 → 17. `ensure_graph_index_current_inner` re-extracts only rows below the current version, so without the bump an existing database keeps its stale classification and missing `dispatch_handle` edge until the source file changes or the index is rebuilt by hand.
- Unit tests beside the existing dispatch tests covering the predicate, `classify_call`, and `enum_variant_key` — the predicate's other production consumer.
- `crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs`: coverage over persisted `edges_data` rows, including a forced v16 database that re-extracts to v17, and a shared database with a base checkout plus a linked worktree.

The boundary is deliberately narrower than either option the issue floated, and it is your call to overrule. Rejecting any segment containing `_` would leave `NOW.elapsed()` misread and would newly break `Wrapped(payload).to_string()`. Rejecting a leading uppercase run longer than one character would demote `HTTPResponse` from constructor to handler. Reading only the head fixes `TOOL_NAMES.iter().map(…)` and `NOW.elapsed()` while leaving `HTTPResponse` and `Wrapped(payload).to_string()` exactly where they are. The underscore boundary is a one-line change if you prefer it.

`XID_Continue` and `char::is_alphanumeric` are incomparable rather than nested, so the head scan is not simply a narrowing. `XID_Continue` accepts characters `is_alphanumeric` rejects (U+0301 COMBINING ACUTE ACCENT, U+203F UNDERTIE) and rejects characters it accepts (U+00B2 SUPERSCRIPT TWO, which is not valid in a Rust identifier). Both directions are pinned by tests, along with a character in both sets (U+05B0 HEBREW POINT SHEVA) as an unchanged anchor.

## Testing

`cargo test -p rag-rat-core` for the dispatch, `enum_variant_key` and graph-heal tests, plus fork CI under this project's `--no-default-features --locked` configuration: rustfmt, clippy and test all green.

The predicate tests fail on assertions — not compile errors — when the head scan is reverted to `char::is_alphanumeric`, across every boundary class above. The graph-heal test fails when `GRAPH_INDEX_VERSION` is returned to 16, so the upgrade path is covered rather than assumed. The real multi-line site at `crates/rag-rat-mcp/src/server/service.rs:43` classifies `Delegate` with the change and `Wrapper` without it.

## Bugs Discovered

- #1171 cargo-deny fails on main since 2026-08-12 on RUSTSEC-2026-0253 in lru 0.18.1

## Follow-ups / Known Limitations

Existing v16 databases re-extract on open and advance eligible file rows to version 17. In a database shared by several checkouts, only rows whose indexed bytes match the active checkout heal on that open; a sibling worktree row whose bytes differ stays at 16 until the index is opened from a checkout containing those bytes.

## Dependencies

Adds `unicode-ident` as a direct production dependency for Rust `XID_Continue` classification, at the version already present in the workspace lockfile.

## Footer

Generated by Claude Opus 5 (implementation, review, testing), GPT-5.6 Luna (implementation), GPT-5.6 Sol (review)
Generated by Kimi K3 (implementation, testing)