### PR TITLE
fix(index): heal orphaned overlay deletion tombstones

### DIFF
--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -41,10 +41,19 @@ struct PreparedIncrementalPass {
 }
 
 impl PreparedIncrementalPass {
-    /// The repo-relative paths this pass INDEXES — discovery's own verdict that the checkout
-    /// claims them (walked, in-target, not ignored, on disk). The overlay heal uses it as the only
-    /// admissible proof that a deletion tombstone is an orphan; re-deriving that rule from the
-    /// target set would be a second copy of discovery's inclusion logic, free to drift from it.
+    /// The repo-relative paths this pass INDEXES. Every mode builds it the same way — the pass's
+    /// own file set, whatever produced it (a Discover walk, the git-dirty set in Changed, the
+    /// caller's list in Paths) — which is what makes it usable as proof: a path here is one this
+    /// pass just derived and wrote, so a deletion tombstone shadowing it contradicts that write.
+    /// A path absent from the set is simply not proven, and the overlay heal leaves its tombstone
+    /// alone. Re-deriving that claim from the target set plus the ignore rules would be a second
+    /// copy of discovery's inclusion logic, free to drift from it.
+    ///
+    /// The set is derived off the write lock with everything else the pass prepared, so it can be
+    /// one editor-keystroke stale (a `.gitignore` edit landing before `BEGIN IMMEDIATE` makes a
+    /// tracked path ignored without moving its git status). The cost is bounded and self-healing:
+    /// the same stale plan already wrote the committed row, and the next discover pass
+    /// re-tombstones the path — one extra pass of churn, never a lost row.
     fn reindexed_base_paths(&self) -> BTreeSet<String> {
         self.prepared_files
             .iter()
@@ -969,6 +978,14 @@ impl IndexDatabase {
     ///   the next discover pass reindexes the path at the commit scope (sha mismatch), and the pass
     ///   after that takes the first branch.
     ///
+    /// A DELETION TOMBSTONE (`kind = 'deleted'`) is healed only when this pass re-indexed its path
+    /// (#1217): it then shadows a file the checkout demonstrably has, and the committed row takes
+    /// over as above. Absent that proof the tombstone stands — it is the index's record that the
+    /// checkout does not serve the path, and git status cannot tell the two apart (it is silent
+    /// about a gitignored-but-tracked path, one a target `exclude` drops, and one inside a
+    /// submodule). Such a tombstone is permanent by design, so it is filtered out of the candidate
+    /// set rather than carried into the walk. A tombstone is never re-stamped to the commit scope.
+    ///
     /// Returns the number of rows healed. Purely a read when nothing is stale, so an idle pass
     /// stays write-free (#63). Non-git contexts (`active_commit_sha` empty) are untouched —
     /// overlay rows ARE their canonical scope.
@@ -980,7 +997,7 @@ impl IndexDatabase {
         if self.active_commit_sha.is_empty() {
             return Ok(0);
         }
-        let overlays: Vec<(i64, String, String, String)> = {
+        let mut overlays: Vec<(i64, String, String, String)> = {
             let conn = self.storage.connection();
             // Direct `main.files` probes bypass the repo-scoped `files` view, so they carry the
             // `repo_id` predicate explicitly (A3): in a consolidated DB two forks at the same
@@ -1007,11 +1024,21 @@ impl IndexDatabase {
             )?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
+        // Drop the tombstones this pass could not heal anyway BEFORE the walk-free check below.
+        // The deliberate outcome of the tombstone rule is that some tombstones are PERMANENT — a
+        // gitignored-but-tracked path, one a target `exclude` drops, one inside a submodule —
+        // and a permanent candidate would be a permanent reason to walk: every pass of every repo
+        // holding one would run a `git status` inside `BEGIN IMMEDIATE`, forever, which is the
+        // idle-pass cost #63 exists to keep at zero. Filtering here also keeps the rule in ONE
+        // place: below, a surviving tombstone is healable by construction.
+        overlays.retain(|(_, path, _, kind)| kind != "deleted" || reindexed.contains(path));
         // No overlay candidates → nothing to heal and NO walk under the lock (the common clean-tree
         // / idle pass pays nothing).
         if overlays.is_empty() {
             return Ok(0);
         }
+        #[cfg(test)]
+        self.overlay_status_walks.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // Authoritative dirty set, walked INSIDE the write txn (#561). The off-lock discovery
         // snapshot CANNOT soundly pre-filter these: the flock excludes rag-rat writers but NOT the
         // user's editor, so between prepare and now a file dirty-at-prepare may have been restored
@@ -1035,26 +1062,18 @@ impl IndexDatabase {
                 // deleted (#561).
                 continue;
             }
-            // A TOMBSTONE IS ONLY AN ORPHAN IF THIS PASS INDEXED THE PATH (#1217 review). A quiet
-            // git status is NOT that proof: it says nothing about a path that is gitignored while
-            // still tracked, that a target config now excludes, or that lives inside a submodule
-            // — and for all three the tombstone is CORRECT while the committed row survives, so
-            // healing on silence alone un-hides content the checkout does not serve and starts a
-            // re-tombstone/re-heal loop of its own. `reindexed` names the paths discovery walked
-            // and this pass wrote into the commit scope; a tombstone shadowing one of them
-            // contradicts a write that just happened, which is the whole orphan case. A path
-            // discovery did NOT claim is absent from that set and its tombstone stands.
+            // Every surviving tombstone is one this pass re-indexed (the `retain` above), so it
+            // contradicts a derivation that just happened — the orphan case. `reindexed` proves
+            // the path was claimed, not where its row landed (a dirty path's write goes to the
+            // overlay scope), so the committed-row probe is what establishes there is something
+            // to hand the path back to; with none, the tombstone shadows nothing. It is never
+            // re-stamped into the commit scope below: that would publish a deletion marker as the
+            // file's committed row.
             if kind == "deleted" {
-                if !reindexed.contains(&path) {
-                    continue;
-                }
                 if self.committed_row_exists(&path)? {
                     self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
                     healed += 1;
                 }
-                // With no committed row to take over, the tombstone shadows nothing. It is never
-                // re-stamped into the commit scope below: that would publish a deletion marker as
-                // the file's committed row.
                 continue;
             }
             if self.committed_row_exists(&path)? {

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -964,7 +964,7 @@ impl IndexDatabase {
         if self.active_commit_sha.is_empty() {
             return Ok(0);
         }
-        let overlays: Vec<(i64, String, String)> = {
+        let overlays: Vec<(i64, String, String, String)> = {
             let conn = self.storage.connection();
             // Direct `main.files` probes bypass the repo-scoped `files` view, so they carry the
             // `repo_id` predicate explicitly (A3): in a consolidated DB two forks at the same
@@ -974,14 +974,20 @@ impl IndexDatabase {
             // Also generation-qualified (A6): the heal operates on THIS connection's live
             // generation only — a staged or superseded generation's overlay rows are the
             // rebuild's / gc's business.
+            // DELETION TOMBSTONES ARE CANDIDATES TOO (#1217). A `kind = 'deleted'` overlay row
+            // shadows its committed counterpart out of the scoped view, so once the path is back
+            // on disk and clean the row is an orphan that hides a file the checkout HAS —
+            // discovery then re-indexes that path into the commit scope on EVERY pass while the
+            // view keeps hiding it. Nothing else reaps it: the overlay refresh prunes only the
+            // scopes it visits, and it skips the active checkout. Excluding tombstones here left
+            // that loop with no owner.
             let mut stmt = conn.prepare(
-                "SELECT id, path, sha256 FROM main.files
-                 WHERE repo_id = ?1 AND worktree_id = ?2 AND worktree_id != '' AND kind != \
-                 'deleted' AND generation = ?3",
+                "SELECT id, path, sha256, kind FROM main.files
+                 WHERE repo_id = ?1 AND worktree_id = ?2 AND worktree_id != '' AND generation = ?3",
             )?;
             let rows = stmt.query_map(
                 params![self.active_repo_id, self.active_worktree_id, self.active_generation],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
@@ -1004,7 +1010,7 @@ impl IndexDatabase {
             Err(_) => return Ok(0),
         };
         let mut healed = 0usize;
-        for (file_id, path, sha) in overlays {
+        for (file_id, path, sha, kind) in overlays {
             let p = Path::new(&path);
             if changes.changed.contains(p) || changes.deleted.contains(p) {
                 // Dirtied OR deleted since the snapshot — the overlay is NOT stale-clean. Skipping
@@ -1026,6 +1032,13 @@ impl IndexDatabase {
             if committed_exists {
                 self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
                 healed += 1;
+                continue;
+            }
+            // A tombstone stands for the ABSENCE of content, so the re-stamp below — which hands
+            // the row to the commit scope — must never see one: it would replace the committed
+            // file with a deletion marker. With no committed row to take over, an unowned
+            // tombstone shadows nothing and can wait for the next full overlay refresh.
+            if kind == "deleted" {
                 continue;
             }
             let disk_matches = self

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -41,6 +41,17 @@ struct PreparedIncrementalPass {
 }
 
 impl PreparedIncrementalPass {
+    /// The repo-relative paths this pass INDEXES — discovery's own verdict that the checkout
+    /// claims them (walked, in-target, not ignored, on disk). The overlay heal uses it as the only
+    /// admissible proof that a deletion tombstone is an orphan; re-deriving that rule from the
+    /// target set would be a second copy of discovery's inclusion logic, free to drift from it.
+    fn reindexed_base_paths(&self) -> BTreeSet<String> {
+        self.prepared_files
+            .iter()
+            .map(|prepared| rag_rat_base::paths::path_string(&prepared.file.relative_path))
+            .collect()
+    }
+
     /// The repo-relative base paths this pass will reindex or delete — the clone-delta changed-set
     /// hint (#830). Uses the SAME `path_string` normalization the file writes use, so the strings
     /// match `files.path` / `clone_subblock_postings.path` byte-for-byte. A superset of the paths
@@ -414,7 +425,8 @@ impl IndexDatabase {
             // any destructive decision, so a path dirtied/restored/deleted during the off-lock
             // window or the BEGIN wait cannot be mis-healed (#561). Read-only +
             // walk-free when there are no overlay candidates (#63).
-            let healed = db.heal_stale_overlay_rows(&config.root)?;
+            let healed =
+                db.heal_stale_overlay_rows(&config.root, &prepared.reindexed_base_paths())?;
             let mut mutated = indexed > 0
                 || healed > 0
                 || carried > 0
@@ -960,7 +972,11 @@ impl IndexDatabase {
     /// Returns the number of rows healed. Purely a read when nothing is stale, so an idle pass
     /// stays write-free (#63). Non-git contexts (`active_commit_sha` empty) are untouched —
     /// overlay rows ARE their canonical scope.
-    pub(super) fn heal_stale_overlay_rows(&self, root: &Path) -> anyhow::Result<usize> {
+    pub(super) fn heal_stale_overlay_rows(
+        &self,
+        root: &Path,
+        reindexed: &BTreeSet<String>,
+    ) -> anyhow::Result<usize> {
         if self.active_commit_sha.is_empty() {
             return Ok(0);
         }
@@ -975,12 +991,12 @@ impl IndexDatabase {
             // generation only — a staged or superseded generation's overlay rows are the
             // rebuild's / gc's business.
             // DELETION TOMBSTONES ARE CANDIDATES TOO (#1217). A `kind = 'deleted'` overlay row
-            // shadows its committed counterpart out of the scoped view, so once the path is back
-            // on disk and clean the row is an orphan that hides a file the checkout HAS —
-            // discovery then re-indexes that path into the commit scope on EVERY pass while the
-            // view keeps hiding it. Nothing else reaps it: the overlay refresh prunes only the
-            // scopes it visits, and it skips the active checkout. Excluding tombstones here left
-            // that loop with no owner.
+            // shadows its committed counterpart out of the scoped view, so a tombstone the
+            // checkout has outgrown hides a file it HAS: discovery re-indexes that path into the
+            // commit scope on EVERY pass while the view keeps hiding it. Nothing else reaps it —
+            // the overlay refresh prunes only the scopes it visits, and it skips the active
+            // checkout — so excluding tombstones here left that loop with no owner. `reindexed`
+            // is what separates an outgrown tombstone from a load-bearing one; see the branch.
             let mut stmt = conn.prepare(
                 "SELECT id, path, sha256, kind FROM main.files
                  WHERE repo_id = ?1 AND worktree_id = ?2 AND worktree_id != '' AND generation = ?3",
@@ -1019,26 +1035,31 @@ impl IndexDatabase {
                 // deleted (#561).
                 continue;
             }
-            let committed_exists: bool = self.storage.connection().query_row(
-                // Generation-qualified (A6): only a committed row at THIS connection's live
-                // generation can take over from the overlay — a staged or superseded generation's
-                // committed row must not trigger deleting a live overlay.
-                "SELECT EXISTS(SELECT 1 FROM main.files
-                 WHERE repo_id = ?1 AND path = ?2 AND commit_sha = ?3 AND worktree_id = ''
-                   AND generation = ?4)",
-                params![self.active_repo_id, path, self.active_commit_sha, self.active_generation],
-                |row| row.get(0),
-            )?;
-            if committed_exists {
-                self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
-                healed += 1;
+            // A TOMBSTONE IS ONLY AN ORPHAN IF THIS PASS INDEXED THE PATH (#1217 review). A quiet
+            // git status is NOT that proof: it says nothing about a path that is gitignored while
+            // still tracked, that a target config now excludes, or that lives inside a submodule
+            // — and for all three the tombstone is CORRECT while the committed row survives, so
+            // healing on silence alone un-hides content the checkout does not serve and starts a
+            // re-tombstone/re-heal loop of its own. `reindexed` names the paths discovery walked
+            // and this pass wrote into the commit scope; a tombstone shadowing one of them
+            // contradicts a write that just happened, which is the whole orphan case. A path
+            // discovery did NOT claim is absent from that set and its tombstone stands.
+            if kind == "deleted" {
+                if !reindexed.contains(&path) {
+                    continue;
+                }
+                if self.committed_row_exists(&path)? {
+                    self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
+                    healed += 1;
+                }
+                // With no committed row to take over, the tombstone shadows nothing. It is never
+                // re-stamped into the commit scope below: that would publish a deletion marker as
+                // the file's committed row.
                 continue;
             }
-            // A tombstone stands for the ABSENCE of content, so the re-stamp below — which hands
-            // the row to the commit scope — must never see one: it would replace the committed
-            // file with a deletion marker. With no committed row to take over, an unowned
-            // tombstone shadows nothing and can wait for the next full overlay refresh.
-            if kind == "deleted" {
+            if self.committed_row_exists(&path)? {
+                self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
+                healed += 1;
                 continue;
             }
             let disk_matches = self
@@ -1056,6 +1077,19 @@ impl IndexDatabase {
             }
         }
         Ok(healed)
+    }
+
+    /// Does a committed row for `path` exist in THIS connection's live scope? Generation-qualified
+    /// (A6): only a committed row at the live generation can take over from an overlay row — a
+    /// staged or superseded generation's committed row must not trigger deleting a live overlay.
+    fn committed_row_exists(&self, path: &str) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.files
+             WHERE repo_id = ?1 AND path = ?2 AND commit_sha = ?3 AND worktree_id = ''
+               AND generation = ?4)",
+            params![self.active_repo_id, path, self.active_commit_sha, self.active_generation],
+            |row| row.get(0),
+        )?)
     }
 
     /// Prepare + apply a file plan in one shot, parsing INSIDE the caller's transaction. Retained
@@ -1119,10 +1153,11 @@ impl IndexDatabase {
         for path in deleted {
             // A git-deleted path may have been RESTORED on disk during the off-lock window (#561).
             // Tombstoning it would HIDE it — and a file restored to HEAD-clean content is in no
-            // later CHANGED set and the stale-overlay heal skips `kind='deleted'` rows,
-            // so it would not self-heal until a discover pass. Skip the tombstone only when the
-            // path is a regular FILE on disk again — via `symlink_metadata` (does NOT follow), so a
-            // SYMLINK or a directory recreated at that path is NOT treated as a restored source
+            // later CHANGED set, while the stale-overlay heal reaps a tombstone only for a path
+            // the pass re-indexed, so it would not self-heal until a discover pass walks it. Skip
+            // the tombstone only when the path is a regular FILE on disk again — via
+            // `symlink_metadata` (does NOT follow), so a SYMLINK or a directory
+            // recreated at that path is NOT treated as a restored source
             // file (the walker skips both and would never re-index them), and its stale
             // row still tombstones (#659 review).
             if revalidate_fs_deletions

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -44,7 +44,9 @@ impl PreparedIncrementalPass {
     /// The repo-relative paths this pass INDEXES. Every mode builds it the same way — the pass's
     /// own file set, whatever produced it (a Discover walk, the git-dirty set in Changed, the
     /// caller's list in Paths) — which is what makes it usable as proof: a path here is one this
-    /// pass just derived and wrote, so a deletion tombstone shadowing it contradicts that write.
+    /// pass DERIVED, so a deletion tombstone shadowing it contradicts a derivation that just
+    /// happened. Derived, not written: a file whose parse failed is listed here and records a
+    /// parser failure instead of a `files` row, so a caller that needs a row must probe for one.
     /// A path absent from the set is simply not proven, and the overlay heal leaves its tombstone
     /// alone. Re-deriving that claim from the target set plus the ignore rules would be a second
     /// copy of discovery's inclusion logic, free to drift from it.

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -215,6 +215,8 @@ impl IndexDatabase {
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            overlay_status_walks: std::sync::atomic::AtomicUsize::new(0),
         };
         if matches!(mode, BareOpenMode::ConfigLess) {
             db.ensure_graph_index_current()?;
@@ -243,6 +245,8 @@ impl IndexDatabase {
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            overlay_status_walks: std::sync::atomic::AtomicUsize::new(0),
         };
         db.storage.set_source_root(config.root.clone());
         // Register/adopt BEFORE anything repo-scoped runs, then install the scope context so the
@@ -432,6 +436,8 @@ impl IndexDatabase {
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            overlay_status_walks: std::sync::atomic::AtomicUsize::new(0),
         };
         // Install the scope context BEFORE the heal-owed gates: `set_context` mirrors the resolved
         // `repo_id` into `temp.connection_context` (writable even on a read-only main DB), so the
@@ -595,6 +601,8 @@ impl IndexDatabase {
             logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            overlay_status_walks: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -220,6 +220,12 @@ pub struct IndexDatabase {
     /// connection, so batch tests can assert the once-per-pass rebuild cardinality.
     #[cfg(test)]
     pub(crate) logical_symbol_rebuilds: AtomicUsize,
+    /// Test-only #63 observability: how many in-transaction `git status` walks
+    /// [`Self::heal_stale_overlay_rows`] ran on this connection. The walk-free idle pass is an
+    /// invariant a comment cannot hold on its own — a candidate set that quietly grows a
+    /// permanent member puts a status walk inside `BEGIN IMMEDIATE` on every pass forever.
+    #[cfg(test)]
+    pub(crate) overlay_status_walks: AtomicUsize,
     /// #216 lens: a bounded set of filtered clone edge sets + components keyed by generation,
     /// scope, content, and theta. Treemap and file-clone requests commonly use different theta
     /// values, so retaining several immutable variants avoids alternating repository-wide scans.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -853,6 +853,22 @@ fn insert_stale_overlay_row(db: &IndexDatabase, path: &str, worktree_id: &str) -
     db.storage.connection().last_insert_rowid()
 }
 
+/// Insert an overlay DELETION TOMBSTONE for a path that is present on disk and committed — the
+/// orphan a pass leaves when it records "deleted in this checkout" and the file later comes back
+/// (#1217). It shadows the committed row out of the scoped view without standing in for it.
+fn insert_overlay_tombstone_row(db: &IndexDatabase, path: &str, worktree_id: &str) -> i64 {
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES (?1, 'unknown', 'deleted', '', \
+             0, 0, '', ?2, ?3, ?4)",
+            rusqlite::params![path, worktree_id, db.active_repo_id, db.active_generation],
+        )
+        .unwrap();
+    db.storage.connection().last_insert_rowid()
+}
+
 /// Every `ON DELETE CASCADE`/`RESTRICT` FK to a reindex-volatile parent, as
 /// `(child_table, parent_table, on_delete)`, scanned from a FULLY-MIGRATED DB. Enumerates EVERY
 /// table in `sqlite_master` (not a hand-maintained list) so a new offender is caught automatically.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -1059,16 +1059,16 @@ fn incremental_pass_heals_an_orphaned_overlay_tombstone() {
     );
     drop(db);
 
-    // Convergence is the point: without it a pass that re-indexes the same file forever looks
-    // exactly like a pass doing real work.
-    let mut discovered = usize::MAX;
-    let _db = IndexDatabase::index_discover_with_progress(&config, |progress| {
-        if let IndexProgress::Discovered { files } = progress {
-            discovered = files;
-        }
-    })
-    .unwrap();
-    assert_eq!(discovered, 0, "the follow-up pass indexes nothing — the loop is closed");
+    // Convergence is the point: without it a pass that rewrites the same rows forever looks
+    // exactly like a pass doing real work. `content_changed` is the instrument, not the
+    // discovered-file count — a re-tombstone/re-heal cycle writes rows while discovering nothing.
+    let (_db, report) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!report.content_changed, "the follow-up pass is idle — the loop is closed");
+    assert_eq!(
+        report.clone_delta_hint,
+        Some(std::collections::BTreeSet::new()),
+        "and it touched no base path, so the clone delta needs no full scan"
+    );
 
     let _ = fs::remove_dir_all(&root);
 }
@@ -1107,6 +1107,98 @@ fn a_heal_keeps_the_tombstone_of_a_file_deleted_in_the_working_tree() {
             .unwrap(),
         0,
         "and the deleted file stays out of the scoped view"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #1217 review: a quiet `git status` does not prove a tombstone is an orphan. A tracked file that
+/// becomes gitignored leaves the walk, so discovery tombstones it while its committed row lives on
+/// — and git reports nothing about it, ever. Healing on silence would un-hide content this
+/// checkout no longer serves and would re-tombstone/re-heal it on every pass.
+#[test]
+fn a_heal_keeps_the_tombstone_of_a_tracked_file_that_became_gitignored() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    fs::write(root.join(".gitignore"), "src/extra.rs\n").unwrap();
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = 'src/extra.rs' AND kind = 'deleted'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "leaving the walk tombstones the path"
+    );
+    drop(db);
+
+    let (db, report) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!report.content_changed, "the follow-up pass is idle — no re-tombstone/re-heal churn");
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = 'src/extra.rs' AND kind = 'deleted'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "the tombstone of an ignored-but-tracked file is load-bearing and stands"
+    );
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'src/extra.rs'", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "and the ignored file stays out of the scoped view"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #1217 review, the same class through the target config: a path an `exclude` glob drops is off
+/// the walk while present on disk and clean in git. Its tombstone is the index's record of that
+/// exclusion, not a leftover.
+#[test]
+fn a_heal_keeps_the_tombstone_of_a_target_excluded_file() {
+    let (root, mut config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    config.targets[0].exclude = vec!["src/extra.rs".to_string()];
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    drop(db);
+    let (db, report) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!report.content_changed, "the follow-up pass is idle");
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = 'src/extra.rs' AND kind = 'deleted'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "an excluded path's tombstone stands"
+    );
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'src/extra.rs'", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "and the excluded file stays out of the scoped view"
     );
 
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -1010,3 +1010,104 @@ fn clone_substrate_has_token_bag_blob_and_no_postings_on_fresh_and_migrated_dbs(
         .expect("query3");
     assert_eq!(df, 1, "clone_token_df must exist after migrate_forward");
 }
+
+/// #1217: an overlay tombstone for a path that is present on disk is an orphan — the scoped view
+/// hides the path (the worktree leg drops `kind = 'deleted'` rows, and the base leg's shadow
+/// sub-select does not), so every pass rediscovers the file, re-indexes it into the commit scope,
+/// and the next pass sees the same hole. The heal owns the repair: the tombstone falls exactly
+/// like a stale content overlay, and the pass converges.
+#[test]
+fn incremental_pass_heals_an_orphaned_overlay_tombstone() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let worktree_id = db.active_worktree_id.clone();
+    insert_overlay_tombstone_row(&db, "src/lib.rs", &worktree_id);
+    // The orphan's signature: the committed row is shadowed out of the scoped view even though
+    // the file is on disk and unchanged.
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'src/lib.rs'", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "fixture precondition: the tombstone hides the committed row"
+    );
+    drop(db);
+
+    let db = IndexDatabase::index_discover_with_progress(&config, |_| {}).unwrap();
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = 'src/lib.rs' AND kind = 'deleted'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0,
+        "the orphaned tombstone is healed away"
+    );
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'src/lib.rs'", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        1,
+        "the committed row is visible again"
+    );
+    drop(db);
+
+    // Convergence is the point: without it a pass that re-indexes the same file forever looks
+    // exactly like a pass doing real work.
+    let mut discovered = usize::MAX;
+    let _db = IndexDatabase::index_discover_with_progress(&config, |progress| {
+        if let IndexProgress::Discovered { files } = progress {
+            discovered = files;
+        }
+    })
+    .unwrap();
+    assert_eq!(discovered, 0, "the follow-up pass indexes nothing — the loop is closed");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #1217 counterpart: a tombstone for a file the working tree has ACTUALLY deleted is doing its
+/// job — the heal must leave it alone, or the pass resurrects the committed version the checkout
+/// just removed.
+#[test]
+fn a_heal_keeps_the_tombstone_of_a_file_deleted_in_the_working_tree() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let worktree_id = db.active_worktree_id.clone();
+    insert_overlay_tombstone_row(&db, "src/lib.rs", &worktree_id);
+    drop(db);
+    fs::remove_file(root.join("src/lib.rs")).unwrap();
+
+    let db = IndexDatabase::index_discover_with_progress(&config, |_| {}).unwrap();
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = 'src/lib.rs' AND kind = 'deleted' \
+                 AND worktree_id = ?1",
+                [&worktree_id],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "the tombstone of a genuinely deleted file survives"
+    );
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'src/lib.rs'", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0,
+        "and the deleted file stays out of the scoped view"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -1203,3 +1203,35 @@ fn a_heal_keeps_the_tombstone_of_a_target_excluded_file() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+/// #63 + #1217: a permanent tombstone must not become a permanent reason to walk. The tombstones
+/// this fix deliberately keeps forever — gitignored, target-excluded, submodule-internal — are
+/// unhealable by construction, so they are filtered out of the heal's candidate set before the
+/// walk-free check. Otherwise every pass of every repo holding one pays a `git status` inside the
+/// write transaction, which is the idle-pass cost the whole issue is about.
+#[test]
+fn a_permanent_tombstone_does_not_make_every_idle_pass_walk_git_status() {
+    let walks =
+        |db: &IndexDatabase| db.overlay_status_walks.load(std::sync::atomic::Ordering::Relaxed);
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    fs::write(root.join(".gitignore"), "src/extra.rs\n").unwrap();
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert_eq!(walks(&db), 0, "tombstoning a path that left the walk needs no status walk");
+    drop(db);
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert_eq!(walks(&db), 0, "and the idle pass that follows stays walk-free, forever");
+    drop(db);
+
+    // Control: a real content overlay is a healable candidate, so the walk DOES run — without
+    // this the assertions above would also pass if the heal never ran at all.
+    fs::write(root.join("src/lib.rs"), "pub fn dirty() -> i32 { 9 }\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    drop(db);
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert_eq!(walks(&db), 1, "a dirty file's overlay row is healable, so its pass walks");
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -1208,9 +1208,10 @@ fn a_heal_keeps_the_tombstone_of_a_target_excluded_file() {
 /// this fix deliberately keeps forever — gitignored, target-excluded, submodule-internal — are
 /// unhealable by construction, so they are filtered out of the heal's candidate set before the
 /// walk-free check. Otherwise every pass of every repo holding one pays a `git status` inside the
-/// write transaction, which is the idle-pass cost the whole issue is about.
+/// write transaction, which is the idle-pass cost the whole issue is about. The counter is the
+/// IN-TRANSACTION walk only; a Discover pass always walks once off the lock at prepare.
 #[test]
-fn a_permanent_tombstone_does_not_make_every_idle_pass_walk_git_status() {
+fn a_permanent_tombstone_keeps_the_idle_passs_write_txn_walk_free() {
     let walks =
         |db: &IndexDatabase| db.overlay_status_walks.load(std::sync::atomic::Ordering::Relaxed);
     let (root, config) = git_fixture_for_overlay_tests();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
@@ -1189,3 +1189,60 @@ fn worktree_overlay_gc_prunes_a_removed_worktrees_refresh_basis() {
     let _ = fs::remove_dir_all(&removed);
     let _ = fs::remove_dir_all(&kept);
 }
+
+/// #1217: the active checkout's stale-overlay heal reaps deletion tombstones, and that reach stops
+/// at its own scope. A linked worktree that deleted a file owns a tombstone recording it; a pass
+/// driven from the MAIN checkout — where the same path is present and clean — must heal nothing
+/// there, or the sibling's branch view resurrects a file its branch removed.
+#[test]
+fn an_active_checkout_heal_leaves_a_linked_worktrees_deletion_tombstone_standing() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_a() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn base_b() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-drop", linked.to_str().unwrap()]);
+    fs::remove_file(linked.join("src/a.rs")).unwrap();
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    let linked_id = crate::watch::enclosing_worktree_id(&linked);
+    let tombstones = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = 'src/a.rs' AND kind = 'deleted' AND \
+                 worktree_id = ?1",
+                [&linked_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(tombstones(&db), 1, "the linked worktree's deletion is recorded as a tombstone");
+    drop(db);
+
+    // A full pass from the main checkout, where src/a.rs is present and clean.
+    let db = IndexDatabase::index_discover_with_progress(&config, |_| {}).unwrap();
+    assert_eq!(tombstones(&db), 1, "the sibling's tombstone is not this checkout's to heal");
+
+    let mut db = db;
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert!(
+        names_in_scope(&db, "src/a.rs").is_empty(),
+        "the branch that deleted the file still sees it gone"
+    );
+
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(&main);
+}


### PR DESCRIPTION
Fixes #1217.

## The loop

An overlay row with `kind = 'deleted'` shadows its committed counterpart out of the scoped view — the worktree leg drops deletion rows, and the base leg's shadow sub-select does not filter them. That is correct while the checkout does not serve the path. Once discovery claims the path again, the row hides a file the checkout has: discovery rediscovers it every pass, re-indexes it into the commit scope, and the view keeps hiding it, so the next pass repeats.

Nothing reaped those rows. `prune_overlay_rows_not_in_delta` runs only for the scopes an overlay refresh visits, and the active checkout is not one of them; `heal_stale_overlay_rows`, which owns the active checkout's overlay rows, filtered tombstones out of its candidate query.

Measured on a real 134-file repo: 18 files re-parsed, re-chunked and rewritten every ~60s for eight days — `discovered 18 files` on a clean tree with `index` reporting `0 files` for the same state, and `gc` pruning nothing. Deleting exactly those rows took the pass from 18 files / 11.0s CPU to 0 files / 7.6s CPU.

## The fix

`heal_stale_overlay_rows` takes tombstones as candidates, and reaps one only when **this pass re-indexed that path**.

A quiet `git status` is not proof that a tombstone has been outgrown: git is silent about a path that is gitignored while still tracked, one a target `exclude` glob drops, and one inside a submodule, and in all three the tombstone is load-bearing while the committed row survives. Healing on silence would un-hide content the checkout does not serve and start a re-tombstone/re-heal cycle reporting a content change on every idle pass. The pass's own file set is the proof instead — a path in it was just derived and written, so a tombstone shadowing it contradicts that write. Re-deriving the claim from the target set plus ignore rules would work today and drift from discovery tomorrow.

Tombstones that fail that test are permanent by design, so they are filtered out of the candidate set *before* the walk-free check. A permanent candidate would otherwise be a permanent reason to walk — a `git status` inside `BEGIN IMMEDIATE` on every pass of every repo holding one, which is the idle-pass cost this issue is about. That invariant was a comment with nothing enforcing it; it now has a test-only walk counter on the connection (the same shape as the existing logical-symbol rebuild counter) and a test that pins zero walks across two passes, with a dirty-file control so it cannot pass by the heal never running.

The existing guards carry over unchanged: a fresh in-transaction `git status` walk, and a skip for any path currently changed or deleted in the working tree. The tombstone branch is explicit rather than a guard above the overlay→commit re-stamp, so a deletion marker can never be published as a file's committed row, and the committed-row probe both branches share moved into one helper.

## Scope limits, deliberate

- **Changed mode effectively never heals a tombstone.** In `IndexMode::Changed` the pass's file set is exactly the git-dirty set, and dirty paths are skipped by the earlier guard, so a plain `rag-rat index` will not close the loop. (The one opening is a path dirty at prepare and restored to HEAD-clean before the in-transaction walk; healing is correct there, and the overlay write has usually replaced the tombstone at the same key already.) The watcher, `rag-rat maintenance` and `index --discover` all run Discover passes, which do.
- **A carried row starves the heal for one pass.** A path adopted through the #502 carry (a retained committed row at a previous HEAD matching on sha/language/kind) produces no entry in the pass's file set, so its tombstone survives that pass. The carry re-stamps the row onto the active commit, so the following pass takes the normal route and heals. It starves indefinitely only if HEAD moves before every pass.
- **`gc` is untouched.** The heal owns the active checkout's overlay rows; a second reaper for the same rows would be a place for the two to disagree.

## Tests

Load-bearing for this change:

- `incremental_pass_heals_an_orphaned_overlay_tombstone` — the orphan is healed, the committed row is visible again, and the follow-up pass is idle. Convergence is asserted through `IncrementalPassReport::content_changed` and an empty clone-delta hint, not a discovered-file count: a pass that rewrites rows while discovering nothing is exactly what a count cannot see.
- `a_heal_keeps_the_tombstone_of_a_tracked_file_that_became_gitignored` and `a_heal_keeps_the_tombstone_of_a_target_excluded_file` — the two classes git status cannot report. Each keeps its tombstone, stays out of the scoped view, and leaves the follow-up pass idle.
- `a_permanent_tombstone_keeps_the_idle_passs_write_txn_walk_free` — zero in-transaction walks across two passes, one for the dirty-file control. (A Discover pass still walks once off the lock at prepare; the counter is about the walk inside `BEGIN IMMEDIATE`.)

Regression pins for guards this change inherits rather than introduces (both also pass without it): `a_heal_keeps_the_tombstone_of_a_file_deleted_in_the_working_tree` (the working-tree-deletion skip) and `an_active_checkout_heal_leaves_a_linked_worktrees_deletion_tombstone_standing` (the scope predicate, driven through a real `git worktree add` sibling sharing the database).

Workspace green: `cargo nextest run --workspace --no-default-features --locked` (5097 tests), `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings`, `cargo +nightly fmt --all --check`.
