### PR TITLE
feat(sync): pull contribution owners and grantees automatically on every reconcile pass

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -352,13 +352,15 @@ pub(crate) enum SyncCommand {
                             materializes them locally. This is how a contributor gets the \
                             owner's memories, and how an owner collects a contributor's — each \
                             side syncs the other's account, because memories are offered by \
-                            whoever AUTHORED them, not by the stream they live on. Run it \
-                            whenever you want those memories: automatic sync currently covers \
-                            only this store's OWN account, so cross-account memories move when \
-                            you run this and not before. The peer must be serving (`rag-rat sync \
-                            serve`) and reachable via --peer or [sync] server_peers, and no \
-                            other sync session (a resident MCP host, `serve`, or a device sync) \
-                            may be running — they share this database's node identity.")]
+                            whoever AUTHORED them, not by the stream they live on. Automatic \
+                            sync already pulls every configured contribution owner and every \
+                            writer grantee from [sync] server_peers on each pass, so this \
+                            command is the escape hatch: a one-off account, a --peer automation \
+                            does not know, or a pull you do not want to wait a cadence for. The \
+                            peer must be serving (`rag-rat sync serve`) and reachable via --peer \
+                            or [sync] server_peers, and no other sync session (a resident MCP \
+                            host, `serve`, or a device sync) may be running — they share this \
+                            database's node identity.")]
     Pull {
         /// The 64-hex account id to fetch, from that side's `rag-rat sync whoami`.
         #[arg(value_name = "ACCOUNT_ID")]

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -105,7 +105,7 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "grantee_account_id": account,
                 "grant_id": grant_id,
                 "role": "writer",
-                "note": "the grantee may now author memories into this repo once it syncs this account's log; revoke is a separate command (not yet available)",
+                "note": "the grantee may now author memories into this repo once it holds this account's log — its automatic sync pulls it when this host is in its [sync] server_peers; revoke is a separate command (not yet available)",
             }))
         },
         SyncCommand::Contribute { account } => {
@@ -114,7 +114,7 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "status": "contributing",
                 "repo_id": db.active_repo_id,
                 "owner_account_id": account,
-                "note": "memory changes for this repo now target the owner's stream; the owner must `sync grant` this account and this store must sync the owner's log before authoring succeeds",
+                "note": "memory changes for this repo now target the owner's stream; the owner must `sync grant` this account, and this store needs the owner's log — automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
             }))
         },
         SyncCommand::Serve { .. }
@@ -677,16 +677,31 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
     };
     drop(repo_lock);
 
-    let peers: Vec<String> = match peer_override {
+    let peer_ids: Vec<String> = match peer_override {
         Some(peer) => vec![peer.to_string()],
         None => config.sync.server_peers.clone(),
     };
-    if peers.is_empty() {
+    if peer_ids.is_empty() {
         bail!(
             "no peer to pull from: pass --peer <NODE_ID> or set [sync] server_peers. Discovery \
              cannot find a FOREIGN account's host — its discovery tag derives from that account's \
              own secret, which only its own devices hold"
         );
+    }
+    // An invalid entry skips to the next peer rather than aborting: one typo in a configured
+    // peer list must not block a pull another entry could serve.
+    let mut peers = Vec::with_capacity(peer_ids.len());
+    let mut resolve_error = None;
+    for peer_id in peer_ids {
+        match rag_rat_sync::peer_addr(&peer_id, &relay) {
+            Ok(addr) => peers.push((peer_id, addr)),
+            Err(error) => {
+                resolve_error = Some(format!("peer `{peer_id}` is not a valid node id: {error}"));
+            },
+        }
+    }
+    if peers.is_empty() {
+        bail!("{}", resolve_error.expect("at least one peer was configured"));
     }
 
     let runtime =
@@ -697,123 +712,19 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
             .await
             .with_context(|| format!("binding the sync endpoint over relay {relay}"))?;
 
-        let mut last_error: Option<String> = None;
-        // Durable across attempts: a peer can store entries and then fail to converge, and those
-        // bytes stay. Reporting only the final peer's tally would undercount — sometimes to zero.
-        let mut account_entries = 0usize;
-        let mut content_entries = 0usize;
-        let mut reached: Option<(String, bool)> = None;
-        for peer_id in &peers {
-            let addr = match rag_rat_sync::peer_addr(peer_id, &relay) {
-                Ok(addr) => addr,
-                Err(error) => {
-                    last_error = Some(format!("peer `{peer_id}` is not a valid node id: {error}"));
-                    continue;
-                },
-            };
-            // ACCOUNT LOG FIRST, then content: content acceptance re-derives authority from the
-            // account log, so a content session run first would park every candidate until a later
-            // settle. One command, correct order, nothing parked in the normal case.
-            //
-            // `PublicRead`, never `Closed`: on first contact this store holds ZERO roster facts for
-            // the foreign account, so `authorize` returns `Unavailable` — which `Closed` maps to
-            // `Unauthorized`, failing every first pull. `PublicRead` maps `Unavailable` + dialer to
-            // the ReadWrite bootstrap fallback built for exactly this. Admission is not trust:
-            // `account_ingest` / `content_ingest` re-verify every entry from scratch.
-            let mut account_store = OplogSyncStore::new(conn, target, time::now_ms);
-            let account_report = match rag_rat_sync::connect_and_reconcile(
-                &endpoint,
-                addr.clone(),
-                rag_rat_sync::SYNC_ALPN,
-                &mut account_store,
-                AuthPolicy::PublicRead,
-                time::now_ms,
-                rag_rat_sync::MAX_RECONCILE_ROUNDS,
-            )
-            .await
-            {
-                Ok(report) => report,
-                Err(error) => {
-                    last_error = Some(format!("{peer_id}: account log: {error}"));
-                    continue;
-                },
-            };
-            // A non-converged account leg means the round cap was hit with the store still possibly
-            // incomplete. Content acceptance re-derives authority from that log, so proceeding
-            // would silently leave valid entries unaccepted — and a cross-account pull has no
-            // automatic retry to repair it later. Treat the peer as unusable and try the next.
-            account_entries += account_report.entries_newly_stored;
-            // A pull exists to RECEIVE. If this side granted the peer only `ReadOnly`, its entries
-            // are rejected on arrival, so an all-quiet round means "structurally unable to receive"
-            // rather than "in sync" — and `converged` would report success on an incomplete
-            // account. This is the resumed-bootstrap wedge: once a partial pull leaves
-            // `account_effective_count > 0` for the target, a serving device whose `DeviceAdd` has
-            // not arrived folds `Rejected` (not `Unavailable`), which loses the bootstrap fallback.
-            if account_report.peer_capability != PeerCapability::ReadWrite {
-                last_error = Some(format!(
-                    "{peer_id}: this store holds a PARTIAL roster for that account, so it could \
-                     not authorize this peer to serve — the peer was admitted read-only and sent \
-                     nothing. Pull from the peer whose device is already in the roster you hold \
-                     (usually the account's own host), or start from a store with no entries for \
-                     it"
-                ));
-                continue;
-            }
-            // A quiet round can also mean the peer simply had nothing: an EMPTY account store
-            // completes the PublicRead protocol, and `Unavailable` hands the dialer the bootstrap
-            // ReadWrite capability, so round one is quiet and `converged` is true without this
-            // store ever learning the account. Require the target to actually be known here.
-            if rag_rat_oplog::account_effective_count(conn, target)? == 0 {
-                last_error = Some(format!(
-                    "{peer_id}: completed the exchange without sending account {}'s log — it does \
-                     not hold that account. Check the id, or point --peer at a machine that does",
-                    hash::hex_lower(&target.to_bytes())
-                ));
-                continue;
-            }
-            if !account_report.converged {
-                last_error = Some(format!(
-                    "{peer_id}: the account log did not converge before the round limit; its \
-                     content would be judged against incomplete authority"
-                ));
-                continue;
-            }
-            let mut content_store = OplogContentSyncStore::new(conn, target, time::now_ms);
-            let content_report = match rag_rat_sync::connect_and_reconcile(
-                &endpoint,
-                addr,
-                rag_rat_sync::CONTENT_SYNC_ALPN,
-                &mut content_store,
-                AuthPolicy::PublicRead,
-                time::now_ms,
-                rag_rat_sync::MAX_RECONCILE_ROUNDS,
-            )
-            .await
-            {
-                Ok(report) => report,
-                Err(error) => {
-                    last_error = Some(format!("{peer_id}: content: {error}"));
-                    continue;
-                },
-            };
-            content_entries += content_report.entries_newly_stored;
-            if !content_report.converged {
-                // Same treatment as the account leg: a healthy later peer may finish the job, and
-                // breaking here would pin every re-run on the same non-converging first peer. The
-                // entries this peer did store are durable and stay counted.
-                last_error =
-                    Some(format!("{peer_id}: content did not converge before the round limit"));
-                continue;
-            }
-            reached = Some((peer_id.clone(), true));
-            break;
-        }
-
-        let Some((peer_id, converged)) = reached else {
+        // The per-peer loop — account leg, then the receive-capability / account-known /
+        // convergence gates, then content — is the shared primitive behind the automatic
+        // cross-account pass; the gates are security decisions and live in ONE place.
+        let outcome =
+            rag_rat_core::sync_driver::pull_account_via_peers(conn, &endpoint, target, &peers)
+                .await?;
+        let account_entries = outcome.account_entries;
+        let content_entries = outcome.content_entries;
+        let Some(peer_id) = outcome.peer else {
             bail!(
                 "could not pull account {} from any configured peer: {}",
                 hash::hex_lower(&target.to_bytes()),
-                last_error.unwrap_or_else(|| "no peer reachable".to_string())
+                outcome.last_error.unwrap_or_else(|| "no peer reachable".to_string())
             );
         };
 
@@ -827,10 +738,9 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
         rag_rat_core::resolve_synced_distill_anchors(conn)?;
         db.fold_wal();
 
-        let note = if !converged {
-            "the round limit was reached before this account converged — re-run to finish; what \
-             arrived is durable"
-        } else if effects.nodes_written > 0 || effects.edges_written > 0 {
+        // A successful pull implies convergence — the shared helper only reports a peer after
+        // both legs converged, so there is no "incomplete success" to describe.
+        let note = if effects.nodes_written > 0 || effects.edges_written > 0 {
             "these memories are searchable locally; their code anchors do not cross an account \
              boundary, so they will not attach as drive-by context"
         } else if !effects.is_empty() {
@@ -844,7 +754,7 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
             "already up to date with this account"
         };
         crate::print_output(&serde_json::json!({
-            "status": if converged { "pulled" } else { "incomplete" },
+            "status": "pulled",
             "account_id": hash::hex_lower(&target.to_bytes()),
             "peer": peer_id,
             "account_entries_stored": account_entries,
@@ -853,7 +763,7 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
             "memories_removed": effects.nodes_removed,
             "edges_written": effects.edges_written,
             "edges_removed": effects.edges_removed,
-            "converged": converged,
+            "converged": true,
             "note": note,
         }))?;
         anyhow::Ok(())

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -281,8 +281,9 @@ fn grantee_context(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<Gr
         .with_context(|| {
             format!(
                 "no effective writer grant for this account on repo `{repo_id}`'s owner stream — \
-                 the owner must `sync grant` this account (its id from `sync whoami`) and this \
-                 store must sync the owner's log before it can contribute"
+                 the owner must `sync grant` this account (its id from `sync whoami`), and this \
+                 store needs the owner's log: automatic sync pulls it once the owner's host is in \
+                 [sync] server_peers, or run `rag-rat sync pull <owner-account>` now"
             )
         })?;
     Ok(Some(GranteeContext { owner_account, stream, grant_id }))

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -863,6 +863,12 @@ async fn reconcile(
             tracing::warn!(peer, %error, "device sync table reconciliation failed");
         }
     }
+    // Cross-account contribution (#1175): pull each foreign account this store depends on, so
+    // memories move on the same trigger as device sync — no command required. Failures are logged
+    // and retried on the next cadence; they never fail the device-sync pass.
+    if let Err(error) = pull_foreign_accounts(config, conn, endpoint, account).await {
+        tracing::warn!(%error, "cross-account pull pass failed; the next cadence retries");
+    }
     // Resolve any anchors this run's table reconciliation pulled against the local index, so they
     // surface as drive-by without waiting for the next index open (idempotent when nothing
     // changed).
@@ -870,6 +876,207 @@ async fn reconcile(
     let ok = reached.iter().filter(|reached| **reached).count();
     let peers = reached.len() + resolved.unresolved_configured;
     Ok((peers, ok, peers - ok))
+}
+
+/// The foreign accounts automatic sync must pull. Content is offered by AUTHOR, so each direction
+/// of contribution (#1164) needs the OTHER side's account synced here:
+///
+/// * each configured contribution owner — this store authors onto the owner's stream and needs the
+///   owner's log for authority plus the owner's content for read-back;
+/// * each effective writer grantee of this account — the grantee's contributions sit on THIS
+///   account's streams but only a session scoped to the GRANTEE's account carries them.
+fn foreign_pull_targets(
+    conn: &Connection,
+    local: rag_rat_oplog::AccountId,
+) -> anyhow::Result<Vec<rag_rat_oplog::AccountId>> {
+    let mut targets: Vec<rag_rat_oplog::AccountId> =
+        crate::memory_write::contribution_targets(conn)?.into_iter().map(|(_, o)| o).collect();
+    targets.extend(rag_rat_oplog::effective_writer_grantees(conn, local)?);
+    targets.sort_unstable_by_key(|target| target.to_bytes());
+    targets.dedup();
+    targets.retain(|target| *target != local);
+    Ok(targets)
+}
+
+/// Which peer answered for which foreign account, so quiet cycles dial ONE peer instead of
+/// re-probing (and re-warning about) every configured peer that does not hold the account.
+const PULL_PEER_MEMO_PREFIX: &str = "sync_pull_peer:";
+
+async fn pull_foreign_accounts(
+    config: &Config,
+    conn: &Connection,
+    endpoint: &iroh::Endpoint,
+    local: rag_rat_oplog::AccountId,
+) -> anyhow::Result<()> {
+    let targets = foreign_pull_targets(conn, local)?;
+    if targets.is_empty() {
+        return Ok(());
+    }
+    let peers = &config.sync.server_peers;
+    if peers.is_empty() {
+        // Discovery cannot stand in: a foreign account's discovery tag derives from that
+        // account's own secret, which only its own devices hold.
+        tracing::warn!(
+            "cross-account sync has accounts to pull but no [sync] server_peers to pull from"
+        );
+        return Ok(());
+    }
+    let relay = relay_url(config);
+    for target in targets {
+        let account_hex = hash::hex_lower(&target.to_bytes());
+        let memo_key = format!("{PULL_PEER_MEMO_PREFIX}{account_hex}");
+        let memo = rag_rat_db::meta::read_meta(conn, &memo_key)?;
+        let ordered: Vec<(String, rag_rat_sync::EndpointAddr)> = memo
+            .iter()
+            .chain(peers.iter().filter(|peer| Some(*peer) != memo.as_ref()))
+            .filter_map(|peer| match rag_rat_sync::peer_addr(peer, &relay) {
+                Ok(addr) => Some((peer.clone(), addr)),
+                Err(error) => {
+                    tracing::warn!(peer, %error, "skipping cross-account peer: invalid node id");
+                    None
+                },
+            })
+            .collect();
+        let outcome = pull_account_via_peers(conn, endpoint, target, &ordered).await?;
+        match outcome.peer {
+            Some(peer) =>
+                if memo.as_deref() != Some(peer.as_str()) {
+                    rag_rat_db::meta::set_meta(conn, &memo_key, &peer)?;
+                },
+            None => tracing::warn!(
+                account = %account_hex,
+                error = outcome.last_error.as_deref().unwrap_or("no peer reachable"),
+                "cross-account pull did not complete; the next cadence retries"
+            ),
+        }
+    }
+    // Materialize whatever landed, once for the whole pass (idempotent when nothing changed).
+    crate::drain_synced_memory(conn)?;
+    Ok(())
+}
+
+/// The outcome of pulling one FOREIGN account across a set of candidate peers.
+pub struct ForeignPullOutcome {
+    /// The peer that completed the pull: account log converged, capability sufficient, content
+    /// converged. `None` when every peer failed a gate.
+    pub peer: Option<String>,
+    /// Entries stored across ALL attempts. Durable across a failed peer: a peer can store entries
+    /// and then miss convergence, and those bytes stay — reporting only the final peer's tally
+    /// would undercount, sometimes to zero.
+    pub account_entries: usize,
+    pub content_entries: usize,
+    /// The most recent per-peer failure, for reporting when `peer` is `None`.
+    pub last_error: Option<String>,
+}
+
+/// Pull a foreign account's log and content from the first of `peers` that can actually serve it.
+/// This is the shared primitive behind `rag-rat sync pull` and the automatic cross-account pass —
+/// the admission gates below are security decisions and must not drift between the two.
+pub async fn pull_account_via_peers(
+    conn: &Connection,
+    endpoint: &iroh::Endpoint,
+    target: rag_rat_oplog::AccountId,
+    peers: &[(String, rag_rat_sync::EndpointAddr)],
+) -> anyhow::Result<ForeignPullOutcome> {
+    let mut outcome =
+        ForeignPullOutcome { peer: None, account_entries: 0, content_entries: 0, last_error: None };
+    for (peer_id, addr) in peers {
+        // ACCOUNT LOG FIRST, then content: content acceptance re-derives authority from the
+        // account log, so a content session run first would park every candidate until a later
+        // settle. One pass, correct order, nothing parked in the normal case.
+        //
+        // `PublicRead`, never `Closed`: on first contact this store holds ZERO roster facts for
+        // the foreign account, so `authorize` returns `Unavailable` — which `Closed` maps to
+        // `Unauthorized`, failing every first pull. `PublicRead` maps `Unavailable` + dialer to
+        // the ReadWrite bootstrap fallback built for exactly this. Admission is not trust:
+        // `account_ingest` / `content_ingest` re-verify every entry from scratch.
+        let mut account_store = OplogSyncStore::new(conn, target, time::now_ms);
+        let account_report = match rag_rat_sync::connect_and_reconcile(
+            endpoint,
+            addr.clone(),
+            rag_rat_sync::SYNC_ALPN,
+            &mut account_store,
+            AuthPolicy::PublicRead,
+            time::now_ms,
+            rag_rat_sync::MAX_RECONCILE_ROUNDS,
+        )
+        .await
+        {
+            Ok(report) => report,
+            Err(error) => {
+                outcome.last_error = Some(format!("{peer_id}: account log: {error}"));
+                continue;
+            },
+        };
+        outcome.account_entries += account_report.entries_newly_stored;
+        // A pull exists to RECEIVE. If this side granted the peer only `ReadOnly`, its entries
+        // are rejected on arrival, so an all-quiet round means "structurally unable to receive"
+        // rather than "in sync" — and `converged` would report success on an incomplete
+        // account. This is the resumed-bootstrap wedge: once a partial pull leaves
+        // `account_effective_count > 0` for the target, a serving device whose `DeviceAdd` has
+        // not arrived folds `Rejected` (not `Unavailable`), which loses the bootstrap fallback.
+        if account_report.peer_capability != PeerCapability::ReadWrite {
+            outcome.last_error = Some(format!(
+                "{peer_id}: this store holds a PARTIAL roster for that account, so it could not \
+                 authorize this peer to serve — the peer was admitted read-only and sent nothing. \
+                 Pull from the peer whose device is already in the roster you hold (usually the \
+                 account's own host), or start from a store with no entries for it"
+            ));
+            continue;
+        }
+        // A quiet round can also mean the peer simply had nothing: an EMPTY account store
+        // completes the PublicRead protocol, and `Unavailable` hands the dialer the bootstrap
+        // ReadWrite capability, so round one is quiet and `converged` is true without this
+        // store ever learning the account. Require the target to actually be known here.
+        if rag_rat_oplog::account_effective_count(conn, target)? == 0 {
+            outcome.last_error = Some(format!(
+                "{peer_id}: completed the exchange without sending account {}'s log — it does not \
+                 hold that account. Check the id, or point at a machine that does",
+                hash::hex_lower(&target.to_bytes())
+            ));
+            continue;
+        }
+        // A non-converged account leg means the round cap was hit with the store still possibly
+        // incomplete. Content acceptance re-derives authority from that log, so proceeding would
+        // silently leave valid entries unaccepted. Treat the peer as unusable and try the next.
+        if !account_report.converged {
+            outcome.last_error = Some(format!(
+                "{peer_id}: the account log did not converge before the round limit; its content \
+                 would be judged against incomplete authority"
+            ));
+            continue;
+        }
+        let mut content_store = OplogContentSyncStore::new(conn, target, time::now_ms);
+        let content_report = match rag_rat_sync::connect_and_reconcile(
+            endpoint,
+            addr.clone(),
+            rag_rat_sync::CONTENT_SYNC_ALPN,
+            &mut content_store,
+            AuthPolicy::PublicRead,
+            time::now_ms,
+            rag_rat_sync::MAX_RECONCILE_ROUNDS,
+        )
+        .await
+        {
+            Ok(report) => report,
+            Err(error) => {
+                outcome.last_error = Some(format!("{peer_id}: content: {error}"));
+                continue;
+            },
+        };
+        outcome.content_entries += content_report.entries_newly_stored;
+        if !content_report.converged {
+            // Same treatment as the account leg: a healthy later peer may finish the job, and
+            // breaking here would pin every re-run on the same non-converging first peer. The
+            // entries this peer did store are durable and stay counted.
+            outcome.last_error =
+                Some(format!("{peer_id}: content did not converge before the round limit"));
+            continue;
+        }
+        outcome.peer = Some(peer_id.clone());
+        break;
+    }
+    Ok(outcome)
 }
 
 pub fn relay_url(config: &Config) -> String {
@@ -984,13 +1191,15 @@ mod tests {
     use std::time::Duration;
 
     use rag_rat_base::config::Config;
+    use rag_rat_base::{hash, time};
+    use rag_rat_sync::AuthPolicy;
     use rusqlite::Connection;
 
     use super::{
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PerPeerSessionLimiter, PersistedAdvertisement,
         RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host, can_sync,
-        device_sync_run, nudge_resident_host, read_advertisement, refused_publication_is_due,
-        retry_is_due, write_advertisement,
+        device_sync_run, foreign_pull_targets, nudge_resident_host, pull_account_via_peers,
+        read_advertisement, refused_publication_is_due, retry_is_due, write_advertisement,
     };
 
     fn schema_conn() -> Connection {
@@ -1323,5 +1532,244 @@ mod tests {
             limiter.try_acquire(PEER_A, 1).is_some(),
             "the slot was released on the panic unwind, not leaked",
         );
+    }
+
+    #[test]
+    fn foreign_pull_targets_cover_both_directions_and_exclude_the_local_account() {
+        use rusqlite::{Transaction, TransactionBehavior};
+
+        let store = schema_conn();
+        let local = rag_rat_oplog::local_account(&store, 1_000).unwrap();
+        assert!(foreign_pull_targets(&store, local).unwrap().is_empty());
+
+        // Contributor direction: a configured contribution owner becomes a pull target.
+        store
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+                 ('repo-a','a',0)",
+                [],
+            )
+            .unwrap();
+        let owner = rag_rat_oplog::AccountId::from_bytes([0x77; 32]);
+        rag_rat_db::meta::set_repo_meta(
+            &store,
+            "repo-a",
+            "memory_contribution_owner",
+            &hash::hex_lower(&owner.to_bytes()),
+        )
+        .unwrap();
+        assert_eq!(foreign_pull_targets(&store, local).unwrap(), vec![owner]);
+
+        // Owner direction: an effective writer grantee of THIS account becomes a pull target too.
+        let grantee = rag_rat_oplog::AccountId::from_bytes([0x22; 32]);
+        {
+            let tx = Transaction::new_unchecked(&store, TransactionBehavior::Immediate).unwrap();
+            let stream = rag_rat_oplog::ensure_owned_stream_v2_with_mode_in_tx(
+                &tx,
+                "repo-a",
+                rag_rat_oplog::AccessMode::PublicRead,
+                1_000,
+            )
+            .unwrap();
+            rag_rat_oplog::author_stream_grant_in_tx(
+                &tx,
+                stream,
+                grantee,
+                rag_rat_oplog::GrantRole::Writer,
+                1_000,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        let targets = foreign_pull_targets(&store, local).unwrap();
+        assert!(targets.contains(&owner) && targets.contains(&grantee));
+        assert_eq!(targets.len(), 2);
+
+        // A repo configured (nonsensically) to contribute to the LOCAL account never self-pulls.
+        store
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+                 ('repo-b','b',0)",
+                [],
+            )
+            .unwrap();
+        rag_rat_db::meta::set_repo_meta(
+            &store,
+            "repo-b",
+            "memory_contribution_owner",
+            &hash::hex_lower(&local.to_bytes()),
+        )
+        .unwrap();
+        assert_eq!(foreign_pull_targets(&store, local).unwrap().len(), 2);
+    }
+
+    /// A relay-free endpoint pair for exercising the pull helper over a real wire.
+    async fn loopback_endpoints() -> (iroh::Endpoint, iroh::Endpoint) {
+        let bind = |seed: [u8; 32]| async move {
+            iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+                .alpns(vec![
+                    rag_rat_sync::SYNC_ALPN.to_vec(),
+                    rag_rat_sync::CONTENT_SYNC_ALPN.to_vec(),
+                ])
+                .relay_mode(iroh::RelayMode::Disabled)
+                .secret_key(iroh::SecretKey::from_bytes(&seed))
+                .bind()
+                .await
+                .unwrap()
+        };
+        (bind([0x31; 32]).await, bind([0x32; 32]).await)
+    }
+
+    /// A directly dialable address for a loopback endpoint (its 127.0.0.1 socket).
+    fn direct_addr(endpoint: &iroh::Endpoint) -> iroh::EndpointAddr {
+        let port = endpoint
+            .addr()
+            .ip_addrs()
+            .next()
+            .expect("a bound endpoint advertises at least one socket address")
+            .port();
+        iroh::EndpointAddr::new(endpoint.id())
+            .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+    }
+
+    #[tokio::test]
+    async fn pulling_a_contributors_account_lands_its_memory_in_the_owners_repo() {
+        use rusqlite::{Transaction, TransactionBehavior};
+        const NOW: i64 = 1_000;
+
+        // OWNER: real account, PublicRead stream for `repo-a`, repo registered so the drain
+        // mirrors the stream into `repo_memories`.
+        let owner = schema_conn();
+        let owner_account = rag_rat_oplog::local_account(&owner, NOW).unwrap();
+        let stream = {
+            let tx = Transaction::new_unchecked(&owner, TransactionBehavior::Immediate).unwrap();
+            let stream = rag_rat_oplog::ensure_owned_stream_v2_with_mode_in_tx(
+                &tx,
+                "repo-a",
+                rag_rat_oplog::AccessMode::PublicRead,
+                NOW,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+            stream
+        };
+        owner
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+                 ('repo-a','a',0)",
+                [],
+            )
+            .unwrap();
+
+        // CONTRIBUTOR: separate identity, granted Writer, learns the grant from the owner's log.
+        let contributor = schema_conn();
+        let contributor_account = rag_rat_oplog::local_account(&contributor, NOW).unwrap();
+        {
+            let tx = Transaction::new_unchecked(&owner, TransactionBehavior::Immediate).unwrap();
+            rag_rat_oplog::author_stream_grant_in_tx(
+                &tx,
+                stream,
+                contributor_account,
+                rag_rat_oplog::GrantRole::Writer,
+                NOW,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        for entry in rag_rat_oplog::account_entries_for_sync(&owner, owner_account).unwrap() {
+            rag_rat_oplog::account_ingest(&contributor, &entry.signed_bytes, NOW).unwrap();
+        }
+        let grant_id = rag_rat_oplog::effective_writer_grant(
+            &contributor,
+            owner_account,
+            stream,
+            contributor_account,
+        )
+        .unwrap()
+        .expect("the grant reached the contributor");
+        {
+            let tx =
+                Transaction::new_unchecked(&contributor, TransactionBehavior::Immediate).unwrap();
+            rag_rat_oplog::author_grantee_content_batch_in_tx(
+                &tx,
+                stream,
+                owner_account,
+                grant_id,
+                &[rag_rat_oplog::MemoryOp::NodeCreate {
+                    node_id: rag_rat_oplog::NodeId::from("contributed-1"),
+                    content: rag_rat_oplog::NodeContent {
+                        kind: "Invariant".into(),
+                        title: "from the contributor".into(),
+                        body: "body".into(),
+                        confidence: "high".into(),
+                        source: "agent".into(),
+                        tags: Vec::new(),
+                        payload: None,
+                    },
+                }],
+                NOW,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+
+        // THE AUTOMATIC DIRECTION: the owner pulls the CONTRIBUTOR's account over a real wire
+        // through the shared helper the reconcile pass and `sync pull` both use.
+        let (contributor_ep, owner_ep) = loopback_endpoints().await;
+        let peers = vec![("contributor-host".to_string(), direct_addr(&contributor_ep))];
+        // Serve inbound connections until the pull finishes — a fixed accept count would hang
+        // the test forever if the pull legitimately stopped after fewer connections.
+        // The serving stores use REAL time: the dialing helper verifies the acceptor's node
+        // binding against the wall clock, so a fixture clock would read as an expired binding.
+        let server = async {
+            loop {
+                let mut serve_account = rag_rat_sync::OplogSyncStore::new(
+                    &contributor,
+                    contributor_account,
+                    time::now_ms,
+                );
+                let mut serve_content = rag_rat_sync::OplogContentSyncStore::new(
+                    &contributor,
+                    contributor_account,
+                    time::now_ms,
+                );
+                rag_rat_sync::accept_and_dispatch(
+                    &contributor_ep,
+                    &mut serve_account,
+                    &mut serve_content,
+                    AuthPolicy::PublicRead,
+                    time::now_ms,
+                )
+                .await
+                .unwrap();
+            }
+        };
+        let pull = pull_account_via_peers(&owner, &owner_ep, contributor_account, &peers);
+        let outcome = tokio::select! {
+            outcome = pull => outcome.unwrap(),
+            _ = server => unreachable!("the serve loop never exits"),
+            _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                panic!("the pull did not finish within the test deadline")
+            },
+        };
+        assert_eq!(outcome.peer.as_deref(), Some("contributor-host"), "{:?}", outcome.last_error);
+        assert!(outcome.account_entries > 0, "the contributor's log arrived");
+        assert!(outcome.content_entries > 0, "the contribution arrived");
+
+        // The drain materializes the contribution into the owner's repo memories.
+        rag_rat_oplog::settle_pending_content_refolds(
+            &owner,
+            &rag_rat_oplog::ContentRefoldBudget::unbounded(),
+            NOW,
+        )
+        .unwrap();
+        let effects = crate::drain_synced_memory(&owner).unwrap();
+        assert!(effects.nodes_written >= 1, "the memory materialized: {effects:?}");
+        let title: String = owner
+            .query_row("SELECT title FROM repo_memories WHERE repo_id = 'repo-a'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(title, "from the contributor");
     }
 }

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -782,8 +782,17 @@ async fn reconcile(
         },
     )
     .await;
-    let mut reached = vec![false; resolved.peers.len()];
-    for (index, (peer, address)) in resolved.peers.iter().enumerate() {
+    // Scope the DEVICE-sync phases to peers that can serve this account. A peer memoized as a
+    // FOREIGN-account host serves only its own account by construction, so dialing it here would
+    // fail the account-scope handshake, log a device-sync failure, and count an error on every
+    // cadence — while the cross-account pass below succeeds against the same host. Until the
+    // first successful foreign pull memoizes a host it is still dialed once per pass; that
+    // warmup noise is bounded and self-healing, unlike the permanent false alarm it replaces.
+    let foreign_hosts = foreign_pull_hosts(conn)?;
+    let device_peers: Vec<(String, rag_rat_sync::EndpointAddr)> =
+        resolved.peers.into_iter().filter(|(peer, _)| !foreign_hosts.contains(peer)).collect();
+    let mut reached = vec![false; device_peers.len()];
+    for (index, (peer, address)) in device_peers.iter().enumerate() {
         let mut store = OplogSyncStore::new(conn, account, time::now_ms);
         match rag_rat_sync::connect_and_reconcile(
             endpoint,
@@ -803,7 +812,7 @@ async fn reconcile(
     }
     ensure_founder_incarnations(conn)?;
     // A newly authored founder incarnation must reach peers before their table manifests run.
-    for (index, (peer, address)) in resolved.peers.iter().enumerate() {
+    for (index, (peer, address)) in device_peers.iter().enumerate() {
         if !reached[index] {
             continue;
         }
@@ -830,7 +839,7 @@ async fn reconcile(
             },
         }
     }
-    for (index, (peer, address)) in resolved.peers.iter().enumerate() {
+    for (index, (peer, address)) in device_peers.iter().enumerate() {
         if !reached[index] {
             continue;
         }
@@ -902,6 +911,33 @@ fn foreign_pull_targets(
 /// re-probing (and re-warning about) every configured peer that does not hold the account.
 const PULL_PEER_MEMO_PREFIX: &str = "sync_pull_peer:";
 
+/// Peers memoized as FOREIGN-account hosts. A production host serves only its OWN account, so
+/// the local-account (device sync) phase can never succeed against one of these — dialing them
+/// there fails the account-scope handshake and reads as a broken device sync every cadence.
+fn foreign_pull_hosts(conn: &Connection) -> anyhow::Result<Vec<String>> {
+    rag_rat_db::meta::meta_values_with_prefix(conn, PULL_PEER_MEMO_PREFIX)
+}
+
+/// The peers to dial for one foreign account, memoized answerer first. The memo ORDERS the
+/// configured peer set, never extends it: a host removed from `[sync] server_peers` must stop
+/// being dialed, so a memo that is no longer configured is cleared rather than honored.
+fn ordered_pull_peers(
+    conn: &Connection,
+    memo_key: &str,
+    peers: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let memo = rag_rat_db::meta::read_meta(conn, memo_key)?.filter(|peer| peers.contains(peer));
+    if memo.is_none() {
+        // Clears a decommissioned host's memo; a no-op when nothing was stored.
+        rag_rat_db::meta::delete_meta(conn, memo_key)?;
+    }
+    Ok(memo
+        .iter()
+        .chain(peers.iter().filter(|peer| Some(*peer) != memo.as_ref()))
+        .cloned()
+        .collect())
+}
+
 async fn pull_foreign_accounts(
     config: &Config,
     conn: &Connection,
@@ -925,24 +961,21 @@ async fn pull_foreign_accounts(
     for target in targets {
         let account_hex = hash::hex_lower(&target.to_bytes());
         let memo_key = format!("{PULL_PEER_MEMO_PREFIX}{account_hex}");
-        let memo = rag_rat_db::meta::read_meta(conn, &memo_key)?;
-        let ordered: Vec<(String, rag_rat_sync::EndpointAddr)> = memo
-            .iter()
-            .chain(peers.iter().filter(|peer| Some(*peer) != memo.as_ref()))
-            .filter_map(|peer| match rag_rat_sync::peer_addr(peer, &relay) {
-                Ok(addr) => Some((peer.clone(), addr)),
-                Err(error) => {
-                    tracing::warn!(peer, %error, "skipping cross-account peer: invalid node id");
-                    None
-                },
-            })
-            .collect();
+        let ordered: Vec<(String, rag_rat_sync::EndpointAddr)> = ordered_pull_peers(
+            conn, &memo_key, peers,
+        )?
+        .into_iter()
+        .filter_map(|peer| match rag_rat_sync::peer_addr(&peer, &relay) {
+            Ok(addr) => Some((peer, addr)),
+            Err(error) => {
+                tracing::warn!(peer, %error, "skipping cross-account peer: invalid node id");
+                None
+            },
+        })
+        .collect();
         let outcome = pull_account_via_peers(conn, endpoint, target, &ordered).await?;
         match outcome.peer {
-            Some(peer) =>
-                if memo.as_deref() != Some(peer.as_str()) {
-                    rag_rat_db::meta::set_meta(conn, &memo_key, &peer)?;
-                },
+            Some(peer) => rag_rat_db::meta::set_meta(conn, &memo_key, &peer)?,
             None => tracing::warn!(
                 account = %account_hex,
                 error = outcome.last_error.as_deref().unwrap_or("no peer reachable"),
@@ -1196,10 +1229,11 @@ mod tests {
     use rusqlite::Connection;
 
     use super::{
-        DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PerPeerSessionLimiter, PersistedAdvertisement,
-        RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host, can_sync,
-        device_sync_run, foreign_pull_targets, nudge_resident_host, pull_account_via_peers,
-        read_advertisement, refused_publication_is_due, retry_is_due, write_advertisement,
+        DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PULL_PEER_MEMO_PREFIX, PerPeerSessionLimiter,
+        PersistedAdvertisement, RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host,
+        can_sync, device_sync_run, foreign_pull_hosts, foreign_pull_targets, nudge_resident_host,
+        ordered_pull_peers, pull_account_via_peers, read_advertisement, refused_publication_is_due,
+        retry_is_due, write_advertisement,
     };
 
     fn schema_conn() -> Connection {
@@ -1601,6 +1635,40 @@ mod tests {
         )
         .unwrap();
         assert_eq!(foreign_pull_targets(&store, local).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn a_memoized_peer_orders_the_configured_set_and_a_decommissioned_one_is_cleared() {
+        let conn = schema_conn();
+        let key = format!("{PULL_PEER_MEMO_PREFIX}aa");
+        let peers = vec!["node-a".to_string(), "node-b".to_string()];
+
+        // No memo: configured order, nothing stored.
+        assert_eq!(ordered_pull_peers(&conn, &key, &peers).unwrap(), peers);
+
+        // A memoized answerer moves to the front without duplicating.
+        rag_rat_db::meta::set_meta(&conn, &key, "node-b").unwrap();
+        assert_eq!(ordered_pull_peers(&conn, &key, &peers).unwrap(), vec![
+            "node-b".to_string(),
+            "node-a".to_string()
+        ]);
+
+        // Decommissioned: the memoized host left [sync] server_peers, so it is neither dialed
+        // nor kept — the memo orders the configured set, never extends it.
+        let remaining = vec!["node-a".to_string()];
+        assert_eq!(ordered_pull_peers(&conn, &key, &remaining).unwrap(), remaining);
+        assert_eq!(rag_rat_db::meta::read_meta(&conn, &key).unwrap(), None, "stale memo cleared");
+    }
+
+    #[test]
+    fn only_pull_memo_keys_mark_a_peer_as_a_foreign_host() {
+        let conn = schema_conn();
+        assert!(foreign_pull_hosts(&conn).unwrap().is_empty());
+        rag_rat_db::meta::set_meta(&conn, &format!("{PULL_PEER_MEMO_PREFIX}aa"), "node-f").unwrap();
+        // Unrelated meta keys — including other sync keys — never mark a device-sync peer.
+        rag_rat_db::meta::set_meta(&conn, RESIDENT_NUDGE, "5").unwrap();
+        rag_rat_db::meta::set_meta(&conn, "sync_pull_peerless", "node-x").unwrap();
+        assert_eq!(foreign_pull_hosts(&conn).unwrap(), vec!["node-f".to_string()]);
     }
 
     /// A relay-free endpoint pair for exercising the pull helper over a real wire.

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -789,8 +789,11 @@ async fn reconcile(
     // first successful foreign pull memoizes a host it is still dialed once per pass; that
     // warmup noise is bounded and self-healing, unlike the permanent false alarm it replaces.
     let foreign_hosts = foreign_pull_hosts(conn)?;
-    let device_peers: Vec<(String, rag_rat_sync::EndpointAddr)> =
-        resolved.peers.into_iter().filter(|(peer, _)| !foreign_hosts.contains(peer)).collect();
+    let device_peers: Vec<(String, rag_rat_sync::EndpointAddr)> = resolved
+        .peers
+        .into_iter()
+        .filter(|(_, address)| !foreign_hosts.contains(&Ok(*address.id.as_bytes())))
+        .collect();
     let mut reached = vec![false; device_peers.len()];
     for (index, (peer, address)) in device_peers.iter().enumerate() {
         let mut store = OplogSyncStore::new(conn, account, time::now_ms);
@@ -911,29 +914,46 @@ fn foreign_pull_targets(
 /// re-probing (and re-warning about) every configured peer that does not hold the account.
 const PULL_PEER_MEMO_PREFIX: &str = "sync_pull_peer:";
 
-/// Peers memoized as FOREIGN-account hosts. A production host serves only its OWN account, so
-/// the local-account (device sync) phase can never succeed against one of these — dialing them
-/// there fails the account-scope handshake and reads as a broken device sync every cadence.
-fn foreign_pull_hosts(conn: &Connection) -> anyhow::Result<Vec<String>> {
-    rag_rat_db::meta::meta_values_with_prefix(conn, PULL_PEER_MEMO_PREFIX)
+/// The identity a peer STRING names, for comparing peers across spellings: the parsed 32-byte
+/// node id when the string parses (hex and base32 spellings of one node compare equal), or the
+/// trimmed literal otherwise (an unparseable entry still compares as itself). Node-id strings
+/// must never be compared literally — `[sync] server_peers` accepts several spellings of one
+/// node, and the memo stores whichever spelling answered.
+fn peer_identity(peer: &str) -> Result<[u8; 32], String> {
+    rag_rat_sync::parse_node_id(peer).map_err(|_| peer.trim().to_string())
+}
+
+/// Peers memoized as FOREIGN-account hosts, as [`peer_identity`] values. A production host serves
+/// only its OWN account, so the local-account (device sync) phase can never succeed against one of
+/// these — dialing them there fails the account-scope handshake and reads as a broken device sync
+/// every cadence.
+fn foreign_pull_hosts(conn: &Connection) -> anyhow::Result<Vec<Result<[u8; 32], String>>> {
+    Ok(rag_rat_db::meta::meta_values_with_prefix(conn, PULL_PEER_MEMO_PREFIX)?
+        .iter()
+        .map(|peer| peer_identity(peer))
+        .collect())
 }
 
 /// The peers to dial for one foreign account, memoized answerer first. The memo ORDERS the
 /// configured peer set, never extends it: a host removed from `[sync] server_peers` must stop
 /// being dialed, so a memo that is no longer configured is cleared rather than honored.
+/// Membership is decided by [`peer_identity`], so a memo still counts as configured when the
+/// config spells the same node differently.
 fn ordered_pull_peers(
     conn: &Connection,
     memo_key: &str,
     peers: &[String],
 ) -> anyhow::Result<Vec<String>> {
-    let memo = rag_rat_db::meta::read_meta(conn, memo_key)?.filter(|peer| peers.contains(peer));
+    let memo = rag_rat_db::meta::read_meta(conn, memo_key)?
+        .filter(|memo| peers.iter().any(|peer| peer_identity(peer) == peer_identity(memo)));
     if memo.is_none() {
         // Clears a decommissioned host's memo; a no-op when nothing was stored.
         rag_rat_db::meta::delete_meta(conn, memo_key)?;
     }
+    let memo_identity = memo.as_deref().map(peer_identity);
     Ok(memo
         .iter()
-        .chain(peers.iter().filter(|peer| Some(*peer) != memo.as_ref()))
+        .chain(peers.iter().filter(|peer| Some(peer_identity(peer)) != memo_identity))
         .cloned()
         .collect())
 }
@@ -1232,8 +1252,8 @@ mod tests {
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PULL_PEER_MEMO_PREFIX, PerPeerSessionLimiter,
         PersistedAdvertisement, RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host,
         can_sync, device_sync_run, foreign_pull_hosts, foreign_pull_targets, nudge_resident_host,
-        ordered_pull_peers, pull_account_via_peers, read_advertisement, refused_publication_is_due,
-        retry_is_due, write_advertisement,
+        ordered_pull_peers, peer_identity, pull_account_via_peers, read_advertisement,
+        refused_publication_is_due, retry_is_due, write_advertisement,
     };
 
     fn schema_conn() -> Connection {
@@ -1668,7 +1688,53 @@ mod tests {
         // Unrelated meta keys — including other sync keys — never mark a device-sync peer.
         rag_rat_db::meta::set_meta(&conn, RESIDENT_NUDGE, "5").unwrap();
         rag_rat_db::meta::set_meta(&conn, "sync_pull_peerless", "node-x").unwrap();
-        assert_eq!(foreign_pull_hosts(&conn).unwrap(), vec!["node-f".to_string()]);
+        assert_eq!(foreign_pull_hosts(&conn).unwrap(), vec![peer_identity("node-f")]);
+    }
+
+    /// Standard base32, no padding — an alternate spelling `parse_node_id` accepts for the node a
+    /// 64-char lowercase hex string names.
+    fn base32_nopad(bytes: &[u8; 32]) -> String {
+        const ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        let mut out = String::with_capacity(52);
+        let (mut acc, mut bits) = (0u32, 0u32);
+        for &byte in bytes {
+            acc = (acc << 8) | u32::from(byte);
+            bits += 8;
+            while bits >= 5 {
+                bits -= 5;
+                out.push(ALPHABET[((acc >> bits) & 0x1f) as usize] as char);
+            }
+        }
+        if bits > 0 {
+            out.push(ALPHABET[((acc << (5 - bits)) & 0x1f) as usize] as char);
+        }
+        out
+    }
+
+    #[test]
+    fn peer_comparisons_recognize_alternate_spellings_of_one_node() {
+        let conn = schema_conn();
+        let bytes = rag_rat_sync::node_id_from_secret([7; 32]);
+        let hex = rag_rat_sync::node_id_to_string(&bytes).unwrap();
+        let base32 = base32_nopad(&bytes);
+        assert_ne!(hex, base32);
+
+        // The memo holds the spelling that answered while the config spells the same node
+        // differently: the memo still counts as configured (kept and fronted), and the
+        // equivalent configured spelling is not dialed a second time.
+        let key = format!("{PULL_PEER_MEMO_PREFIX}bb");
+        rag_rat_db::meta::set_meta(&conn, &key, &base32).unwrap();
+        let peers = vec![hex.clone(), "node-a".to_string()];
+        assert_eq!(ordered_pull_peers(&conn, &key, &peers).unwrap(), vec![
+            base32.clone(),
+            "node-a".to_string()
+        ]);
+        assert!(rag_rat_db::meta::read_meta(&conn, &key).unwrap().is_some(), "memo kept");
+
+        // Device sync excludes a memoized foreign host by parsed identity — the bytes a
+        // resolved `EndpointAddr` carries — never by spelling.
+        assert!(foreign_pull_hosts(&conn).unwrap().contains(&Ok(bytes)));
+        assert_eq!(peer_identity(&hex), Ok(bytes));
     }
 
     /// A relay-free endpoint pair for exercising the pull helper over a real wire.

--- a/crates/rag-rat-db/src/meta.rs
+++ b/crates/rag-rat-db/src/meta.rs
@@ -283,6 +283,15 @@ pub fn delete_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The values of every `index_meta` key starting with `prefix`. GLOB (not LIKE) so `_` in a key
+/// prefix stays literal; callers pass fixed prefixes without GLOB metacharacters (`*?[`).
+pub fn meta_values_with_prefix(conn: &Connection, prefix: &str) -> anyhow::Result<Vec<String>> {
+    let mut stmt =
+        conn.prepare("SELECT value FROM index_meta WHERE key GLOB ?1 || '*' ORDER BY key")?;
+    let rows = stmt.query_map([prefix], |row| row.get::<_, String>(0))?;
+    Ok(rows.collect::<Result<Vec<_>, _>>()?)
+}
+
 pub fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
     Ok(conn
         .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -133,9 +133,10 @@ pub use storage::{
     account_entries_for_enrollment, account_entries_for_sync, account_entry_ref,
     account_holds_effective_public_writer_grant, account_ingest, account_is_fully_public,
     account_signed_entry_exists, account_signed_hash, auth_len_freshness,
-    backfill_authority_projection, effective_writer_grant, grant_effective_for_device,
-    grant_effective_in_snapshot, owned_streams_for_account, owner_control_authority,
-    owner_control_authority_in_snapshot, owner_secrets_authority, roster_content_authority,
-    stream_access_mode, stream_owner_account, stream_owner_effective, verify_enrollment_device_add,
+    backfill_authority_projection, effective_writer_grant, effective_writer_grantees,
+    grant_effective_for_device, grant_effective_in_snapshot, owned_streams_for_account,
+    owner_control_authority, owner_control_authority_in_snapshot, owner_secrets_authority,
+    roster_content_authority, stream_access_mode, stream_owner_account, stream_owner_effective,
+    verify_enrollment_device_add,
 };
 pub(crate) use storage::{device_is_effective_writer, stored_device_pubkeys};

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -875,6 +875,32 @@ pub fn effective_writer_grant(
     grant_id.map(|bytes| fixed(&bytes)).transpose()
 }
 
+/// The distinct accounts holding an effective (not-closed) Writer grant on any stream owned by
+/// `owner_account_id`. Automatic cross-account sync (#1175) pulls each grantee's own account —
+/// content is offered by AUTHOR, so a contributor's entries on the owner's stream travel only when
+/// the OWNER dials the contributor and syncs the CONTRIBUTOR's account. Reader grants never
+/// author, so they are excluded. Owner-leading, so the scan rides the `(owner, stream, grantee)`
+/// index.
+pub fn effective_writer_grantees(
+    conn: &Connection,
+    owner_account_id: AccountId,
+) -> anyhow::Result<Vec<AccountId>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT grantee_account_id FROM account_stream_grants
+         WHERE owner_account_id = ?1 AND role = ?2 AND closed_at IS NULL
+         ORDER BY grantee_account_id",
+    )?;
+    let rows = stmt.query_map(
+        params![owner_account_id.to_bytes().as_slice(), GrantRole::Writer.as_db_str()],
+        |row| row.get::<_, Vec<u8>>(0),
+    )?;
+    let mut grantees = Vec::new();
+    for row in rows {
+        grantees.push(AccountId::from_bytes(fixed(&row?)?));
+    }
+    Ok(grantees)
+}
+
 /// Whether `grantee_account_id` holds an effective (not-closed) Writer grant on a stream that
 /// resolves **`PublicRead`**. Unlike [`effective_writer_grant`], which answers "may this account
 /// write to THIS stream", this answers "is this account a public contributor at all" — the question
@@ -4614,6 +4640,54 @@ mod tests {
             error.to_string().contains("open grant unexpectedly has a persisted device cut"),
             "unexpected corrupt-projection error: {error:#}",
         );
+    }
+
+    #[test]
+    fn effective_writer_grantees_lists_open_writer_grants_only() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let writer = AccountId::from_bytes([0x44; 32]);
+        let reader = AccountId::from_bytes([0x55; 32]);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (stream_id, own_op) = stream_own(account_id);
+        let (own_bytes, own_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own_op);
+        account_ingest(&conn, &own_bytes, NOW + 1).unwrap();
+        let writer_op = AccountOp::StreamGrant {
+            stream_id,
+            grantee_account_id: writer,
+            grant_role: GrantRole::Writer,
+        };
+        let (writer_bytes, grant_id) =
+            op(account_id, &founder, 2, Some(own_hash), Some(genesis_hash), &writer_op);
+        account_ingest(&conn, &writer_bytes, NOW + 2).unwrap();
+        // A Reader never authors content, so it must not become a pull target.
+        let reader_op = AccountOp::StreamGrant {
+            stream_id,
+            grantee_account_id: reader,
+            grant_role: GrantRole::Reader,
+        };
+        let (reader_bytes, reader_hash) =
+            op(account_id, &founder, 3, Some(grant_id), Some(genesis_hash), &reader_op);
+        account_ingest(&conn, &reader_bytes, NOW + 3).unwrap();
+        assert_eq!(effective_writer_grantees(&conn, account_id).unwrap(), vec![writer]);
+
+        let revoke_op = AccountOp::StreamRevoke {
+            stream_id,
+            grantee_account_id: writer,
+            grant_id,
+            device_cuts: vec![DeviceCut {
+                device_fingerprint: Dev::new(2).fp,
+                seq: u64::MAX,
+                hash: [0x99; 32],
+            }],
+            reason: "access ended".to_string(),
+        };
+        let (revoke_bytes, _) =
+            op(account_id, &founder, 4, Some(reader_hash), Some(genesis_hash), &revoke_op);
+        account_ingest(&conn, &revoke_bytes, NOW + 4).unwrap();
+        assert!(effective_writer_grantees(&conn, account_id).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -115,7 +115,7 @@ pub use account::{
     content_op_is_authorable, content_op_is_sealed_authorable, content_signed_entry_exists,
     content_signed_hash, content_stream_has_pending_refold, content_stream_has_sealed_ratchet,
     content_stream_is_empty, current_sealing_key, decode_content_signed, effective_writer_grant,
-    enroll_stream_keys_for_device_in_tx, enrollment_authoring_fits,
+    effective_writer_grantees, enroll_stream_keys_for_device_in_tx, enrollment_authoring_fits,
     enrollment_authoring_requirements, enrollment_budget, ensure_owned_stream_v2_in_tx,
     ensure_owned_stream_v2_with_mode_in_tx, ensure_repo_incarnation,
     ensure_stream_key_current_in_tx, established_owned_stream_v2,

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -113,6 +113,16 @@ pub fn node_id_from_secret(secret_key: [u8; 32]) -> [u8; 32] {
     *SecretKey::from_bytes(&secret_key).public().as_bytes()
 }
 
+/// Parse a peer's node id from any supported spelling (64-char lowercase hex or standard base32)
+/// into its raw 32 bytes — the canonical comparison identity. Callers holding node-id STRINGS
+/// must compare through here, never literally: three distinct strings can name one node (see
+/// [`discover_peers`]), so a string comparison silently treats one peer as several.
+pub fn parse_node_id(node_id: &str) -> Result<[u8; 32], EndpointError> {
+    let id =
+        EndpointId::from_str(node_id.trim()).map_err(|e| EndpointError::PeerId(e.to_string()))?;
+    Ok(*id.as_bytes())
+}
+
 /// Build a dialable [`EndpointAddr`] from a peer's node id (the 64-char lowercase hex form
 /// `endpoint.id()` prints; standard base32 is also accepted) and the shared relay URL. The
 /// device-side sync driver configures server peers by node id and reaches each through the pinned

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -38,7 +38,8 @@ pub use endpoint::{
     accept_connection, accept_connection_within_rate, accept_enrollment, build_endpoint,
     connect_and_enroll, connect_and_reconcile, connect_and_sync, connect_and_table_reconcile,
     connect_and_table_sync, discover_peers, dispatch_connection, dispatch_connection_multi,
-    endpoint_addr, node_id_from_secret, node_id_to_string, peer_addr, peer_addr_from_bytes,
+    endpoint_addr, node_id_from_secret, node_id_to_string, parse_node_id, peer_addr,
+    peer_addr_from_bytes,
 };
 pub use enrollment::{
     ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -155,6 +155,14 @@ server_peers = ["<the node id `sync serve` printed>"]
 The trade is that a host you have not pinned becomes unreachable, so pin every host you intend to
 use — including any you add later.
 
+`server_peers` is also where cross-account hosts go: a contribution owner's host, or a
+contributor's. Discovery cannot find them — a foreign account's discovery tag derives from a
+secret only its own devices hold — so automatic cross-account sync dials only pinned peers. Once
+a pinned host answers for a foreign account, the device remembers which one and skips it during
+its own device sync (a host serves only its own account, so dialing it there could never
+succeed). Removing a host from `server_peers` stops all dialing to it, including remembered
+cross-account pulls.
+
 ## What each service learns
 
 - **The relay** forwards opaque encrypted QUIC traffic between peers.


### PR DESCRIPTION
Fixes #1175.

Automatic sync only ever synced the local account (`reconcile` built every store for it), so cross-account contribution (#1164) moved memories exclusively through the manual `sync pull` verb — the HEAD-change trigger, nudge, and resident election all fired, but synced the wrong set of accounts.

**What changes**

- Every reconcile pass (resident host and the no-resident hook fallback alike) now also pulls each foreign account this store depends on: the configured **contribution owner** of every contributing repo, and every effective **writer grantee** of the local account. Content is offered by its AUTHOR, so each direction of contribution needs the *other* side's account synced here.
- Foreign hosts are dialed from `[sync] server_peers` — discovery cannot stand in, because a foreign account's discovery tag derives from a secret only its own devices hold. The peer that answered for an account is remembered and tried first, so converged cycles dial one peer instead of re-probing (and re-warning about) every configured peer each pass. Per-account failures are warnings retried on the next cadence and never fail the device-sync pass.
- The per-peer pull loop — account log first, then the receive-capability / account-known / convergence gates, then content — moved from the CLI into core (`pull_account_via_peers`); both `sync pull` and the automatic pass call it, so the admission gates cannot drift between the two. The helper takes pre-resolved peer addresses; an invalid configured peer entry is skipped with the next one tried, as before.
- New oplog read `effective_writer_grantees` enumerates open Writer grants owner-leading over the existing `(owner, stream, grantee)` index. Reader grants never author and are excluded.
- User-facing copy that promised cross-account memories move only via `sync pull` now describes the automatic path, with `pull` as the escape hatch (one-off accounts, a peer automation doesn't know, or not wanting to wait a cadence).

**Verification**

- New wire test: a loopback pull through the shared helper lands a contributor's memory in the owner's `repo_memories` with no command involved.
- Unit tests: `foreign_pull_targets` covers both directions, dedupes, and excludes the local account; `effective_writer_grantees` lists open Writer grants only (Reader excluded, revoked closed).
- Gate: nightly fmt, all four CI clippy configs, `cargo nextest run --workspace` (5055 passed), `cargo test --workspace` (exit 0).