### PR TITLE
chore(deps): bump lru to 0.18.2 for RUSTSEC-2026-0253

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,7 +2141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3734,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
`cargo-deny` has failed on `main` since 2026-08-12 on an unchanged tree: RUSTSEC-2026-0253 (potential use-after-free due to lack of panic safety in `LruCache::pop`) was published against `lru` 0.18.1, which `Cargo.lock` pinned. The red check then showed up on every open PR, where it is indistinguishable from a failure that PR introduced.

`lru` is a transitive dependency and upstream fixed the unsoundness in a patch release, so this is a lockfile bump only — 0.18.1 → 0.18.2, no manifest change, no `deny.toml` suppression to carry and later forget.

Verified locally:

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo check --workspace` → clean

Fixes #1171