### PR TITLE
test(query): make three assertions pin the behavior they describe

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -65,6 +65,10 @@ pub use search::SearchRequest;
 /// Volume cap on the memories `read_chunk` attaches as drive-by context. The binding is
 /// structural, so every hit is relevant; the cap is purely about how much of a reader's attention
 /// one chunk read may spend (the grep-augment hook lanes budget 4).
+///
+/// A cap this tight makes the ordering load-bearing: `memories_for_chunk` returns chunk-bound
+/// memories ahead of the file's path-bound ones, so a recently-touched file-level note cannot
+/// spend the last slot the chunk's own memory needed.
 const DRIVE_BY_CHUNK_MEMORY_LIMIT: u32 = 6;
 
 impl IndexDatabase {
@@ -775,17 +779,16 @@ mod oracle_surfacing_tests;
 mod drive_by_memory_cap_tests {
     use rag_rat_query::graph_meta::GraphMetaMode;
     use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
-    use rusqlite::Connection;
+    use rusqlite::{Connection, params};
 
     use crate::index::IndexDatabase;
 
-    /// A store holding one chunk with `n` memories bound to it — the shape `read_chunk` attaches
-    /// drive-by context to. Seeded through a bare connection first so the opened
-    /// [`IndexDatabase`] scopes to the seeded repo.
-    fn db_with_chunk_memories(n: usize) -> (tempfile::TempDir, IndexDatabase, i64) {
+    /// A store holding one chunk of `src/a.rs` and the bare connection to seed memories through —
+    /// the shape `read_chunk` attaches drive-by context to. Seeding happens before the
+    /// [`IndexDatabase`] opens so it scopes to the seeded repo.
+    fn store_with_one_chunk() -> (tempfile::TempDir, Connection, i64) {
         let dir = tempfile::tempdir().unwrap();
-        let database = dir.path().join("index.sqlite");
-        let conn = Connection::open(&database).unwrap();
+        let conn = Connection::open(dir.path().join("index.sqlite")).unwrap();
         rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
         conn.execute(
             "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
@@ -808,25 +811,55 @@ mod drive_by_memory_cap_tests {
         .unwrap();
         let chunk_id = conn.last_insert_rowid();
         rag_rat_db::chunk_text_store::seed_chunk_text(&conn, chunk_id, "fn foo() {}").unwrap();
-        for i in 0..n {
-            crate::memory_write::create_memory(&conn, RepoMemoryCreate {
-                kind: "Invariant".to_string(),
-                title: format!("Drive-by memory {i}"),
-                body: format!("Body of drive-by memory {i}."),
-                confidence: "high".to_string(),
-                created_by: Some("test".to_string()),
-                source: None,
-                tags: vec![],
-                payload_json: None,
-                bind: RepoMemoryBindTarget {
-                    chunk_id: Some(chunk_id),
-                    ..RepoMemoryBindTarget::default()
-                },
-            })
-            .unwrap();
-        }
+        (dir, conn, chunk_id)
+    }
+
+    /// Opens the seeded store, releasing the seeding connection first.
+    fn open_seeded(dir: &tempfile::TempDir, conn: Connection) -> IndexDatabase {
         drop(conn);
-        let db = IndexDatabase::open(&database).unwrap();
+        IndexDatabase::open(&dir.path().join("index.sqlite")).unwrap()
+    }
+
+    fn create_memory_bound_to(
+        conn: &Connection,
+        title: &str,
+        bind: RepoMemoryBindTarget,
+    ) -> String {
+        crate::memory_write::create_memory(conn, RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: format!("Body of {title}."),
+            confidence: "high".to_string(),
+            created_by: Some("test".to_string()),
+            source: None,
+            tags: vec![],
+            payload_json: None,
+            bind,
+        })
+        .unwrap()
+        .memory
+        .memory_id
+    }
+
+    /// `create_memory` stamps the wall clock, so a test that ranks on recency sets the timestamps
+    /// itself rather than relying on creation order landing in distinct milliseconds.
+    fn stamp_updated_at(conn: &Connection, memory_id: &str, updated_at_ms: i64) {
+        conn.execute("UPDATE repo_memories SET updated_at_ms = ?2 WHERE id = ?1", params![
+            memory_id,
+            updated_at_ms
+        ])
+        .unwrap();
+    }
+
+    fn db_with_chunk_memories(n: usize) -> (tempfile::TempDir, IndexDatabase, i64) {
+        let (dir, conn, chunk_id) = store_with_one_chunk();
+        for i in 0..n {
+            create_memory_bound_to(&conn, &format!("Drive-by memory {i}"), RepoMemoryBindTarget {
+                chunk_id: Some(chunk_id),
+                ..RepoMemoryBindTarget::default()
+            });
+        }
+        let db = open_seeded(&dir, conn);
         (dir, db, chunk_id)
     }
 
@@ -851,6 +884,53 @@ mod drive_by_memory_cap_tests {
             chunk.memories.len(),
             usize::try_from(super::DRIVE_BY_CHUNK_MEMORY_LIMIT).unwrap(),
             "9 bound memories, capped to the drive-by limit"
+        );
+    }
+
+    /// The cap makes the ranking load-bearing. A chunk binding names THIS code; a path binding
+    /// names the whole file, and a file accrues far more of them. Ranked on recency alone, file
+    /// notes touched after the chunk's own memory take every slot, and the read that exists to
+    /// surface the specific anchor never shows it.
+    #[test]
+    fn a_chunk_bound_memory_outranks_the_files_newer_path_bound_ones() {
+        let (dir, conn, chunk_id) = store_with_one_chunk();
+        let chunk_bound =
+            create_memory_bound_to(&conn, "The chunk's own invariant", RepoMemoryBindTarget {
+                chunk_id: Some(chunk_id),
+                ..RepoMemoryBindTarget::default()
+            });
+        stamp_updated_at(&conn, &chunk_bound, 0);
+        // More than the cap, every one of them newer than the chunk-bound memory.
+        for i in 0..8i64 {
+            let path_bound = create_memory_bound_to(
+                &conn,
+                &format!("File-level note {i}"),
+                RepoMemoryBindTarget {
+                    path: Some("src/a.rs".to_string()),
+                    ..RepoMemoryBindTarget::default()
+                },
+            );
+            stamp_updated_at(&conn, &path_bound, 1_000 + i);
+        }
+        let db = open_seeded(&dir, conn);
+
+        let chunk = db
+            .read_chunk_with_graph_and_memories(
+                chunk_id,
+                GraphMetaMode::Full,
+                20,
+                true,
+                rag_rat_base::config::MemorySurface::Full,
+            )
+            .unwrap()
+            .expect("chunk");
+
+        let ids: Vec<&str> = chunk.memories.iter().map(|m| m.memory_id.as_str()).collect();
+        assert_eq!(ids.len(), usize::try_from(super::DRIVE_BY_CHUNK_MEMORY_LIMIT).unwrap());
+        assert_eq!(
+            ids.first().copied(),
+            Some(chunk_bound.as_str()),
+            "the chunk's own binding leads eight newer path-bound notes: {ids:?}"
         );
     }
 }

--- a/crates/rag-rat-query/src/graph/tests.rs
+++ b/crates/rag-rat-query/src/graph/tests.rs
@@ -211,8 +211,10 @@ fn an_ambiguous_short_name_does_not_absorb_unrelated_unresolved_calls() {
 
     let options = syntactic(target);
     let hops = callers(&conn, "a.rs::target", &options);
-    let summary =
-        traversal_summary(&conn, "a.rs::target", true, 100, &options, hops.len()).unwrap();
+    // The summary limit sits BETWEEN the gated candidate count (1) and the ungated one (4):
+    // `truncated` is `total_matching_edges > limit`, so only a limit the absorbed candidates
+    // would overrun tells the two apart. At a limit above both, the assertion holds either way.
+    let summary = traversal_summary(&conn, "a.rs::target", true, 2, &options, hops.len()).unwrap();
 
     assert_eq!(hops.len(), 1, "the one bound call site is still the only caller");
     assert_eq!(summary.unresolved, 0, "an ambiguous short name claims no unresolved candidate");

--- a/crates/rag-rat-query/src/memory/api.rs
+++ b/crates/rag-rat-query/src/memory/api.rs
@@ -76,9 +76,23 @@ pub fn memories_for_chunk(
 ) -> anyhow::Result<Vec<RepoMemory>> {
     let scope = memory_repo_scope(conn)?;
     let repo_clause = memory_repo_scope_clause(&scope);
+    // Two binding kinds answer for one chunk, and they are not equally specific: a chunk binding
+    // names THIS code, a path binding names the whole file. The caller's `limit` is a volume cap,
+    // so under a shared ranking a file-level note touched today evicts the memory an author
+    // anchored to this exact chunk — the more specific binding, and the reason the attachment
+    // exists. Specificity leads, recency breaks the tie within each tier.
+    //
+    // GROUP BY, not DISTINCT: the tier is a PER-ROW expression, so a memory holding BOTH a chunk
+    // and a path binding joins twice and DISTINCT would key on (id, tier, updated_at_ms) and return
+    // it once per binding. The aggregate is what folds the two rows into one tier value — DISTINCT
+    // over the id alone would have collapsed them, but it cannot carry the tier. `IS` (not `=`)
+    // keeps a path binding's NULL `chunk_id` scoring 0 rather than NULL, so the tiers stay
+    // comparable.
     let mut stmt = conn.prepare(&format!(
         "
-        SELECT DISTINCT repo_memories.id AS memory_id
+        SELECT repo_memories.id AS memory_id,
+               MAX(repo_memory_bindings.chunk_id IS ?1) AS binds_this_chunk,
+               repo_memories.updated_at_ms AS updated_at_ms
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
          AND repo_memory_bindings.repo_id = repo_memories.repo_id
@@ -89,7 +103,8 @@ pub fn memories_for_chunk(
               repo_memory_bindings.chunk_id = ?1
               OR (files.path IS NOT NULL AND repo_memory_bindings.path = files.path)
           )
-        ORDER BY repo_memories.updated_at_ms DESC
+        GROUP BY repo_memories.id
+        ORDER BY binds_this_chunk DESC, updated_at_ms DESC
         LIMIT ?2
         "
     ))?;
@@ -486,11 +501,17 @@ mod memory_search_dedup_tests {
 
     /// The duplicate must not eat a result slot: `limit` counts distinct memories, so it has to be
     /// applied AFTER the duplicate rows collapse, not to the raw FTS row set.
+    ///
+    /// The DISTINCTNESS of the ids is the whole claim — a row count of 3 alone is exactly what the
+    /// rejected `DISTINCT (memory_id, bm25)` shape returns, with `m` twice and one memory pushed
+    /// out.
     #[test]
     fn a_duplicate_fts_row_does_not_consume_a_limit_slot() {
         let conn = conn_with_duplicated_fts_row();
         let hits = memory_search(&conn, "quokkaform", 3).unwrap();
-        assert_eq!(hits.len(), 3, "limit counts distinct memories, not FTS rows: {hits:?}");
+        let ids: BTreeSet<&str> = hits.iter().map(|hit| hit.memory_id.as_str()).collect();
+        assert_eq!(hits.len(), 3, "the limit is spent in full: {hits:?}");
+        assert_eq!(ids.len(), 3, "limit counts distinct memories, not FTS rows: {hits:?}");
     }
 }
 


### PR DESCRIPTION
Three assertions advertised coverage they did not provide. A test that cannot fail is worse than no test, because it stops anyone from looking.

Each fix below was verified by reverting the behavior it guards and confirming that specific test fails.

## The three

**Ambiguous short name / `truncated`.** The test asserted `!summary.truncated` at a limit of 100 against 4 candidate edges, so it read `false` whether the uniqueness gate suppressed the absorbed candidates or not (`4 > 100` and `1 > 100` are both false). The limit now sits between the gated count (1) and the ungated one (4) — the only range where the flag separates them. Confirmed: at limit 100 the assertion passes under the removed gate; at limit 2 it fails.

**FTS duplicate rows.** `a_duplicate_fts_row_does_not_consume_a_limit_slot` asserted `hits.len() == 3` but never that the three were *distinct memories*, which is the whole claim — it passed under precisely the `DISTINCT (memory_id, bm25)` shape its own comment argues against. Now asserts distinct ids. Confirmed: reverting the `GROUP BY` fails the new assertion (`left: 2, right: 3`, hits `[m, m, m2]`) while the old length assertion still passes, which is exactly the vacuity.

## The behavior change

**`memories_for_chunk` ranked purely by recency** and treated a chunk-id binding and a path binding as equal. That was tolerable at a budget of 20; with the drive-by cap now 6, a recently-touched path-bound memory can evict the chunk-bound one — the more specific binding, and the reason the attachment exists.

Chunk-bound bindings now sort ahead of path-bound ones, with recency deciding inside each tier. `GROUP BY` replaces `DISTINCT` so a memory carrying both bindings collapses to one row holding its best; `MAX(chunk_id IS ?1)` uses `IS` so a path binding's NULL `chunk_id` scores 0 rather than NULL. The cap's doc now records that a budget this tight makes the ordering load-bearing.

New test `a_chunk_bound_memory_outranks_the_files_newer_path_bound_ones`; reverting the `ORDER BY` fails it.

Fixes #1219.
