### PR TITLE
fix(oracle): find an ancestor tsconfig when the index root is a package

### DIFF
--- a/crates/rag-rat-oracle/src/backend/documents.rs
+++ b/crates/rag-rat-oracle/src/backend/documents.rs
@@ -89,7 +89,9 @@ pub(super) fn find_document_in_project(
     markers: &[&str],
     inside_project: bool,
 ) -> Option<PathBuf> {
-    let inside_project = inside_project || markers.iter().any(|marker| dir.join(marker).exists());
+    let inside_project = inside_project
+        || enclosing_project_dir(checkout, dir, markers).is_some()
+        || markers.iter().any(|marker| dir.join(marker).exists());
     let mut subdirectories = Vec::new();
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
         let Ok(kind) = entry.file_type() else {

--- a/crates/rag-rat-oracle/src/backend/documents.rs
+++ b/crates/rag-rat-oracle/src/backend/documents.rs
@@ -89,9 +89,7 @@ pub(super) fn find_document_in_project(
     markers: &[&str],
     inside_project: bool,
 ) -> Option<PathBuf> {
-    let inside_project = inside_project
-        || enclosing_project_dir(checkout, dir, markers).is_some()
-        || markers.iter().any(|marker| dir.join(marker).exists());
+    let inside_project = inside_project || markers.iter().any(|marker| dir.join(marker).exists());
     let mut subdirectories = Vec::new();
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
         let Ok(kind) = entry.file_type() else {

--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -353,13 +353,24 @@ impl LiveBackend {
             ReadinessPolicy::ServerStatus => None,
             ReadinessPolicy::WorkDoneProgress =>
                 self.project_model.and_then(|model| match model.scope {
-                    ProjectScope::Enclosing => documents::find_document_in_project(
-                        checkout,
-                        checkout.root(),
-                        self.languages,
-                        model.files(),
-                        false,
-                    ),
+                    ProjectScope::Enclosing => {
+                        // `enclosing_project_dir` accepts a file path and starts at its parent;
+                        // the synthetic child makes the checkout root the first directory it
+                        // probes while preserving the helper's file-oriented semantics.
+                        let inside_project = documents::enclosing_project_dir(
+                            checkout,
+                            &checkout.root().join("__warmup_document__"),
+                            model.files(),
+                        )
+                        .is_some();
+                        documents::find_document_in_project(
+                            checkout,
+                            checkout.root(),
+                            self.languages,
+                            model.files(),
+                            inside_project,
+                        )
+                    },
                     // The marker can sit anywhere, so the two halves are searched independently
                     // and a document only counts once the marker has been found somewhere.
                     // The warm-up must pick a document the session can actually configure, or it

--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -354,9 +354,10 @@ impl LiveBackend {
             ReadinessPolicy::WorkDoneProgress =>
                 self.project_model.and_then(|model| match model.scope {
                     ProjectScope::Enclosing => {
-                        // `enclosing_project_dir` accepts a file path and starts at its parent;
-                        // the synthetic child makes the checkout root the first directory it
-                        // probes while preserving the helper's file-oriented semantics.
+                        // `enclosing_project_dir` takes a file path and starts at its parent, so
+                        // the synthetic child makes the configured index root the first directory
+                        // it probes. Its checkout ceiling check bounds the ancestor walk to the
+                        // checkout while preserving the helper's file-oriented semantics.
                         let inside_project = documents::enclosing_project_dir(
                             checkout,
                             &checkout.root().join("__warmup_document__"),

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -876,6 +876,30 @@ fn a_warmup_document_is_found_at_any_depth_and_only_inside_a_project() {
 }
 
 #[test]
+fn a_warmup_document_is_found_when_the_project_marker_is_above_the_index_root() {
+    let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
+    let (_dir_guard, dir) = checkout("ts-lsp-warmup-ancestor-marker");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("packages/app/src")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(checkout.join("tsconfig.json"), "{}").unwrap();
+    std::fs::write(checkout.join("packages/app/src/main.ts"), "export function greet() {}\n")
+        .unwrap();
+    let scope = scope(&checkout.join("packages/app"));
+    let layout = ts.resolve_layout(&scope);
+
+    assert_eq!(
+        ts.warmup_document(&scope, &layout),
+        Some(checkout.join("packages/app/src/main.ts")),
+        "a project marker above the index root still makes its indexed descendants warmable",
+    );
+    assert!(
+        ts.checkout_can_signal_readiness(&scope, &layout),
+        "the ancestor project marker must keep the checkout from being blocked",
+    );
+}
+
+#[test]
 fn the_warmup_search_refuses_a_document_the_checkout_does_not_index() {
     // `node_modules` ships thousands of tsconfigs describing DEPENDENCIES. Warming on one would
     // report the checkout usable while none of ITS files ever resolve.

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -900,6 +900,25 @@ fn a_warmup_document_is_found_when_the_project_marker_is_above_the_index_root() 
 }
 
 #[test]
+fn a_warmup_document_is_not_found_when_marker_is_above_checkout_ceiling() {
+    let ts = LiveBackend::for_tool(OracleTool::TsLsp).unwrap();
+    let (_dir_guard, dir) = checkout("ts-lsp-marker-above-ceiling");
+    let checkout = dir.join("repo");
+    std::fs::create_dir_all(checkout.join("src")).unwrap();
+    rag_rat_base::test_git::run(&checkout, &["init"]);
+    std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
+    std::fs::write(checkout.join("src/main.ts"), "export function greet() {}\n").unwrap();
+    let scope = scope(&checkout);
+    let layout = ts.resolve_layout(&scope);
+
+    assert_eq!(
+        ts.warmup_document(&scope, &layout),
+        None,
+        "a marker above the checkout ceiling must not govern checkout files",
+    );
+}
+
+#[test]
 fn the_warmup_search_refuses_a_document_the_checkout_does_not_index() {
     // `node_modules` ships thousands of tsconfigs describing DEPENDENCIES. Warming on one would
     // report the checkout usable while none of ITS files ever resolve.


### PR DESCRIPTION
## Summary

A checkout whose only `tsconfig.json` sits above the configured index root produced no warm-up document, so `checkout_can_signal_readiness` was false and the backend reported `Blocked`. The warm-up search now consults the ancestor chain the way the per-file walk already did, so an ordinary monorepo with a top-level config and `[index] root` pointed at one package warms normally.

## Related Issues and Pull Requests

Fixes #1038

## Changes

- `crates/rag-rat-oracle/src/backend/registry.rs`: the `ProjectScope::Enclosing` warm-up arm performs one ancestor lookup before the descent and passes the result as the `inside_project` seed. It calls the existing file-oriented `enclosing_project_dir` with a synthetic child of the configured index root, so the helper first probes that index root and its existing ceiling check bounds the ancestor walk to the checkout. The existing recursive search propagates that seed while still detecting markers at or below the index root. A comment at the call site records that contract.
- `crates/rag-rat-oracle/src/backend/tests.rs`: a regression test for a marker above the index root but inside the checkout, and a boundary test asserting that a marker above the checkout ceiling does not govern checkout files. The existing at-or-below warm-up tests stay as anchors.

This closes the last place where "which project governs this document" still had two answers depending on which search asked. `enclosing_project_dir` already stopped at the checkout ceiling after #1031, but that fix was unreachable for this layout because the prerequisite gate blocked the spawn before any per-file walk ran.

Seeding at the call site rather than inside the recursion matters for two reasons. Doing it in the recursive function walked the ancestor chain again at every frame — quadratic in descent depth on a markerless subtree, worst in exactly the full-traversal `Blocked` case. It also started the walk at the index root, whose lexical parent is already outside the checkout when the root and the ceiling coincide, so the ceiling comparison never matched and a marker outside the checkout could be admitted. Both are covered by tests.

`enclosing_project_dir` itself and its existing per-file caller are unchanged, so clangd and the readiness predicate keep their current behaviour.

## Testing

`cargo test -p rag-rat-oracle` for the warm-up tests, plus fork CI under this project's `--no-default-features --locked` configuration: rustfmt, clippy and test all green.

Each new test fails on an assertion rather than a compile error when its production change is reverted: the ancestor test with `left: None` against the expected `packages/app/src/main.ts`, and the boundary test with the checkout's own `src/main.ts` where `None` is expected.

## Follow-ups / Known Limitations

The seed reuses the file-oriented helper by passing a synthetic child of the configured index root, because that helper discards the final component before any filesystem access and never touches the leaf. A small directory-oriented wrapper would express the same thing more directly if you would prefer one.

## Footer

Generated by Claude Opus 5 (brief, review), GPT-5.6 Luna (implementation, testing), GPT-5.6 Sol (verification)
