### PR TITLE
feat(core): gate the grep-augment memory lane on relevance

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -62,6 +62,11 @@ pub use memory::SyncCatchUpReport;
 pub use oracle_runs::OracleShaSnapshots;
 pub use search::SearchRequest;
 
+/// Volume cap on the memories `read_chunk` attaches as drive-by context. The binding is
+/// structural, so every hit is relevant; the cap is purely about how much of a reader's attention
+/// one chunk read may spend (the grep-augment hook lanes budget 4).
+const DRIVE_BY_CHUNK_MEMORY_LIMIT: u32 = 6;
+
 impl IndexDatabase {
     pub fn status(&self, database: &Path) -> anyhow::Result<IndexStatus> {
         let mut counts = BTreeMap::new();
@@ -483,8 +488,11 @@ impl IndexDatabase {
             // heal-and-retry.
             chunk.memories = crate::index::retry_once_on_fts_corruption(
                 || {
-                    let mut memories =
-                        rag_rat_query::memory::memories_for_chunk(conn, chunk_id, 20)?;
+                    let mut memories = rag_rat_query::memory::memories_for_chunk(
+                        conn,
+                        chunk_id,
+                        DRIVE_BY_CHUNK_MEMORY_LIMIT,
+                    )?;
                     rag_rat_query::memory::apply_memory_surface(conn, &mut memories, surface)?;
                     Ok(memories)
                 },
@@ -762,6 +770,90 @@ fn annotate_completeness_with_externals(
 
 #[cfg(test)]
 mod oracle_surfacing_tests;
+
+#[cfg(test)]
+mod drive_by_memory_cap_tests {
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+    use rusqlite::Connection;
+
+    use crate::index::IndexDatabase;
+
+    /// A store holding one chunk with `n` memories bound to it — the shape `read_chunk` attaches
+    /// drive-by context to. Seeded through a bare connection first so the opened
+    /// [`IndexDatabase`] scopes to the seeded repo.
+    fn db_with_chunk_memories(n: usize) -> (tempfile::TempDir, IndexDatabase, i64) {
+        let dir = tempfile::tempdir().unwrap();
+        let database = dir.path().join("index.sqlite");
+        let conn = Connection::open(&database).unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               commit_sha, worktree_id, repo_id, generation)
+             VALUES ('src/a.rs', 'rust', 'source', 'h', 0, 0, '', '', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
+                                start_line, end_line, text_hash)
+             VALUES (1, 'symbol', 'a::foo', 0, 10, 1, 2, 'h1')",
+            [],
+        )
+        .unwrap();
+        let chunk_id = conn.last_insert_rowid();
+        rag_rat_db::chunk_text_store::seed_chunk_text(&conn, chunk_id, "fn foo() {}").unwrap();
+        for i in 0..n {
+            crate::memory_write::create_memory(&conn, RepoMemoryCreate {
+                kind: "Invariant".to_string(),
+                title: format!("Drive-by memory {i}"),
+                body: format!("Body of drive-by memory {i}."),
+                confidence: "high".to_string(),
+                created_by: Some("test".to_string()),
+                source: None,
+                tags: vec![],
+                payload_json: None,
+                bind: RepoMemoryBindTarget {
+                    chunk_id: Some(chunk_id),
+                    ..RepoMemoryBindTarget::default()
+                },
+            })
+            .unwrap();
+        }
+        drop(conn);
+        let db = IndexDatabase::open(&database).unwrap();
+        (dir, db, chunk_id)
+    }
+
+    /// #1200: `read_chunk` used to attach up to 20 memories per chunk — enough to bury the chunk
+    /// itself. The bindings are structural, so this is a volume cap, not a relevance gate, and it
+    /// belongs to the read path: the test drives the real `read_chunk` call so raising the literal
+    /// back at the call site fails it.
+    #[test]
+    fn read_chunk_attaches_at_most_the_drive_by_cap() {
+        let (_dir, db, chunk_id) = db_with_chunk_memories(9);
+        let chunk = db
+            .read_chunk_with_graph_and_memories(
+                chunk_id,
+                GraphMetaMode::Full,
+                20,
+                true,
+                rag_rat_base::config::MemorySurface::Full,
+            )
+            .unwrap()
+            .expect("chunk");
+        assert_eq!(
+            chunk.memories.len(),
+            usize::try_from(super::DRIVE_BY_CHUNK_MEMORY_LIMIT).unwrap(),
+            "9 bound memories, capped to the drive-by limit"
+        );
+    }
+}
 
 #[cfg(test)]
 mod name_based_tests {

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -19,6 +19,24 @@ pub(crate) const MAX_MEMORIES: u32 = 4;
 const MAX_LEXICAL_HITS: u32 = 3;
 /// Lexical hits below this fraction of the best hit's score are dropped as low-relevance noise.
 const LEXICAL_RELATIVE_FLOOR: f64 = 0.6;
+/// FTS memory hits below this fraction of the best hit's bm25 magnitude are dropped as
+/// low-relevance noise.
+///
+/// SCOPE: this catches ONE case — a hit whose only match is a token so common that fts5 clamps its
+/// idf to 1e-6, which lands it ~6 orders of magnitude below the best hit. It is not a general
+/// "did this answer the query" gate, and it is NOT comparable to [`LEXICAL_RELATIVE_FLOOR`], which
+/// grades bounded reciprocal-rank scores.
+///
+/// The value is set by what a LEGITIMATE match can score, not by what noise scores, because bm25
+/// magnitude does not separate the two once idf stays positive: it folds term coverage together
+/// with term frequency and body length. Measured on a 43-memory corpus with a 3-term query, an
+/// all-terms match carrying a ~1 300-char body scores 0.098 of the best hit, while a co-match on a
+/// single token present in 10 of the 43 scores 0.126 — the noise ranks ABOVE the real match. Any
+/// floor tight enough to cut that noise therefore drops exact matches for their body length, which
+/// is strictly worse than the noise it removes. This one sits an order of magnitude under the
+/// worst legitimate match measured and four orders above the clamped-idf case, so it can only fire
+/// where it decides correctly. Moderately-common-token co-matches are left to [`MAX_MEMORIES`].
+const MEMORY_RELATIVE_FLOOR: f64 = 0.01;
 
 /// Maximum body length in a rendered memory digest line; longer bodies are truncated with `…`.
 const MAX_MEMORY_BODY_CHARS: usize = 240;
@@ -282,8 +300,15 @@ pub fn compose(
         }
     }
 
-    // Memory lane: always. FTS over the normalized pattern + path-bound memories.
-    for m in memory::memory_search(conn, &normalized, MAX_MEMORIES)? {
+    // Memory lane: always. FTS over the normalized pattern + path-bound memories. The FTS half is
+    // relevance-gated (a corpus-wide token in the pattern otherwise drags in MAX_MEMORIES
+    // unrelated memories); the path half is not — it is a structural binding, not a text match.
+    // The gate runs over the FULL hit set, BEFORE session dedupe (the blanket retain below):
+    // relevance is a property of the query, not of what this session happened to show. Dropping an
+    // already-seen hit first would hand the reference score to the runner-up, and the weak tail
+    // would pass the gate for the rest of the resurface window — exactly the noise it removes.
+    let fts_hits = memory::memory_search_scored(conn, &normalized, MAX_MEMORIES)?;
+    for m in memories_above_relative_floor(fts_hits) {
         if seen_memory_ids.insert(m.memory_id.clone()) {
             memories.push(m);
         }
@@ -336,6 +361,21 @@ fn lexical_lines_from_hits(hits: Vec<lexical::SearchHit>) -> Vec<String> {
         .filter(|hit| seen.insert((hit.path.clone(), hit.start_line, hit.end_line)))
         .map(|hit| format!("- {}:{}-{} — {}", hit.path, hit.start_line, hit.end_line, hit.summary))
         .collect()
+}
+
+/// Drop the weak tail of the FTS memory lane: keep only hits within [`MEMORY_RELATIVE_FLOOR`] of
+/// the best hit's match strength.
+///
+/// INVARIANT: the paired score is SQLite's `bm25()`, which is NEGATIVE and lower-is-better — the
+/// OPPOSITE sign convention from the lexical lane's positive scores. It is negated into a
+/// higher-is-better strength before any comparison; filtering on the raw bm25 value would invert
+/// the gate and keep exactly the irrelevant memories this drops. Strength is therefore never
+/// negative, so the floor never rises above the best hit and a lone match always survives, however
+/// weak in absolute terms.
+fn memories_above_relative_floor(hits: Vec<(memory::RepoMemory, f64)>) -> Vec<memory::RepoMemory> {
+    let best = hits.iter().map(|(_, bm25)| -bm25).fold(f64::NEG_INFINITY, f64::max);
+    let floor = best * MEMORY_RELATIVE_FLOOR;
+    hits.into_iter().filter(|(_, bm25)| -bm25 >= floor).map(|(m, _)| m).collect()
 }
 
 /// A single rendered symbol line plus the key that identifies it in the dedupe set.
@@ -728,6 +768,227 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    /// A memory reachable ONLY through the FTS lane: bound to the seeded file's path, which
+    /// `compose` never consults here because these tests pass `search_path: None`.
+    fn seed_fts_memory(conn: &Connection, title: &str, body: &str) -> memory::RepoMemory {
+        crate::memory_write::create_memory(conn, RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test".to_string()),
+            source: None,
+            tags: vec![],
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some("src/watch.rs".to_string()),
+                ..RepoMemoryBindTarget::default()
+            },
+        })
+        .unwrap()
+        .memory
+    }
+
+    /// #1200: the FTS memory lane had no relevance gate, so one common token in the normalized
+    /// pattern surfaced up to `MAX_MEMORIES` unrelated memories. The magnitudes are the ones
+    /// `compose_memory_lane_drops_weak_fts_co_matches` actually produces — the co-match's only
+    /// token is corpus-wide, so fts5 clamps its idf to 1e-6. bm25 is NEGATIVE and lower-is-better,
+    /// so a sign slip here would keep exactly the memory this drops.
+    #[test]
+    fn memory_floor_keeps_the_strong_match_and_drops_the_weak_tail() {
+        let conn = seeded_conn();
+        let strong = seed_fts_memory(&conn, "Strong bm25 match", "matches every query term");
+        let weak = seed_fts_memory(&conn, "Weak bm25 match", "matches one corpus-wide term");
+        let kept = memories_above_relative_floor(vec![(strong, -1.63), (weak, -1.02e-6)]);
+        assert_eq!(kept.len(), 1, "only the strong match survives: {kept:?}");
+        assert_eq!(kept[0].title, "Strong bm25 match");
+    }
+
+    /// The floor's VALUE is load-bearing, not just its existence: two orders of magnitude below the
+    /// best hit, so the tf/body-length spread between equally-relevant matches never reaches it.
+    #[test]
+    fn memory_floor_cuts_two_orders_of_magnitude_below_the_best_hit() {
+        let conn = seeded_conn();
+        let best = seed_fts_memory(&conn, "Best bm25 match", "the strongest match");
+        let above = seed_fts_memory(&conn, "Just above the floor", "same terms, a longer body");
+        let below = seed_fts_memory(&conn, "Just below the floor", "an incidental co-match");
+        let kept = memories_above_relative_floor(vec![(best.clone(), -10.0), (above, -0.11)]);
+        assert_eq!(kept.len(), 2, "0.011 of the best hit survives: {kept:?}");
+        let kept = memories_above_relative_floor(vec![(best, -10.0), (below, -0.09)]);
+        assert_eq!(kept.len(), 1, "0.009 of the best hit is dropped: {kept:?}");
+    }
+
+    /// The false-drop guard on the constant. These are the magnitudes measured on a 43-memory
+    /// corpus for the 3-term query `zebraglyph quokkaform rebuildpass`: the best hit is a short
+    /// all-terms memory, the second is an all-terms memory whose ~1 300-char body dilutes it to
+    /// 0.098 of the best. A floor anywhere near a tenth of the best hit discards that real match,
+    /// which is worse than the noise a tighter floor would remove.
+    #[test]
+    fn memory_floor_keeps_a_length_diluted_exact_match() {
+        let conn = seeded_conn();
+        let best = seed_fts_memory(&conn, "Short exact match", "every query term, briefly");
+        let diluted =
+            seed_fts_memory(&conn, "Long-bodied exact match", "every query term, at length");
+        let kept = memories_above_relative_floor(vec![(best, -10.005), (diluted, -0.981)]);
+        assert_eq!(kept.len(), 2, "body length must not disqualify an exact match: {kept:?}");
+    }
+
+    /// The gate is a RELATIVE floor, never a minimum score: the best hit is always its own
+    /// reference, so a lone match surfaces however weak it is in absolute terms.
+    #[test]
+    fn memory_floor_keeps_a_lone_hit_however_weak() {
+        let conn = seeded_conn();
+        let weak = seed_fts_memory(&conn, "Weak bm25 match", "matches one incidental term");
+        assert_eq!(memories_above_relative_floor(vec![(weak, -0.01)]).len(), 1);
+    }
+
+    /// End-to-end: a pattern whose terms one memory answers fully and another merely brushes
+    /// injects only the former.
+    #[test]
+    fn compose_memory_lane_drops_weak_fts_co_matches() {
+        let conn = seeded_conn();
+        seed_fts_memory(
+            &conn,
+            "Zebraglyph routing pins quokkaform",
+            "zebraglyph quokkaform lorikeetwise — the zebraglyph router pins quokkaform to \
+             lorikeetwise on every zebraglyph rebuild.",
+        );
+        seed_fts_memory(
+            &conn,
+            "Unrelated cache eviction note",
+            "The cache evicts on write; it happens to mention lorikeetwise once.",
+        );
+        let out = compose(
+            &conn,
+            "zebraglyph quokkaform lorikeetwise",
+            None,
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
+        assert!(
+            out.context.contains("Zebraglyph routing pins quokkaform"),
+            "the strong match surfaces: {}",
+            out.context
+        );
+        assert!(
+            !out.context.contains("Unrelated cache eviction note"),
+            "the weak co-match is floored out: {}",
+            out.context
+        );
+    }
+
+    /// End-to-end in the regime the two small-corpus tests never reach: a shared token present in
+    /// 10 of 43 memories keeps a POSITIVE idf, so the co-matches land at ~0.13 of the best hit
+    /// rather than the ~1e-6 a corpus-wide token clamps to. The gate is scoped to the clamped case
+    /// and deliberately does not fire here — bm25 magnitude cannot separate these co-matches from
+    /// a length-diluted exact match, so `MAX_MEMORIES` is what bounds them. This pins that scope:
+    /// a future tightening that starts dropping hits here is dropping real matches with them.
+    #[test]
+    fn compose_memory_lane_gate_is_scoped_to_corpus_wide_tokens() {
+        let conn = seeded_conn();
+        seed_fts_memory(
+            &conn,
+            "Zebraglyph routing pins quokkaform",
+            "zebraglyph quokkaform rebuildpass — the zebraglyph router pins quokkaform on every \
+             rebuildpass.",
+        );
+        for i in 0..10 {
+            seed_fts_memory(
+                &conn,
+                &format!("Rebuildpass note {i}"),
+                "The rebuildpass drains the queue before the next tick; unrelated to routing.",
+            );
+        }
+        for i in 0..30 {
+            seed_fts_memory(&conn, &format!("Filler note {i}"), "Nothing relevant lives here.");
+        }
+        let out = compose(
+            &conn,
+            "zebraglyph quokkaform rebuildpass",
+            None,
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
+        assert!(
+            out.context.contains("Zebraglyph routing pins quokkaform"),
+            "the all-terms match surfaces: {}",
+            out.context
+        );
+        assert!(
+            out.context.contains("Rebuildpass note"),
+            "a positive-idf co-match is NOT floored out — only the cap bounds it: {}",
+            out.context
+        );
+    }
+
+    /// End-to-end counterpart: the same weak memory is the ONLY hit for its own rare token, so it
+    /// still surfaces — proof the floor stayed relative rather than becoming an absolute gate.
+    #[test]
+    fn compose_memory_lane_surfaces_a_lone_weak_match() {
+        let conn = seeded_conn();
+        seed_fts_memory(
+            &conn,
+            "Unrelated cache eviction note",
+            "The cache evicts on write; it happens to mention kestrelmark once.",
+        );
+        let out = compose(
+            &conn,
+            "kestrelmark",
+            None,
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
+        assert!(
+            out.context.contains("Unrelated cache eviction note"),
+            "a lone weak match still surfaces: {}",
+            out.context
+        );
+    }
+
+    /// Session dedupe must not move the floor: the reference is the best hit for the QUERY, so the
+    /// weak co-match stays floored out even while the strong hit is suppressed as already-seen.
+    /// Gating the survivors instead would re-admit the weak tail for the whole resurface window.
+    #[test]
+    fn memory_floor_ignores_session_dedupe() {
+        let conn = seeded_conn();
+        let strong = seed_fts_memory(
+            &conn,
+            "Zebraglyph routing pins quokkaform",
+            "zebraglyph quokkaform lorikeetwise — the zebraglyph router pins quokkaform to \
+             lorikeetwise on every zebraglyph rebuild.",
+        );
+        seed_fts_memory(
+            &conn,
+            "Unrelated cache eviction note",
+            "The cache evicts on write; it happens to mention lorikeetwise once.",
+        );
+        let dedupe = DedupeFilter {
+            memory_ids: HashSet::from([strong.memory_id.clone()]),
+            symbol_keys: HashSet::new(),
+        };
+        let out = compose(
+            &conn,
+            "zebraglyph quokkaform lorikeetwise",
+            None,
+            &dedupe,
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap();
+        // Nothing else in the seeded corpus answers this pattern, so suppressing both the
+        // already-seen hit and the floored co-match legitimately leaves no payload at all.
+        let context = out.map(|payload| payload.context).unwrap_or_default();
+        assert!(
+            !context.contains("Unrelated cache eviction note"),
+            "the weak co-match stays floored out while the strong hit is deduped: {context}"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -297,6 +297,11 @@ pub(crate) fn call_tool_with_db(
     Ok(result)
 }
 
+/// Volume cap on the memories `symbol_lookup` attaches per candidate. The binding is structural,
+/// so every hit is relevant; the cap is purely about how much of a reader's attention one lookup
+/// may spend, and it is paid once PER CANDIDATE (the grep-augment hook lanes budget 4 in total).
+const SYMBOL_LOOKUP_MEMORY_LIMIT: u32 = 5;
+
 pub(crate) fn symbol_lookup_tool(
     db: &IndexDatabase,
     args: SymbolArgs,
@@ -316,7 +321,7 @@ pub(crate) fn symbol_lookup_tool(
     // serialized candidates no longer expose it (#149), so the old read of `candidate["symbol_id"]`
     // found nothing and dropped every memory — zip by position against the source hits instead.
     for (candidate, hit) in candidates.iter_mut().zip(&lookup.candidates) {
-        let memories = db.memory_for_symbol(hit, 10, memory_surface)?;
+        let memories = db.memory_for_symbol(hit, SYMBOL_LOOKUP_MEMORY_LIMIT, memory_surface)?;
         if !memories.is_empty() {
             candidate["memories"] = json!(memories);
         }
@@ -762,4 +767,98 @@ pub(crate) fn clones_for_symbol_tool(
 ) -> anyhow::Result<Value> {
     let selector = args.into_selector()?;
     Ok(json!(db.clones_for_symbol(selector)?))
+}
+
+#[cfg(test)]
+mod symbol_lookup_memory_cap_tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
+    use rag_rat_base::language::Language;
+    use rag_rat_base::test_scratch::{self, ScratchDir};
+    use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+
+    use super::*;
+
+    /// An indexed one-symbol repo carrying `n` memories bound to that symbol — more than
+    /// `symbol_lookup` is willing to attach.
+    fn db_with_symbol_memories(n: usize) -> (ScratchDir, IndexDatabase) {
+        let scratch = ScratchDir::new("rag-rat-symbol-memory-cap");
+        let root = test_scratch::canonical_config_root(scratch.path());
+        let mut config = Config::minimal_for_database(root.join("index.sqlite"), root.clone());
+        config.database_key_pinned = true;
+        config.targets = vec![ResolvedTarget {
+            name: "rust".into(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("src")],
+            include: vec!["**/*.rs".into()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }];
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let hit = db
+            .symbol_candidates(
+                &rag_rat_query::symbol::SymbolSelector {
+                    logical_symbol_id: None,
+                    symbol_id: None,
+                    symbol_path: None,
+                    symbol: Some("target".to_string()),
+                    language: None,
+                    allow_ambiguous: false,
+                    limit: 10,
+                },
+                false,
+            )
+            .unwrap()
+            .candidates
+            .remove(0);
+        for i in 0..n {
+            db.memory_create(RepoMemoryCreate {
+                kind: "Invariant".to_string(),
+                title: format!("Bound memory {i}"),
+                body: format!("Body of bound memory {i}."),
+                confidence: "high".to_string(),
+                created_by: Some("test".to_string()),
+                source: None,
+                tags: vec![],
+                payload_json: None,
+                bind: RepoMemoryBindTarget {
+                    logical_symbol_id: hit.logical_symbol_id,
+                    ..RepoMemoryBindTarget::default()
+                },
+            })
+            .unwrap();
+        }
+        (scratch, db)
+    }
+
+    fn lookup_args() -> SymbolArgs {
+        SymbolArgs {
+            symbol: Some("target".to_string()),
+            symbol_path: None,
+            logical_symbol_id: None,
+            language: None,
+            allow_ambiguous: false,
+            limit: 10,
+            include: None,
+            worktree: None,
+        }
+    }
+
+    /// #1200: `symbol_lookup` used to attach up to 10 memories PER CANDIDATE, so an ambiguous
+    /// lookup spent most of its response on drive-by memories.
+    #[test]
+    fn symbol_lookup_attaches_at_most_the_per_candidate_cap() {
+        let (_scratch, db) = db_with_symbol_memories(8);
+        let value = symbol_lookup_tool(&db, lookup_args(), MemorySurface::Full).unwrap();
+        let attached = value["candidates"][0]["memories"].as_array().expect("memories attached");
+        assert_eq!(
+            attached.len(),
+            usize::try_from(SYMBOL_LOOKUP_MEMORY_LIMIT).unwrap(),
+            "8 bound memories, capped to the per-candidate limit"
+        );
+    }
 }

--- a/crates/rag-rat-query/src/memory/api.rs
+++ b/crates/rag-rat-query/src/memory/api.rs
@@ -366,6 +366,21 @@ pub fn memory_search(
     query: &str,
     limit: u32,
 ) -> anyhow::Result<Vec<RepoMemory>> {
+    Ok(memory_search_scored(conn, query, limit)?.into_iter().map(|(memory, _)| memory).collect())
+}
+
+/// Keyword search over active+stale memories, best match first, carrying each hit's raw
+/// `bm25(repo_memory_fts)` rank so a caller can gate on RELATIVE relevance (the plain
+/// [`memory_search`] drops it).
+///
+/// INVARIANT: the returned score is SQLite's bm25, which is NEGATIVE and lower-is-better — a
+/// stronger match is MORE negative. Callers comparing scores must invert first; treating the
+/// raw value as a higher-is-better strength inverts the ranking.
+pub fn memory_search_scored(
+    conn: &Connection,
+    query: &str,
+    limit: u32,
+) -> anyhow::Result<Vec<(RepoMemory, f64)>> {
     let query = fts_query(query);
     if query.is_empty() {
         return Ok(Vec::new());
@@ -376,21 +391,107 @@ pub fn memory_search(
     // never surface here.
     let scope = memory_repo_scope(conn)?;
     let repo_clause = memory_repo_scope_clause(&scope);
+    // GROUP BY, not DISTINCT: selecting the score alongside the id makes the DISTINCT key the
+    // (memory_id, bm25) PAIR, so a stray duplicate FTS row for one memory — an interrupted heal, an
+    // import that inserts before its scoped DELETE — scores differently and survives it, and then
+    // consumes a LIMIT slot that a distinct memory should have had. Grouping collapses the
+    // duplicates BEFORE the LIMIT, so `limit` still means `limit` distinct memories, and MIN takes
+    // the best of the duplicate rows (bm25 is negative, lower is better). The bm25 call must be
+    // scored in a MATERIALIZED CTE: fts5 rejects its auxiliary functions inside an aggregate, and
+    // an inline subquery gets flattened back into the aggregate query and rejected the same way.
     let mut stmt = conn.prepare(&format!(
         "
-        SELECT DISTINCT repo_memory_fts.memory_id
-        FROM repo_memory_fts
-        JOIN repo_memories ON repo_memories.id = repo_memory_fts.memory_id
-        WHERE repo_memory_fts MATCH ?1
-          AND repo_memories.status IN ('active', 'stale'){repo_clause}
-        ORDER BY bm25(repo_memory_fts)
+        WITH scored AS MATERIALIZED (
+            SELECT repo_memory_fts.memory_id AS memory_id,
+                   bm25(repo_memory_fts) AS bm25_rank
+            FROM repo_memory_fts
+            JOIN repo_memories ON repo_memories.id = repo_memory_fts.memory_id
+            WHERE repo_memory_fts MATCH ?1
+              AND repo_memories.status IN ('active', 'stale'){repo_clause}
+        )
+        SELECT memory_id, MIN(bm25_rank) AS bm25_rank
+        FROM scored
+        GROUP BY memory_id
+        ORDER BY bm25_rank
         LIMIT ?2
         "
     ))?;
-    ids_to_memories(
-        conn,
-        stmt.query_map(params![query, i64::from(limit)], |row| row.get("memory_id"))?,
-    )
+    let ranked = stmt
+        .query_map(params![query, i64::from(limit)], |row| {
+            Ok((row.get::<_, String>("memory_id")?, row.get::<_, f64>("bm25_rank")?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut hits = Vec::with_capacity(ranked.len());
+    for (memory_id, rank) in ranked {
+        if let Some(memory) = memory_by_id(conn, &memory_id)? {
+            hits.push((memory, rank));
+        }
+    }
+    Ok(hits)
+}
+
+#[cfg(test)]
+mod memory_search_dedup_tests {
+    use super::*;
+
+    /// A corpus where one memory's FTS mirror carries a stray SECOND row — what an interrupted
+    /// heal, or an import that inserts before its scoped DELETE, leaves behind. The bodies differ,
+    /// so the two rows score differently and a `DISTINCT` keyed on the id + score pair keeps both.
+    fn conn_with_duplicated_fts_row() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        let insert_memory = |id: &str, body: &str| {
+            conn.execute(
+                "INSERT INTO repo_memories(id, kind, title, body, confidence, status,
+                        created_at_ms, updated_at_ms, source, memory_version, repo_id)
+                 VALUES (?1, 'Invariant', 'Quokkaform routing', ?2, 'high', 'active', 0, 0,
+                         'agent', 'v1', 'r')",
+                [id, body],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+                 VALUES ('r', ?1, 'Quokkaform routing', ?2, 'Invariant', '')",
+                [id, body],
+            )
+            .unwrap();
+        };
+        // `m` is the strongest match by term frequency, so BOTH of its rows outrank the others.
+        insert_memory("m", "quokkaform quokkaform quokkaform");
+        for other in ["m2", "m3", "m4"] {
+            insert_memory(other, "quokkaform is pinned by the router on every rebuild");
+        }
+        // The stray duplicate mirror row for `m`, scoring differently from its real one.
+        conn.execute(
+            "INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+             VALUES ('r', 'm', 'Quokkaform routing', 'quokkaform quokkaform quokkaform rebuild',
+                     'Invariant', '')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn duplicate_fts_rows_collapse_to_one_hit_per_memory() {
+        let conn = conn_with_duplicated_fts_row();
+        let hits = memory_search(&conn, "quokkaform", 10).unwrap();
+        assert_eq!(hits.len(), 4, "one hit per memory, not one per FTS row: {hits:?}");
+    }
+
+    /// The duplicate must not eat a result slot: `limit` counts distinct memories, so it has to be
+    /// applied AFTER the duplicate rows collapse, not to the raw FTS row set.
+    #[test]
+    fn a_duplicate_fts_row_does_not_consume_a_limit_slot() {
+        let conn = conn_with_duplicated_fts_row();
+        let hits = memory_search(&conn, "quokkaform", 3).unwrap();
+        assert_eq!(hits.len(), 3, "limit counts distinct memories, not FTS rows: {hits:?}");
+    }
 }
 
 /// Flat summary of one repo memory — boundary DTO for the CLI `memory list` surface.


### PR DESCRIPTION
The grep-augmentation memory lane ran on every augmented grep and emitted its top four FTS matches unconditionally. `memory_search` computed a bm25 score for ordering and then discarded it, so a match on one common token in the normalized pattern text surfaced up to four unrelated memories.

The lexical lane beside it already gated on a relative floor. The memory lane was the only text-matched lane without one.

That matters more than the token cost: attachments that are usually irrelevant train a reader to skim past them, which is exactly when the one that mattered gets missed.

## What changed

`memory_search` returns the bm25 score with each hit, and the lane drops anything far below the best match.

The floor is computed over the **full FTS hit set, before session dedupe**, so the reference score depends only on the query. Computing it after dedupe would let the 30-minute resurface window change the outcome: with the best hit already shown, the runner-up becomes its own reference and the weak tail it was meant to exclude passes instead.

Two properties the tests pin, because getting either wrong inverts the feature:

- **The floor is relative, not absolute.** A lone weak match still surfaces — the alternative is silence whenever the corpus holds only one relevant note.
- **SQLite's `bm25()` is negative, and more-negative is better.** The score is normalized before comparison. The inverted form of this filter would keep precisely the wrong memories while looking like it worked.

## What the floor actually removes — and what it does not

The threshold is 0.01, two orders of magnitude below the best hit, and its honest reach is narrow: it drops co-matches on a token whose idf fts5 clamps.

For a **single-term query** — an identifier, which is the dominant grep shape here — the floor cannot fire at all. `fts_query` ORs the tokens, so with one term every hit shares the same idf, and the remaining tf/length spread is bounded near 0.09 by the 8000-character body cap. Nothing lands two orders of magnitude down. For those greps the four-memory lane cap remains the entire mechanism, exactly as before this change.

It does not fire on merely-common multi-term tokens either, and deliberately so: bm25 magnitude ranks a length-diluted exact match (0.098 of the best hit) *below* a one-token co-match (0.126), so any tighter floor would drop real matches before it dropped noise. Moderately-common co-matches stay bounded by the cap, not the floor.

So this is a targeted fix for the pathological case — a query term so common that fts5 clamps it — plus the plumbing (a returned score, an ordering that does not depend on session state) that makes a better-tuned gate possible later. It is not a general-purpose relevance filter, and the PR should not be read as claiming one.

Path-bound attachments stay ungated — those are structural bindings, not text matches.

## Also

Scoring moved into a materialized CTE with `GROUP BY memory_id`, so duplicate FTS mirror rows collapse *before* the `LIMIT` and `limit` still counts distinct memories. Adding the score to a `SELECT DISTINCT` projection alone would have widened the dedup key to `(id, score)` and let one memory occupy two slots.

Two drive-by volume caps are trimmed. Both attach by binding, so every hit is relevant by construction; this is about how much of a reader's attention one call may spend, and they were budgeted far above the hook's 4:

- `read_chunk`: 20 → 6
- `symbol_lookup`: 10 per candidate → 5

## Tests

The cap test previously re-implemented the call it was supposed to exercise, so it passed with the change reverted. It now drives `read_chunk_with_graph_and_memories` itself; reverting the call site to the literal `20` fails it.

Fixes #1200.

