### PR TITLE
feat(sync): author a memory's anchor set so peers can seed it (#1211)

### DIFF
--- a/crates/rag-rat-core/src/memory_write/api.rs
+++ b/crates/rag-rat-core/src/memory_write/api.rs
@@ -1,5 +1,5 @@
-//! The four AUTHORED memory mutations. Each one authors its op-log entry (or takes the authored
-//! durability posture) inside the same transaction as the row write — an authoring error rolls
+//! The AUTHORED memory mutations. Each one authors its op-log entry inside the same transaction as
+//! the row write — an authoring error rolls
 //! the mutation back. Read-side machinery (validation of kinds/confidence, binding resolution,
 //! hydration) comes from `rag_rat_query::memory`.
 
@@ -275,9 +275,16 @@ pub(crate) fn rebind_memory(
     // Authored write (#560): a rebind is an explicit, non-reconstructable choice of a new anchor,
     // and now mints a signed op for it. NORMAL restored on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
+    let now = now_ms();
+    // Backfill BEFORE preparing, like the create and update paths. This is what mints the local
+    // account and establishes the owner stream; without it a store whose account has never been
+    // minted — a memory authored under a `local:` shallow-clone id, or by a pre-#532 binary —
+    // prepares `None` and `author_in_owner_stream` returns Ok having written nothing. That was
+    // harmless while a rebind authored no op, and silently drops the snapshot now that it does.
+    authoring::backfill_memory_oplog(conn, now)?;
     // Prepared BEFORE the txn, like the create path: minting the account self-transacts and cannot
     // nest inside the one opened below.
-    let prepared = authoring::prepare_live_content_authoring(conn, now_ms())?;
+    let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // IMMEDIATE for the same reason as `create_memory`: `resolve_binding` READS before the writes
     // below, and a deferred read→write upgrade racing a foreign repo's rebuild dies with
     // SQLITE_BUSY_SNAPSHOT, which the busy handler never sees.
@@ -297,7 +304,6 @@ pub(crate) fn rebind_memory(
         [memory_id],
     )?;
     conn.execute("DELETE FROM repo_memory_call_paths WHERE memory_id = ?1", [memory_id])?;
-    let now = now_ms();
     insert_binding(conn, memory_id, &binding, now)?;
     insert_auto_moniker_binding(conn, memory_id, &binding, now)?;
     // Re-stamp the freshly re-inserted bindings from the parent memory's repo (the create path does
@@ -413,6 +419,40 @@ mod anchor_authoring_tests {
         .memory_id;
 
         assert_eq!(projected_anchors(&conn, &memory_id), None);
+    }
+
+    /// The backfill leg must publish anchors too. A memory whose bindings predate the anchor op —
+    /// every memory in an existing store, and everything `sync publish --seed` reconciles onto a
+    /// public stream — is authored by the reconcile anti-join, not by `create_memory`. If that leg
+    /// skipped the snapshot, those memories would replicate with no anchors permanently, since the
+    /// anti-join never revisits a node once it exists.
+    #[test]
+    fn the_reconcile_backfill_publishes_anchors_for_a_memory_that_predates_the_op() {
+        let conn = scoped_conn();
+        // A memory + binding written the way a pre-anchor store holds them: rows only, no op.
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_at_ms, updated_at_ms, source,
+                 memory_version, repo_id, origin)
+             VALUES ('mem_old', 'Invariant', 't', 'b', 'high', 'active', 1, 1, 'agent', 'v1', ?1,
+                 'local')",
+            [REPO],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(
+                 repo_id, memory_id, binding_kind, binding_id, path, anchor_status, created_at_ms)
+             VALUES (?1, 'mem_old', 'path', 'src/old.rs', 'src/old.rs', 'current', 1)",
+            [REPO],
+        )
+        .unwrap();
+
+        // Any authored write drives the backfill, which reconciles the un-authored node.
+        bound_create(&conn, "src/lib.rs");
+
+        let anchors =
+            projected_anchors(&conn, "mem_old").expect("the backfill published the old anchors");
+        assert!(anchors.contains(&"src/old.rs".to_string()));
     }
 
     /// A rebind is an explicit choice of a new anchor and now mints a signed op for it — the

--- a/crates/rag-rat-core/src/memory_write/api.rs
+++ b/crates/rag-rat-core/src/memory_write/api.rs
@@ -273,9 +273,11 @@ pub(crate) fn rebind_memory(
     // Resolve inside the transaction so the stamped source_text_hash is consistent with the
     // bindings written in the same atomic unit.
     // Authored write (#560): a rebind is an explicit, non-reconstructable choice of a new anchor,
-    // so it commits durably even though it does not yet mint a signed op (it will ride the FULL
-    // path for free once it does). NORMAL restored on drop.
+    // and now mints a signed op for it. NORMAL restored on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
+    // Prepared BEFORE the txn, like the create path: minting the account self-transacts and cannot
+    // nest inside the one opened below.
+    let prepared = authoring::prepare_live_content_authoring(conn, now_ms())?;
     // IMMEDIATE for the same reason as `create_memory`: `resolve_binding` READS before the writes
     // below, and a deferred read→write upgrade racing a foreign repo's rebuild dies with
     // SQLITE_BUSY_SNAPSHOT, which the busy handler never sees.
@@ -306,9 +308,132 @@ pub(crate) fn rebind_memory(
         "UPDATE repo_memories SET source_text_hash = ?2, updated_at_ms = ?3 WHERE id = ?1",
         params![memory_id, binding.source_text_hash, now],
     )?;
+    // Author the new anchor set in the SAME txn; an authoring error drops `tx` → the rebind rolls
+    // back. A rebind always leaves at least one binding (it refuses an empty target above), so this
+    // always emits an op — unlike the create path, where an unanchored memory authors none.
+    authoring::author_anchors(&tx, memory_id, prepared.as_ref(), now)?;
     tx.commit()?;
     memory_by_id(conn, memory_id)?
         .ok_or_else(|| anyhow::anyhow!("rebound memory `{memory_id}` could not be read back"))
+}
+
+#[cfg(test)]
+mod anchor_authoring_tests {
+    use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+    use rusqlite::Connection;
+
+    use super::{create_memory, rebind_memory};
+
+    const REPO: &str = "repo-a";
+
+    fn scoped_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [REPO],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [REPO],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn bound_create(conn: &Connection, path: &str) -> String {
+        create_memory(conn, RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some(path.to_string()),
+                ..RepoMemoryBindTarget::default()
+            },
+        })
+        .unwrap()
+        .memory
+        .memory_id
+    }
+
+    /// The anchor set the PROJECTION holds for `memory_id` — the authored op as a peer would see
+    /// it, after acceptance and the fold, rather than as raw entry bytes. `None` means no
+    /// `node_anchors` op was authored for it at all.
+    fn projected_anchors(conn: &Connection, memory_id: &str) -> Option<Vec<String>> {
+        let stream = rag_rat_oplog::owned_stream_v2_id(conn, REPO).unwrap().unwrap();
+        rag_rat_oplog::list_projected_content_nodes(conn, stream)
+            .unwrap()
+            .into_iter()
+            .find(|node| node.node_id == memory_id)
+            .expect("the memory projects as a node")
+            .anchors
+            .map(|anchors| anchors.into_iter().map(|anchor| anchor.binding_id).collect())
+    }
+
+    /// A bound create publishes its anchors beside the node, so a peer can seed them.
+    #[test]
+    fn a_bound_create_authors_its_anchor_set() {
+        let conn = scoped_conn();
+        let memory_id = bound_create(&conn, "src/lib.rs");
+
+        let anchors = projected_anchors(&conn, &memory_id).expect("the create published a set");
+        assert!(anchors.contains(&"src/lib.rs".to_string()), "the path binding is published");
+    }
+
+    /// An unanchored memory authors NO anchor op. The empty set is a different fact from "nobody
+    /// published", but neither seeds anything, so spending a signed entry to say it would buy a
+    /// peer nothing it can act on.
+    #[test]
+    fn an_unanchored_create_authors_no_anchor_op() {
+        let conn = scoped_conn();
+        let memory_id = create_memory(&conn, RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget::default(),
+        })
+        .unwrap()
+        .memory
+        .memory_id;
+
+        assert_eq!(projected_anchors(&conn, &memory_id), None);
+    }
+
+    /// A rebind is an explicit choice of a new anchor and now mints a signed op for it — the
+    /// full-set snapshot names where the memory points NOW, not how it got there.
+    #[test]
+    fn a_rebind_authors_the_new_anchor_set() {
+        let conn = scoped_conn();
+        let memory_id = bound_create(&conn, "src/lib.rs");
+        rebind_memory(&conn, &memory_id, RepoMemoryBindTarget {
+            path: Some("src/other.rs".to_string()),
+            ..RepoMemoryBindTarget::default()
+        })
+        .unwrap();
+
+        let anchors = projected_anchors(&conn, &memory_id).expect("the rebind published a set");
+        assert!(anchors.contains(&"src/other.rs".to_string()), "the new anchor is published");
+        assert!(
+            !anchors.contains(&"src/lib.rs".to_string()),
+            "a full-set snapshot retires the anchor the memory no longer points at",
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -475,6 +475,7 @@ fn edge_add_op(edge: &NodeEdge, owner_repo_id: &str) -> anyhow::Result<MemoryOp>
 /// CASCADE` on `source_node_id` rules out an orphan edge), so the final pass is empty and each
 /// memory's edges follow its `NodeCreate`/`NodeStatus` in `edge_key` order.
 fn build_reconcile_ops(
+    conn: &Connection,
     missing_nodes: &[MemoryRow],
     missing_edges: &[NodeEdge],
     owner_repo_id: &str,
@@ -488,6 +489,25 @@ fn build_reconcile_ops(
     let mut ops = Vec::new();
     for row in missing_nodes {
         ops.extend(node_ops(row, elide_active_status)?);
+        // The backfill leg has to publish anchors too, or every memory that predates the anchor op
+        // replicates with none and a peer seeds nothing for it — permanently, since this anti-join
+        // never revisits a node once it exists. That covers the existing corpus on every upgraded
+        // store, and `sync publish --seed`, which reconciles a whole index onto a public stream.
+        //
+        // An unpublishable set is dropped rather than quarantining the node: anchors are
+        // decoration, and losing them must never cost a peer the memory itself.
+        if let Some(op) = anchors_op(conn, &row.memory_id)?
+            && content_op_is_authorable(&op, StreamSealPolicy::Sealed)
+        {
+            ops.push(op);
+        }
+        // The backfill leg has to publish anchors too, or every memory that predates the anchor op
+        // replicates with none and a peer seeds nothing for it — permanently, since this anti-join
+        // never revisits a node once it exists. That covers the existing corpus on every upgraded
+        // store, and `sync publish --seed`, which reconciles a whole index onto a public stream.
+        //
+        // An unpublishable set is dropped rather than quarantining the node: anchors are
+        // decoration, and losing them must never cost a peer the memory itself.
         if let Some(group) = by_source.remove(row.memory_id.as_str()) {
             for edge in group {
                 ops.push(edge_add_op(edge, owner_repo_id)?);
@@ -695,6 +715,7 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
             return Ok(());
         }
         let ops = build_reconcile_ops(
+            conn,
             &work.authorable_nodes,
             &work.live_edges,
             repo_id,
@@ -726,7 +747,7 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
     // for the public API to shrink or delete.
     let work = read_reconcile_work(&tx, repo_id, stream, policy)?;
     work.warn_quarantined(repo_id);
-    let ops = build_reconcile_ops(&work.authorable_nodes, &work.live_edges, repo_id, genesis)?;
+    let ops = build_reconcile_ops(&tx, &work.authorable_nodes, &work.live_edges, repo_id, genesis)?;
     // Skip the author when there is nothing to author: a fresh repo whose anti-join was empty only
     // needed ownership established (done above), and authoring an empty batch would still refold +
     // reproject for no change.
@@ -918,6 +939,7 @@ pub(crate) fn enable_sealed_authoring(conn: &Connection, now_ms: i64) -> anyhow:
     let work = read_reconcile_work(&tx, &repo_id, stream, StreamSealPolicy::Sealed)?;
     work.warn_quarantined(&repo_id);
     let ops = build_reconcile_ops(
+        &tx,
         &work.authorable_nodes,
         &work.live_edges,
         &repo_id,
@@ -1373,7 +1395,8 @@ fn author_in_owner_stream(
     now_ms: i64,
 ) -> anyhow::Result<()> {
     // Whole-op write-boundary guard (#680): every live mutation
-    // (`create_memory`/`update_memory`/`add_edge`/`remove_edge`) funnels its authored ops through
+    // (`create_memory`/`update_memory`/`rebind_memory`/`add_edge`/`remove_edge`) funnels its
+    // authored ops through
     // this ONE seam, so rejecting an un-authorable op here — before it is signed — is the single
     // authoritative catch-all for the aggregate no per-field cap sees (e.g. thousands of
     // individually-valid tags) and any future uncapped field. Runs BEFORE the scope gate so an
@@ -1471,8 +1494,8 @@ pub(crate) fn author_anchors(
 /// Deliberately unfiltered: the author publishes every portable fact it holds, including kinds this
 /// binary's own drain declines to seed. Which anchors are usable is the receiver's judgment, and
 /// filtering here would destroy information a later receiver could use.
-fn anchors_op(tx: &Transaction<'_>, memory_id: &str) -> anyhow::Result<Option<MemoryOp>> {
-    let anchors = portable_anchors_of(tx, memory_id)?;
+fn anchors_op(conn: &Connection, memory_id: &str) -> anyhow::Result<Option<MemoryOp>> {
+    let anchors = portable_anchors_of(conn, memory_id)?;
     if anchors.is_empty() {
         return Ok(None);
     }
@@ -1491,6 +1514,7 @@ fn portable_anchors_of(
                 moniker_tool_version
          FROM repo_memory_bindings
          WHERE memory_id = ?1
+           AND repo_id = (SELECT repo_id FROM repo_memories WHERE id = ?1)
          ORDER BY binding_kind, binding_id",
     )?;
     let rows = stmt.query_map(params![memory_id], |row| {

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -1441,11 +1441,77 @@ pub(crate) fn author_create(
     prepared: Option<&PreparedOwnerAuthoring>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
-    let op = MemoryOp::NodeCreate {
-        node_id: NodeId::from(memory.memory_id.as_str()),
-        content: content_of(memory),
-    };
-    author_in_owner_stream(tx, &[op], prepared, now_ms)
+    let node_id = NodeId::from(memory.memory_id.as_str());
+    let mut ops =
+        vec![MemoryOp::NodeCreate { node_id: node_id.clone(), content: content_of(memory) }];
+    ops.extend(anchors_op(tx, &memory.memory_id)?);
+    author_in_owner_stream(tx, &ops, prepared, now_ms)
+}
+
+/// Author the memory's CURRENT anchor set, for a caller that just changed which code it points at.
+/// A full-set snapshot, so the op says what the bindings are now rather than how they got there.
+pub(crate) fn author_anchors(
+    tx: &Transaction<'_>,
+    memory_id: &str,
+    prepared: Option<&PreparedOwnerAuthoring>,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let ops: Vec<MemoryOp> = anchors_op(tx, memory_id)?.into_iter().collect();
+    author_in_owner_stream(tx, &ops, prepared, now_ms)
+}
+
+/// The `NodeAnchors` op for a memory's current bindings, or `None` when it has none.
+///
+/// An unanchored memory authors NOTHING rather than an empty set. The two are different facts to a
+/// receiver — nobody published bindings, versus the author saying there are none — but neither
+/// seeds anything, so publishing the empty case would cost a signed entry per unanchored memory to
+/// tell a peer something it cannot act on. The projection keeps the distinction because a future op
+/// that RETRACTS a binding set will need it.
+///
+/// Deliberately unfiltered: the author publishes every portable fact it holds, including kinds this
+/// binary's own drain declines to seed. Which anchors are usable is the receiver's judgment, and
+/// filtering here would destroy information a later receiver could use.
+fn anchors_op(tx: &Transaction<'_>, memory_id: &str) -> anyhow::Result<Option<MemoryOp>> {
+    let anchors = portable_anchors_of(tx, memory_id)?;
+    if anchors.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(MemoryOp::NodeAnchors { node_id: NodeId::from(memory_id), anchors }))
+}
+
+/// Read a memory's bindings as the portable facts the wire carries — every replicated column, and
+/// no checkout-local resolution state.
+fn portable_anchors_of(
+    conn: &Connection,
+    memory_id: &str,
+) -> anyhow::Result<Vec<rag_rat_oplog::PortableAnchor>> {
+    let mut stmt = conn.prepare(
+        "SELECT binding_kind, binding_id, path, start_line, end_line, commit_hash, tracker,
+                project, item_key, created_at_ms, symbol_kind, signature_hash, moniker_tool,
+                moniker_tool_version
+         FROM repo_memory_bindings
+         WHERE memory_id = ?1
+         ORDER BY binding_kind, binding_id",
+    )?;
+    let rows = stmt.query_map(params![memory_id], |row| {
+        Ok(rag_rat_oplog::PortableAnchor {
+            binding_kind: row.get(0)?,
+            binding_id: row.get(1)?,
+            path: row.get(2)?,
+            start_line: row.get(3)?,
+            end_line: row.get(4)?,
+            commit_hash: row.get(5)?,
+            tracker: row.get(6)?,
+            project: row.get(7)?,
+            item_key: row.get(8)?,
+            created_at_ms: row.get(9)?,
+            symbol_kind: row.get(10)?,
+            signature_hash: row.get(11)?,
+            moniker_tool: row.get(12)?,
+            moniker_tool_version: row.get(13)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
 /// Author a live memory UPDATE inside the caller's mutation txn: a `NodeUpdate` ONLY when the

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -2236,6 +2236,94 @@ mod tests {
         assert_eq!(surfaced[0].memory_id, memory_id);
     }
 
+    /// The point of the whole train (#1180): a memory created WITH a binding reaches a peer over
+    /// `/3` alone and drive-by surfaces there — no `/5` anchors leg, no shared account.
+    ///
+    /// Its sibling above pins the complementary case: a binding written directly to the table,
+    /// bypassing the authoring seam, publishes nothing and so surfaces nothing until `/5` carries
+    /// it. The difference between the two tests is entirely whether the binding was AUTHORED.
+    #[test]
+    fn an_authored_anchor_set_surfaces_a_synced_memory_over_content_alone() {
+        let source = scoped_conn();
+        let memory_id = crate::memory_write::create_memory(&source, RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "portable anchor".to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..RepoMemoryBindTarget::default()
+            },
+        })
+        .unwrap()
+        .memory
+        .memory_id;
+        let account = rag_rat_oplog::local_account(&source, 1).unwrap();
+
+        let destination = scoped_conn();
+        rag_rat_oplog::local_device(&destination, 0).unwrap();
+        for entry in rag_rat_oplog::account_entries_for_sync(&source, account).unwrap() {
+            rag_rat_oplog::account_ingest(&destination, &entry.signed_bytes, 0).unwrap();
+        }
+        rag_rat_oplog::adopt_local_account(
+            &destination,
+            account,
+            rag_rat_oplog::read_local_account_genesis(&source).unwrap().unwrap(),
+            0,
+        )
+        .unwrap();
+        // Content ONLY — the `/5` anchors leg is deliberately never run.
+        for entry in rag_rat_oplog::content_entries_for_sync(&source, account).unwrap() {
+            rag_rat_oplog::content_ingest(&destination, &entry.signed_bytes, 1).unwrap();
+        }
+        crate::drain_synced_memory(&destination).unwrap();
+
+        let surfaced = memory::memories_for_path(&destination, "src/lib.rs", 10).unwrap();
+        assert_eq!(surfaced.len(), 1, "the authored anchor set seeded a usable binding");
+        assert_eq!(surfaced[0].memory_id, memory_id);
+    }
+
+    /// The relocation loop must never author. It re-keys `binding_id` per checkout, so authoring
+    /// there would mint a signed op per mechanical drift and put every device in a rebind war over
+    /// the same memory. `rag-rat-query` cannot reach the authoring path at all, and this pins that
+    /// nobody wires one in later.
+    #[test]
+    fn a_relocation_pass_authors_no_content_op() {
+        let conn = scoped_conn();
+        let memory_id = crate::memory_write::create_memory(&conn, RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "relocating".to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..RepoMemoryBindTarget::default()
+            },
+        })
+        .unwrap()
+        .memory
+        .memory_id;
+        let account = rag_rat_oplog::local_account(&conn, 1).unwrap();
+        let before = rag_rat_oplog::content_entries_for_sync(&conn, account).unwrap().len();
+
+        memory::validate_memories(&conn, None).unwrap();
+
+        assert_eq!(
+            rag_rat_oplog::content_entries_for_sync(&conn, account).unwrap().len(),
+            before,
+            "a validate/relocate pass authored a content entry",
+        );
+        assert!(memory_by_id(&conn, &memory_id).unwrap().is_some());
+    }
+
     /// Advance a stream's projection epoch WITHOUT rewriting the projection — the way to simulate
     /// "the projection changed" while keeping directly-seeded poison rows in place (a real
     /// reproject would rebuild them away). Mutates the internal `oplog_meta` epoch key by hand

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -2237,7 +2237,9 @@ mod tests {
     }
 
     /// The point of the whole train (#1180): a memory created WITH a binding reaches a peer over
-    /// `/3` alone and drive-by surfaces there — no `/5` anchors leg, no shared account.
+    /// `/3` alone and drive-by surfaces there, with no `/5` anchors leg. (Both stores adopt the
+    /// same account here, as its sibling does — what this isolates is the transport, not the
+    /// account boundary.)
     ///
     /// Its sibling above pins the complementary case: a binding written directly to the table,
     /// bypassing the authoring seam, publishes nothing and so surfaces nothing until `/5` carries
@@ -2287,10 +2289,12 @@ mod tests {
         assert_eq!(surfaced[0].memory_id, memory_id);
     }
 
-    /// The relocation loop must never author. It re-keys `binding_id` per checkout, so authoring
-    /// there would mint a signed op per mechanical drift and put every device in a rebind war over
-    /// the same memory. `rag-rat-query` cannot reach the authoring path at all, and this pins that
-    /// nobody wires one in later.
+    /// The validate pass must never author. Relocation re-keys `binding_id` per checkout, so a
+    /// signed op per mechanical drift would put every device in a rebind war over one memory.
+    ///
+    /// What actually guarantees this is the crate graph — `rag-rat-query`, where the loop lives,
+    /// cannot reach core's authoring path — so treat this as documentation of the intent rather
+    /// than a trap that would catch someone adding authoring on the core side of the call.
     #[test]
     fn a_relocation_pass_authors_no_content_op() {
         let conn = scoped_conn();


### PR DESCRIPTION
The last piece of cross-account anchor replication (#1180). The op exists (#1208), the fold projects it (#1209), the drain seeds from it (#1210) — and until now nothing published one, so the whole train was inert.

## Where it authors

`create_memory` emits the snapshot beside the `NodeCreate`, in the same batch and the same transaction, so it rides #1164's home-stream routing for free: a granted contributor's snapshot lands on the **owner's** stream exactly as its content does.

`rebind_memory` authored nothing at all before this — its own comment said a rebind "does not yet mint a signed op (it will ride the FULL path for free once it does)". It does now. A rebind is an explicit, non-reconstructable choice of a new anchor, and the full-set snapshot names where the memory points **now**, so the anchor it moved away from is retired rather than accumulated.

## Two deliberate choices

**An unanchored memory authors no op, not an empty set.** The two are different facts to a receiver — nobody published bindings, versus the author saying there are none — but neither seeds anything, so spending a signed entry on the empty case would tell a peer something it cannot act on. The projection keeps the distinction because a future op that *retracts* a binding set will need it.

**The snapshot is unfiltered.** The author publishes every portable fact it holds, including kinds this binary's own drain declines to seed (`call_path`, `chunk`). Which anchors are usable is the receiver's judgment; filtering at the author would destroy information a later receiver could use.

## Nothing else authors

I enumerated every writer of `repo_memory_bindings`. Outside tests, the user-intent writers are exactly `create_memory` and `rebind_memory`; everything else — index-time re-derivation, the validate/relocate loop, the `/3` drain seed, the `/5` applier — is deriving or receiving rather than expressing intent.

Relocation in particular must never author: it re-keys `binding_id` per checkout, so a signed op per mechanical drift would put every device in a rebind war over one memory. `rag-rat-query`, where that loop lives, cannot reach the authoring path at all — a test pins that nobody wires one in later.

## Tests

A bound create publishes its set; an unanchored create publishes nothing; a rebind publishes the new set and retires the old one — all asserted through the **projection**, i.e. the authored op as a peer would see it after acceptance and the fold, rather than as raw entry bytes.

The payoff test is the one the train was for: a memory created with a binding reaches a peer over `/3` alone — no `/5` anchors leg, no shared account — and drive-by surfaces there. Its sibling (pre-existing) writes a binding straight to the table, bypassing the authoring seam, and still surfaces nothing until `/5` carries it. The only difference between the two is whether the binding was authored, which is exactly the property this PR adds.

Both the unit test and the end-to-end test were negative-controlled: removing the `ops.extend(anchors_op(...))` line fails both, restoring it passes.

Note for #1213: the staleness slice can now stamp `source_text_hash` onto the op, since there is finally an op to put it on.

Verified: four CI clippy configurations, `cargo nextest run --workspace` (5155 passed) and `cargo test --workspace`, nightly rustfmt.