### PR TITLE
feat(oplog): add the node_anchors content op carrying portable binding facts (#1208)

### DIFF
--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -1295,8 +1295,9 @@ fn stable_owner_stream_for_repo(
     rag_rat_oplog::owned_stream_v2_id_with_mode(conn, repo_id, mode)
 }
 
-/// Reject a live content op whose ASSEMBLED signed `/3` envelope would exceed the §18a 256 KiB cap
-/// (#680) — the AUTHORITATIVE whole-op write-boundary guard. The cheap per-field caps
+/// Reject a live content op the `/3` log cannot carry — either a shape `op::decode` would refuse
+/// at any size, or an ASSEMBLED signed envelope over the §18a 256 KiB cap (#680). The
+/// AUTHORITATIVE whole-op write-boundary guard. The cheap per-field caps
 /// (`validate_payload`'s payload byte cap, `validate_edge_len`'s edge-anchor cap, the title/body
 /// char caps) fast-fail a single pathological field, but they cannot see an AGGREGATE — most
 /// reachably an arbitrary NUMBER of individually-valid tags on a `NodeCreate`/`NodeUpdate`, or a
@@ -1310,8 +1311,25 @@ fn reject_unauthorable_content_op(op: &MemoryOp, policy: StreamSealPolicy) -> an
     if content_op_is_authorable(op, policy) {
         return Ok(());
     }
-    // The per-field caps have already passed, so the culprit is an aggregate (or a future uncapped
-    // field): name what to shrink rather than surfacing a bare envelope-overflow rollback.
+    // Two different failures reach here and they want different remedies, so name the right one.
+    // A structural refusal is not a size problem: 65 tiny anchors are nowhere near the byte cap,
+    // and a binding named twice is a dedupe fix, not a "shorten it" one.
+    if !rag_rat_oplog::within_wire_limits(op) {
+        match op {
+            MemoryOp::NodeAnchors { node_id, anchors } => anyhow::bail!(
+                "memory `{}` cannot store its {} anchors: an anchor set holds at most {} bindings \
+                 and must not name one binding twice",
+                node_id.as_str(),
+                anchors.len(),
+                rag_rat_oplog::MAX_ANCHORS_PER_OP
+            ),
+            // No other op kind has a structural limit today; this arm keeps the branch total.
+            _ => anyhow::bail!("this memory operation has a shape the op log cannot encode"),
+        }
+    }
+    // Past the structural gate the culprit is size: an aggregate the per-field caps cannot see (or
+    // a future uncapped field). Name what to shrink rather than surfacing a bare envelope-overflow
+    // rollback.
     match op {
         MemoryOp::NodeCreate { node_id, .. } | MemoryOp::NodeUpdate { node_id, .. } =>
             anyhow::bail!(
@@ -1326,8 +1344,8 @@ fn reject_unauthorable_content_op(op: &MemoryOp, policy: StreamSealPolicy) -> an
             edge.source_node_id.as_str()
         ),
         MemoryOp::NodeAnchors { node_id, anchors } => anyhow::bail!(
-            "memory `{}` has too many or too large anchors to store: its {} bindings exceed the \
-             256 KiB signed-entry cap — reduce the number of bindings, or shorten their paths",
+            "memory `{}` is too large to store: its {} anchors exceed the 256 KiB signed-entry \
+             cap — shorten their paths, or bind the memory to fewer places",
             node_id.as_str(),
             anchors.len()
         ),

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -1325,6 +1325,12 @@ fn reject_unauthorable_content_op(op: &MemoryOp, policy: StreamSealPolicy) -> an
              signed-entry cap — shorten the target anchor / target repo id",
             edge.source_node_id.as_str()
         ),
+        MemoryOp::NodeAnchors { node_id, anchors } => anyhow::bail!(
+            "memory `{}` has too many or too large anchors to store: its {} bindings exceed the \
+             256 KiB signed-entry cap — reduce the number of bindings, or shorten their paths",
+            node_id.as_str(),
+            anchors.len()
+        ),
         // NodeStatus / EdgeRemove / Rebind carry no unbounded free-form field and cannot exceed the
         // cap; this arm keeps the guard total over the op vocabulary.
         _ => anyhow::bail!(

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -98,6 +98,7 @@ const CONTENT_OP_BODY_MAX_BYTES: usize =
 /// the create/update boundary to reject oversized input before the row is persisted (#680). Checks
 /// the encoded body only; the header + signature are the fixed overhead `CONTENT_OP_BODY_MAX_BYTES`
 /// already reserves for.
+///
 /// Also gates the STRUCTURAL limits `op::decode` enforces, not just size: an op can be small and
 /// still unreadable (an over-cap or duplicate-carrying anchor set). `/3` ingest never decodes op
 /// bytes, so such an entry would be signed, accepted and forwarded, then silently skipped at
@@ -124,6 +125,9 @@ const CONTENT_SEALED_OP_BODY_MAX_BYTES: usize =
 /// entry once the AEAD nonce + tag are added to its body (S2, #608). The live reconcile uses
 /// this to QUARANTINE an un-authorable op on a sealed stream — exactly as the suite-0 predicate
 /// does on a plaintext one — instead of `bail!`ing the whole batch at sign time.
+///
+/// Gates the same structural limits as its twin: a shape `op::decode` refuses is unreadable whether
+/// or not it is sealed, so both predicates must agree on it.
 pub fn content_op_is_sealed_authorable(op: &MemoryOp) -> bool {
     op::within_wire_limits(op) && op::encode(op).len() <= CONTENT_SEALED_OP_BODY_MAX_BYTES
 }
@@ -992,6 +996,62 @@ mod tests {
             !content_op_is_authorable(&edge_add("mem_src", &"a".repeat(300 * 1024))),
             "an oversized edge anchor exceeds the /3 envelope",
         );
+    }
+
+    /// Both predicates must refuse a shape `op::decode` cannot read back, whatever its size — a
+    /// small unreadable op would otherwise be signed, accepted and forwarded, then silently skipped
+    /// at projection by every peer, its author included.
+    ///
+    /// This pins the WIRING, not the primitive: dropping `within_wire_limits` from either predicate
+    /// must fail here. The sealed twin is asserted separately because it is a separate line that a
+    /// refactor can drop on its own.
+    #[test]
+    fn both_authorable_predicates_refuse_a_structurally_unreadable_op() {
+        let anchor = |binding_id: &str| op::PortableAnchor {
+            binding_kind: "symbol".to_string(),
+            binding_id: binding_id.to_string(),
+            path: Some("src/lib.rs".to_string()),
+            start_line: Some(1),
+            end_line: Some(2),
+            commit_hash: None,
+            tracker: None,
+            project: None,
+            item_key: None,
+            created_at_ms: 1,
+            symbol_kind: None,
+            signature_hash: None,
+            moniker_tool: None,
+            moniker_tool_version: None,
+        };
+        let anchors_op = |anchors: Vec<op::PortableAnchor>| MemoryOp::NodeAnchors {
+            node_id: NodeId::from("mem_1"),
+            anchors,
+        };
+
+        // Two anchors naming ONE binding: tiny, so every size bound passes.
+        let duplicated = anchors_op(vec![anchor("src/lib.rs::run"), anchor("src/lib.rs::run")]);
+        assert!(
+            !content_op_is_authorable(&duplicated),
+            "a duplicate binding identity is unreadable"
+        );
+        assert!(
+            !content_op_is_sealed_authorable(&duplicated),
+            "sealing does not make a duplicate identity readable",
+        );
+
+        // One past the count cap, also far inside the byte bounds.
+        let over_cap = anchors_op(
+            (0..=op::MAX_ANCHORS_PER_OP).map(|index| anchor(&format!("id_{index:03}"))).collect(),
+        );
+        assert!(!content_op_is_authorable(&over_cap), "an over-cap anchor set is unreadable");
+        assert!(
+            !content_op_is_sealed_authorable(&over_cap),
+            "sealing does not raise the anchor cap",
+        );
+
+        let clean = anchors_op(vec![anchor("src/lib.rs::run"), anchor("src/lib.rs::walk")]);
+        assert!(content_op_is_authorable(&clean), "a well-formed anchor set is authorable");
+        assert!(content_op_is_sealed_authorable(&clean), "and authorable on a sealed stream");
     }
 
     /// A `NodeCreate` on `id` whose canonical-CBOR body (`op::encode`) is EXACTLY `encoded_len`

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -98,8 +98,12 @@ const CONTENT_OP_BODY_MAX_BYTES: usize =
 /// the create/update boundary to reject oversized input before the row is persisted (#680). Checks
 /// the encoded body only; the header + signature are the fixed overhead `CONTENT_OP_BODY_MAX_BYTES`
 /// already reserves for.
+/// Also gates the STRUCTURAL limits `op::decode` enforces, not just size: an op can be small and
+/// still unreadable (an over-cap or duplicate-carrying anchor set). `/3` ingest never decodes op
+/// bytes, so such an entry would be signed, accepted and forwarded, then silently skipped at
+/// projection by every peer including its author — a shape worth refusing before it is durable.
 pub fn content_op_is_authorable(op: &MemoryOp) -> bool {
-    op::encode(op).len() <= CONTENT_OP_BODY_MAX_BYTES
+    op::within_wire_limits(op) && op::encode(op).len() <= CONTENT_OP_BODY_MAX_BYTES
 }
 
 /// The AEAD expansion a suite-1 seal adds to the op body on the wire: the 24-byte XChaCha nonce +
@@ -121,7 +125,7 @@ const CONTENT_SEALED_OP_BODY_MAX_BYTES: usize =
 /// this to QUARANTINE an un-authorable op on a sealed stream — exactly as the suite-0 predicate
 /// does on a plaintext one — instead of `bail!`ing the whole batch at sign time.
 pub fn content_op_is_sealed_authorable(op: &MemoryOp) -> bool {
-    op::encode(op).len() <= CONTENT_SEALED_OP_BODY_MAX_BYTES
+    op::within_wire_limits(op) && op::encode(op).len() <= CONTENT_SEALED_OP_BODY_MAX_BYTES
 }
 
 /// The `/3` chain tail for one `(stream, author, device)` coordinate: its highest-`seq` entry.

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -164,8 +164,8 @@ pub use content_projection::{
 // — and the only direction of the dependency (`oplog` never depends back on `query::memory`).
 pub use identity::{LocalDevice, load_local_device, local_device};
 pub use op::{
-    DeviceFingerprint, EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus,
-    ParseDeviceFingerprintError, ResolvedAnchor,
+    DeviceFingerprint, EdgeKey, EdgeSpec, MAX_ANCHORS_PER_OP, MemoryOp, NodeContent, NodeId,
+    NodeStatus, ParseDeviceFingerprintError, PortableAnchor, ResolvedAnchor,
 };
 // The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
 // standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -165,7 +165,7 @@ pub use content_projection::{
 pub use identity::{LocalDevice, load_local_device, local_device};
 pub use op::{
     DeviceFingerprint, EdgeKey, EdgeSpec, MAX_ANCHORS_PER_OP, MemoryOp, NodeContent, NodeId,
-    NodeStatus, ParseDeviceFingerprintError, PortableAnchor, ResolvedAnchor,
+    NodeStatus, ParseDeviceFingerprintError, PortableAnchor, ResolvedAnchor, within_wire_limits,
 };
 // The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
 // standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only

--- a/crates/rag-rat-oplog/src/op.rs
+++ b/crates/rag-rat-oplog/src/op.rs
@@ -298,11 +298,54 @@ impl PortableAnchor {
 /// practice (its own, plus an auto-moniker), so this is a generous structural bound rather than a
 /// budget.
 ///
-/// RAISING IT IS A FORMAT CHANGE. A binary that knows `node_anchors` hard-rejects an over-cap op,
-/// so an older peer would refuse an entry a newer one authored — the chain wedges rather than
-/// degrading. A larger limit ships as a NEW op kind, the same discipline `snapshot` documents for
-/// its payload.
+/// RAISING IT IS A FORMAT CHANGE, and the failure it causes is SILENT. `/3` ingest never decodes op
+/// bytes (they may be sealed), so an over-cap op from a newer peer is accepted, retained, and
+/// forwarded; the projection then treats an undecodable body as a local skip, not an acceptance
+/// failure, so the memory's anchors simply never appear on the older peer and nothing reports it. A
+/// larger limit ships as a NEW op kind, the same discipline `snapshot` documents for its payload.
 pub const MAX_ANCHORS_PER_OP: usize = 64;
+
+/// The `PortableAnchor` fields, in wire order. Pinned against the `anchors/1` spec by a test in
+/// that scope's own module, so adding a column there fails loudly instead of silently seeding NULL
+/// across the account boundary.
+pub(crate) const PORTABLE_ANCHOR_FIELDS: &[&str] = &[
+    "binding_kind",
+    "binding_id",
+    "path",
+    "start_line",
+    "end_line",
+    "commit_hash",
+    "tracker",
+    "project",
+    "item_key",
+    "created_at_ms",
+    "symbol_kind",
+    "signature_hash",
+    "moniker_tool",
+    "moniker_tool_version",
+];
+
+/// Whether `op` satisfies the structural limits `decode` enforces — the guard that keeps an op from
+/// being signed and replicated in a shape NO binary can read back, its author included.
+///
+/// Byte size is bounded separately, by the content-entry caps. What this catches is the shapes that
+/// are *small* and still undecodable: an over-cap anchor count, and a duplicated row identity. Both
+/// encode happily, and `/3` would accept, retain and forward them, so without this gate they become
+/// permanent entries whose anchors every peer silently drops at projection.
+pub fn within_wire_limits(op: &MemoryOp) -> bool {
+    match op {
+        MemoryOp::NodeAnchors { anchors, .. } => {
+            if anchors.len() > MAX_ANCHORS_PER_OP {
+                return false;
+            }
+            let mut identities: Vec<(&str, &str)> =
+                anchors.iter().map(PortableAnchor::identity).collect();
+            identities.sort_unstable();
+            identities.windows(2).all(|pair| pair[0] != pair[1])
+        },
+        _ => true,
+    }
+}
 
 /// The frozen op set (§5.4 / §6.3). Each op mutates exactly one LWW register of one node/edge (see
 /// the fold), except `NodeCreate`, which also establishes existence.
@@ -463,9 +506,13 @@ fn encode_resolved(enc: &mut VecEncoder<'_>, resolved: &ResolvedAnchor) {
 /// query that produced it perturbs the canonical bytes — the rule `tags` already follows.
 ///
 /// Duplicates are deliberately NOT deduped here. Two anchors sharing `(binding_kind, binding_id)`
-/// name one row twice, and the payload cannot say which of them wins; `decode` rejects that
-/// outright, and because these bytes then fail the `encode == bytes` identity check, a
-/// duplicate-carrying op can never round-trip through the wire.
+/// name one row twice, and the payload cannot say which of them wins, so `decode`'s
+/// strictly-increasing check rejects them.
+///
+/// That check is the SOLE rejector — the `encode == bytes` identity check is not a second net here,
+/// and must not be mistaken for one. It is unreachable (decode errors first), and it would pass
+/// anyway: this sort is stable, so a duplicate-carrying payload re-encodes to the bytes it came
+/// from. Relaxing the `>=` to `>` would let duplicates straight through.
 fn encode_anchors(enc: &mut VecEncoder<'_>, anchors: &[PortableAnchor]) {
     let mut ordered: Vec<&PortableAnchor> = anchors.iter().collect();
     ordered.sort_by(|a, b| a.identity().cmp(&b.identity()));
@@ -843,7 +890,7 @@ mod tests {
     }
 
     /// Write one anchor into a hand-rolled envelope — the fixture builder for the canonical-order
-    /// and cap rejections, which need wire forms `encode` would never produce.
+    /// rejections, which need wire forms `encode` would never produce.
     fn raw_anchor(enc: &mut VecEncoder<'_>, kind: &str, id: &str) {
         enc.array(14).unwrap();
         enc.str(kind).unwrap();
@@ -972,6 +1019,49 @@ mod tests {
 
         let err = decode(&buf).unwrap_err().to_string();
         assert!(err.contains("strictly increasing"), "{err}");
+    }
+
+    /// The round-trip direction the hand-rolled duplicate test cannot reach: an op BUILT with two
+    /// anchors for one row must not survive its own encode. Pins that `decode`'s strict ordering is
+    /// what rejects it — the `encode == bytes` check cannot, since the stable sort re-encodes such
+    /// a payload to the very bytes it came from.
+    #[test]
+    fn an_op_carrying_a_duplicate_identity_cannot_round_trip() {
+        let mut duplicated = anchors();
+        duplicated.push(duplicated[0].clone());
+        let op = MemoryOp::NodeAnchors { node_id: NodeId::from("mem_1"), anchors: duplicated };
+
+        let err = decode(&encode(&op)).unwrap_err().to_string();
+        assert!(err.contains("strictly increasing"), "{err}");
+    }
+
+    /// The authoring-side twin: such an op is refused BEFORE it is signed, so it never becomes a
+    /// permanent entry whose anchors every peer silently drops at projection.
+    #[test]
+    fn wire_limits_reject_what_decode_cannot_read_back() {
+        let mut duplicated = anchors();
+        duplicated.push(duplicated[0].clone());
+        assert!(!within_wire_limits(&MemoryOp::NodeAnchors {
+            node_id: NodeId::from("mem_1"),
+            anchors: duplicated,
+        }));
+
+        let over_cap: Vec<PortableAnchor> = (0..=MAX_ANCHORS_PER_OP)
+            .map(|index| PortableAnchor {
+                binding_id: format!("id_{index:03}"),
+                ..anchors()[0].clone()
+            })
+            .collect();
+        assert!(!within_wire_limits(&MemoryOp::NodeAnchors {
+            node_id: NodeId::from("mem_1"),
+            anchors: over_cap,
+        }));
+
+        assert!(within_wire_limits(&MemoryOp::NodeAnchors {
+            node_id: NodeId::from("mem_1"),
+            anchors: anchors(),
+        }));
+        assert!(every_variant().iter().all(|(_, op)| within_wire_limits(op)));
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/op.rs
+++ b/crates/rag-rat-oplog/src/op.rs
@@ -343,7 +343,17 @@ pub fn within_wire_limits(op: &MemoryOp) -> bool {
             identities.sort_unstable();
             identities.windows(2).all(|pair| pair[0] != pair[1])
         },
-        _ => true,
+        // Listed rather than wildcarded ON PURPOSE: this seam's contract is "reject exactly what
+        // `decode` rejects", so the next op kind that grows a count cap or an ordering rule must
+        // fail to compile here instead of silently answering `true` — the same under-approximation
+        // this function was added to close.
+        MemoryOp::NodeCreate { .. }
+        | MemoryOp::NodeUpdate { .. }
+        | MemoryOp::NodeStatus { .. }
+        | MemoryOp::EdgeAdd { .. }
+        | MemoryOp::EdgeRemove { .. }
+        | MemoryOp::Rebind { .. }
+        | MemoryOp::Snapshot => true,
     }
 }
 

--- a/crates/rag-rat-oplog/src/op.rs
+++ b/crates/rag-rat-oplog/src/op.rs
@@ -259,6 +259,51 @@ pub struct ResolvedAnchor {
     pub anchor_status: String,
 }
 
+/// The portable half of one `repo_memory_bindings` row: the PK tail plus every column the
+/// `anchors/1` table scope replicates, and nothing checkout-local. The `(repo_id, memory_id)` half
+/// of that PK is context rather than payload — the repo being drained, and the op's own `node_id` —
+/// so it is not carried per anchor.
+///
+/// Field order mirrors the `anchors/1` spec: the PK tail, then its synced columns. Keeping the two
+/// readable against each other is the point; a column added to that scope has to be added here as a
+/// new op kind, since widening this one would break the byte-canonical identity below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortableAnchor {
+    pub binding_kind: String,
+    pub binding_id: String,
+    pub path: Option<String>,
+    pub start_line: Option<i64>,
+    pub end_line: Option<i64>,
+    pub commit_hash: Option<String>,
+    pub tracker: Option<String>,
+    pub project: Option<String>,
+    pub item_key: Option<String>,
+    pub created_at_ms: i64,
+    pub symbol_kind: Option<String>,
+    pub signature_hash: Option<String>,
+    pub moniker_tool: Option<String>,
+    pub moniker_tool_version: Option<String>,
+}
+
+impl PortableAnchor {
+    /// The row this anchor names — the half of the binding PK an anchor set is ordered and
+    /// deduplicated by. Deliberately NOT a derived `Ord` over the whole struct: two anchors sharing
+    /// an identity are a conflict to reject, not two distinct members to order by their payloads.
+    fn identity(&self) -> (&str, &str) {
+        (self.binding_kind.as_str(), self.binding_id.as_str())
+    }
+}
+
+/// The most anchors one `node_anchors` op may carry. A memory holds a handful of bindings in
+/// practice (its own, plus an auto-moniker), so this is a generous structural bound rather than a
+/// budget.
+///
+/// RAISING IT IS A FORMAT CHANGE. A binary that knows `node_anchors` hard-rejects an over-cap op,
+/// so an older peer would refuse an entry a newer one authored — the chain wedges rather than
+/// degrading. A larger limit ships as a NEW op kind, the same discipline `snapshot` documents for
+/// its payload.
+pub const MAX_ANCHORS_PER_OP: usize = 64;
+
 /// The frozen op set (§5.4 / §6.3). Each op mutates exactly one LWW register of one node/edge (see
 /// the fold), except `NodeCreate`, which also establishes existence.
 #[derive(Debug, Clone, PartialEq)]
@@ -275,6 +320,8 @@ pub enum MemoryOp {
     EdgeRemove { edge_key: EdgeKey },
     /// Re-resolve an edge's local anchor; NEVER mutates the `edge_key` or presence.
     Rebind { edge_key: EdgeKey, resolved: ResolvedAnchor },
+    /// A node's portable anchor set — a FULL-SET snapshot, never a delta.
+    NodeAnchors { node_id: NodeId, anchors: Vec<PortableAnchor> },
     /// A converged-state boundary marker; inert in the fold this increment (§5.4/C4).
     Snapshot,
 }
@@ -289,6 +336,7 @@ impl MemoryOp {
             Self::EdgeAdd { .. } => "edge_add",
             Self::EdgeRemove { .. } => "edge_remove",
             Self::Rebind { .. } => "rebind",
+            Self::NodeAnchors { .. } => "node_anchors",
             Self::Snapshot => "snapshot",
         }
     }
@@ -359,6 +407,11 @@ fn encode_payload(enc: &mut VecEncoder<'_>, op: &MemoryOp) {
             enc.str(edge_key.as_str()).expect(INFALLIBLE);
             encode_resolved(enc, resolved);
         },
+        MemoryOp::NodeAnchors { node_id, anchors } => {
+            enc.array(2).expect(INFALLIBLE);
+            enc.str(node_id.as_str()).expect(INFALLIBLE);
+            encode_anchors(enc, anchors);
+        },
         MemoryOp::Snapshot => {
             // Inert boundary marker: a strictly-null payload. A future snapshot that carries a
             // coverage manifest (§5.4/C4) is a NEW op kind — NOT a non-null payload under this kind
@@ -406,6 +459,49 @@ fn encode_resolved(enc: &mut VecEncoder<'_>, resolved: &ResolvedAnchor) {
     enc.str(&resolved.anchor_status).expect(INFALLIBLE);
 }
 
+/// Encode the anchor SET, ordered by identity so neither the caller's insertion sequence nor the
+/// query that produced it perturbs the canonical bytes — the rule `tags` already follows.
+///
+/// Duplicates are deliberately NOT deduped here. Two anchors sharing `(binding_kind, binding_id)`
+/// name one row twice, and the payload cannot say which of them wins; `decode` rejects that
+/// outright, and because these bytes then fail the `encode == bytes` identity check, a
+/// duplicate-carrying op can never round-trip through the wire.
+fn encode_anchors(enc: &mut VecEncoder<'_>, anchors: &[PortableAnchor]) {
+    let mut ordered: Vec<&PortableAnchor> = anchors.iter().collect();
+    ordered.sort_by(|a, b| a.identity().cmp(&b.identity()));
+    enc.array(ordered.len() as u64).expect(INFALLIBLE);
+    for anchor in ordered {
+        encode_anchor(enc, anchor);
+    }
+}
+
+fn encode_anchor(enc: &mut VecEncoder<'_>, anchor: &PortableAnchor) {
+    enc.array(14).expect(INFALLIBLE);
+    enc.str(&anchor.binding_kind).expect(INFALLIBLE);
+    enc.str(&anchor.binding_id).expect(INFALLIBLE);
+    encode_opt_str(enc, anchor.path.as_deref());
+    encode_opt_i64(enc, anchor.start_line);
+    encode_opt_i64(enc, anchor.end_line);
+    encode_opt_str(enc, anchor.commit_hash.as_deref());
+    encode_opt_str(enc, anchor.tracker.as_deref());
+    encode_opt_str(enc, anchor.project.as_deref());
+    encode_opt_str(enc, anchor.item_key.as_deref());
+    enc.i64(anchor.created_at_ms).expect(INFALLIBLE);
+    encode_opt_str(enc, anchor.symbol_kind.as_deref());
+    encode_opt_str(enc, anchor.signature_hash.as_deref());
+    encode_opt_str(enc, anchor.moniker_tool.as_deref());
+    encode_opt_str(enc, anchor.moniker_tool_version.as_deref());
+}
+
+/// Encode an optional integer as an integer item or CBOR `null` — the `encode_opt_str` rule for the
+/// nullable INTEGER columns (`start_line` / `end_line`), which a tracker binding leaves unset.
+fn encode_opt_i64(enc: &mut VecEncoder<'_>, value: Option<i64>) {
+    match value {
+        Some(number) => enc.i64(number).expect(INFALLIBLE),
+        None => enc.null().expect(INFALLIBLE),
+    };
+}
+
 /// Encode an optional string as a text item or CBOR `null` — a distinct, unambiguous absent marker.
 fn encode_opt_str(enc: &mut VecEncoder<'_>, value: Option<&str>) {
     match value {
@@ -449,6 +545,10 @@ fn decode_envelope(bytes: &[u8]) -> Result<DecodedOp, CborError> {
         "rebind" => {
             let (edge_key, resolved) = decode_rebind(&mut d)?;
             Some(MemoryOp::Rebind { edge_key, resolved })
+        },
+        "node_anchors" => {
+            let (node_id, anchors) = decode_node_anchors(&mut d)?;
+            Some(MemoryOp::NodeAnchors { node_id, anchors })
         },
         "snapshot" => {
             d.null()?;
@@ -541,6 +641,72 @@ fn decode_rebind(d: &mut Decoder<'_>) -> Result<(EdgeKey, ResolvedAnchor), CborE
     let edge_key = EdgeKey::from(d.str()?);
     let resolved = decode_resolved(d)?;
     Ok((edge_key, resolved))
+}
+
+fn decode_node_anchors(d: &mut Decoder<'_>) -> Result<(NodeId, Vec<PortableAnchor>), CborError> {
+    cbor::expect_array(d, 2)?;
+    let node_id = NodeId::from(d.str()?);
+    let anchors = decode_anchors(d)?;
+    Ok((node_id, anchors))
+}
+
+fn decode_anchors(d: &mut Decoder<'_>) -> Result<Vec<PortableAnchor>, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    // Judge the COUNT from the header before decoding a single element. The length is
+    // attacker-controlled, so this both bounds the work and stays clear of trusting it enough to
+    // preallocate — the `decode_str_array` rule.
+    if len > MAX_ANCHORS_PER_OP as u64 {
+        return Err(CborError::message(format!(
+            "node_anchors carries {len} anchors, over the {MAX_ANCHORS_PER_OP} limit"
+        )));
+    }
+    let mut out: Vec<PortableAnchor> = Vec::new();
+    for _ in 0..len {
+        let anchor = decode_anchor(d)?;
+        // Canonical SET order: strictly increasing by identity. One comparison rejects both an
+        // unsorted payload and a duplicated row identity — the latter names one row twice, and
+        // nothing in the op says which of the two should win.
+        if let Some(previous) = out.last()
+            && previous.identity() >= anchor.identity()
+        {
+            return Err(CborError::message(
+                "node_anchors must be strictly increasing by (binding_kind, binding_id)",
+            ));
+        }
+        out.push(anchor);
+    }
+    Ok(out)
+}
+
+fn decode_anchor(d: &mut Decoder<'_>) -> Result<PortableAnchor, CborError> {
+    cbor::expect_array(d, 14)?;
+    // Field order is the wire order; struct-literal fields evaluate top to bottom, so this reads
+    // the array in the sequence `encode_anchor` wrote it.
+    Ok(PortableAnchor {
+        binding_kind: d.str()?.to_string(),
+        binding_id: d.str()?.to_string(),
+        path: decode_opt_str(d)?,
+        start_line: decode_opt_i64(d)?,
+        end_line: decode_opt_i64(d)?,
+        commit_hash: decode_opt_str(d)?,
+        tracker: decode_opt_str(d)?,
+        project: decode_opt_str(d)?,
+        item_key: decode_opt_str(d)?,
+        created_at_ms: d.i64()?,
+        symbol_kind: decode_opt_str(d)?,
+        signature_hash: decode_opt_str(d)?,
+        moniker_tool: decode_opt_str(d)?,
+        moniker_tool_version: decode_opt_str(d)?,
+    })
+}
+
+fn decode_opt_i64(d: &mut Decoder<'_>) -> Result<Option<i64>, CborError> {
+    if d.datatype()? == Type::Null {
+        d.null()?;
+        Ok(None)
+    } else {
+        Ok(Some(d.i64()?))
+    }
 }
 
 fn decode_resolved(d: &mut Decoder<'_>) -> Result<ResolvedAnchor, CborError> {
@@ -636,6 +802,66 @@ mod tests {
         }
     }
 
+    /// A symbol binding and a tracker binding: between them every nullable column is exercised in
+    /// both states, since neither shape populates the other's columns. Already in identity order —
+    /// encode canonicalizes, so a round-trip yields the sorted set.
+    fn anchors() -> Vec<PortableAnchor> {
+        vec![
+            PortableAnchor {
+                binding_kind: "symbol".to_string(),
+                binding_id: "crates/x/src/lib.rs::run".to_string(),
+                path: Some("crates/x/src/lib.rs".to_string()),
+                start_line: Some(10),
+                end_line: Some(20),
+                commit_hash: Some("c0ffee".to_string()),
+                tracker: None,
+                project: None,
+                item_key: None,
+                created_at_ms: 1_700_000_000_000,
+                symbol_kind: Some("function".to_string()),
+                signature_hash: Some("5ig".to_string()),
+                moniker_tool: Some("scip-rust".to_string()),
+                moniker_tool_version: Some("0.3".to_string()),
+            },
+            PortableAnchor {
+                binding_kind: "tracker".to_string(),
+                binding_id: "github:owner/repo#7".to_string(),
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                tracker: Some("github".to_string()),
+                project: Some("owner/repo".to_string()),
+                item_key: Some("7".to_string()),
+                created_at_ms: 1_700_000_000_001,
+                symbol_kind: None,
+                signature_hash: None,
+                moniker_tool: None,
+                moniker_tool_version: None,
+            },
+        ]
+    }
+
+    /// Write one anchor into a hand-rolled envelope — the fixture builder for the canonical-order
+    /// and cap rejections, which need wire forms `encode` would never produce.
+    fn raw_anchor(enc: &mut VecEncoder<'_>, kind: &str, id: &str) {
+        enc.array(14).unwrap();
+        enc.str(kind).unwrap();
+        enc.str(id).unwrap();
+        enc.null().unwrap(); // path
+        enc.null().unwrap(); // start_line
+        enc.null().unwrap(); // end_line
+        enc.null().unwrap(); // commit_hash
+        enc.null().unwrap(); // tracker
+        enc.null().unwrap(); // project
+        enc.null().unwrap(); // item_key
+        enc.i64(1).unwrap(); // created_at_ms
+        enc.null().unwrap(); // symbol_kind
+        enc.null().unwrap(); // signature_hash
+        enc.null().unwrap(); // moniker_tool
+        enc.null().unwrap(); // moniker_tool_version
+    }
+
     /// One representative op per variant — the golden + round-trip fixtures.
     fn every_variant() -> Vec<(&'static str, MemoryOp)> {
         vec![
@@ -656,6 +882,10 @@ mod tests {
             ("rebind", MemoryOp::Rebind {
                 edge_key: EdgeKey::from("edgekey_1"),
                 resolved: resolved(),
+            }),
+            ("node_anchors", MemoryOp::NodeAnchors {
+                node_id: NodeId::from("mem_1"),
+                anchors: anchors(),
             }),
             ("snapshot", MemoryOp::Snapshot),
         ]
@@ -687,6 +917,10 @@ mod tests {
                 "rebind",
                 "836c7261672d7261742f6f702f3166726562696e648269656467656b65795f3183667265706f5f74676d656d5f6473746763757272656e74",
             ),
+            (
+                "node_anchors",
+                "836c7261672d7261742f6f702f316c6e6f64655f616e63686f727382656d656d5f31828e6673796d626f6c78186372617465732f782f7372632f6c69622e72733a3a72756e736372617465732f782f7372632f6c69622e72730a1466633066666565f6f6f61b0000018bcfe568006866756e6374696f6e6335696769736369702d7275737463302e338e67747261636b6572736769746875623a6f776e65722f7265706f2337f6f6f6f6666769746875626a6f776e65722f7265706f61371b0000018bcfe56801f6f6f6f6",
+            ),
             ("snapshot", "836c7261672d7261742f6f702f3168736e617073686f74f6"),
         ];
         let got_refs: Vec<(&str, &str)> =
@@ -707,6 +941,111 @@ mod tests {
                 },
             }
         }
+    }
+
+    /// An anchor set is a SET: the wire bytes must not depend on the order the caller assembled it
+    /// in, or two devices holding the same bindings would author byte-different ops.
+    #[test]
+    fn node_anchors_encodes_in_identity_order_whatever_the_input_order() {
+        let sorted = MemoryOp::NodeAnchors { node_id: NodeId::from("mem_1"), anchors: anchors() };
+        let mut reversed_anchors = anchors();
+        reversed_anchors.reverse();
+        let reversed =
+            MemoryOp::NodeAnchors { node_id: NodeId::from("mem_1"), anchors: reversed_anchors };
+        assert_eq!(encode(&sorted), encode(&reversed));
+    }
+
+    /// Two anchors naming ONE row: the op cannot say which wins, so it is rejected outright rather
+    /// than silently deduped. Encode does not dedup either, so such an op cannot round-trip.
+    #[test]
+    fn node_anchors_rejects_a_duplicate_row_identity() {
+        let buf = raw_envelope(|enc| {
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("node_anchors").unwrap();
+            enc.array(2).unwrap();
+            enc.str("mem_1").unwrap();
+            enc.array(2).unwrap();
+            raw_anchor(enc, "symbol", "same");
+            raw_anchor(enc, "symbol", "same");
+        });
+
+        let err = decode(&buf).unwrap_err().to_string();
+        assert!(err.contains("strictly increasing"), "{err}");
+    }
+
+    #[test]
+    fn node_anchors_rejects_an_unsorted_set() {
+        let buf = raw_envelope(|enc| {
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("node_anchors").unwrap();
+            enc.array(2).unwrap();
+            enc.str("mem_1").unwrap();
+            enc.array(2).unwrap();
+            raw_anchor(enc, "tracker", "b");
+            raw_anchor(enc, "symbol", "a");
+        });
+
+        let err = decode(&buf).unwrap_err().to_string();
+        assert!(err.contains("strictly increasing"), "{err}");
+    }
+
+    /// The cap is judged from the array HEADER, before a single element is decoded — an
+    /// attacker-controlled count must not buy work (or an allocation) proportional to itself. The
+    /// envelope below declares an over-cap count and then carries NOTHING, so only a header-first
+    /// check can produce the cap error rather than a truncation error.
+    #[test]
+    fn node_anchors_rejects_an_over_cap_count_from_the_header() {
+        let buf = raw_envelope(|enc| {
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("node_anchors").unwrap();
+            enc.array(2).unwrap();
+            enc.str("mem_1").unwrap();
+            enc.array(MAX_ANCHORS_PER_OP as u64 + 1).unwrap();
+        });
+
+        let err = decode(&buf).unwrap_err().to_string();
+        assert!(err.contains(&format!("over the {MAX_ANCHORS_PER_OP} limit")), "{err}");
+    }
+
+    /// The off-by-one guard the sibling `row_op` cap carries: a set exactly AT the limit is legal,
+    /// so the cap can never be read as "fewer than".
+    #[test]
+    fn an_anchor_count_at_the_cap_is_not_refused_by_the_cap() {
+        let anchors: Vec<PortableAnchor> = (0..MAX_ANCHORS_PER_OP)
+            .map(|index| PortableAnchor {
+                binding_kind: "symbol".to_string(),
+                // Zero-padded so identity order matches numeric order — an unpadded `10` would sort
+                // before `9` and trip the strictly-increasing check for reasons unrelated to the
+                // cap.
+                binding_id: format!("id_{index:03}"),
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                tracker: None,
+                project: None,
+                item_key: None,
+                created_at_ms: 1,
+                symbol_kind: None,
+                signature_hash: None,
+                moniker_tool: None,
+                moniker_tool_version: None,
+            })
+            .collect();
+        let op = MemoryOp::NodeAnchors { node_id: NodeId::from("mem_1"), anchors };
+        assert_eq!(decode(&encode(&op)).unwrap(), DecodedOp::Known(op));
+    }
+
+    /// An anchor set is legitimately empty for an unanchored memory; that must be a valid op, not a
+    /// degenerate one, so the drain can distinguish "no bindings" from "no snapshot".
+    #[test]
+    fn node_anchors_accepts_an_empty_set() {
+        let op = MemoryOp::NodeAnchors { node_id: NodeId::from("mem_1"), anchors: Vec::new() };
+        let decoded = decode(&encode(&op)).unwrap();
+        assert_eq!(decoded, DecodedOp::Known(op));
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/project.rs
+++ b/crates/rag-rat-oplog/src/project.rs
@@ -129,6 +129,11 @@ pub fn project(entries: &[Entry]) -> ProjectedState {
                 // Re-resolves the local anchor only — never presence, never the key.
                 edges.entry(edge_key.clone()).or_default().resolved = Some(resolved.clone());
             },
+            // Inert here: this fold projects the node/edge registers, and an anchor set is a
+            // separate dimension whose projection lands with the column that stores it (#1209).
+            // Retaining the op without projecting it is the same posture an unknown kind gets, so
+            // a later binary re-folds the stream and picks the anchors up.
+            MemoryOp::NodeAnchors { .. } => {},
             // Inert boundary marker this increment (§5.4/C4).
             MemoryOp::Snapshot => {},
         }

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -1835,6 +1835,27 @@ fn default_matches_sql(declared: DefaultValue, physical: Option<&str>) -> bool {
 mod tests {
     use super::*;
 
+    /// The `anchors/1` columns and `op::PortableAnchor` are ONE fact in two places: the `/3`
+    /// `node_anchors` op carries these columns across the account boundary, and the drain seeds
+    /// binding rows from them. A column added here without a matching op field would not fail to
+    /// compile — it would seed as NULL on every peer, discovered long after the fact — so this
+    /// fails at the edit instead.
+    ///
+    /// Widening the op is a wire-format change, so the fix when this breaks is a new op kind, never
+    /// an extra field on the existing one.
+    #[test]
+    fn the_anchors_scope_columns_match_the_portable_anchor_op_fields() {
+        let spec = SYNCABLE_TABLES
+            .iter()
+            .find(|spec| spec.scope_id == "anchors/1")
+            .expect("the anchors/1 scope is registered");
+        // The op omits the `(repo_id, memory_id)` head of the pk: the repo is the drain's context
+        // and the memory is the op's own node id, so neither is repeated per anchor.
+        let carried: Vec<&str> =
+            spec.pk[2..].iter().chain(spec.columns.iter()).map(|column| column.name).collect();
+        assert_eq!(carried, crate::op::PORTABLE_ANCHOR_FIELDS);
+    }
+
     const DEMO_PK: &[ColumnSpec] = &[ColumnSpec::required("id", ValueType::Text)];
     const DEMO_COLUMNS: &[ColumnSpec] = &[
         ColumnSpec::required("title", ValueType::Text),


### PR DESCRIPTION
First slice of cross-account anchor replication (#1180). Adds the wire type only — nothing authors or projects it yet, so this ships inert.

## Why `/3` carries the facts

A contributor's memories reach the owner's machine but their bindings do not, so the memories never attach to code as drive-by context there. `anchors/1` cannot carry them across the boundary: its table-sync streams are single-account, and #935 recorded that extending grants into `device_is_effective_writer` is not the route. `/3` already crosses the boundary under a writer grant, so the portable facts ride there and `anchors/1` stays exactly as it is.

## The op

`MemoryOp::NodeAnchors` carries a **full-set snapshot** of one node's portable anchors: the `anchors/1` PK tail plus every column that scope replicates, and nothing checkout-local. The `(repo_id, memory_id)` half of the binding PK is context rather than payload — the repo being drained, and the op's own node id — so it is not repeated per anchor. Field order mirrors the table spec so the two stay readable against each other.

A sibling op kind rather than a wider `node_create`: an old binary retains an unknown kind inert, so widening the create op would stop a mixed-version account from seeing **new memories at all** until upgrade, while a sibling degrades to losing only the anchors. It also leaves the most central op kind unforked.

## Canonical rules

Both are enforced at decode by the existing `encode == bytes` identity check:

- The set is ordered by `(binding_kind, binding_id)`, so the bytes do not depend on the order the caller assembled it in — two devices holding the same bindings author identical ops.
- That order is **strictly** increasing, which rejects a duplicated row identity in the same comparison. Two anchors naming one row leave the op unable to say which wins; encode deliberately does not dedup, so a duplicate-carrying op cannot round-trip.

`MAX_ANCHORS_PER_OP` is judged from the array header **before any element is decoded**, so an attacker-controlled count cannot buy work proportional to itself — the rule `decode_str_array` already follows by refusing to preallocate. Raising the cap is a format change: a binary that knows the kind hard-rejects an over-cap op, so an older peer would refuse an entry a newer one authored and the chain would wedge rather than degrade. A larger limit ships as a new op kind, the discipline `snapshot` already documents for its payload.

Size is bounded by the existing `CONTENT_ENVELOPE_MAX_BYTES` / `CONTENT_OP_BODY_MAX_BYTES` caps, as it is for `node_create`'s body and tags; the authorability guard in `memory_write` gains a matching arm so an over-cap set names what to shrink instead of falling to the generic message.

## Fold

The fold ignores the op. Projecting it needs the column that stores it (#1209), and retaining-without-projecting is the posture an unknown kind already gets — so a later binary re-folds the stream and picks the anchors up.

## Tests

Golden vector pinning the wire bytes; round-trip across every variant; encode order independent of input order; rejection of a duplicate identity, an unsorted set, and an over-cap header count (with an envelope carrying no elements, so only a header-first check can produce the cap error rather than a truncation error); an at-the-cap set accepted, mirroring the sibling `row_op` boundary guard; and an empty set accepted, so the drain can distinguish "no bindings" from "no snapshot".

Verified: four CI clippy configurations, `cargo nextest run --workspace` (5097 passed) and `cargo test --workspace`, nightly rustfmt.