### PR TITLE
chore(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
The supply-chain gate fails on `RUSTSEC-2026-0258`: h2 0.4.15 accepts and queues empty DATA
frames without limit, which can grow memory unboundedly (or panic on length overflow) when
streams are not actively drained. Patched upstream in 0.4.16.

h2 is transitive here — `iroh` → `hickory-resolver` → `hickory-net` → `h2` — so the fix is a
lockfile bump only.

The h2 entry is edited in place rather than via `cargo update -p h2`, which additionally
re-resolves ~14 unrelated `windows-sys` dependency edges downward. `cargo metadata --locked`
passes, so the two-line lockfile is consistent.

Verified locally: `cargo deny check` and `cargo audit` both exit 0 (the five remaining audit
entries are allowed unmaintained warnings: atomic-polyfill, bincode, number_prefix, paste,
proc-macro-error2), and `cargo check -p rag-rat-sync` is clean.