### PR TITLE
perf(build): build every dependency at opt-level 3 in dev and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,11 +186,13 @@ tree-sitter-typescript = "=0.23.2"
 # drop (already in the tree transitively via ed25519-dalek; pinned here as a direct dep).
 zeroize = "1"
 
-# `cc` compiles the bundled SQLite amalgamation at the profile's opt-level, which is 0 for
-# `cargo build`/`cargo test` — an unoptimized SQLite is dramatically slower at the heavy INSERT
-# workload the indexing tests run. Build just this one C-heavy dep at opt-level 3 so dev/test stays
-# fast; it's compiled once then cached.
-[profile.dev.package.libsqlite3-sys]
+# Dependencies build at the profile's opt-level, which is 0 for `cargo build`/`cargo test`. The
+# tests lean hard on compute-heavy deps — ed25519/x25519 signing and verification, SQLite's bundled
+# amalgamation, blake3/sha2, tree-sitter, zstd — and unoptimized they run one to two orders of
+# magnitude slower, which is most of the test suite's wall time. Build every non-workspace dep at
+# opt-level 3; they are compiled once and then cached, while the workspace crates stay at 0 so
+# incremental rebuilds of the code under edit remain fast.
+[profile.dev.package."*"]
 opt-level = 3
 
 # The profile that 'dist' will build with


### PR DESCRIPTION
Dependencies compile at the profile's `opt-level`, which is 0 for `cargo build` and `cargo test`. The test suite leans hard on compute-heavy dependencies — ed25519/x25519 signing and verification, blake3/sha2, tree-sitter, zstd, and the bundled SQLite amalgamation — and unoptimized they run one to two orders of magnitude slower. That accounted for most of the suite's wall time.

`Cargo.toml` already carried this override for `libsqlite3-sys` alone, with exactly this rationale. This widens it to every non-workspace package. Workspace crates stay at `opt-level = 0`, so incremental rebuilds of the code under edit are unchanged.

Measured on an 8-core box, `cargo nextest run --workspace --no-fail-fast`, both runs from a warm build:

| | before | after |
|---|---|---|
| suite wall time | 423.2s | 315.4s |
| `account::fold::tests::a_deep_incarnation_chain_folds_without_a_stack_overflow` | 37.7s | 1.6s |
| `refine::split::tests::coherence_split_class_count_bounded_by_split_groups` | 24.0s | 17.3s |
| `backend::tests::a_realistically_large_compilation_database_is_validated_in_one_pass` | 23.3s | 17.4s |
| `index::parser_tests::every_recursive_tree_descender_grows_the_stack` | 12.5s | 3.2s |

5042 tests pass either way; the baseline run had 3 flaky retries, the optimized run had none.

Cost is a one-time dependency compile roughly a minute longer (6m28s → 7m25s cold), which `Swatinem/rust-cache` keys on `Cargo.lock` and so pays once per lockfile change. What remains at the top of the list is now wall-clock waits on real timeouts (the cookbook teardown and discovery-stall tests, ~10s each), not compute.