### PR TITLE
fix(mcp): emit SEP-2549 cache hints on tools/list for 2026-07-28 peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1082,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1114,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2141,7 +2175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5584,11 +5618,10 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3797d226787327b35b0b6f9e878fe55f3af2bb4daf916c0411079885454042f0"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
- "async-trait",
  "base64 0.23.0",
  "chrono",
  "futures",
@@ -5600,6 +5633,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "uuid",
@@ -5607,15 +5641,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 # when installed in the OS store; minimal Linux images must include a CA bundle. The transport is
 # driven on the papertrail module's private runtime at the sync boundary.
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-rmcp = { version = "3.0.1", features = ["transport-io"] }
+rmcp = { version = "3.1.2", features = ["transport-io"] }
 rusqlite = { version = "0.40", features = ["bundled", "functions"] }
 rayon = "1.12"
 regex = "1.13"

--- a/crates/rag-rat-mcp/Cargo.toml
+++ b/crates/rag-rat-mcp/Cargo.toml
@@ -47,6 +47,9 @@ windows-sys.workspace = true
 # Already built transitively via rag-rat-core; a direct dev-dep lets the busy-retry test (#220)
 # construct a SQLITE_BUSY error to drive `with_busy_retry`.
 rusqlite.workspace = true
+# `client` lets the cache-hint tests drive `list_tools` through a real in-process
+# client/server pair, exercising the negotiated-protocol-version gate end to end.
+rmcp = { workspace = true, features = ["client"] }
 tower = { version = "0.5", features = ["util"] }
 
 [features]

--- a/crates/rag-rat-mcp/src/server/service.rs
+++ b/crates/rag-rat-mcp/src/server/service.rs
@@ -1,6 +1,6 @@
 use rmcp::model::{
-    CallToolRequestParams, CallToolResponse, Implementation, ListToolsResult,
-    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CacheScope, CallToolRequestParams, CallToolResponse, Implementation, ListToolsResult,
+    PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, RoleServer, ServerHandler};
@@ -38,7 +38,7 @@ impl ServerHandler for RagRatService {
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         let tools = crate::tools::TOOL_NAMES
             .iter()
@@ -50,10 +50,86 @@ impl ServerHandler for RagRatService {
                 Tool::new((*name).to_string(), crate::tools::description(name), input_schema)
             })
             .collect();
-        // `with_all_items` fills the SEP-2322 / SEP-2549 result fields with their protocol
-        // defaults (`result_type: complete`, no TTL, no cache scope). The whole catalog ships in
-        // one page, so there is no cursor; rmcp strips `result_type` again for peers that
-        // negotiated a protocol version predating the field.
-        Ok(ListToolsResult::with_all_items(tools))
+        // `with_all_items` fills the SEP-2322 result field with its protocol default
+        // (`result_type: complete`). The whole catalog ships in one page, so there is no cursor;
+        // rmcp strips `result_type` again for peers that negotiated a protocol version predating
+        // the field.
+        let mut result = ListToolsResult::with_all_items(tools);
+        // SEP-2549 makes `ttlMs` / `cacheScope` REQUIRED on list results as of protocol
+        // 2026-07-28 — strict clients reject a `tools/list` response without them, which bricks
+        // the whole server (no tools ever load). Immediately-stale public hints preserve the
+        // pre-SEP-2549 behavior (no client caching). Older peers may reject unknown fields, so
+        // the hints are gated on the negotiated version, mirroring rmcp's `#[tool_handler]`.
+        let supports_cache_hints = context
+            .protocol_version()
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28);
+        if supports_cache_hints {
+            result = result.with_ttl_ms(0).with_cache_scope(CacheScope::Public);
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::model::ClientInfo;
+    use rmcp::{ClientHandler, ServiceExt};
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct VersionedClient {
+        protocol_version: ProtocolVersion,
+    }
+
+    impl ClientHandler for VersionedClient {
+        fn get_info(&self) -> ClientInfo {
+            let mut info = ClientInfo::default();
+            info.protocol_version = self.protocol_version.clone();
+            info
+        }
+    }
+
+    /// Drive `tools/list` through a real in-process client/server pair so the negotiated protocol
+    /// version reaches the handler exactly as it does over stdio.
+    async fn list_tools_at(protocol_version: ProtocolVersion) -> ListToolsResult {
+        let (server_transport, client_transport) = tokio::io::duplex(1 << 20);
+        let service = RagRatService::new_dormant(rag_rat_core::OutputFormat::Json);
+        let server = tokio::spawn(async move {
+            service.serve(server_transport).await?.waiting().await?;
+            anyhow::Ok(())
+        });
+        let client = VersionedClient { protocol_version }
+            .serve(client_transport)
+            .await
+            .expect("client should connect");
+        let tools = client.list_tools(None).await.expect("tools/list should succeed");
+        client.cancel().await.expect("client should cancel");
+        server.await.expect("server task should join").expect("server should exit cleanly");
+        tools
+    }
+
+    /// SEP-2549: strict 2026-07-28 clients reject a `tools/list` response without `ttlMs` /
+    /// `cacheScope`, which bricks the whole server — no tools ever load.
+    #[tokio::test]
+    async fn list_tools_emits_required_cache_hints_for_2026_07_28() {
+        let tools = list_tools_at(ProtocolVersion::V_2026_07_28).await;
+        assert_eq!(
+            (tools.ttl_ms, tools.cache_scope),
+            (Some(0), Some(CacheScope::Public)),
+            "2026-07-28 peers must receive the required cache hints"
+        );
+    }
+
+    /// Peers on older protocol versions keep the pre-SEP-2549 wire shape: strict legacy clients
+    /// may reject unknown fields.
+    #[tokio::test]
+    async fn list_tools_omits_cache_hints_for_legacy_peers() {
+        let tools = list_tools_at(ProtocolVersion::V_2025_06_18).await;
+        assert_eq!(
+            (tools.ttl_ms, tools.cache_scope),
+            (None, None),
+            "legacy peers must keep the pre-SEP-2549 wire shape"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Clients that negotiate MCP protocol version 2026-07-28 require `ttlMs` and `cacheScope` on list results (SEP-2549) and reject a `tools/list` response without them:

```
Invalid result for tools/list:
  ttlMs: Invalid input: expected number, received undefined
  cacheScope: Invalid option: expected one of "public"|"private"
```

Because the rejection happens at `tools/list`, the server connects with **no tools at all** — every session against a strict 2026-07-28 client is bricked.

## Fix

The hand-written `ServerHandler::list_tools` now emits immediately-stale public cache hints (`ttlMs: 0`, `cacheScope: "public"`) when the negotiated protocol version is 2026-07-28 or newer, and keeps the pre-SEP-2549 wire shape for legacy peers that may reject unknown fields. This mirrors what rmcp's `#[tool_handler]` macro does since 3.1.1 (modelcontextprotocol/rust-sdk#1120) — the macro fix doesn't reach hand-written handlers, so the gate is applied at our handler.

`ttlMs: 0` deliberately opts out of client-side caching: the catalog is static per *binary*, not per server identity — hot-upgrade (SIGUSR1 exec) and version bumps can change it with no client-visible signal, and the only fetch it would save is one local stdio round trip per session. A real TTL should only land together with `tools/listChanged` wiring.

Also bumps rmcp 3.0.1 → 3.1.2.

## Verification

- Two new tests drive `tools/list` through a real in-process client/server pair (rmcp `client` feature as a dev-dependency, scoped out of the production feature set by resolver 3), asserting the hints are present for a 2026-07-28 peer and absent for a legacy peer; the positive test fails if the gate is reverted.
- Full `rag-rat-mcp` suite green under nextest and `cargo test`; clippy `--no-default-features` and default-features legs clean under `-D warnings`; nightly rustfmt applied.