### PR TITLE
fix(query): seed oracle-resolved callers into the flat impact lane

### DIFF
--- a/crates/rag-rat-query/src/graph/predicates.rs
+++ b/crates/rag-rat-query/src/graph/predicates.rs
@@ -132,12 +132,18 @@ const ORACLE_SEED_EDGE_CAP: usize = 5000;
 /// the gap means moving this seed behind that crate, not adding a fourth spelling of a table this
 /// crate cannot see (#1215).
 ///
-/// SCOPE is reverse `traverse_with_options` / `traversal_summary` — which is also what the
-/// SYMBOL-SELECTED `impact_surface` report traverses (`impact_surface_report_for_symbol` →
-/// `oracle_ranked_neighbors`), so its `direct_semantic_callers` carry the seeded rows too. The FLAT
-/// `Vec<ImpactItem>` lane — a free-text query, or the `allow_ambiguous` fallback — instead runs
-/// `impact::neighbors::graph_neighbors`, whose own reverse predicate has no oracle arm and which
-/// gets no enrichment pass either, so that lane still answers the pre-seed caller count (#1214).
+/// SCOPE is the two reverse caller lanes of this crate. `traverse_with_options` /
+/// `traversal_summary` — which is also what the SYMBOL-SELECTED `impact_surface` report traverses
+/// (`impact_surface_report_for_symbol` → `oracle_ranked_neighbors`), so its
+/// `direct_semantic_callers` carry the seeded rows. And the FLAT `Vec<ImpactItem>` lane — a
+/// free-text query, or the `allow_ambiguous` fallback — which calls this itself per target from
+/// `impact::neighbors::graph_neighbors`, splices the ids into its own reverse predicate, and,
+/// having no enrichment pass, marks the seeded rows from that same id list.
+/// `rag_rat_core::query::grep_augment::edge_counts` is the reverse caller lane this does NOT reach:
+/// its `{N} callers` line still answers the pre-seed count. It lives in `rag-rat-core`, so covering
+/// it means exporting this seed across that crate boundary rather than growing a fourth spelling of
+/// the query — the same call as the #1215 note above. FORWARD traversal never seeds: a verdict
+/// names the edge's target, which is what a reverse lookup matches on.
 pub(crate) fn reverse_oracle_seeded_edge_ids(
     conn: &Connection,
     symbol: &str,

--- a/crates/rag-rat-query/src/graph/tests.rs
+++ b/crates/rag-rat-query/src/graph/tests.rs
@@ -294,7 +294,7 @@ fn oracle_verdicts_seed_the_call_sites_the_resolver_left_unbound() {
 
 /// The symbol-selected `impact_surface` report traverses through `traverse_with_options`, so it
 /// answers with the same seeded callers `find_callers` does. Its flat `Vec<ImpactItem>` sibling
-/// has its own reverse SQL and does not (#1214).
+/// keeps its own reverse SQL and seeds separately; `impact::neighbors` covers that lane.
 #[test]
 fn the_symbol_selected_impact_report_carries_an_oracle_seeded_caller() {
     let conn = scoped_conn();

--- a/crates/rag-rat-query/src/impact/neighbors.rs
+++ b/crates/rag-rat-query/src/impact/neighbors.rs
@@ -1,7 +1,17 @@
+use std::collections::HashSet;
+
 use rusqlite::params_from_iter;
 use rusqlite::types::Value;
 
 use super::*;
+
+/// One `graph_neighbors` row: the neighbour's file/symbol columns, the edge's kind and stored
+/// confidence, and `edges.id` — the handle the oracle seed list is keyed on.
+type NeighborRow = (String, String, String, Option<String>, String, String, i64);
+
+fn neighbor_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<NeighborRow> {
+    Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?))
+}
 
 pub(crate) fn graph_neighbors(
     conn: &Connection,
@@ -39,10 +49,11 @@ pub(crate) fn graph_neighbors(
     // operator. Graph traversal and graph metadata already require a resolved operator target;
     // impact must too.
     let resolved_operator_only = crate::graph::RESOLVED_OPERATOR_ONLY;
-    let sql = format!(
-        "
+    let sql_for = |predicate: &str| {
+        format!(
+            "
         SELECT {source_path_col}, {source_language_col}, {source_kind_col},
-               {source_symbol_col}, edges.edge_kind, edges.confidence
+               {source_symbol_col}, edges.edge_kind, edges.confidence, edges.id
         FROM edges
         LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
         LEFT JOIN files from_files ON from_files.id = from_symbols.file_id
@@ -67,32 +78,69 @@ pub(crate) fn graph_neighbors(
             edges.edge_kind,
             {source_path_col},
             {source_symbol_col}
-        ",
-    );
-    let mut stmt = conn.prepare(&sql)?;
+        "
+        )
+    };
+    let mut stmt = conn.prepare(&sql_for(predicate))?;
     // Bind exactly the placeholders the CHOSEN predicate references. Every arm uses `?1` (the
     // symbol id), but only the name-matching arms use `?2` — the two `Exact` arms match on the id
     // alone. Binding an unreferenced `?2` makes rusqlite reject the statement outright ("Wrong
     // number of parameters passed to query. Got 2, needed 1"), which is why `impact_surface` with
     // `resolution = exact` returned an error instead of a surface.
+    //
+    // The oracle arm adds no placeholder — the edge ids are spliced, as they are in
+    // `graph::reverse_predicate` — so this stays keyed on the base predicate.
     let binds_name = predicate.contains("?2");
     for target in targets {
+        // REVERSE ONLY: an edge the resolver left unbound records the callee name AS WRITTEN at the
+        // call site — a RECEIVER-qualified name (`h::target` for `h.target(..)`), never the
+        // definition's path-qualified name — so neither the id arm nor the qualified-name arm above
+        // reaches it, and a compiler verdict naming this target is the only way that caller can
+        // surface. Enrichment could not add it either: it relabels rows the query already returned,
+        // and this lane runs no enrichment pass at all. Forward neighbours have no such seed. With
+        // no oracle verdict the list is empty and the SQL is the base statement, unchanged.
+        //
+        // `SymbolTarget` carries no logical id, so the seed runs NON-LOGICAL — attributed to the
+        // target symbol plus its qualified-name twins, which is also the attribution this lane's
+        // heuristic arms use. `find_callers` fills `logical_symbol_id` in, so a verdict resolving
+        // to a SIBLING member of a logical group seeds there and still does not seed here: the two
+        // lanes agree on the non-logical seed set, not on logical groups.
+        let (oracle_arm, seeded_edge_ids) = if reverse {
+            let options = GraphTraversalOptions {
+                resolution_mode,
+                symbol_id: Some(target.id),
+                ..GraphTraversalOptions::default()
+            };
+            let edge_ids =
+                graph::reverse_oracle_seeded_edge_ids(conn, &target.qualified_name, &options)?;
+            (graph::oracle_seed_in_list(&edge_ids), HashSet::<i64>::from_iter(edge_ids))
+        } else {
+            (None, HashSet::new())
+        };
+        let mut seeded_stmt = match &oracle_arm {
+            Some(list) => Some(conn.prepare(&sql_for(&format!("{predicate} OR {list}")))?),
+            None => None,
+        };
+        let stmt = seeded_stmt.as_mut().unwrap_or(&mut stmt);
         let mut args = vec![Value::Integer(target.id)];
         if binds_name {
             args.push(Value::Text(target.qualified_name.clone()));
         }
-        let rows = stmt.query_map(params_from_iter(args), |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, String>(5)?,
-            ))
-        })?;
+        let rows = stmt.query_map(params_from_iter(args), neighbor_row)?;
         for row in rows {
-            let (path, language, kind, symbol, edge_kind, confidence) = row?;
+            let (path, language, kind, symbol, edge_kind, confidence, edge_id) = row?;
+            // A seeded row's STORED confidence describes the name the resolver wrote down, not why
+            // the row is here: an unbound edge carries `NameOnly` against a receiver-qualified
+            // name, so rendering that alone reports the best-evidenced caller in the surface as the
+            // weakest and attributes it to a target the edge does not record. The seed query
+            // applied the run-currency, content-key and live-definition gates, so membership in its
+            // id list IS the evidence — but this lane runs no enrichment pass, so nothing has
+            // re-checked the verdict against the row being rendered or arbitrated between tools.
+            let confidence = if seeded_edge_ids.contains(&edge_id) {
+                format!("{confidence}, compiler-verified")
+            } else {
+                confidence
+            };
             surface.push(
                 ImpactCategory::DirectStructural,
                 FileSymbol { path, language, kind, symbol },
@@ -109,18 +157,9 @@ pub(crate) fn graph_neighbors(
         {
             continue;
         }
-        let rows = stmt.query_map(params![Option::<i64>::None, name], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, String>(5)?,
-            ))
-        })?;
+        let rows = stmt.query_map(params![Option::<i64>::None, name], neighbor_row)?;
         for row in rows {
-            let (path, language, kind, symbol, edge_kind, confidence) = row?;
+            let (path, language, kind, symbol, edge_kind, confidence, _) = row?;
             surface.push(
                 ImpactCategory::DirectStructural,
                 FileSymbol { path, language, kind, symbol },
@@ -320,7 +359,103 @@ pub(crate) fn textual_fallback(
 
 #[cfg(test)]
 mod tests {
+    use rag_rat_core::index::install_scope_view;
+
     use super::*;
+
+    const COMMIT: &str = "c0ffee";
+
+    /// The FLAT `Vec<ImpactItem>` lane — reached from a free-text `query` and from the
+    /// `allow_ambiguous` fallback — must name the same callers `find_callers` does, or the same
+    /// symbol reports a different caller set depending only on how it was selected (#1214).
+    ///
+    /// The fixture is the shape the seed exists for: a call the resolver could not bind, recorded
+    /// under the callee name AS WRITTEN (`h::target`), which matches neither the target's
+    /// qualified name nor any symbol id — so no heuristic arm reaches it and only the compiler
+    /// verdict can.
+    #[test]
+    fn the_flat_lane_returns_an_oracle_seeded_caller() {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_core::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               commit_sha, worktree_id)
+             VALUES ('a.rs', 'rust', 'source', 'sha-a', 0, 0, ?1, '')",
+            params![COMMIT],
+        )
+        .unwrap();
+        let file = conn.last_insert_rowid();
+        let add_symbol = |name: &str, qualified: &str| -> i64 {
+            conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![
+                qualified
+            ])
+            .unwrap();
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind,
+                                     start_byte, end_byte, signature, docs)
+                 VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3),
+                         'function', 0, 10, NULL, NULL)",
+                params![file, name, qualified],
+            )
+            .unwrap();
+            conn.last_insert_rowid()
+        };
+        let target = add_symbol("target", "a.rs::target");
+        let caller = add_symbol("caller", "a.rs::caller");
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence,
+                               source_start_byte, source_end_byte,
+                               callee_start_byte, callee_end_byte)
+             VALUES (?1, ?2, NULL, 'target', 'h::target', 'calls_name', 'NameOnly',
+                     100, 105, 100, 105)",
+            params![file, caller],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at,
+                                     status)
+             VALUES ('rust-analyzer', 'ra 1.0', ?1, '', 0, 'ok')",
+            params![COMMIT],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO edge_oracle(source_path, source_start_byte, source_end_byte,
+                                     callee_start_byte, callee_end_byte, edge_kind, file_sha,
+                                     tool, tool_version, resolved_symbol_id, scip_symbol, kind,
+                                     computed_at)
+             VALUES ('a.rs', 100, 105, 100, 105, 'calls_name', 'sha-a',
+                     'rust-analyzer', 'ra 1.0', ?1, 'scip x', 'upgrade', 0)",
+            params![target],
+        )
+        .unwrap();
+        install_scope_view(&conn, COMMIT, "").unwrap();
+
+        let items =
+            impact_surface_with_options(&conn, "a.rs::target", 50, GraphResolutionMode::Syntactic)
+                .unwrap();
+        let callers =
+            items.iter().filter(|item| item.reason == "direct_caller").collect::<Vec<_>>();
+        assert_eq!(
+            callers.len(),
+            1,
+            "the compiler-resolved call site is the one caller: {items:#?}"
+        );
+        assert_eq!(callers[0].symbol.as_deref(), Some("a.rs::caller"));
+        // The row is here because the compiler resolved it, and the evidence must say so: the
+        // stored `NameOnly` alone would report the surface's best-evidenced caller as its weakest,
+        // and attribute it to a target the edge does not record.
+        assert_eq!(
+            callers[0].evidence,
+            vec!["calls_name edge to a.rs::target (NameOnly, compiler-verified)"],
+            "the seeded row must carry the verdict in its evidence: {items:#?}"
+        );
+        // Forward neighbours carry no seed: the same verdict must not invent a callee.
+        assert!(
+            !items.iter().any(|item| item.reason == "direct_callee"),
+            "the reverse-only seed must not leak into the callee lane: {items:#?}"
+        );
+    }
 
     /// #692: pin the real predicate strings to the indexed-id form so a refactor cannot silently
     /// reintroduce the value-joined `target_qualified_name` / `from_name` seed (which full-scans


### PR DESCRIPTION
`impact_surface` has two caller lanes, and only one of them saw oracle-resolved callers.

The symbol-selected report traverses through `traverse_with_options`, so it already answered with the seeded callers `find_callers` returns. The flat lane — a free-text `query`, or the `allow_ambiguous` fallback — builds its own reverse predicate in `impact::neighbors` and had no oracle arm. The same symbol therefore reported different callers depending on how it happened to be selected.

## What changed

The flat lane now seeds per target, reverse only.

It was not deliberately answering a cheaper question: it runs the same edge-kind set, the same resolved-operator guard and the same confidence ordering as the traversal. The only difference was the missing arm.

**Forward neighbours are untouched.** A verdict names the edge's *target*, which is what a reverse lookup matches on; seeding forward would attribute a verdict to the wrong end. A test pins that no `direct_callee` item appears.

**The name-only `target_names` pass is also unseeded.** It runs with no symbol id, so there is no target to attribute a verdict to — it is the name fallback, not a symbol selection. `find_callers` has no analogue of it.

**A repo with no oracle run pays** a `repo_id` column probe and one empty indexed join per target per reverse call. The seed list comes back empty, so the base statement — prepared once — is the only statement executed, and it is byte-identical to before.

**The bind layout is unchanged.** The arm splices literal edge ids rather than adding a placeholder, exactly as `graph::reverse_predicate` does, so `?1`/`?2` numbering and the pinned predicate test are untouched. Appending ` OR <ids>` is safe for every reverse arm: reverse `Exact` early-returns an empty seed, reverse `Syntactic` and `Fuzzy` are pure OR chains, and the call site already wraps the whole predicate in `AND (...)`. The one arm with a top-level `AND` is forward `Syntactic`, which never receives the seed.

## Seeded rows are marked, not left at the stored confidence

An unbound edge stores `NameOnly` against the receiver-qualified name written at the call site, so rendering a seeded row at its stored confidence reported the surface's best-evidenced caller as its weakest, and attributed it to a target the edge does not record. The lane now selects `edges.id` and appends `compiler-verified` to the evidence of any row the seed list names.

Appended rather than substituted: a seed also covers a `confirm` verdict on an edge a heuristic arm already matched, and this lane cannot tell which arm matched without another column. The stored confidence stays factually the edge's, with the verdict stated beside it — and the wording keeps the claim honest, since the row is *seeded*, not enriched. The seed query applied the currency gates; nothing re-checked the verdict per rendered row or arbitrated between tools.

`SymbolTarget` carries no logical id, so the seed here runs non-logical, matching the lane's own heuristic arms. The lanes therefore agree on the non-logical seed set: a verdict resolving to a sibling member of a logical group still seeds `find_callers` and not this lane.

Unlike the traversal, this lane has no enrichment pass, so seeded rows arrive at their stored confidence rather than relabelled as compiler-verified.

## Tests

`the_flat_lane_returns_an_oracle_seeded_caller` — an unresolved call site plus a current upgrade verdict. Neutering the seed drops it to zero callers, with the surface showing only definition/sibling/textual items and no `direct_caller`.

Fixes #1214.

