### PR TITLE
fix(db): give the refold steps the projection shape they fold into

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2341,3 +2341,64 @@ fn migration_097_covers_every_worktree_id_column_in_the_schema() {
          and is deleted by the next GC as a checkout that no longer exists",
     );
 }
+
+/// A store older than the earliest refold step still reaches the tip.
+///
+/// The ladder attaches the all-account refold to V064/V065/V099/V115, and that hook runs the
+/// CURRENT projector — so it writes every column the projector writes TODAY, not the ones that
+/// existed when the step was written. `content_projected_nodes.anchors_json` arrives in V118, three
+/// steps AFTER the V115 refold, so a store replaying from below V115 folded into a table without it
+/// and failed to open, on a column its own migration body never mentions (#1229).
+///
+/// The fixture drops the column as well as truncating the ledger: the ledger decides which steps
+/// replay, but the SHAPE is what the fold hits, and a truncation alone leaves the column standing
+/// from the initial apply.
+///
+/// The real hook folds per account, so on an account-less scratch store it returns without writing
+/// anything and cannot observe the defect. The probe below stands in for it, asserting the shape at
+/// the moment the ladder hands it the transaction — which is the ordering under test.
+#[test]
+fn a_store_below_the_first_refold_step_migrates_to_the_tip() {
+    fn refold_probe(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<()> {
+        let present: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM pragma_table_info('content_projected_nodes') WHERE name \
+             = 'anchors_json')",
+            [],
+            |row| row.get(0),
+        )?;
+        if present {
+            return Ok(());
+        }
+        Err(rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::other(
+            "the refold ran before content_projected_nodes.anchors_json existed",
+        ))))
+    }
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    conn.execute_batch("ALTER TABLE content_projected_nodes DROP COLUMN anchors_json")
+        .expect("drop the projected-node anchors column");
+    assert!(
+        !conn_table_columns(&conn, "content_projected_nodes").contains(&"anchors_json".to_string()),
+        "the fixture starts without the column the refold needs",
+    );
+    truncate_schema_to(&conn, 114);
+
+    let hooks = rag_rat_db::MigrationHooks {
+        backfill_authority_projection: refold_probe,
+        ..crate::index::migration_hooks()
+    };
+    schema::migrate_forward(&conn, &hooks)
+        .expect("a store below the first refold step reaches the tip");
+
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip",
+    );
+    assert!(
+        conn_table_columns(&conn, "content_projected_nodes").contains(&"anchors_json".to_string()),
+        "the refold's shape requirement is satisfied by the tip",
+    );
+}

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -8531,6 +8531,33 @@ pub(crate) fn apply_content_author_stream_index(conn: &Connection) -> rusqlite::
 /// Guarded on the shape, so a full-ladder replay over a store already provisioned from the
 /// end-state snapshot is a no-op rather than a duplicate-column failure.
 pub(crate) fn apply_content_projected_node_anchors(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_content_projection_shape(conn)
+}
+
+/// Every column the CURRENT content projector writes, applied ahead of any migration that replays
+/// the fold.
+///
+/// A refold migration runs today's projector against a store frozen at that migration's version, so
+/// it needs the projection's FINAL shape, not the shape that existed when it was written. Adding a
+/// projected-node column therefore has two obligations: the owning migration, and this function.
+/// Miss the second and every store older than the earliest refold step fails to open, on a column
+/// its own migration body never mentions.
+///
+/// Each step is guarded on the shape, so calling this before a refold and again from the owning
+/// migration is a no-op rather than a duplicate-column failure. The whole body is additionally
+/// guarded on the TABLE, because the refold steps start at V064 while the projection itself arrives
+/// later in the ladder — a store replaying from before it has nothing to widen yet, and reaches the
+/// column through the owning migration on the way to the tip.
+pub(crate) fn ensure_content_projection_shape(conn: &Connection) -> rusqlite::Result<()> {
+    let projected_nodes_exist: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = \
+         'content_projected_nodes')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !projected_nodes_exist {
+        return Ok(());
+    }
     add_column_if_missing(conn, "content_projected_nodes", "anchors_json", "TEXT")
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -1140,6 +1140,13 @@ fn apply_and_record_migration(
     // a domain builder this crate cannot link.
     if matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID | MIGRATION_099_ID | MIGRATION_115_ID)
     {
+        // The hook runs the CURRENT fold, so it writes whatever columns today's projector writes —
+        // not the ones that existed when the migration was written. A refold step therefore depends
+        // on the projection's final shape even though its own body says nothing about it, and a
+        // column added by a LATER migration is missing when an older store replays this one. Bring
+        // the shape forward here, once, for every step that refolds: each helper is guarded on the
+        // shape, so the owning migration stays authoritative and re-running it is a no-op.
+        migrations::ensure_content_projection_shape(&tx)?;
         (hooks.backfill_authority_projection)(&tx)?;
     }
     migrations::record_migration(&tx, step.id, step.checksum, step.description)?;


### PR DESCRIPTION
Opening an existing index with a build carrying migration 118 failed outright, leaving the database unmigrated:

```
Error: account projection backfill failed: table content_projected_nodes has no column named anchors_json
```

Reproduced on a `.backup` copy of a real index at schema 112 — what the released 0.23.0 migrates to, so this is every installation. After the failure `last_migration_to_version` was still 112 and the column absent; the open aborts rather than half-migrating.

## Cause

The ladder attaches the all-account refold hook to V064/V065/V099/V115:

```rust
if matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID | MIGRATION_099_ID | MIGRATION_115_ID) {
    (hooks.backfill_authority_projection)(&tx)?;
}
```

That hook runs the **current** projector, so it writes every column the projector writes today — not the ones that existed when the step was written. `anchors_json` arrives in V118, three steps after the V115 refold, so a store replaying from below V115 folds into a table that does not have it yet.

Nothing in V115 hints at the dependency: its `apply` body is a no-op, and the failure comes entirely from the hook the ladder attaches to it. Reading the migration tells you nothing about a column three steps ahead.

## Fix

The projection shape is brought forward once, at the single site that invokes the hook, so all four refold steps are covered rather than only the one that happened to break.

Two guards, for different reasons:

- **On the column** — the owning migration stays authoritative, and running both is a no-op rather than a duplicate-column failure.
- **On the table** — the refold steps begin at V064 while the projection arrives later in the ladder, so a store replaying from before it has nothing to widen. Without this guard the ladder fails at V064 with `no such table`, which is how the first attempt at this fix broke three existing tests.

## Test

The obvious test — drop the column, truncate the ledger below 115, migrate — **passes without the fix**, because the real hook folds per account and an account-less scratch store has nothing to fold. It would have advertised coverage it did not have.

Instead the test substitutes a probe for the refold hook that asserts the shape at the moment the ladder hands it the transaction, which is the ordering actually under test. With the fix removed it fails with `the refold ran before content_projected_nodes.anchors_json existed`.

Verified end to end against the real 112 database: it now migrates to 118 with the column present.

Fixes #1229.
