### PR TITLE
fix(base): make the test suite pass on windows-latest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Check text files out with LF everywhere, overriding the Windows runners' core.autocrlf=true.
+# Byte-identical checkouts are load-bearing: crates/rag-rat-db/src/schema/end_state.sql is
+# include_str!-embedded and compared byte-wise against ladder-generated DDL, so a CRLF checkout
+# fails `end_state_matches_the_ladder` on windows-latest.
+* text=auto eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5010,6 +5010,7 @@ dependencies = [
  "libc",
  "minicbor",
  "path-slash",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/rag-rat-base/Cargo.toml
+++ b/crates/rag-rat-base/Cargo.toml
@@ -20,6 +20,7 @@ gix.workspace = true
 globset.workspace = true
 libc.workspace = true
 path-slash.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/rag-rat-base/src/config/globs.rs
+++ b/crates/rag-rat-base/src/config/globs.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
 use globset::GlobBuilder;
-use regex::bytes::Regex;
+use regex::bytes::{Regex, RegexBuilder};
 
 /// Compiled matchers keyed by the pattern text, so a pattern is turned into a regex once per
 /// process instead of once per file.
@@ -97,12 +97,14 @@ fn compile(pattern: &str) -> Option<Regex> {
                 return None;
             },
         };
-    match Regex::new(glob.regex()) {
+    // `dot_matches_new_line` is a BUILDER flag in globset (not part of the emitted pattern), so it
+    // must be re-applied here or a file whose NAME contains a newline escapes every `**`.
+    match RegexBuilder::new(glob.regex()).dot_matches_new_line(true).build() {
         Ok(re) => Some(re),
         Err(error) => {
-            // globset guarantees its emitted regex is valid for the regex crate's bytes API, so
-            // this arm is unreachable short of a globset bug; claim nothing rather than panic.
-            tracing::warn!(pattern, %error, "compiled glob regex did not parse; it claims no files");
+            // The emitted pattern is always valid, but a huge (still legal) brace alternation can
+            // exceed the regex crate's compiled-size limit; claim nothing rather than panic.
+            tracing::warn!(pattern, %error, "glob regex did not compile; it claims no files");
             None
         },
     }
@@ -126,6 +128,14 @@ mod tests {
         // otherwise claim different files on Unix and Windows. Pinned ON: `\\` is one literal `\`.
         assert!(pattern_claims("drafts\\secret.md", "drafts\\\\secret.md"));
         assert!(!pattern_claims("drafts/secret.md", "drafts\\\\secret.md"));
+    }
+
+    #[test]
+    fn a_newline_in_a_name_does_not_escape_a_subtree_glob() {
+        // `**` compiles to `.*`; without `dot_matches_new_line` re-applied at regex build, a
+        // newline-bearing name would slip past every subtree exclude.
+        assert!(pattern_claims("src/a\nb.rs", "src/**"));
+        assert!(pattern_claims("src/a\nb.rs", "src/"));
     }
 
     #[test]

--- a/crates/rag-rat-base/src/config/globs.rs
+++ b/crates/rag-rat-base/src/config/globs.rs
@@ -19,20 +19,25 @@
 //!    Unix, *false* on Windows. Left unpinned, one `rag-rat.toml` would claim different files on
 //!    different platforms. Pinned on, `\` escapes the next character everywhere, so a pattern
 //!    reaches a Unix file whose NAME contains a backslash by spelling it `\\`.
-//! 3. **The candidate is built from the rendered BYTES**, never re-derived through a [`Path`]. The
-//!    caller already holds the `/`-separated rendering `files.path` is stored with
-//!    ([`crate::paths::path_string`]); round-tripping it through `Path` would re-run
-//!    platform-specific separator handling over a string that is already canonical.
+//! 3. **The match runs the compiled glob's regex over the rendered BYTES**, never through
+//!    [`globset`]'s `Candidate`. The caller already holds the `/`-separated rendering `files.path`
+//!    is stored with ([`crate::paths::path_string`]); `Candidate` re-runs platform-specific
+//!    separator handling over that already-canonical string (on Windows it rewrites `\` to `/`,
+//!    turning a Unix file NAMED `drafts\secret.md` into a child of `drafts/`), so one config would
+//!    again claim different files on different platforms. [`Glob::regex`] is `globset`'s documented
+//!    escape hatch for exactly this: the emitted pattern is built for the [`regex`] crate's bytes
+//!    API.
 //!
 //! One shape is normalized before compiling rather than pinned as an option: a trailing `/` names a
 //! subtree, so `src/` compiles as `src/**` (see [`compile`]).
 //!
-//! [`Path`]: std::path::Path
+//! [`Glob::regex`]: globset::Glob::regex
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
-use globset::{Candidate, GlobBuilder, GlobMatcher};
+use globset::GlobBuilder;
+use regex::bytes::Regex;
 
 /// Compiled matchers keyed by the pattern text, so a pattern is turned into a regex once per
 /// process instead of once per file.
@@ -42,7 +47,7 @@ use globset::{Candidate, GlobBuilder, GlobMatcher};
 /// must not sit on that path. The pattern set is bounded by the config file, so the map needs no
 /// eviction. A pattern that fails to compile is memoized as [`None`] — the compile error is
 /// reported once, not once per file.
-static COMPILED: LazyLock<RwLock<HashMap<String, Option<GlobMatcher>>>> =
+static COMPILED: LazyLock<RwLock<HashMap<String, Option<Regex>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Whether one config glob claims `path`, a `/`-separated repo-relative rendering.
@@ -51,17 +56,16 @@ static COMPILED: LazyLock<RwLock<HashMap<String, Option<GlobMatcher>>>> =
 /// reported once. Config load does not reject such a pattern today, so the matcher has to answer
 /// something; claiming nothing keeps a typo from silently widening an `include`.
 pub(crate) fn pattern_claims(path: &str, pattern: &str) -> bool {
-    let candidate = Candidate::from_bytes(path.as_bytes());
     let cached = COMPILED.read().ok().and_then(|compiled| {
         compiled
             .get(pattern)
-            .map(|matcher| matcher.as_ref().is_some_and(|m| m.is_match_candidate(&candidate)))
+            .map(|matcher| matcher.as_ref().is_some_and(|re| re.is_match(path.as_bytes())))
     });
     if let Some(claims) = cached {
         return claims;
     }
     let matcher = compile(pattern);
-    let claims = matcher.as_ref().is_some_and(|m| m.is_match_candidate(&candidate));
+    let claims = matcher.as_ref().is_some_and(|re| re.is_match(path.as_bytes()));
     if let Ok(mut compiled) = COMPILED.write() {
         compiled.entry(pattern.to_string()).or_insert(matcher);
     }
@@ -78,17 +82,27 @@ pub(crate) fn pattern_claims(path: &str, pattern: &str) -> bool {
 /// match `a/src/`). Here `src/` is the ROOT `src/`, matching what the old substring fallback got
 /// *approximately* right — it matched `src/` by containment, but also claimed `a/src/lib.rs`.
 /// Normalizing to `src/**` keeps the intent and adds the anchor the fallback lacked.
-fn compile(pattern: &str) -> Option<GlobMatcher> {
+fn compile(pattern: &str) -> Option<Regex> {
     let subtree = pattern.strip_suffix('/').map(|dir| format!("{dir}/**"));
     let pattern = subtree.as_deref().unwrap_or(pattern);
-    match GlobBuilder::new(pattern).literal_separator(true).backslash_escape(true).build() {
-        Ok(glob) => Some(glob.compile_matcher()),
+    let glob =
+        match GlobBuilder::new(pattern).literal_separator(true).backslash_escape(true).build() {
+            Ok(glob) => glob,
+            Err(error) => {
+                tracing::warn!(
+                    pattern,
+                    %error,
+                    "target include/exclude pattern is not a valid glob; it claims no files",
+                );
+                return None;
+            },
+        };
+    match Regex::new(glob.regex()) {
+        Ok(re) => Some(re),
         Err(error) => {
-            tracing::warn!(
-                pattern,
-                %error,
-                "target include/exclude pattern is not a valid glob; it claims no files",
-            );
+            // globset guarantees its emitted regex is valid for the regex crate's bytes API, so
+            // this arm is unreachable short of a globset bug; claim nothing rather than panic.
+            tracing::warn!(pattern, %error, "compiled glob regex did not parse; it claims no files");
             None
         },
     }

--- a/crates/rag-rat-base/src/test_git.rs
+++ b/crates/rag-rat-base/src/test_git.rs
@@ -116,18 +116,19 @@ mod tests {
         std::fs::create_dir_all(&hooks).unwrap();
         let marker = root.join("hook-ran.marker");
         let pre_commit = hooks.join("pre-commit");
-        std::fs::write(&pre_commit, format!("#!/bin/sh\ntouch '{}'\nexit 1\n", marker.display()))
+        // Forward-slash the paths handed to git: a `\` in a gitconfig VALUE is an escape character
+        // (git rejects `C:\Users\…` as a bad config line, the commit dies before the hook runs),
+        // and the hook body runs under sh, where a Windows path only survives spelled with `/`.
+        let slash = |p: &Path| crate::paths::path_string(p);
+        std::fs::write(&pre_commit, format!("#!/bin/sh\ntouch '{}'\nexit 1\n", slash(&marker)))
             .unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&pre_commit, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        std::fs::write(
-            root.join("gitconfig"),
-            format!("[core]\nhooksPath = {}\n", hooks.display()),
-        )
-        .unwrap();
+        std::fs::write(root.join("gitconfig"), format!("[core]\nhooksPath = {}\n", slash(&hooks)))
+            .unwrap();
         run(&root, &["init", "-q"]);
         std::fs::write(root.join("f.txt"), "x\n").unwrap();
         run(&root, &["add", "."]);


### PR DESCRIPTION
Fixes #1191.

The v0.23.0 tag's cross-platform run failed on `test (windows-latest)` with three independent failure groups; each gets its root-cause fix:

**Glob matching lost literal backslashes on Windows.** `config::globs::pattern_claims` matched through `globset::Candidate`, whose `normalize_path` rewrites `\` to `/` on Windows — silently undoing the pinned `backslash_escape(true)` semantics, so one config would claim different files on different platforms (a Unix file *named* `drafts\secret.md` became a child of `drafts/`). The matcher now compiles the glob to its regex (`Glob::regex()`, globset's documented escape hatch for byte-level matching) and runs it over the raw `/`-separated rendering. On Unix the candidate normalization was already the identity, so behavior there is unchanged; the memo map and illegal-pattern handling are untouched.

**`test_git::the_ambient_failure_mode_is_real`** wrote Windows paths (`C:\Users\…`) into a gitconfig value and an sh hook body. A `\` in a gitconfig value is an escape character, so git rejected the config as a bad line and the commit died *before* the hostile hook ran, failing the marker assertion. The repro now renders both paths with forward slashes via `paths::path_string`.

**`schema::end_state::end_state_matches_the_ladder`**: the Windows runner's `core.autocrlf=true` checked out `end_state.sql` with CRLF, `include_str!` embedded it, and the provisioned DDL then differed from the ladder-generated DDL by `\r` alone — the `line counts differ: 2237 vs 2237` panic, since `lines()` strips `\r`. A repo-wide `.gitattributes` (`* text=auto eol=lf`) pins byte-identical checkouts; no committed file carried CRLF, so the renormalization is a no-op for existing content.

Verified: full workspace suite (`cargo nextest run --workspace --no-default-features --locked --profile ci`, 5058 passed) and both CI clippy legs green on Linux; a manual `ci-cross-platform.yml` dispatch on this branch is validating windows-latest/macos-latest.