### PR TITLE
feat(mcp): declare the per-request worktree parameter in tool schemas

### DIFF
--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -268,7 +268,45 @@ pub fn description(name: &str) -> &'static str {
     }
 }
 
+/// The `worktree` request field every worktree-scoped read honors, declared ONCE here rather than
+/// as a field on each arg struct: the dispatcher reads it as a COMMON field off the raw request
+/// (`worktree_arg`), so N per-struct copies would be N chances to drift from it.
+/// The silent-fallback warning is load-bearing: `resolve_worktree_scope` drops a path that isn't a
+/// linked worktree of this repo to the base scope without an error, so a typo reads as a plausible
+/// answer about the wrong checkout — the exact failure the parameter exists to prevent.
+const WORKTREE_PARAM_DESCRIPTION: &str =
+    "Absolute path of the checkout to scope reads to — pass a linked worktree to read its branch \
+     overlay. Defaults to the server's working directory. A path that is not a linked worktree of \
+     this repo is silently ignored: results then come from the indexed checkout, with no error.";
+
 pub fn schema(name: &str) -> Value {
+    let mut schema = arg_schema(name);
+    // Only advertise the parameter on the tools that actually honor it: a write tool and
+    // `compare_graph_to_text` stay base-scoped by contract, so declaring it there would promise a
+    // scoping the dispatcher deliberately ignores.
+    if tool_honors_worktree_scope(name) {
+        declare_worktree_property(&mut schema);
+    }
+    schema
+}
+
+/// Add the optional `worktree` property to a generated arg schema. Optional = absent from
+/// `required`, which the generated schema never lists it in. The insert OVERWRITES any property an
+/// arg struct generates under the same name, so an arg struct that grows a `worktree` field of its
+/// own cannot leave a divergent spec in the advertised schema.
+fn declare_worktree_property(schema: &mut Value) {
+    let Some(object) = schema.as_object_mut() else { return };
+    // An `EmptyArgs` tool's generated schema carries no `properties` map at all.
+    let properties = object.entry("properties").or_insert_with(|| json!({}));
+    if let Some(properties) = properties.as_object_mut() {
+        properties.insert(
+            "worktree".to_string(),
+            json!({"type": "string", "description": WORKTREE_PARAM_DESCRIPTION}),
+        );
+    }
+}
+
+fn arg_schema(name: &str) -> Value {
     match name {
         "semantic_search"
         | "commit_search"
@@ -315,5 +353,68 @@ pub fn schema(name: &str) -> Value {
         "dream" => schema_for::<DreamArgs>(),
         "dream_review" => schema_for::<DreamReviewArgs>(),
         _ => json!({"type": "object"}),
+    }
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+
+    /// The tools that must NOT advertise `worktree`: every write tool (writing under a linked
+    /// overlay scope would reindex the overlay with the main checkout's contents) plus the one read
+    /// tool that compares the graph against live main-checkout text. Spelled out rather than
+    /// derived from `tool_honors_worktree_scope`, which `schema` is implemented in terms of — a
+    /// derived expectation would agree with the code by construction and guard nothing.
+    const BASE_SCOPED_TOOLS: &[&str] = &[
+        "heal_index",
+        "memory_create",
+        "memory_rebind",
+        "memory_update",
+        "memory_edge_add",
+        "memory_edge_remove",
+        "memory_mark_obsolete",
+        "memory_validate",
+        "dream",
+        "dream_review",
+        "compare_graph_to_text",
+    ];
+
+    fn worktree_property(name: &str) -> Option<Value> {
+        schema(name).get("properties")?.get("worktree").cloned()
+    }
+
+    #[test]
+    fn every_read_tool_declares_the_worktree_param_and_the_base_scoped_ones_do_not() {
+        // Per-request worktree scoping is unusable if no schema mentions it: serde tolerates the
+        // field (no `deny_unknown_fields`), but a client can only pass what the catalog declares.
+        for name in TOOL_NAMES {
+            if BASE_SCOPED_TOOLS.contains(name) {
+                assert!(
+                    worktree_property(name).is_none(),
+                    "{name}: base-scoped by contract — advertising `worktree` would promise a \
+                     scoping the dispatcher discards",
+                );
+                continue;
+            }
+            // Covers the reads whose checkout-dependence isn't obvious from the name:
+            // `index_status`'s per-language counts, `llm_status`'s chunk counts and
+            // `memory_doctor`'s re-anchor candidates all read the per-connection `files` view.
+            // `index_status` is also the `EmptyArgs` case, whose generated schema carries no
+            // `properties` map of its own.
+            let declared =
+                worktree_property(name).unwrap_or_else(|| panic!("{name} declares `worktree`"));
+            assert_eq!(
+                declared,
+                json!({"type": "string", "description": WORKTREE_PARAM_DESCRIPTION}),
+                "{name}: every read tool advertises the ONE canonical spec — an arg struct that \
+                 also carries the field must not leave a divergent one behind",
+            );
+            assert!(
+                !schema(name)["required"]
+                    .as_array()
+                    .is_some_and(|required| required.iter().any(|field| field == "worktree")),
+                "{name}: `worktree` is optional — it must never be listed as required",
+            );
+        }
     }
 }

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -844,7 +844,6 @@ mod symbol_lookup_memory_cap_tests {
             allow_ambiguous: false,
             limit: 10,
             include: None,
-            worktree: None,
         }
     }
 

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -92,6 +92,22 @@ fn tool_compares_against_live_source(name: &str) -> bool {
     matches!(name, "compare_graph_to_text")
 }
 
+/// Whether `name`'s reads are scoped by the common `worktree` request field. The single gate for
+/// both halves of the contract: `call_tool_for_config` scopes the connection by it, and
+/// `catalog::schema` declares the parameter by it — so the advertised surface can't drift from the
+/// tools that honor it.
+///
+/// Deliberately every read tool, not a hand-curated "results actually differ per checkout" list:
+/// the two errors cost wildly different amounts. Declaring it where the scope happens to be inert
+/// changes nothing about the answer; withholding it from a tool that DOES read the per-connection
+/// `files` view leaves a strict client unable to scope that tool at all. The tools that look
+/// checkout-independent by name mostly aren't — `index_status` counts files per language,
+/// `llm_status` counts chunks, and `memory_doctor`'s re-anchor candidates come from live symbols,
+/// all through that view.
+pub(crate) fn tool_honors_worktree_scope(name: &str) -> bool {
+    is_read_only_tool(name) && !tool_compares_against_live_source(name)
+}
+
 pub fn call_tool_for_config(
     config: &Config,
     name: &str,
@@ -106,7 +122,7 @@ pub fn call_tool_for_config(
     let worktree = worktree_arg(&arguments);
     // A tool that compares the graph against LIVE main-checkout text stays BASE-scoped even with a
     // `worktree` arg, so its graph and text sides come from the same checkout (#219 review).
-    let scope_worktree = if tool_compares_against_live_source(name) { None } else { worktree };
+    let scope_worktree = if tool_honors_worktree_scope(name) { worktree } else { None };
     // Read tools run on a lock-free read-only connection (#143). Two fall-backs to the read-write
     // open: (1) `try_open_config_read_only` returns `None` when the index still owes a heal/migrate
     // write; (2) a handful of read tools lazily WRITE on a cold path (`semantic_search` heals stale

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -243,11 +243,6 @@ pub struct SearchArgs {
     pub include_graph: McpGraphMode,
     #[serde(default = "default_search_graph_limit")]
     pub graph_limit: u32,
-    /// Absolute path to a linked git worktree you're working in. When set, results are served from
-    /// that worktree's branch overlay (its committed + uncommitted changes) on top of the indexed
-    /// checkout; omit to query the indexed checkout. An unrelated/invalid path falls back to it.
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
@@ -332,11 +327,6 @@ pub struct SymbolArgs {
     /// generated bindings back into the results). Pass `include: []` to suppress memories.
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<SymbolInclude>>,
-    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
-    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
-    /// checkout.
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 /// Pure symbol-selector args (symbol/ref/id/lang) with no `include` — for tools that resolve ONE
@@ -391,11 +381,6 @@ pub struct SymbolGraphArgs {
     pub include: Option<Vec<GraphInclude>>,
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
-    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
-    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
-    /// checkout.
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -460,11 +445,6 @@ pub struct ImpactArgs {
     /// is also reachable via `memory_for_symbol` / `memory_for_path` / `memory_for_call_path`.
     #[serde(default)]
     pub full_memories: bool,
-    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
-    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
-    /// checkout.
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -488,10 +468,6 @@ pub struct CheckLibraryUsageArgs {
     /// Max dependency-symbol entries returned; summary counts always cover the full set.
     #[serde(default = "default_graph_limit")]
     pub limit: u32,
-    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
-    /// overlay over the indexed checkout. Omit for the indexed checkout.
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -504,11 +480,6 @@ pub struct ReadChunkArgs {
     /// What to include: `memories` (on by default). Pass `include: []` to suppress.
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<MemoriesInclude>>,
-    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
-    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
-    /// checkout.
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1217,6 +1217,85 @@ fn worktree_param_routes_query_to_branch_overlay() {
     );
 }
 
+/// Add a linked worktree on `branch` whose `src/a.rs` defines `symbol`, and index its overlay.
+fn linked_worktree_with(
+    config: &Config,
+    root: &Path,
+    branch: &str,
+    symbol: &str,
+) -> rag_rat_base::test_scratch::ScratchDir {
+    let linked = unique_temp_root();
+    git(root, &["worktree", "add", "-q", "-b", branch, linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), format!("pub fn {symbol}() {{}}\n")).unwrap();
+    git(&linked, &["add", "."]);
+    git(&linked, &["commit", "-q", "-m", branch]);
+    let mut db = IndexDatabase::open_config(config).unwrap();
+    db.index_worktree_overlay(config, &linked, &mut |_| {}).unwrap();
+    linked
+}
+
+/// The scoping field `name` ADVERTISES, read back out of the generated schema so the calls below
+/// drive the declared name. A client can only pass what the catalog declares, so an undeclared
+/// parameter is an unusable one however faithfully the dispatcher honors it (#1201).
+fn advertised_worktree_param(name: &str) -> String {
+    let schema = schema(name);
+    let (param, _) = schema["properties"]
+        .as_object()
+        .and_then(|properties| properties.get_key_value("worktree"))
+        .unwrap_or_else(|| panic!("{name} advertises the worktree parameter"));
+    param.clone()
+}
+
+#[test]
+fn the_advertised_worktree_param_serves_that_checkout_and_not_its_siblings() {
+    let param = advertised_worktree_param("symbol_lookup");
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    git(&root, &["init", "-q", "-b", "main"]);
+    git(&root, &["config", "user.email", "t@e"]);
+    git(&root, &["config", "user.name", "t"]);
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-q", "-m", "base"]);
+    let config = rust_config(root.to_path_buf());
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let first = linked_worktree_with(&config, &root, "feat-a", "first_fn");
+    let second = linked_worktree_with(&config, &root, "feat-b", "second_fn");
+    let (first, second) = (first.to_str().unwrap(), second.to_str().unwrap());
+    let call = |tool: &str, mut args: Value, worktree: Option<&str>| {
+        if let Some(worktree) = worktree {
+            args[param.as_str()] = json!(worktree);
+        }
+        call_tool_for_config(&config, tool, args).unwrap()
+    };
+    let found = |symbol: &str, worktree: Option<&str>| {
+        candidate_count(&call("symbol_lookup", json!({"symbol": symbol}), worktree)) > 0
+    };
+
+    // Active-checkout scope: the requested worktree's overlay shadows the base file.
+    assert!(found("first_fn", Some(first)), "the scoped checkout's own symbol");
+    assert!(!found("base_fn", Some(first)), "the overlay shadows the base file");
+    // Sibling isolation: the OTHER linked checkout's overlay must not leak into this scope.
+    assert!(!found("second_fn", Some(first)), "a sibling checkout's symbol must not");
+    assert!(found("second_fn", Some(second)), "each checkout serves its own overlay");
+
+    // Unscoped: the base scope, with neither overlay visible.
+    assert!(found("base_fn", None), "unscoped reads serve the base checkout");
+    assert!(!found("first_fn", None));
+    assert!(!found("second_fn", None));
+
+    // A tool a client could NOT scope until the catalog declared the parameter for it:
+    // `SymbolRefArgs` has no `worktree` field of its own. It resolves its symbol through the
+    // scoped views, answering `null` for a symbol absent from the requested checkout.
+    assert_eq!(advertised_worktree_param("git_history_for_symbol"), param);
+    let history = |symbol: &str, worktree: &str| {
+        call("git_history_for_symbol", json!({"symbol": symbol}), Some(worktree))
+    };
+    assert!(!history("first_fn", first).is_null(), "the scoped checkout resolves its symbol");
+    assert!(history("first_fn", second).is_null(), "a sibling checkout does not");
+}
+
 #[test]
 fn compare_graph_to_text_stays_base_scoped_under_a_worktree_param() {
     // #219 review (3440746678): `compare_graph_to_text` reads LIVE source text through

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -55,9 +55,11 @@ To run from a checkout without installing, use a project-scoped server whose com
 ## Tools
 
 The MCP surface is **47 tools** in nine groups. The signatures are below; the prose sections that
-follow describe response shapes and per-tool behavior. Every symbol/search/read tool additionally
-accepts an optional `"worktree": string` — an absolute path to a linked git worktree, served as a
-branch overlay over the indexed checkout — omitted from the signatures below for brevity.
+follow describe response shapes and per-tool behavior. Every read tool additionally accepts an
+optional `"worktree": string` — an absolute path to a linked git worktree, served as a branch
+overlay over the indexed checkout — omitted from the signatures below for brevity. The write tools
+and `compare_graph_to_text` do not: they stay scoped to the indexed checkout, so they neither
+declare the parameter nor honor one.
 
 **Search & symbols**
 


### PR DESCRIPTION
> **Stacked on #1205** (base `fix/memory-lane-relevance-floor`). It carries a one-line follow-up to a test that PR adds, so it needs to merge after it. Review the top commit only; the diff rebases clean once #1205 lands.

Per-request worktree scoping already worked — the dispatcher reads a `worktree` field off the request and scopes the connection to that checkout — but only about a dozen tools advertised it. Six arg structs had each grown their own `worktree` field; the other ~23 checkout-scoped read tools declared nothing, and serde accepted the parameter there only because the structs do not deny unknown fields.

So for most read tools the parameter was undiscoverable: a client reading `tools/list` had no way to know it existed. The fallback is the MCP **server process's** launch directory, not the client's, so an agent working in a linked worktree got base-scope answers with nothing indicating the results described a different checkout — even though that worktree's overlay was indexed and current.

## What changed

Every read tool whose results are checkout-scoped now advertises the parameter, injected once where schemas are assembled rather than redeclared per arg struct. Write tools and `compare_graph_to_text` keep their documented base-scope behavior and do not advertise it.

The predicate stays deliberately broad. The two error directions aren't symmetric: declaring the parameter on a tool whose scope is inert changes no answer, while withholding it from one that does read the scope view leaves a strict client unable to scope that tool at all — the exact bug this fixes. Several tools that look repo-scoped aren't: `index_status` counts through the scoped `files` view, `llm_status`'s chunk count does too, and `memory_doctor` resolves re-anchor targets from scoped symbol rows.

Six arg structs had grown their own `worktree` field. The shared injection overwrites the property they generate and no handler reads them, so they're removed — the declaration now has one source.

## Tests

Coverage is additive — `worktree_param_routes_query_to_branch_overlay` and `compare_graph_to_text_stays_base_scoped_under_a_worktree_param` are unchanged.

A new test drives its calls through the parameter name read back out of the generated schema, so it fails if the catalog stops declaring it, and adds two legs the existing test does not cover: sibling isolation (a second linked worktree's symbol must not resolve under the first's scope), and `git_history_for_symbol`, whose arg struct never carried a `worktree` field of its own and which no client could scope until the catalog declared the parameter for it.

A new catalog test pins the advertised spec byte-for-byte across every advertising tool, against a literal list of the eleven base-scoped exceptions. The previous catalog assertion could not fail: it compared `declared.is_some()` against the same predicate `schema` is implemented by calling.

## Note on what this does not do

An agent that omits the parameter still silently gets base scope. The server cannot detect that — it never sees the client's working directory. An earlier draft added a response note when the effective scope was base and linked worktrees existed, but with the cwd fallback that fires on essentially every call in any repo with a worktree, so it was dropped as ambient noise. Closing that gap needs the client to send its cwd, which is a protocol-level change.

Fixes #1201.


