### PR TITLE
feat(sync): seed a synced memory's bindings from its anchor snapshot (#1210)

### DIFF
--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -432,9 +432,24 @@ fn drain_node(
         },
     };
     // Seed AFTER materialization, and only for a node that belongs to THIS repo — the sibling-repo
-    // arm above must not touch that repo's bindings any more than it touches its content.
-    if node_in_repo(tx, &node.node_id, repo_id)? {
-        seed_node_anchors(tx, repo_id, node)?;
+    // arm above must not touch that repo's bindings any more than it touches its content. The
+    // snapshot check comes first because it is free: until anchors are authored, every node answers
+    // `None` and this costs no query at all.
+    if node.anchors.is_some() && node_in_repo(tx, &node.node_id, repo_id)? {
+        let seeded = seed_node_anchors(tx, repo_id, node)?;
+        if seeded > 0 {
+            // `anchors/1` declares that a write to this table advances these lanes, and the `/5`
+            // applier bumps them for exactly this reason. The seed is a second writer to the same
+            // table, and on the converged path no `repo_memories` row is touched — so the row
+            // triggers that normally carry the lanes never fire, and without this a reader's Lens
+            // view keeps serving a revision that predates the bindings.
+            if rag_rat_db::schema::repo_id_is_registered(tx, repo_id)? {
+                rag_rat_db::meta::bump_lens_revisions(tx, repo_id, &[
+                    rag_rat_db::meta::LENS_ENRICHMENT_REVISION_META,
+                    rag_rat_db::meta::LENS_MEMORIES_REVISION_META,
+                ])?;
+            }
+        }
     }
     Ok(effect)
 }
@@ -443,20 +458,19 @@ fn drain_node(
 /// from a peer's snapshot. An unknown kind is a newer peer's vocabulary: it means nothing here, so
 /// it is skipped row-wise rather than quarantining the node over its decoration.
 ///
-/// `call_path` is deliberately absent even though the local path produces it: its supporting
-/// `repo_memory_call_paths` / `_edges` rows are in NO replication scope, so a seeded call-path
-/// binding could never resolve here — it would sit unverifiable forever.
-const SEEDABLE_BINDING_KINDS: &[&str] = &[
-    "logical_symbol",
-    "symbol",
-    "chunk",
-    "edge",
-    "scip_moniker",
-    "path",
-    "dir",
-    "commit",
-    "tracker",
-];
+/// Two kinds the local path DOES produce are deliberately absent, both because a seeded row could
+/// never resolve here and would sit `unverified` forever:
+/// - `call_path`, whose supporting `repo_memory_call_paths` / `_edges` rows are in no replication
+///   scope, so the path it names does not exist locally.
+/// - `chunk`, whose `binding_id` IS a checkout-local rowid — reassigned on every re-chunk, so a
+///   peer's integer is meaningless here. Its validator also short-circuits `unverified` whenever
+///   the local `chunk_id` column is NULL, which is exactly what a seeded row leaves it as, so the
+///   hash-relocation fallback that might have rescued it is unreachable.
+///
+/// Everything remaining is portable by construction: qualified names with name-based relocation,
+/// an edge fingerprint, or a plain string.
+const SEEDABLE_BINDING_KINDS: &[&str] =
+    &["logical_symbol", "symbol", "edge", "scip_moniker", "path", "dir", "commit", "tracker"];
 
 /// Seed a synced memory's bindings from the anchor snapshot its author published — ONLY when this
 /// store holds none for it.
@@ -484,15 +498,25 @@ fn seed_node_anchors(
     }
     let mut seeded = 0;
     for anchor in anchors {
-        if !SEEDABLE_BINDING_KINDS.contains(&anchor.binding_kind.as_str())
-            || anchor.binding_id.is_empty()
-        {
+        if !SEEDABLE_BINDING_KINDS.contains(&anchor.binding_kind.as_str()) {
+            // A deliberately-excluded kind is the ordinary case, not an anomaly — a call-path-bound
+            // memory reaching a peer is normal — and the projection re-offers it on every pass, so
+            // warning here would repeat forever for a decision this store already made.
+            tracing::debug!(
+                repo_id,
+                node_id = %node.node_id,
+                binding_kind = %anchor.binding_kind,
+                "not seeding an anchor of a kind this store cannot resolve",
+            );
+            continue;
+        }
+        if anchor.binding_id.is_empty() {
             tracing::warn!(
                 repo_id,
                 node_id = %node.node_id,
                 binding_kind = %anchor.binding_kind,
-                "skipping an anchor this store cannot seed: unknown binding kind, or an empty \
-                 binding id that would make a degenerate primary key",
+                "skipping an anchor with an empty binding id: it would make a degenerate primary \
+                 key",
             );
             continue;
         }
@@ -946,6 +970,13 @@ mod tests {
         node_id: &str,
         anchors: Option<&[(&str, &str)]>,
     ) {
+        // Idempotent in the node row, so a test can re-run this to add a snapshot to content it
+        // already seeded — the "the snapshot arrived in a later entry" shape.
+        conn.execute(
+            "DELETE FROM content_projected_nodes WHERE stream_id = ?1 AND node_id = ?2",
+            params![stream.to_bytes().as_slice(), node_id],
+        )
+        .unwrap();
         seed_projected_node(conn, stream, node_id, "Invariant", "t", "b", "active", &[]);
         let anchors_json = anchors.map(|anchors| {
             let rows: Vec<serde_json::Value> = anchors
@@ -1046,18 +1077,10 @@ mod tests {
         )
         .unwrap();
 
-        // Forget the drain watermark so the next pass genuinely re-examines this node — otherwise
-        // the drain short-circuits as caught-up and this test would pass with the gate removed.
-        conn.execute("DELETE FROM oplog_meta WHERE key = 'content:drain-wm:' || hex(?1)", params![
-            stream.to_bytes().as_slice()
-        ])
-        .unwrap();
-        assert!(
-            rag_rat_oplog::content_drain_needed(&conn, stream).unwrap(),
-            "the second pass must actually run, or this test proves nothing",
-        );
-
-        // A later drain must not put the original identity back beside the relocated row.
+        // `drain_worker` calls the in-transaction drain directly, so there is no caught-up
+        // short-circuit to defeat here — the second pass re-walks every projected node
+        // unconditionally. A later drain must not put the original identity back beside the
+        // relocated row.
         drain_worker(&conn, stream, 2_000);
         assert_eq!(bindings_of(&conn, "mem_peer"), vec![(
             "symbol".to_string(),
@@ -1065,19 +1088,65 @@ mod tests {
         )]);
     }
 
-    /// An author publishing an EMPTY set is a statement that the memory has no bindings; it must
-    /// seed nothing, and must not be confused with the `None` of nobody having published.
+    /// The reason `drain_node` computes an effect and then seeds, instead of returning early: an
+    /// anchor snapshot can arrive in a LATER entry than the content it describes. On that second
+    /// pass the content has already converged, so the node takes the `unchanged` arm — and if that
+    /// arm returned, the memory would never get its bindings.
+    ///
+    /// Restoring the early return must fail this test; nothing else in the suite reaches that arm
+    /// with a seed pending.
     #[test]
-    fn neither_an_empty_snapshot_nor_an_absent_one_seeds_anything() {
+    fn a_snapshot_arriving_after_its_content_still_seeds() {
         let conn = scoped_conn();
         let stream = StreamId::from_bytes([0x44; 32]);
-        seed_projected_node_with_anchors(&conn, stream, "mem_empty", Some(&[]));
-        seed_projected_node_with_anchors(&conn, stream, "mem_absent", None);
-
+        // Pass one: content only, no snapshot yet.
+        seed_projected_node_with_anchors(&conn, stream, "mem_peer", None);
         drain_worker(&conn, stream, 1_000);
+        assert!(
+            bindings_of(&conn, "mem_peer").is_empty(),
+            "nobody has published this memory's bindings yet",
+        );
 
-        assert!(bindings_of(&conn, "mem_empty").is_empty());
-        assert!(bindings_of(&conn, "mem_absent").is_empty());
+        // Pass two: the snapshot lands with the content byte-identical, so the node converges and
+        // takes the `unchanged` arm.
+        seed_projected_node_with_anchors(
+            &conn,
+            stream,
+            "mem_peer",
+            Some(&[("symbol", "src/lib.rs::run")]),
+        );
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(outcome.nodes_written, 0, "the content did not change on this pass");
+        assert_eq!(bindings_of(&conn, "mem_peer"), vec![(
+            "symbol".to_string(),
+            "src/lib.rs::run".to_string()
+        )]);
+    }
+
+    /// An author publishing an EMPTY set states the memory has no bindings, which is not the `None`
+    /// of nobody having published — but neither seeds, and crucially neither ARMS the gate: a later
+    /// real snapshot must still be able to seed, which an over-eager "we have seen a snapshot" gate
+    /// would prevent.
+    #[test]
+    fn an_empty_snapshot_seeds_nothing_and_does_not_arm_the_gate() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x44; 32]);
+        seed_projected_node_with_anchors(&conn, stream, "mem_peer", Some(&[]));
+        drain_worker(&conn, stream, 1_000);
+        assert!(bindings_of(&conn, "mem_peer").is_empty(), "an empty set seeds nothing");
+
+        seed_projected_node_with_anchors(
+            &conn,
+            stream,
+            "mem_peer",
+            Some(&[("symbol", "src/lib.rs::run")]),
+        );
+        drain_worker(&conn, stream, 2_000);
+        assert_eq!(
+            bindings_of(&conn, "mem_peer").len(),
+            1,
+            "the earlier empty set did not consume this memory's one chance to be seeded",
+        );
     }
 
     /// A binding kind this store cannot produce is a newer peer's vocabulary: skipped row-wise,

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -357,9 +357,9 @@ fn drain_node(
         return Ok(if removed { NodeEffect::Removed } else { NodeEffect::Unchanged });
     }
     let projected_status = node.status.as_db_str();
-    match read_existing_node(tx, &node.node_id)? {
+    let effect = match read_existing_node(tx, &node.node_id)? {
         // A row with this id already belongs to ANOTHER repo — never touch a sibling's content.
-        Some(existing) if existing.repo_id != repo_id => Ok(NodeEffect::Unchanged),
+        Some(existing) if existing.repo_id != repo_id => NodeEffect::Unchanged,
         Some(existing) => {
             let current_tags = memory::tags_for_memory(tx, &node.node_id)?;
             let want_tags = memory::normalize_tags(&node.content.tags);
@@ -372,30 +372,34 @@ fn drain_node(
                 && existing.status == projected_status
                 && current_tags == want_tags;
             if unchanged {
-                return Ok(NodeEffect::Unchanged);
+                // Content converged, but the anchor snapshot may have arrived in a later entry, so
+                // fall through to the seed rather than returning here.
+                NodeEffect::Unchanged
+            } else {
+                // Converge to the account-wide LWW value; `origin` is intentionally NOT in the SET,
+                // so whatever the row was (local or synced) is preserved — a
+                // projected local row carries a peer's accepted edit, not an echo
+                // to ignore.
+                tx.execute(
+                    "UPDATE repo_memories
+                     SET kind = ?2, title = ?3, body = ?4, confidence = ?5, source = ?6,
+                         payload_json = ?7, status = ?8, updated_at_ms = ?9
+                     WHERE id = ?1",
+                    params![
+                        node.node_id,
+                        node.content.kind,
+                        node.content.title,
+                        node.content.body,
+                        node.content.confidence,
+                        node.content.source,
+                        node.content.payload,
+                        projected_status,
+                        now_ms,
+                    ],
+                )?;
+                write_node_children(tx, &node.node_id, &node.content.tags)?;
+                NodeEffect::Written
             }
-            // Converge to the account-wide LWW value; `origin` is intentionally NOT in the SET, so
-            // whatever the row was (local or synced) is preserved — a projected local row carries a
-            // peer's accepted edit, not an echo to ignore.
-            tx.execute(
-                "UPDATE repo_memories
-                 SET kind = ?2, title = ?3, body = ?4, confidence = ?5, source = ?6,
-                     payload_json = ?7, status = ?8, updated_at_ms = ?9
-                 WHERE id = ?1",
-                params![
-                    node.node_id,
-                    node.content.kind,
-                    node.content.title,
-                    node.content.body,
-                    node.content.confidence,
-                    node.content.source,
-                    node.content.payload,
-                    projected_status,
-                    now_ms,
-                ],
-            )?;
-            write_node_children(tx, &node.node_id, &node.content.tags)?;
-            Ok(NodeEffect::Written)
         },
         None => {
             // First sight of this node — received from a peer. `created_by` / `source_text_hash` /
@@ -424,9 +428,121 @@ fn drain_node(
                 ],
             )?;
             write_node_children(tx, &node.node_id, &node.content.tags)?;
-            Ok(NodeEffect::Written)
+            NodeEffect::Written
         },
+    };
+    // Seed AFTER materialization, and only for a node that belongs to THIS repo — the sibling-repo
+    // arm above must not touch that repo's bindings any more than it touches its content.
+    if node_in_repo(tx, &node.node_id, repo_id)? {
+        seed_node_anchors(tx, repo_id, node)?;
     }
+    Ok(effect)
+}
+
+/// The binding kinds the local write path can produce, and therefore the only ones worth seeding
+/// from a peer's snapshot. An unknown kind is a newer peer's vocabulary: it means nothing here, so
+/// it is skipped row-wise rather than quarantining the node over its decoration.
+///
+/// `call_path` is deliberately absent even though the local path produces it: its supporting
+/// `repo_memory_call_paths` / `_edges` rows are in NO replication scope, so a seeded call-path
+/// binding could never resolve here — it would sit unverifiable forever.
+const SEEDABLE_BINDING_KINDS: &[&str] = &[
+    "logical_symbol",
+    "symbol",
+    "chunk",
+    "edge",
+    "scip_moniker",
+    "path",
+    "dir",
+    "commit",
+    "tracker",
+];
+
+/// Seed a synced memory's bindings from the anchor snapshot its author published — ONLY when this
+/// store holds none for it.
+///
+/// The gate is what keeps this a fallback rather than a second writer. `anchors/1` remains the
+/// carrier of ongoing rebinds and relocations within an account; this writes into vacuum exactly
+/// once, so the two never contend for a live row and there is no clock to arbitrate.
+///
+/// It is per-MEMORY, not per-row: the validate/relocate loop re-keys `binding_id`, a PK column, so
+/// a per-row gate would look at a row the loop had moved, find its old identity absent, and
+/// resurrect it as a duplicate sibling — forever.
+///
+/// `None` anchors means nobody published this memory's bindings, which is NOT the same as an author
+/// publishing an empty set; only the latter is a statement, and neither seeds anything.
+fn seed_node_anchors(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    node: &ProjectedContentNode,
+) -> anyhow::Result<usize> {
+    let Some(anchors) = node.anchors.as_deref() else {
+        return Ok(0);
+    };
+    if anchors.is_empty() || memory_has_any_binding(tx, repo_id, &node.node_id)? {
+        return Ok(0);
+    }
+    let mut seeded = 0;
+    for anchor in anchors {
+        if !SEEDABLE_BINDING_KINDS.contains(&anchor.binding_kind.as_str())
+            || anchor.binding_id.is_empty()
+        {
+            tracing::warn!(
+                repo_id,
+                node_id = %node.node_id,
+                binding_kind = %anchor.binding_kind,
+                "skipping an anchor this store cannot seed: unknown binding kind, or an empty \
+                 binding id that would make a degenerate primary key",
+            );
+            continue;
+        }
+        // Portable columns only. Every checkout-local column — `anchor_status`, the resolved ids,
+        // the relocation bookkeeping — is left at its schema default, which is exactly the row
+        // state a `/5` apply produces, so the validate/relocate loop takes it from here with
+        // nothing special-cased for a seeded row.
+        tx.execute(
+            "INSERT INTO repo_memory_bindings(
+                 repo_id, memory_id, binding_kind, binding_id, path, start_line, end_line,
+                 commit_hash, tracker, project, item_key, created_at_ms, symbol_kind,
+                 signature_hash, moniker_tool, moniker_tool_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                repo_id,
+                node.node_id,
+                anchor.binding_kind,
+                anchor.binding_id,
+                anchor.path,
+                anchor.start_line,
+                anchor.end_line,
+                anchor.commit_hash,
+                anchor.tracker,
+                anchor.project,
+                anchor.item_key,
+                anchor.created_at_ms,
+                anchor.symbol_kind,
+                anchor.signature_hash,
+                anchor.moniker_tool,
+                anchor.moniker_tool_version,
+            ],
+        )?;
+        seeded += 1;
+    }
+    Ok(seeded)
+}
+
+/// Whether this store holds ANY binding for `(repo_id, memory_id)` — the per-memory seed gate.
+fn memory_has_any_binding(
+    conn: &Connection,
+    repo_id: &str,
+    memory_id: &str,
+) -> anyhow::Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM repo_memory_bindings WHERE repo_id = ?1 AND memory_id = ?2
+         )",
+        params![repo_id, memory_id],
+        |row| row.get::<_, i64>(0),
+    )? == 1)
 }
 
 /// Whether a `repo_memories` row with this id exists UNDER `repo_id`. The edge-drain source guard
@@ -820,6 +936,175 @@ mod tests {
             params![stream.to_bytes().as_slice(), node_id, content_json, status],
         )
         .unwrap();
+    }
+
+    /// Seed a projected node carrying an anchor snapshot. `anchors` is `(binding_kind, binding_id)`
+    /// per row; `None` writes SQL NULL, the "nobody published bindings" state.
+    fn seed_projected_node_with_anchors(
+        conn: &Connection,
+        stream: StreamId,
+        node_id: &str,
+        anchors: Option<&[(&str, &str)]>,
+    ) {
+        seed_projected_node(conn, stream, node_id, "Invariant", "t", "b", "active", &[]);
+        let anchors_json = anchors.map(|anchors| {
+            let rows: Vec<serde_json::Value> = anchors
+                .iter()
+                .map(|(kind, id)| {
+                    serde_json::json!({
+                        "binding_kind": kind,
+                        "binding_id": id,
+                        "path": "src/lib.rs",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "commit_hash": null,
+                        "tracker": null,
+                        "project": null,
+                        "item_key": null,
+                        "created_at_ms": 7,
+                        "symbol_kind": null,
+                        "signature_hash": null,
+                        "moniker_tool": null,
+                        "moniker_tool_version": null,
+                    })
+                })
+                .collect();
+            serde_json::to_string(&rows).unwrap()
+        });
+        conn.execute(
+            "UPDATE content_projected_nodes SET anchors_json = ?3
+             WHERE stream_id = ?1 AND node_id = ?2",
+            params![stream.to_bytes().as_slice(), node_id, anchors_json],
+        )
+        .unwrap();
+    }
+
+    fn bindings_of(conn: &Connection, memory_id: &str) -> Vec<(String, String)> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT binding_kind, binding_id FROM repo_memory_bindings
+                 WHERE repo_id = ?1 AND memory_id = ?2 ORDER BY binding_kind, binding_id",
+            )
+            .unwrap();
+        let rows =
+            stmt.query_map(params![REPO, memory_id], |row| Ok((row.get(0)?, row.get(1)?))).unwrap();
+        rows.map(Result::unwrap).collect()
+    }
+
+    /// The happy path: a synced memory arrives with no bindings here, so its author's snapshot
+    /// seeds them — portable columns carried, every checkout-local column left at its default,
+    /// which is the row state a `/5` apply produces.
+    #[test]
+    fn a_synced_memory_with_no_bindings_is_seeded_from_its_snapshot() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x44; 32]);
+        seed_projected_node_with_anchors(
+            &conn,
+            stream,
+            "mem_peer",
+            Some(&[("symbol", "src/lib.rs::run"), ("path", "src/lib.rs")]),
+        );
+
+        drain_worker(&conn, stream, 1_000);
+
+        assert_eq!(bindings_of(&conn, "mem_peer"), vec![
+            ("path".to_string(), "src/lib.rs".to_string()),
+            ("symbol".to_string(), "src/lib.rs::run".to_string()),
+        ]);
+        let (status, symbol_id): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT anchor_status, symbol_id FROM repo_memory_bindings
+                 WHERE memory_id = 'mem_peer' AND binding_kind = 'symbol'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "unverified", "local resolution state starts at its default");
+        assert_eq!(symbol_id, None, "no checkout-local id is carried across the wire");
+    }
+
+    /// The gate, and the reason it is per-MEMORY rather than per-row: the validate/relocate loop
+    /// re-keys `binding_id`, a PK column, so a per-row gate would find the pre-relocation identity
+    /// absent and resurrect it beside the row the loop had moved.
+    #[test]
+    fn a_memory_that_already_holds_a_binding_is_never_seeded() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x44; 32]);
+        seed_projected_node_with_anchors(
+            &conn,
+            stream,
+            "mem_peer",
+            Some(&[("symbol", "src/lib.rs::run")]),
+        );
+        drain_worker(&conn, stream, 1_000);
+
+        // Stand in for the relocation loop: the row moves to a new identity.
+        conn.execute(
+            "UPDATE repo_memory_bindings SET binding_id = 'src/lib.rs::run_renamed'
+             WHERE memory_id = 'mem_peer'",
+            [],
+        )
+        .unwrap();
+
+        // Forget the drain watermark so the next pass genuinely re-examines this node — otherwise
+        // the drain short-circuits as caught-up and this test would pass with the gate removed.
+        conn.execute("DELETE FROM oplog_meta WHERE key = 'content:drain-wm:' || hex(?1)", params![
+            stream.to_bytes().as_slice()
+        ])
+        .unwrap();
+        assert!(
+            rag_rat_oplog::content_drain_needed(&conn, stream).unwrap(),
+            "the second pass must actually run, or this test proves nothing",
+        );
+
+        // A later drain must not put the original identity back beside the relocated row.
+        drain_worker(&conn, stream, 2_000);
+        assert_eq!(bindings_of(&conn, "mem_peer"), vec![(
+            "symbol".to_string(),
+            "src/lib.rs::run_renamed".to_string()
+        )]);
+    }
+
+    /// An author publishing an EMPTY set is a statement that the memory has no bindings; it must
+    /// seed nothing, and must not be confused with the `None` of nobody having published.
+    #[test]
+    fn neither_an_empty_snapshot_nor_an_absent_one_seeds_anything() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x44; 32]);
+        seed_projected_node_with_anchors(&conn, stream, "mem_empty", Some(&[]));
+        seed_projected_node_with_anchors(&conn, stream, "mem_absent", None);
+
+        drain_worker(&conn, stream, 1_000);
+
+        assert!(bindings_of(&conn, "mem_empty").is_empty());
+        assert!(bindings_of(&conn, "mem_absent").is_empty());
+    }
+
+    /// A binding kind this store cannot produce is a newer peer's vocabulary: skipped row-wise,
+    /// with the rest of the snapshot still seeded. `call_path` is skipped for a different
+    /// reason — its supporting tables are in no replication scope, so it could never resolve
+    /// here.
+    #[test]
+    fn an_unseedable_kind_is_skipped_without_losing_the_rest() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x44; 32]);
+        seed_projected_node_with_anchors(
+            &conn,
+            stream,
+            "mem_peer",
+            Some(&[
+                ("symbol", "src/lib.rs::run"),
+                ("call_path", "abc123"),
+                ("from_the_future", "whatever"),
+            ]),
+        );
+
+        drain_worker(&conn, stream, 1_000);
+
+        assert_eq!(bindings_of(&conn, "mem_peer"), vec![(
+            "symbol".to_string(),
+            "src/lib.rs::run".to_string()
+        )]);
     }
 
     /// Seed one row into `content_projected_edges`. `resolved` is `(target_repo, target_node,


### PR DESCRIPTION
Third slice of cross-account anchor replication (#1180). #1208 added the `node_anchors` op, #1209 projected it; this is the slice that makes a contributor's memories actually drive-by surface on the owner's machine.

## The gate is the design

Apply a snapshot **only when this store holds no binding for that memory**. That single rule is what keeps the op a fallback rather than a second writer: `anchors/1` remains the carrier of ongoing rebinds and relocations within an account, the seed writes into vacuum exactly once, and the two never contend for a live row — so there is no clock to arbitrate and no cadence war to lose.

It is **per-memory, not per-row**. The validate/relocate loop re-keys `binding_id`, a PK column, so a per-row gate would find the pre-relocation identity absent and resurrect it as a duplicate sibling of the row the loop had just moved — permanently, since nothing later removes it. The test for this stands in for the relocation loop by re-keying a seeded row, then forces a genuine second drain pass and asserts the original identity does not come back.

## Where it runs

For every node that belongs to this repo, whatever its content effect. An anchor snapshot can arrive in a **later entry** than the content it describes, so the converged-content path falls through to the seed rather than returning early — otherwise a memory whose content had already settled would never get its bindings. The sibling-repo arm still seeds nothing, guarded by the same `node_in_repo` check that already protects a sibling's content.

## Trust boundary

Only kinds the local write path can produce are seeded. An unknown kind is a newer peer's vocabulary — skipped row-wise, never quarantining a node over its decoration. `call_path` is skipped for a different reason worth stating: `repo_memory_call_paths` / `_edges` are in no replication scope, so a seeded call-path binding could never resolve here and would sit unverifiable forever.

Portable columns only; every checkout-local column is left at its schema default. That is byte-for-byte the row state a `/5` apply produces, so the relocation engine, doctor, and the drive-by queries take a seeded row with nothing special-cased for it.

## `None` is still not an empty set

Neither seeds anything, but they mean different things and the code reads both: `None` is nobody having published this memory's bindings, `Some(vec![])` is its author stating it has none.

## Tests

Happy path (portable columns carried, `anchor_status` and the resolved ids left at their defaults); the per-memory gate under a relocation re-key; empty-vs-absent snapshot; an unseedable kind skipped without losing the rest of the set.

The gate test was verified by negative control — removing `memory_has_any_binding` from the condition makes it fail, restoring it makes it pass — and it asserts `content_drain_needed` before the second pass, so it cannot silently degrade into a test that proves nothing when the drain short-circuits as caught-up.

Verified: four CI clippy configurations, `cargo nextest run --workspace` (5143 passed) and `cargo test --workspace`, nightly rustfmt.