### PR TITLE
fix(query): return oracle-resolved callers and report unresolved honestly

### DIFF
--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -1485,6 +1485,13 @@ pub(crate) fn edge_oracle_current_predicate() -> String {
 /// spelling of the gate rather than re-deriving it. The inner `symbols`/`files` names shadow any
 /// outer join of the same tables (SQLite resolves the subquery scope first), exactly as when
 /// appended after [`edge_oracle_scope_join`].
+///
+/// A second consumer lives outside this crate: the reverse-traversal seed arm in
+/// `rag_rat_query::graph::predicates` admits edges by their verdict's `resolved_symbol_id`, and
+/// reaches the same def-drift gate by routing its seed subqueries through the connection's scoped
+/// `files` view instead of embedding this predicate. Seeding a verdict this gate would refuse
+/// asserts a caller the display path then declines to show — so a change to what counts as current
+/// here belongs there too.
 pub(crate) fn edge_oracle_def_current_predicate(commit_slot: &str, worktree_slot: &str) -> String {
     format!(
         " AND (edge_oracle.resolved_symbol_id IS NULL OR EXISTS (SELECT 1 FROM symbols JOIN files \

--- a/crates/rag-rat-oracle/src/tests/edge_view.rs
+++ b/crates/rag-rat-oracle/src/tests/edge_view.rs
@@ -251,7 +251,10 @@ fn graph_traversal_seed_predicates_use_edge_id_indexes() {
         .unwrap();
     assert_eq!(idx_count, 1, "V071 idx_edges_target_qname on edges_data");
 
-    // Reverse (find_callers) Syntactic seed shape — mirror of predicates::reverse_predicate.
+    // Reverse (find_callers) Syntactic seed shape — mirror of predicates::reverse_predicate. The
+    // trailing `id IN (...)` arm is the oracle-seeded rowid list that predicate splices in
+    // whenever a verdict names the seed: an uncorrelated rowid list, so it joins the multi-index OR
+    // as another INTEGER PRIMARY KEY lookup rather than defeating it (#1197).
     let reverse = plan(
         "SELECT id FROM edges
          WHERE edge_kind IN ('calls_name', 'constructs')
@@ -260,7 +263,8 @@ fn graph_traversal_seed_predicates_use_edge_id_indexes() {
                    SELECT id FROM symbols
                    WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x'))
                 OR ('true' = 'true' AND to_symbol_id IN (SELECT id FROM symbols WHERE name = 'y'))
-                OR target_qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x'))",
+                OR target_qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x')
+                OR id IN (11, 22, 33))",
     );
     assert!(
         reverse.contains("idx_edges_to_symbol"),

--- a/crates/rag-rat-query/src/graph/mod.rs
+++ b/crates/rag-rat-query/src/graph/mod.rs
@@ -1,4 +1,6 @@
 mod predicates;
+#[cfg(test)]
+mod tests;
 mod traverse;
 use std::collections::BTreeSet;
 
@@ -99,6 +101,12 @@ pub struct GraphTraversalSummary {
     pub syntactic: u64,
     pub name_only: u64,
     pub ambiguous: u64,
+    /// Matching edges the COMPILER bound to this symbol while the heuristic left `to_symbol_id`
+    /// NULL — the oracle-seeded reverse rows, which the read-side enrichment promotes to the
+    /// `compiler` tier. Counted here rather than under `unresolved` / the confidence buckets,
+    /// which report what tree-sitter alone concluded. Always 0 for a forward traversal, which has
+    /// no oracle seed.
+    pub compiler_verified: u64,
     pub unresolved: u64,
     pub false_positive_risk: String,
     pub completeness_risk: String,

--- a/crates/rag-rat-query/src/graph/predicates.rs
+++ b/crates/rag-rat-query/src/graph/predicates.rs
@@ -39,23 +39,31 @@ pub(crate) fn traversal_params(
     symbol: &str,
     limit: u32,
     edge_kinds: &[String],
-    symbol_id: Option<i64>,
-    logical_symbol_id: Option<i64>,
+    options: &GraphTraversalOptions,
     unique_short_name: bool,
 ) -> Vec<String> {
     let qualified = symbol.to_string();
     let short = short_name(symbol).to_string();
     let fuzzy_qualified = format!("%::{qualified}");
-    let allow_name_fallback = (!is_qualified_symbol(symbol)).to_string();
+    // `?4` gates the by-SHORT-NAME arms, and those live ONLY in the `Fuzzy` predicate and tier —
+    // no `Exact` or `Syntactic` arm reads this slot. Deriving it from the seed's SHAPE alone
+    // therefore switched the arm off for every path-qualified seed, which is every symbol a tool
+    // selects, so `resolution: "fuzzy"` was indistinguishable from `syntactic` in reverse (#1199).
+    // Fuzzy is the caller explicitly asking for the loosest match, so the seed's shape must not
+    // veto it; a name-only caller stays legible because that arm scores `match_tier` 2 and
+    // `resolution_label` reports it as `target_name_fallback`.
+    let allow_name_fallback = (options.resolution_mode == GraphResolutionMode::Fuzzy
+        || !is_qualified_symbol(symbol))
+    .to_string();
     let mut params = vec![
         qualified,
         fuzzy_qualified,
         short,
         allow_name_fallback,
         limit.to_string(),
-        symbol_id.unwrap_or(-1).to_string(),
+        options.symbol_id.unwrap_or(-1).to_string(),
         unique_short_name.to_string(),
-        logical_symbol_id.unwrap_or(-1).to_string(),
+        options.logical_symbol_id.unwrap_or(-1).to_string(),
     ];
     params.extend(edge_kinds.iter().cloned());
     params
@@ -63,16 +71,202 @@ pub(crate) fn traversal_params(
 pub(crate) fn quoted_placeholders(count: usize) -> String {
     (0..count).map(|index| format!("?{}", index + 9)).collect::<Vec<_>>().join(", ")
 }
-pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'static str {
+/// Ceiling on how many oracle-seeded edges [`reverse_oracle_seeded_edge_ids`] splices into one
+/// reverse predicate. Matches the ceiling `oracle_overfetch_limit` puts on the candidate window,
+/// so a pathological fan-in cannot materialize an unbounded literal list; the residual beyond it
+/// is the same accepted loss as an edge upgraded beyond the overfetch window.
+///
+/// The query carries an `ORDER BY edges.id` so which rows the cap keeps is a property of the DATA,
+/// not of the plan SQLite happened to pick — a repeat execution against an unchanged index keeps
+/// the same subset. `traversal_summary` computes the set ONCE and feeds it to both its own
+/// queries, so its promise not to count a seeded caller as a hidden unresolved candidate holds
+/// whatever the cap dropped. `traverse_with_options` executes separately, on a read connection
+/// with no transaction spanning the pair, so a reindex landing between the two can leave the
+/// returned hops and the summary describing marginally different populations — self-correcting on
+/// the next call.
+const ORACLE_SEED_EDGE_CAP: usize = 5000;
+
+/// The live `edges.id` values the COMPILER binds to a reverse traversal's seed — the rows the
+/// heuristic arms structurally cannot reach.
+///
+/// A `calls_name` the resolver could not bind carries `to_symbol_id IS NULL` and, as its only
+/// attribution, the callee name AS WRITTEN AT THE CALL SITE (`h::add_logical_symbol` for a
+/// `h.add_logical_symbol(..)` method call). That is a receiver-qualified name, never the
+/// definition's file-path qualified name, so the unresolved arm of [`reverse_predicate`] cannot
+/// match it and the caller is invisible — even when `edge_oracle` already holds a compiler verdict
+/// naming the seed exactly. Oracle enrichment runs AFTER this SQL and only rewrites rows the query
+/// already returned, so SEEDING is the only point at which a verdict can ADD a caller (#1197).
+///
+/// ATTRIBUTION is the verdict's `resolved_symbol_id` matched against the SAME seed set the
+/// heuristic arms use — logical membership when the traversal carries a logical id, else the seed
+/// symbol plus its qualified-name TWINS, exactly the expansion [`reverse_predicate`]'s `Exact` arm
+/// applies to `to_symbol_id`. A same-qualified-name sibling therefore CAN satisfy the non-logical
+/// arm; that arm is no tighter than the twin set, and the claim to check against is only that the
+/// arm never attributes on the target name AS WRITTEN — the attribution that lets an unrelated
+/// `h::target` call site land here. Every overload the index groups carries a logical symbol, and
+/// on that path membership decides alone.
+///
+/// CURRENCY must admit no row the display path then refuses: the read-side enrichment
+/// (`rag_rat_oracle::store`'s surfacing predicates) would decline to promote it, leaving a caller
+/// asserted with no visible evidence and — because the oracle tier sorts first — displacing
+/// genuine matches under the caller's `LIMIT`. The three gates it applies are mirrored here: the
+/// verdict belongs to the LATEST run of its tool in the active checkout; its callsite file still
+/// hashes to `file_sha` and joins a live edge by the six-column content key; and its
+/// `resolved_symbol_id` is still LIVE IN THIS CHECKOUT. The last gate is why BOTH seed subqueries
+/// join the scoped `files` view instead of reading `symbols` / `logical_symbol_members` raw — edit
+/// the file that DEFINES the seed and the pre-edit `symbols` row survives, shadowed by the
+/// worktree overlay but still carrying the qualified name the twin arm matches, and still the
+/// `resolved_symbol_id` the verdict points at. Only `Upgrade`/`Confirm` count — a `Contradict` is a
+/// disagreement we do not act on, and a `ResolvedExternal` has no `resolved_symbol_id` to match.
+/// `edges.to_symbol_id` is never written back; only which rows the reverse query may seed from
+/// changes.
+///
+/// CROSS-TOOL ARBITRATION IS THE GATE THIS DOES NOT MIRROR. The display path merges the tools in
+/// AUTHORITY order and keeps the FIRST writer per edge, so exactly one tool's verdict decides an
+/// edge; this query takes the UNION over every tool with a current run. The two agree while a
+/// single backend is in play. With two — a canonical batch tool beside a live LSP patch tool
+/// covering the same Rust edges — a LOSING tool's `upgrade` can seed an edge whose winning verdict
+/// is a `contradict` (the hop returns at oracle tier carrying no compiler evidence) or an upgrade
+/// naming a DIFFERENT symbol (the hop returns labelled `compiler` under a seed it does not call).
+/// Arbitrating here needs the per-tool authority ranking, which lives in `rag-rat-oracle`; closing
+/// the gap means moving this seed behind that crate, not adding a fourth spelling of a table this
+/// crate cannot see (#1215).
+///
+/// SCOPE is reverse `traverse_with_options` / `traversal_summary` — which is also what the
+/// SYMBOL-SELECTED `impact_surface` report traverses (`impact_surface_report_for_symbol` →
+/// `oracle_ranked_neighbors`), so its `direct_semantic_callers` carry the seeded rows too. The FLAT
+/// `Vec<ImpactItem>` lane — a free-text query, or the `allow_ambiguous` fallback — instead runs
+/// `impact::neighbors::graph_neighbors`, whose own reverse predicate has no oracle arm and which
+/// gets no enrichment pass either, so that lane still answers the pre-seed caller count (#1214).
+pub(crate) fn reverse_oracle_seeded_edge_ids(
+    conn: &Connection,
+    symbol: &str,
+    options: &GraphTraversalOptions,
+) -> anyhow::Result<Vec<i64>> {
+    // `Exact` is the caller asking for heuristic-verified targets only; an unresolved edge has no
+    // place in it regardless of what the compiler concluded.
+    if options.resolution_mode == GraphResolutionMode::Exact {
+        return Ok(Vec::new());
+    }
+    let (Some(commit_sha), Some(worktree_id)) = (
+        rag_rat_db::schema::connection_context_value(conn, "commit_sha"),
+        rag_rat_db::schema::connection_context_value(conn, "worktree_id"),
+    ) else {
+        // No scope context at all (a raw connection) — there is no checkout to key a run on.
+        return Ok(Vec::new());
+    };
+    // EMPTY-EMPTY IS THE BARE OPEN, not a checkout. `IndexDatabase::open` (the MCP database read
+    // path, `doctor`, tests) writes BOTH context keys as `''` and serves a `files` view spanning
+    // every commit and worktree of the repo. Keying runs on that pair would pair a repo-wide
+    // callsite population with `oracle_runs.commit_sha = '' AND worktree_id = ''`, so a run ever
+    // recorded under an empty checkout key would seed across every checkout in the DB. Only the
+    // PAIR is disqualifying: a non-git index has an empty `commit_sha` beside a real
+    // `worktree_id`, and its runs are legitimately keyed on that.
+    if commit_sha.is_empty() && worktree_id.is_empty() {
+        return Ok(Vec::new());
+    }
+    let scope = rag_rat_db::schema::periphery_repo_scope(conn, "oracle_runs")?;
+    // The seed set: logical membership when the traversal has a logical id (the same attribution
+    // rule the logical arms use), else the seed symbol itself plus its qualified-name twins. Both
+    // forms resolve their symbols THROUGH the scoped `files` view — see CURRENCY above: the raw
+    // `symbols` / `logical_symbol_members` tables still hold the shadowed rows of a re-indexed
+    // definition, and a verdict pointing at one of those is a verdict the display path refuses.
+    let seed = if options.logical_symbol_id.is_some() {
+        "edge_oracle.resolved_symbol_id IN (
+            SELECT members.symbol_id
+            FROM logical_symbol_members members
+            JOIN symbols ON symbols.id = members.symbol_id
+            JOIN files ON files.id = symbols.file_id
+            WHERE members.logical_symbol_id = ?4
+         )"
+    } else {
+        "edge_oracle.resolved_symbol_id IN (
+            SELECT symbols.id
+            FROM symbols
+            JOIN files ON files.id = symbols.file_id
+            WHERE symbols.id = ?4
+               OR symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?3)
+         )"
+    };
+    // SECOND SPELLING (invariant): the run-currency and content-key gates below say the same thing
+    // as `rag_rat_oracle::store`'s `edge_oracle_scope_join` + `edge_oracle_current_predicate` +
+    // `edge_oracle_def_current_predicate`, which is what the read-side enrichment applies. They are
+    // separate SQL because this crate does not depend on `rag-rat-oracle` and because the gates
+    // there are written against the RAW `files` table with explicit commit/worktree bind slots,
+    // while every join here goes through the connection's scoped `files` view. Change one and the
+    // other must move with it, or this query seeds callers enrichment then declines to promote.
+    let sql = format!(
+        "
+        SELECT edges.id
+        FROM edge_oracle
+        JOIN oracle_runs ON oracle_runs.tool = edge_oracle.tool
+                        AND oracle_runs.tool_version = edge_oracle.tool_version
+                        AND oracle_runs.commit_sha = ?1
+                        AND oracle_runs.worktree_id = ?2{runs_repo}
+                        AND oracle_runs.id = (
+                            SELECT MAX(latest.id) FROM oracle_runs latest
+                            WHERE latest.tool = edge_oracle.tool
+                              AND latest.commit_sha = ?1
+                              AND latest.worktree_id = ?2{latest_repo}
+                        )
+        JOIN files ON files.path = edge_oracle.source_path
+                  AND files.sha256 = edge_oracle.file_sha
+        JOIN edges ON edges.source_file_id = files.id
+                  AND edges.source_start_byte = edge_oracle.source_start_byte
+                  AND edges.source_end_byte = edge_oracle.source_end_byte
+                  AND edges.callee_start_byte = edge_oracle.callee_start_byte
+                  AND edges.callee_end_byte = edge_oracle.callee_end_byte
+                  AND edges.edge_kind = edge_oracle.edge_kind
+        WHERE edge_oracle.kind IN ('upgrade', 'confirm')
+          AND {seed}{verdict_repo}
+        ORDER BY edges.id
+        LIMIT {ORACLE_SEED_EDGE_CAP}
+        ",
+        runs_repo = rag_rat_db::schema::periphery_repo_scope_clause(&scope, "oracle_runs"),
+        latest_repo = rag_rat_db::schema::periphery_repo_scope_clause(&scope, "latest"),
+        verdict_repo = rag_rat_db::schema::periphery_repo_scope_clause(&scope, "edge_oracle"),
+    );
+    let seed_id = options.logical_symbol_id.or(options.symbol_id).unwrap_or(-1);
+    let mut stmt = conn.prepare(&sql)?;
+    let ids = stmt
+        .query_map(rusqlite::params![commit_sha, worktree_id, symbol, seed_id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<i64>>>()?;
+    Ok(ids)
+}
+
+/// [`reverse_oracle_seeded_edge_ids`] as a rowid `IN` list, or `None` when the oracle has nothing
+/// to add — the case in every repo without an oracle run, where the traversal SQL is then byte-for-
+/// byte what it was before.
+///
+/// The ids are SPLICED, not bound: they are `i64`s read straight back out of SQLite, and an
+/// uncorrelated rowid `IN` list is what lets the planner keep driving the multi-index OR over the
+/// other seed arms. Binding them instead would push the edge-kind placeholders (`?9`…) around for
+/// every caller.
+pub(crate) fn oracle_seed_in_list(edge_ids: &[i64]) -> Option<String> {
+    if edge_ids.is_empty() {
+        return None;
+    }
+    let ids = edge_ids.iter().map(i64::to_string).collect::<Vec<_>>().join(", ");
+    Some(format!("edges.id IN ({ids})"))
+}
+
+pub(crate) fn reverse_predicate(
+    mode: GraphResolutionMode,
+    logical: bool,
+    oracle_edge_ids: &[i64],
+) -> String {
+    let oracle_arm = oracle_seed_in_list(oracle_edge_ids)
+        .map(|list| format!("\n                 OR {list}"))
+        .unwrap_or_default();
     if logical {
         return match mode {
-            GraphResolutionMode::Exact =>
-                "edges.to_symbol_id IS NOT NULL
+            GraphResolutionMode::Exact => "edges.to_symbol_id IS NOT NULL
                  AND edges.to_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
-                 )",
+                 )"
+            .to_string(),
             // LOGICAL ATTRIBUTION RULE (mirrored in `forward_source_predicate`): a RESOLVED
             // endpoint is attributed by logical membership ALONE. The name arm applies only where
             // `to_symbol_id IS NULL` — an edge the resolver could not bind, whose recorded target
@@ -82,8 +276,11 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
             // overload collapse the logical seed exists to end (#1028). Dropping the arm entirely
             // is the opposite error: this SQL runs BEFORE the read-side oracle enrichment, which
             // rewrites hops in memory and never touches the `edges` row — so an unresolved edge
-            // refused here is one no compiler verdict can put back, in any later run.
-            GraphResolutionMode::Syntactic =>
+            // refused here is one no compiler verdict can put back, in any later run. That is why
+            // the oracle arm seeds by VERDICT here rather than leaving recovery to enrichment; it
+            // attributes on `resolved_symbol_id`, so it admits none of the sibling collapse the
+            // name arm is gated against.
+            GraphResolutionMode::Syntactic => format!(
                 "(edges.to_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
@@ -91,8 +288,9 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
                   )
                   OR (edges.to_symbol_id IS NULL
                       AND edges.target_qualified_name_id =
-                            (SELECT id FROM name_strings WHERE value = ?1)))",
-            GraphResolutionMode::Fuzzy =>
+                            (SELECT id FROM name_strings WHERE value = ?1)){oracle_arm})"
+            ),
+            GraphResolutionMode::Fuzzy => format!(
                 "edges.to_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
@@ -104,7 +302,8 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
                  OR edges.target_qualified_name = ?1
                  OR edges.target_qualified_name LIKE ?2
                  OR (?4 = 'true' AND edges.to_name_id =
-                        (SELECT id FROM name_strings WHERE value = ?3))",
+                        (SELECT id FROM name_strings WHERE value = ?3)){oracle_arm}"
+            ),
         };
     }
     // #682 INDEXED-SEED CONTRACT: the Exact/Syntactic seed branches compare the `edges` view's raw
@@ -118,47 +317,63 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
     // those whose to-symbol has that short name. Fuzzy keeps the `LIKE` forms (opt-in,
     // inherently non-sargable). See the raw-id note in `ensure_edges_view`.
     match mode {
-        GraphResolutionMode::Exact =>
-            "edges.to_symbol_id IS NOT NULL
+        GraphResolutionMode::Exact => "edges.to_symbol_id IS NOT NULL
              AND (edges.to_symbol_id = ?6
                   OR edges.to_symbol_id IN (
                      SELECT id FROM symbols
-                     WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)))",
-        GraphResolutionMode::Syntactic =>
+                     WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)))"
+            .to_string(),
+        GraphResolutionMode::Syntactic => format!(
             "(edges.to_symbol_id = ?6
               OR edges.to_symbol_id IN (
                  SELECT id FROM symbols
                  WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1))
               OR (?7 = 'true' AND edges.to_symbol_id IN (
                  SELECT id FROM symbols WHERE name = ?3))
-              OR edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1))",
-        GraphResolutionMode::Fuzzy =>
+              OR edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = \
+             ?1){oracle_arm})"
+        ),
+        GraphResolutionMode::Fuzzy => format!(
             "to_symbols.name = ?3
              OR to_qn.value = ?1
              OR to_qn.value LIKE ?2
              OR edges.target_qualified_name = ?1
              OR edges.target_qualified_name LIKE ?2
              OR (?4 = 'true' AND edges.to_name_id =
-                    (SELECT id FROM name_strings WHERE value = ?3))",
+                    (SELECT id FROM name_strings WHERE value = ?3)){oracle_arm}"
+        ),
     }
 }
-pub(crate) fn reverse_tier(mode: GraphResolutionMode) -> &'static str {
+/// `match_tier`, the traversal's PRIMARY sort key — and therefore what survives the caller's
+/// `LIMIT`.
+///
+/// The oracle clause sits LAST, after the heuristic arms: a seeded edge that also matches one of
+/// them keeps the label that arm earned it (`resolution_label` reads this tier), while one no
+/// heuristic arm can explain is scored 0 rather than falling to the `ELSE` bucket. Leaving it in
+/// `ELSE` would rank compiler-attributed callers BELOW every name guess and let the overfetch
+/// window truncate exactly the rows the seeding was added to recover.
+pub(crate) fn reverse_tier(mode: GraphResolutionMode, oracle_edge_ids: &[i64]) -> String {
+    let oracle_tier = oracle_seed_in_list(oracle_edge_ids)
+        .map(|list| format!("\n                WHEN {list} THEN 0"))
+        .unwrap_or_default();
     match mode {
-        GraphResolutionMode::Exact => "0",
-        GraphResolutionMode::Syntactic =>
+        GraphResolutionMode::Exact => "0".to_string(),
+        GraphResolutionMode::Syntactic => format!(
             "CASE
                 WHEN edges.to_symbol_id IS NOT NULL THEN 0
-                WHEN edges.target_qualified_name = ?1 THEN 1
+                WHEN edges.target_qualified_name = ?1 THEN 1{oracle_tier}
                 ELSE 4
-             END",
-        GraphResolutionMode::Fuzzy =>
+             END"
+        ),
+        GraphResolutionMode::Fuzzy => format!(
             "CASE
                 WHEN edges.to_symbol_id IS NOT NULL THEN 0
                 WHEN edges.target_qualified_name = ?1 OR edges.target_qualified_name LIKE ?2 THEN 1
                 WHEN ?4 = 'true' AND edges.to_name_id =
-                    (SELECT id FROM name_strings WHERE value = ?3) THEN 2
+                    (SELECT id FROM name_strings WHERE value = ?3) THEN 2{oracle_tier}
                 ELSE 4
-             END",
+             END"
+        ),
     }
 }
 pub(crate) fn forward_source_predicate(mode: GraphResolutionMode, logical: bool) -> &'static str {
@@ -399,6 +614,56 @@ pub fn unique_symbol_name(conn: &Connection, name: &str) -> anyhow::Result<bool>
         |row| row.get("symbol_count"),
     )?;
     Ok(count == 1)
+}
+/// Whether an unresolved call site's callee short name, as WRITTEN, can only have meant this seed.
+///
+/// The seed's own definitions are not rivals for its name. A `#[cfg]`-split pair, or any overload
+/// group, puts several `symbols` rows under one short name while naming ONE callable — so
+/// [`unique_symbol_name`], which counts every scoped row of that name, reads such a seed as
+/// ambiguous and a caller that gates on it gives up on exactly the symbols whose call sites the
+/// resolver is likeliest to have left unbound. The honest question is whether any symbol OUTSIDE
+/// the seed carries the name: logical membership when the traversal has a logical id, else the seed
+/// symbol plus its qualified-name twins — the same seed set [`reverse_predicate`] expands.
+///
+/// A shared name (`get`, `new`) still answers false, since the rival definitions sit outside the
+/// seed by construction.
+///
+/// GENERATION-SCOPED via the `files` view, for the reason spelled out on [`unique_symbol_name`].
+pub(crate) fn short_name_identifies_seed_alone(
+    conn: &Connection,
+    symbol: &str,
+    options: &GraphTraversalOptions,
+) -> anyhow::Result<bool> {
+    let outside_seed = if options.logical_symbol_id.is_some() {
+        "symbols.id NOT IN (
+            SELECT symbol_id FROM logical_symbol_members WHERE logical_symbol_id = ?2
+         )"
+    } else {
+        // `IS NOT` is SQLite's null-safe inequality: a symbol with no interned qualified name, or a
+        // seed name absent from the pool, must still count as outside the seed rather than vanish.
+        "symbols.id != ?2
+         AND symbols.qualified_name_id IS NOT (SELECT id FROM name_strings WHERE value = ?3)"
+    };
+    // Bound per branch: the logical arm never mentions `?3`, and SQLite counts a statement's
+    // parameters by the highest index it references, so passing the seed name there is rejected.
+    let seed_id = options.logical_symbol_id.or(options.symbol_id).unwrap_or(-1);
+    let mut params = vec![
+        rusqlite::types::Value::from(short_name(symbol).to_string()),
+        rusqlite::types::Value::from(seed_id),
+    ];
+    if options.logical_symbol_id.is_none() {
+        params.push(rusqlite::types::Value::from(symbol.to_string()));
+    }
+    let outside_seed_count: i64 = conn.query_row(
+        &format!(
+            "SELECT COUNT(*) AS outside_seed_count FROM symbols
+             JOIN files ON files.id = symbols.file_id
+             WHERE symbols.name = ?1 AND ({outside_seed})"
+        ),
+        params_from_iter(params),
+        |row| row.get("outside_seed_count"),
+    )?;
+    Ok(outside_seed_count == 0)
 }
 /// How many active-scope symbols a NAME seed expands to under the `Syntactic` predicates above.
 ///

--- a/crates/rag-rat-query/src/graph/tests.rs
+++ b/crates/rag-rat-query/src/graph/tests.rs
@@ -1,0 +1,468 @@
+//! Reverse-traversal (`find_callers`) recall and completeness-honesty coverage.
+//!
+//! The fixtures here all reproduce the same real shape: a method call the resolver could not bind,
+//! whose recorded target name is RECEIVER-qualified (`h::target`) and therefore matches no
+//! definition's file-path qualified name. That is the population `summary.unresolved` has to
+//! confess to (#1198), the population a compiler verdict can recover (#1197), and the population
+//! `resolution: "fuzzy"` is supposed to reach by short name (#1199).
+
+use rag_rat_core::index::install_scope_view;
+use rag_rat_db::schema;
+use rusqlite::{Connection, params};
+
+use super::*;
+
+const COMMIT: &str = "c0ffee";
+const TOOL: &str = "rust-analyzer";
+const TOOL_VERSION: &str = "ra 1.0";
+
+fn scoped_conn() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &rag_rat_core::index::migration_hooks()).unwrap();
+    conn
+}
+
+/// A committed file row (`(commit_sha, '')` — the clean-checkout scope).
+fn add_file(conn: &Connection, path: &str, sha: &str) -> i64 {
+    add_scoped_file(conn, path, sha, COMMIT, "")
+}
+
+/// A file row in an explicit scope. Production rows carry EITHER `(commit_sha, '')` OR
+/// `('', worktree_id)`, never both; the scope view lets the worktree row SHADOW the committed row
+/// of the same path, which is how a re-indexed definition leaves its pre-edit `symbols` rows
+/// present-but-invisible.
+fn add_scoped_file(
+    conn: &Connection,
+    path: &str,
+    sha: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                           commit_sha, worktree_id)
+         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, ?4)",
+        params![path, sha, commit_sha, worktree_id],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn add_symbol(conn: &Connection, file_id: i64, name: &str, qualified: &str) -> i64 {
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
+                             end_byte, signature, docs)
+         VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3),
+                 'function', 0, 10, NULL, NULL)",
+        params![file_id, name, qualified],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+/// One logical symbol over `members` — the grouping that makes a `#[cfg]`-split pair, or an
+/// overload set, ONE callable with several `symbols` rows.
+fn add_logical_symbol(conn: &Connection, qualified: &str, members: &[i64]) -> i64 {
+    conn.execute(
+        "INSERT INTO logical_symbols(language, path, logical_name, qualified_name_id, kind,
+                                     variant_count, group_reason)
+         VALUES ('rust', 'a.rs', ?1, (SELECT id FROM name_strings WHERE value = ?2),
+                 'function', ?3, 'test')",
+        params![short_name(qualified), qualified, i64::try_from(members.len()).unwrap()],
+    )
+    .unwrap();
+    let logical_symbol_id = conn.last_insert_rowid();
+    for symbol_id in members {
+        conn.execute(
+            "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, \
+             end_line)
+             VALUES (?1, ?2, 1, 2)",
+            params![logical_symbol_id, symbol_id],
+        )
+        .unwrap();
+    }
+    logical_symbol_id
+}
+
+/// A `calls_name` edge with a distinct call-site byte span (the oracle content key). `to_symbol_id`
+/// NULL is the unresolved case; `target_qualified_name` is what the extractor WROTE at the call
+/// site, which for a method call is receiver-qualified.
+fn add_call(
+    conn: &Connection,
+    file_id: i64,
+    from: i64,
+    to: Option<i64>,
+    to_name: &str,
+    target_qualified_name: &str,
+    span: i64,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                           target_qualified_name, edge_kind, confidence,
+                           source_start_byte, source_end_byte,
+                           callee_start_byte, callee_end_byte)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'calls_name', ?6, ?7, ?8, ?7, ?8)",
+        params![
+            file_id,
+            from,
+            to,
+            to_name,
+            target_qualified_name,
+            if to.is_some() { "Exact" } else { "NameOnly" },
+            span,
+            span + 5,
+        ],
+    )
+    .unwrap();
+    conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap()
+}
+
+/// One completed oracle run in a checkout. Insert order is significant: the latest-run gate keys on
+/// `MAX(oracle_runs.id)`, so a superseded run must be inserted BEFORE the run that supersedes it.
+fn add_oracle_run(conn: &Connection, tool_version: &str, worktree_id: &str) {
+    conn.execute(
+        "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, status)
+         VALUES (?1, ?2, ?3, ?4, 0, 'ok')",
+        params![TOOL, tool_version, COMMIT, worktree_id],
+    )
+    .unwrap();
+}
+
+/// An `upgrade` verdict binding the edge at `span` in `path`/`sha` to `resolved_symbol_id`.
+fn add_upgrade_verdict(
+    conn: &Connection,
+    path: &str,
+    sha: &str,
+    span: i64,
+    resolved_symbol_id: i64,
+    tool_version: &str,
+) {
+    conn.execute(
+        "INSERT INTO edge_oracle(source_path, source_start_byte, source_end_byte,
+                                 callee_start_byte, callee_end_byte, edge_kind, file_sha,
+                                 tool, tool_version, resolved_symbol_id, scip_symbol, kind,
+                                 computed_at)
+         VALUES (?1, ?2, ?3, ?2, ?3, 'calls_name', ?4, ?5, ?6, ?7, 'scip x', 'upgrade', 0)",
+        params![path, span, span + 5, sha, TOOL, tool_version, resolved_symbol_id],
+    )
+    .unwrap();
+}
+
+fn syntactic(symbol_id: i64) -> GraphTraversalOptions {
+    GraphTraversalOptions { symbol_id: Some(symbol_id), ..GraphTraversalOptions::default() }
+}
+
+fn callers(conn: &Connection, symbol: &str, options: &GraphTraversalOptions) -> Vec<GraphHop> {
+    traverse_with_options(conn, symbol, true, 100, options).unwrap()
+}
+
+/// One resolved caller plus three the resolver left unbound: the summary must confess to the three.
+///
+/// Before the null-safe negation, `hidden_unresolved_candidate_count` negated a predicate that is
+/// NULL (never false) on unresolved rows, so it counted 0 and `find_callers` answered
+/// `unresolved: 0, completeness_risk: "low"` — an affirmative claim of completeness on a symbol
+/// with three missed call sites.
+#[test]
+fn summary_counts_unresolved_call_sites_the_seed_could_not_reach() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, Some(target), "target", "a.rs::target", 10);
+    for i in 0..3 {
+        add_call(&conn, file, caller, None, "target", "h::target", 100 + i * 10);
+    }
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let options = syntactic(target);
+    let hops = callers(&conn, "a.rs::target", &options);
+    let summary =
+        traversal_summary(&conn, "a.rs::target", true, 100, &options, hops.len()).unwrap();
+
+    assert_eq!(summary.unresolved, 3, "three receiver-qualified call sites are unreachable");
+    assert_eq!(summary.total_matching_edges, 4);
+    assert_ne!(summary.completeness_risk, "low", "a missed majority cannot read as low risk");
+}
+
+/// The mirror-image dishonesty: an unresolved call site is a candidate of THIS symbol by short name
+/// only while that short name is unique in the checkout.
+///
+/// `target` here names two different definitions, so a bare `.target()` the resolver could not bind
+/// says nothing about which one it meant. Counting those as this symbol's hidden candidates pins
+/// `completeness_risk` at `high` and reports `truncated: true` for every symbol whose short name is
+/// common — `get`, `new`, `execute` run to thousands of rows apiece in a real index — on a
+/// traversal that returned every row it admitted.
+#[test]
+fn an_ambiguous_short_name_does_not_absorb_unrelated_unresolved_calls() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let other_file = add_file(&conn, "b.rs", "sha-b");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    // A second, unrelated definition sharing the short name: `?7` is now false.
+    add_symbol(&conn, other_file, "target", "b.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, Some(target), "target", "a.rs::target", 10);
+    for i in 0..3 {
+        add_call(&conn, file, caller, None, "target", "other::target", 100 + i * 10);
+    }
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let options = syntactic(target);
+    let hops = callers(&conn, "a.rs::target", &options);
+    let summary =
+        traversal_summary(&conn, "a.rs::target", true, 100, &options, hops.len()).unwrap();
+
+    assert_eq!(hops.len(), 1, "the one bound call site is still the only caller");
+    assert_eq!(summary.unresolved, 0, "an ambiguous short name claims no unresolved candidate");
+    assert_eq!(summary.total_matching_edges, 1);
+    assert!(!summary.truncated, "nothing was withheld, so nothing may claim to be");
+}
+
+/// The seed's OWN definitions are not rivals for its short name: a `#[cfg]`-split pair (and every
+/// overload group) puts two `symbols` rows under one name while naming one callable.
+///
+/// Gating the candidate population on the name being unique in the CHECKOUT suppressed the count
+/// for exactly those symbols — `find_callers` answered `unresolved: 0, completeness_risk: "low"` on
+/// a symbol whose receiver-qualified call sites it had all missed, with no genuine ambiguity to
+/// excuse it. The gate asks about symbols OUTSIDE the seed instead.
+#[test]
+fn a_cfg_split_seed_still_counts_the_call_sites_it_could_not_reach() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let native = add_symbol(&conn, file, "target", "a.rs::target");
+    let wasm = add_symbol(&conn, file, "target", "a.rs::target");
+    let logical = add_logical_symbol(&conn, "a.rs::target", &[native, wasm]);
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    for i in 0..3 {
+        add_call(&conn, file, caller, None, "target", "h::target", 100 + i * 10);
+    }
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let options = GraphTraversalOptions {
+        symbol_id: Some(native),
+        logical_symbol_id: Some(logical),
+        ..GraphTraversalOptions::default()
+    };
+    let hops = callers(&conn, "a.rs::target", &options);
+    let summary =
+        traversal_summary(&conn, "a.rs::target", true, 100, &options, hops.len()).unwrap();
+
+    assert!(hops.is_empty(), "no heuristic arm reaches a receiver-qualified name");
+    assert_eq!(summary.unresolved, 3, "the cfg twin is the seed, not a rival for its name");
+    assert_ne!(summary.completeness_risk, "low", "three missed call sites are not low risk");
+}
+
+/// The recall repro: 1 of 4 call sites resolves heuristically, the compiler names all four.
+///
+/// Enrichment runs after the fetch and only relabels rows already returned, so without the
+/// oracle-seeded arm the three upgraded edges are never fetched and `find_callers` answers 1.
+#[test]
+fn oracle_verdicts_seed_the_call_sites_the_resolver_left_unbound() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, Some(target), "target", "a.rs::target", 10);
+    let mut spans = Vec::new();
+    for i in 0..3 {
+        let span = 100 + i * 10;
+        add_call(&conn, file, caller, None, "target", "h::target", span);
+        spans.push(span);
+    }
+    add_oracle_run(&conn, TOOL_VERSION, "");
+    for span in &spans {
+        add_upgrade_verdict(&conn, "a.rs", "sha-a", *span, target, TOOL_VERSION);
+    }
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let options = syntactic(target);
+    assert_eq!(callers(&conn, "a.rs::target", &options).len(), 4, "all four call sites come back");
+
+    // …and the summary stops calling them hidden, so they are counted once, not twice.
+    let summary = traversal_summary(&conn, "a.rs::target", true, 100, &options, 4).unwrap();
+    assert_eq!(summary.total_matching_edges, 4);
+    // The compiler resolved the three; only tree-sitter left them unbound. Counting them as
+    // unresolved reports a fully recalled, compiler-verified answer as the least complete one.
+    assert_eq!(summary.compiler_verified, 3);
+    assert_eq!(summary.unresolved, 0, "a compiler-bound call site is not an unresolved one");
+    assert_eq!(summary.name_only, 0, "nor a name guess");
+    assert_ne!(summary.completeness_risk, "high", "every call site came back");
+    assert_eq!(summary.false_positive_risk, "low");
+}
+
+/// The symbol-selected `impact_surface` report traverses through `traverse_with_options`, so it
+/// answers with the same seeded callers `find_callers` does. Its flat `Vec<ImpactItem>` sibling
+/// has its own reverse SQL and does not (#1214).
+#[test]
+fn the_symbol_selected_impact_report_carries_an_oracle_seeded_caller() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, None, "target", "h::target", 100);
+    add_oracle_run(&conn, TOOL_VERSION, "");
+    add_upgrade_verdict(&conn, "a.rs", "sha-a", 100, target, TOOL_VERSION);
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let hit = crate::symbol::lookup_by_id(&conn, target).unwrap().unwrap();
+    // Graph lanes only: the evidence sections are irrelevant here and several need a populated FTS.
+    let options = crate::impact::ImpactSurfaceOptions {
+        include_tests: false,
+        include_docs: false,
+        include_git: false,
+        include_papertrail: false,
+        include_text_fallback: false,
+        include_memories: false,
+        ..Default::default()
+    };
+    // No promotion reported: the hop is in the report because the traversal SEEDED it, not because
+    // enrichment relabelled one it already had.
+    let report =
+        crate::impact::impact_surface_report_for_symbol(&conn, &hit, 100, &options, |_| Ok(false))
+            .unwrap();
+
+    assert_eq!(report.direct_semantic_callers.len(), 1);
+    assert_eq!(
+        report.direct_semantic_callers[0].target_qualified_name.as_deref(),
+        Some("h::target")
+    );
+}
+
+/// `match_tier` is the traversal's primary sort key, so it decides what survives the caller's
+/// `LIMIT`. A compiler-attributed caller must outrank a bare name guess — scored in the `ELSE`
+/// bucket it would rank below one, and the very rows the seeding recovers would be the first
+/// truncated away.
+#[test]
+fn an_oracle_seeded_caller_outranks_a_name_guess_under_a_tight_limit() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, None, "target", "h::target", 100);
+    // A call site the qualified-name arm admits on its written name alone — the tier-1 guess.
+    add_call(&conn, file, caller, None, "target", "a.rs::target", 200);
+    add_oracle_run(&conn, TOOL_VERSION, "");
+    add_upgrade_verdict(&conn, "a.rs", "sha-a", 100, target, TOOL_VERSION);
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let hops = traverse_with_options(&conn, "a.rs::target", true, 1, &syntactic(target)).unwrap();
+    assert_eq!(hops.len(), 1);
+    assert_eq!(hops[0].target_qualified_name.as_deref(), Some("h::target"));
+}
+
+/// A verdict from a superseded `tool_version` is not evidence: the display path keys on the latest
+/// run, so seeding on a stale one would surface a caller the enrichment then refuses to stand
+/// behind.
+///
+/// The fixture keeps BOTH runs, which is the shape supersession actually takes — `oracle_runs` is
+/// append-only and the old `ra 0.9` row stays beside the new one. With only the newer run present
+/// the plain `oracle_runs.tool_version = edge_oracle.tool_version` join already rejects the stale
+/// verdict and the `MAX(id)` gate is untested; with both, the stale verdict has a run of its own to
+/// join and only the `MAX(id)` gate keeps it out.
+#[test]
+fn a_superseded_oracle_run_does_not_seed_callers() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, None, "target", "h::target", 100);
+    add_oracle_run(&conn, "ra 0.9", "");
+    add_oracle_run(&conn, TOOL_VERSION, "");
+    add_upgrade_verdict(&conn, "a.rs", "sha-a", 100, target, "ra 0.9");
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    assert!(callers(&conn, "a.rs::target", &syntactic(target)).is_empty());
+}
+
+/// A verdict resolving to a SHADOWED definition is not evidence either: the display path's
+/// def-drift gate requires `resolved_symbol_id` to still be live in the active checkout, so seeding
+/// on a stale one produces a hop enrichment then declines to promote — a caller with no visible
+/// evidence, and one that outranks and displaces genuine matches under the caller's `LIMIT`.
+///
+/// The fixture is the ordinary agent loop: edit the file that DEFINES the seed (`def.rs` gets a
+/// dirty worktree row shadowing its committed row), leave the CALLER file alone (so the callsite
+/// sha gate still passes), and run `find_callers` on the seed. The pre-edit `symbols` row survives
+/// in the raw table carrying the same qualified name, and the verdict still points at it.
+#[test]
+fn a_verdict_resolving_to_a_shadowed_definition_does_not_seed_callers() {
+    const WORKTREE: &str = "wt-1";
+    let conn = scoped_conn();
+    let caller_file = add_file(&conn, "a.rs", "sha-a");
+    let caller = add_symbol(&conn, caller_file, "caller", "a.rs::caller");
+    let shadowed_file = add_scoped_file(&conn, "def.rs", "sha-old", COMMIT, "");
+    let shadowed = add_symbol(&conn, shadowed_file, "target", "def.rs::target");
+    let live_file = add_scoped_file(&conn, "def.rs", "sha-new", "", WORKTREE);
+    let live = add_symbol(&conn, live_file, "target", "def.rs::target");
+    add_call(&conn, caller_file, caller, None, "target", "h::target", 100);
+    add_oracle_run(&conn, TOOL_VERSION, WORKTREE);
+    add_upgrade_verdict(&conn, "a.rs", "sha-a", 100, shadowed, TOOL_VERSION);
+    install_scope_view(&conn, COMMIT, WORKTREE).unwrap();
+
+    assert!(
+        callers(&conn, "def.rs::target", &syntactic(live)).is_empty(),
+        "a verdict bound to the pre-edit definition must not seed a caller"
+    );
+}
+
+/// Two symbols share the qualified name `a.rs::target`; the compiler bound the call site to the
+/// FIRST. The oracle-seeded hop must land only under the symbol the verdict names — the sibling
+/// must not steal it the way it can steal a name-attributed unresolved edge.
+#[test]
+fn an_oracle_seeded_hop_lands_on_the_symbol_the_verdict_names() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let named = add_symbol(&conn, file, "target", "a.rs::target");
+    let sibling = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    // Receiver-qualified target name: no heuristic arm reaches it, for either symbol.
+    add_call(&conn, file, caller, None, "target", "h::target", 100);
+    add_oracle_run(&conn, TOOL_VERSION, "");
+    add_upgrade_verdict(&conn, "a.rs", "sha-a", 100, named, TOOL_VERSION);
+
+    // Overloads are attributed by LOGICAL membership, so give each symbol its own logical group.
+    let logical =
+        [named, sibling].map(|symbol_id| add_logical_symbol(&conn, "a.rs::target", &[symbol_id]));
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let for_logical = |logical_symbol_id: i64, symbol_id: i64| GraphTraversalOptions {
+        symbol_id: Some(symbol_id),
+        logical_symbol_id: Some(logical_symbol_id),
+        ..GraphTraversalOptions::default()
+    };
+    assert_eq!(callers(&conn, "a.rs::target", &for_logical(logical[0], named)).len(), 1);
+    assert!(
+        callers(&conn, "a.rs::target", &for_logical(logical[1], sibling)).is_empty(),
+        "the same-qualified-name sibling must not inherit the compiler's hop"
+    );
+}
+
+/// `fuzzy` asked for the loosest match and got the syntactic answer: the by-short-name arm was
+/// gated on the seed NOT being path-qualified, and every tool-selected seed is path-qualified.
+/// Syntactic must not grow in the same fixture — fuzzy is opt-in.
+#[test]
+fn fuzzy_reaches_a_short_name_caller_that_syntactic_cannot() {
+    let conn = scoped_conn();
+    let file = add_file(&conn, "a.rs", "sha-a");
+    let target = add_symbol(&conn, file, "target", "a.rs::target");
+    let caller = add_symbol(&conn, file, "caller", "a.rs::caller");
+    add_call(&conn, file, caller, Some(target), "target", "a.rs::target", 10);
+    // Unbound, and its written target name belongs to no arm but the short-name one.
+    add_call(&conn, file, caller, None, "target", "other::target", 100);
+    install_scope_view(&conn, COMMIT, "").unwrap();
+
+    let options = syntactic(target);
+    assert_eq!(callers(&conn, "a.rs::target", &options).len(), 1, "syntactic must not grow");
+
+    let fuzzy =
+        GraphTraversalOptions { resolution_mode: GraphResolutionMode::Fuzzy, ..syntactic(target) };
+    let hops = callers(&conn, "a.rs::target", &fuzzy);
+    assert_eq!(hops.len(), 2, "fuzzy reaches the short-name call site");
+    let name_only = hops.iter().find(|hop| !hop.verified_target_symbol).unwrap();
+    assert_eq!(
+        name_only.resolution, "target_name_fallback",
+        "a name-only caller must be labelled as one"
+    );
+    assert_eq!(name_only.confidence, "name_only");
+}

--- a/crates/rag-rat-query/src/graph/traverse.rs
+++ b/crates/rag-rat-query/src/graph/traverse.rs
@@ -21,8 +21,10 @@ pub fn traverse_with_options(
     let unique_short_name = unique_symbol_name(conn, short_name(symbol))?;
     let mode = options.resolution_mode;
     let sql = if reverse {
-        let predicate = reverse_predicate(mode, options.logical_symbol_id.is_some());
-        let tier = reverse_tier(mode);
+        let oracle_edge_ids = reverse_oracle_seeded_edge_ids(conn, symbol, options)?;
+        let predicate =
+            reverse_predicate(mode, options.logical_symbol_id.is_some(), &oracle_edge_ids);
+        let tier = reverse_tier(mode, &oracle_edge_ids);
         format!(
             "
             SELECT COALESCE(from_qn.value, edges.from_name) AS from_symbol,
@@ -107,14 +109,7 @@ pub fn traverse_with_options(
             "
         )
     };
-    let params = traversal_params(
-        symbol,
-        limit,
-        &edge_kinds,
-        options.symbol_id,
-        options.logical_symbol_id,
-        unique_short_name,
-    );
+    let params = traversal_params(symbol, limit, &edge_kinds, options, unique_short_name);
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_from_iter(params), |row| {
         let edge_kind: String = row.get("edge_kind")?;
@@ -195,17 +190,38 @@ pub fn traversal_summary(
     let quoted = quoted_placeholders(edge_kinds.len());
     let unique_short_name = unique_symbol_name(conn, short_name(symbol))?;
     let mode = options.resolution_mode;
+    // Computed ONCE for both the summary counts and the hidden-candidate count below: the two must
+    // describe the same admitted population as `traverse_with_options`, or the summary would report
+    // an oracle-seeded caller as a hidden unresolved candidate (double-counting it).
+    let oracle_edge_ids =
+        if reverse { reverse_oracle_seeded_edge_ids(conn, symbol, options)? } else { Vec::new() };
     let sql = if reverse {
-        let predicate = reverse_predicate(mode, options.logical_symbol_id.is_some());
+        let predicate =
+            reverse_predicate(mode, options.logical_symbol_id.is_some(), &oracle_edge_ids);
+        // An oracle-seeded row is one the COMPILER resolved, and the heuristic left `to_symbol_id`
+        // NULL on it — so the buckets below would file it as unresolved and drive
+        // `completeness_risk` to `high` on the very answer the seeding made complete. It gets its
+        // own count and is excluded from the heuristic buckets, which report what tree-sitter alone
+        // concluded. A verdict CONFIRMING an already-resolved edge is not in this population —
+        // `exact_verified` already speaks for it.
+        let compiler_only = oracle_seed_in_list(&oracle_edge_ids)
+            .map(|list| format!("({list} AND edges.to_symbol_id IS NULL)"));
+        let compiler_verified = match &compiler_only {
+            Some(expr) => format!("SUM(CASE WHEN {expr} THEN 1 ELSE 0 END)"),
+            None => "0".to_string(),
+        };
+        let heuristic =
+            compiler_only.as_ref().map(|expr| format!("NOT {expr} AND ")).unwrap_or_default();
         format!(
             "
             SELECT
                 COUNT(*),
                 SUM(CASE WHEN edges.to_symbol_id IS NOT NULL THEN 1 ELSE 0 END),
-                SUM(CASE WHEN edges.confidence = 'Syntactic' THEN 1 ELSE 0 END),
-                SUM(CASE WHEN edges.confidence = 'NameOnly' THEN 1 ELSE 0 END),
-                SUM(CASE WHEN edges.confidence = 'Ambiguous' THEN 1 ELSE 0 END),
-                SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END)
+                SUM(CASE WHEN {heuristic}edges.confidence = 'Syntactic' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN {heuristic}edges.confidence = 'NameOnly' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN {heuristic}edges.confidence = 'Ambiguous' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN {heuristic}edges.to_symbol_id IS NULL THEN 1 ELSE 0 END),
+                {compiler_verified}
             FROM edges
             JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
@@ -226,7 +242,8 @@ pub fn traversal_summary(
                 SUM(CASE WHEN edges.confidence = 'Syntactic' THEN 1 ELSE 0 END),
                 SUM(CASE WHEN edges.confidence = 'NameOnly' THEN 1 ELSE 0 END),
                 SUM(CASE WHEN edges.confidence = 'Ambiguous' THEN 1 ELSE 0 END),
-                SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END)
+                SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END),
+                0
             FROM edges
             JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
@@ -239,14 +256,7 @@ pub fn traversal_summary(
             "
         )
     };
-    let params = traversal_params(
-        symbol,
-        limit,
-        &edge_kinds,
-        options.symbol_id,
-        options.logical_symbol_id,
-        unique_short_name,
-    );
+    let params = traversal_params(symbol, limit, &edge_kinds, options, unique_short_name);
     let mut summary = conn.query_row(&sql, params_from_iter(params), |row| {
         Ok(GraphTraversalSummary {
             returned_count: u64::try_from(returned_count).unwrap_or(u64::MAX),
@@ -257,6 +267,7 @@ pub fn traversal_summary(
             name_only: count_col(row, 3)?,
             ambiguous: count_col(row, 4)?,
             unresolved: count_col(row, 5)?,
+            compiler_verified: count_col(row, 6)?,
             false_positive_risk: String::new(),
             completeness_risk: String::new(),
             completeness_note: None,
@@ -269,6 +280,7 @@ pub fn traversal_summary(
         &edge_kinds,
         options,
         unique_short_name,
+        &oracle_edge_ids,
     )?;
     summary.total_matching_edges = summary.total_matching_edges.saturating_add(hidden_unresolved);
     summary.unresolved = summary.unresolved.saturating_add(hidden_unresolved);
@@ -340,8 +352,11 @@ pub(crate) fn false_positive_risk(
     // Risk reflects whether the *returned* edges could be wrong, not the mode alone. Syntactic is
     // the default mode, so charging it "medium" unconditionally mislabels results where every edge
     // resolved to a verified target symbol (the common, trustworthy case). Only bump for syntactic
-    // mode when some matching edge was NOT verified against the target.
-    let has_unverified = summary.exact_verified < summary.total_matching_edges;
+    // mode when some matching edge was NOT verified against the target — by the heuristic
+    // (`exact_verified`) or by the compiler (`compiler_verified`); a verdict is the stronger
+    // evidence of the two.
+    let has_unverified = summary.exact_verified.saturating_add(summary.compiler_verified)
+        < summary.total_matching_edges;
     if summary.ambiguous > 0 || mode == GraphResolutionMode::Fuzzy {
         "high"
     } else if summary.name_only > 0
@@ -364,6 +379,29 @@ pub(crate) fn completeness_risk(summary: &GraphTraversalSummary) -> &'static str
         "low"
     }
 }
+/// How many unresolved candidate edges the traversal's own predicate EXCLUDED — the count that
+/// makes `summary.unresolved` / `completeness_risk` honest about what the seed could not reach.
+///
+/// NULL-SAFE NEGATION (load-bearing): the excluded rows all have `to_symbol_id IS NULL`, and every
+/// resolved arm of the seed predicate (`to_symbol_id = ?6`, `to_symbol_id IN (…)`) evaluates to
+/// NULL — not false — on exactly those rows. A plain `NOT (<predicate>)` is therefore NULL for the
+/// whole population this counts, SQLite drops every row, and the count is a constant 0: the tool
+/// reports `unresolved: 0, completeness_risk: low` on a symbol whose call sites it mostly missed
+/// (#1198). `coalesce(<predicate>, 0) = 0` is the negation that reads "not admitted" rather than
+/// "provably rejected".
+///
+/// THE BY-SHORT-NAME ARM OF THE CANDIDATE POPULATION IS GATED, because a written callee short name
+/// identifies this symbol only while no OTHER symbol answers to it. Ungated, `find_callers` on a
+/// symbol named `get` or `new` counts every unresolved `.get(..)` in the repo as a candidate of ITS
+/// OWN — thousands of rows — and reports `truncated: true` on a traversal that returned everything
+/// it admitted, with `completeness_risk` pinned at `high` forever.
+///
+/// The gate is `short_name_identifies_seed_alone`, which asks about symbols OUTSIDE the seed, not
+/// `unique_symbol_name`, which counts every scoped row of that name. The seed's own members —
+/// a `#[cfg]`-split pair, an overload group — are not rivals for its name, and gating on global
+/// uniqueness suppresses the count for exactly those symbols: the answer reads `unresolved: 0,
+/// completeness_risk: low` on a symbol whose receiver-qualified call sites were all missed, with no
+/// genuine ambiguity to excuse it (#1198).
 pub(crate) fn hidden_unresolved_candidate_count(
     conn: &Connection,
     symbol: &str,
@@ -371,11 +409,18 @@ pub(crate) fn hidden_unresolved_candidate_count(
     edge_kinds: &[String],
     options: &GraphTraversalOptions,
     unique_short_name: bool,
+    oracle_edge_ids: &[i64],
 ) -> anyhow::Result<u64> {
     let mode = options.resolution_mode;
     let quoted = quoted_placeholders(edge_kinds.len());
     let sql = if reverse {
-        let predicate = reverse_predicate(mode, options.logical_symbol_id.is_some());
+        let predicate =
+            reverse_predicate(mode, options.logical_symbol_id.is_some(), oracle_edge_ids);
+        let short_name_arm = if short_name_identifies_seed_alone(conn, symbol, options)? {
+            "\n                OR edges.to_name_id = (SELECT id FROM name_strings WHERE value = ?3)"
+        } else {
+            ""
+        };
         format!(
             "
             SELECT COUNT(*)
@@ -385,11 +430,10 @@ pub(crate) fn hidden_unresolved_candidate_count(
             LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND edges.to_symbol_id IS NULL
-              AND NOT ({predicate})
+              AND coalesce({predicate}, 0) = 0
               AND (
                 edges.target_qualified_name = ?1
-                OR edges.target_qualified_name LIKE ?2
-                OR edges.to_name_id = (SELECT id FROM name_strings WHERE value = ?3)
+                OR edges.target_qualified_name LIKE ?2{short_name_arm}
               )
             "
         )
@@ -407,19 +451,12 @@ pub(crate) fn hidden_unresolved_candidate_count(
             WHERE edges.edge_kind IN ({quoted})
               AND ({source_predicate})
               AND edges.to_symbol_id IS NULL
-              AND NOT (({target_filter}) AND ({visibility_filter}))
+              AND coalesce(({target_filter}) AND ({visibility_filter}), 0) = 0
               AND ?4 IN ('true', 'false')
             "
         )
     };
-    let params = traversal_params(
-        symbol,
-        0,
-        edge_kinds,
-        options.symbol_id,
-        options.logical_symbol_id,
-        unique_short_name,
-    );
+    let params = traversal_params(symbol, 0, edge_kinds, options, unique_short_name);
     let count = conn.query_row(&sql, params_from_iter(params), |row| count_col(row, 0))?;
     Ok(count)
 }


### PR DESCRIPTION
`find_callers` could only seed from edges the heuristic resolver bound. Oracle verdicts were applied after the fetch, as a display rewrite on rows already returned — so a compiler verdict could re-label a caller the heuristic found, but never add one it missed.

Measured on this repo's own index: `add_logical_symbol` has 18 call sites, all `h.add_logical_symbol(...)`. One row resolved (the receiver type was inferrable); 17 stayed unresolved. `edge_oracle` held a current verdict for all 18, every one naming the same target. `find_callers` returned **1 caller** and reported `unresolved: 0`, `completeness_risk: low`.

## What changed

**Recall (#1197).** The reverse predicate now also seeds from `edge_oracle`: an edge whose current verdict resolves to the seed's logical members matches. Attribution comes from the verdict's `resolved_symbol_id`, not the target name as written, so a same-qualified-name sibling cannot take the hop.

Both seed subqueries join the connection's scoped `files` view. Without that, a verdict bound to a definition a later edit shadowed would seed a hop the display path then refuses to promote — a caller asserted at the top match tier with no visible evidence, displacing genuine matches under the caller's limit. `edges.to_symbol_id` is never written from oracle data; only what the reverse query may seed from changed.

**Honest counts (#1198).** `hidden_unresolved_candidate_count` negated a predicate whose `to_symbol_id IN (...)` arm evaluates to NULL on precisely the rows it counts, so `NOT (NULL OR 0)` discarded all of them. The count always read zero and `completeness_risk` always read `low` — an affirmative claim of coverage on a query that had dropped most of its matches. Now null-safe. On the seed above: 0 before, 17 after.

**Fuzzy mode (#1199).** Its by-name arm was gated on the seed being unqualified, and every tool-selected symbol has a path-qualified seed, so fuzzy was inert in reverse. Unresolved same-name candidates now surface under fuzzy as the existing name-only tier. Default syntactic mode is unchanged, and a test pins that.

## Tests

New `crates/rag-rat-query/src/graph/tests.rs`. Both gates were verified by reverting the source change and confirming only the intended test fails:

- removing the scoped `files` join → `a_verdict_resolving_to_a_shadowed_definition_does_not_seed_callers` fails
- removing the latest-run clause → `a_superseded_oracle_run_does_not_seed_callers` fails

The supersession fixture seeds a second, older `oracle_runs` row, since with a single run the plain tool-version join already rejects the stale verdict and the guard clause under test never runs.

`graph_traversal_seed_predicates_use_edge_id_indexes` now mirrors the shipped predicate including the new arm, so the never-full-scan invariant covers it.

Fixes #1197, fixes #1198, fixes #1199.


## Scope of the honesty count

The hidden-candidate population is gated on the seed's short name being unique. A count claimed for an ambiguous name would absorb every unresolved call to any method sharing it — 6,755 rows for `new` and 8,653 for `get` on this repo's index — which would pin `completeness_risk` at `high` for common-named symbols just as unconditionally as it previously read `low`. Under-counting an ambiguous short name is the truthful answer, matching the posture `syntactic_seed_symbol_count` already takes.

## Compiler-verified callers are counted as such

Seeded edges still have `to_symbol_id IS NULL` — the resolver never bound them — so counting them naively puts the best-evidenced rows in the result into the `unresolved` bucket. On the example above that reported `unresolved: 17, completeness_risk: high` for an answer where 17 of 18 callers carry a compiler verdict, which inverts the honesty this PR is for. They are now counted under `compiler_verified` instead, and `false_positive_risk` weighs them alongside `exact_verified`. A verdict that merely confirms an already-resolved edge is excluded by the `to_symbol_id IS NULL` conjunct, so nothing double-counts; with no oracle run the summary SQL is byte-identical to before.

## Scope of the honesty count

The hidden-candidate population is gated on the seed's short name identifying the seed alone. Counting for an ambiguous name would absorb every unresolved call to any method sharing it — 6,755 rows for `new` and 8,653 for `get` on this repo's index — pinning `completeness_risk` at `high` for common-named symbols as unconditionally as it previously read `low`.

The gate measures ambiguity *relative to the seed*, not global uniqueness: symbols carrying the short name that are not in the seed set (the logical members, or the seed plus its qualified-name twins). Global uniqueness would count a symbol's own cfg-split or overloaded definitions as rivals for its name and suppress the count for exactly the symbols logical grouping exists to disambiguate.

## Known gaps, tracked

- The seed reaches reverse `traverse_with_options`, so `find_callers`, `traversal_summary` and the symbol-selected `impact_surface` report all get it. The free-text / `allow_ambiguous` `impact_surface` lane builds its own predicate and does not — #1214.
- The seed unions across oracle tools with a current run, while the display path arbitrates by tool authority (first-writer-wins per edge). Latent while a single backend runs; the doc states the divergence rather than claiming a mirroring that is not there — #1215.
