### PR TITLE
fix(oracle): decide a verdict on the tightest occurrence, never a wider module

### DIFF
--- a/crates/rag-rat-oracle/src/join.rs
+++ b/crates/rag-rat-oracle/src/join.rs
@@ -6,6 +6,12 @@
 //! range need only overlap on the identifier, not match byte-for-byte (SCIP may bound the range
 //! slightly differently around generics/paths). We require the occurrence to *contain* the edge's
 //! token start, which is robust to those boundary differences while still being per-identifier.
+//!
+//! Containment alone is too generous to decide by, though, because the ranges that contain a token
+//! nest: a segment, the item declaring it, and the module around both. The join takes the TIGHTEST
+//! containing occurrence and never considers a namespace one at all — a module is not something a
+//! call or a type reference can resolve to, so matching one means SCIP had no answer here, not that
+//! it named a different target.
 
 use super::scip::{ScipIndex, ScipOccurrence};
 use super::store::SymbolSpan;
@@ -169,18 +175,48 @@ fn heuristic_resolved_in_corpus(confidence: &str, heuristic_symbol_id: Option<i6
 
 /// The occurrence whose byte range contains the callee token. Prefers a reference occurrence (the
 /// common case for a call site); a definition occurrence only matches a self-referential edge.
-fn find_containing_occurrence(
+///
+/// TIGHTEST WINS WITHIN EACH PASS — a containing reference still outranks a containing definition
+/// of any width, which is what keeps a call site inside a definition's range from being judged
+/// against that definition. Within a pass the width matters: the extractor's callee span is the
+/// token it wrote — for `Type::method` that is the whole path, while SCIP records `Type` and
+/// `method` as separate occurrences. Neither segment CONTAINS the wider span, so the only
+/// containing occurrence left is the enclosing item's or module's definition, which then reads as
+/// the compiler's answer for this edge. Taking the first match in iteration order therefore turned
+/// a span-width disagreement into a confident wrong verdict; [`map_definition_to_symbol`] below
+/// picks the smallest span for the same reason.
+///
+/// A NAMESPACE OCCURRENCE IS A CANDIDATE ONLY WHEN IT EXACTLY BOUNDS THE TOKEN. Where it is wider,
+/// it is the module the token merely sits inside, and a module is not something a call or a type
+/// reference resolves to — matching it is the absence of evidence, not the compiler naming a
+/// different target, so [`classify_edge`] returns `None` into the `no_occurrence` bucket rather
+/// than manufacturing a contradiction against a symbol no heuristic arm could produce (#1223).
+///
+/// The exact-bounds carve-out is not a softening: a namespace CAN be the referent when the token IS
+/// the namespace. TypeScript emits a `references_type` edge for `ns.f()` whose callee range is the
+/// receiver node itself, and for `import * as ns` / `namespace Foo` scip-typescript's occurrence at
+/// that token is the namespace symbol — which this crate does index. Excluding it there would
+/// discard a real verdict, so width is what separates the two cases.
+pub(crate) fn find_containing_occurrence(
     occurrences: &[ScipOccurrence],
     token_start: usize,
     token_end: usize,
 ) -> Option<&ScipOccurrence> {
-    let contains = |occ: &ScipOccurrence| {
-        occ.start_byte <= token_start && token_end <= occ.end_byte && occ.start_byte < occ.end_byte
+    let candidate = |occ: &&ScipOccurrence| {
+        let exactly_bounds_token = occ.start_byte == token_start && occ.end_byte == token_end;
+        occ.start_byte <= token_start
+            && token_end <= occ.end_byte
+            && occ.start_byte < occ.end_byte
+            && (exactly_bounds_token || !super::scip::symbol_is_module(&occ.symbol))
     };
-    occurrences
-        .iter()
-        .find(|occ| !occ.is_definition && contains(occ))
-        .or_else(|| occurrences.iter().find(|occ| contains(occ)))
+    let tightest = |only_references: bool| {
+        occurrences
+            .iter()
+            .filter(|occ| !only_references || !occ.is_definition)
+            .filter(candidate)
+            .min_by_key(|occ| occ.end_byte - occ.start_byte)
+    };
+    tightest(true).or_else(|| tightest(false))
 }
 
 /// A SCIP symbol string names an external package when it parses to a symbol carrying a non-empty

--- a/crates/rag-rat-oracle/src/tests/join_tests.rs
+++ b/crates/rag-rat-oracle/src/tests/join_tests.rs
@@ -18,6 +18,111 @@ fn package_extraction_from_scip_symbol() {
     assert!(!names_external_package("local 0"));
 }
 
+/// A reference occurrence, used where only the range and the symbol matter.
+fn occurrence(start_byte: usize, end_byte: usize, symbol: &str) -> super::scip::ScipOccurrence {
+    super::scip::ScipOccurrence {
+        start_byte,
+        end_byte,
+        symbol: symbol.to_string(),
+        is_definition: false,
+        is_import: false,
+    }
+}
+
+/// The same, carrying the `Definition` role.
+fn definition(start_byte: usize, end_byte: usize, symbol: &str) -> super::scip::ScipOccurrence {
+    super::scip::ScipOccurrence { is_definition: true, ..occurrence(start_byte, end_byte, symbol) }
+}
+
+/// The tightest containing occurrence wins, so a segment's own occurrence is not lost to the item
+/// that encloses it.
+///
+/// The extractor writes the token it saw — for `Type::method` that is the whole path — while SCIP
+/// records each segment separately. Taking the first containing occurrence handed such an edge to
+/// the enclosing definition, which then read as the compiler naming a different target.
+#[test]
+fn containing_occurrence_prefers_the_tightest_span() {
+    let occurrences = vec![
+        occurrence(0, 100, "rust-analyzer cargo demo 0.1 `Enclosing`#"),
+        occurrence(10, 20, "rust-analyzer cargo demo 0.1 `Tight`#"),
+    ];
+    let picked =
+        join::find_containing_occurrence(&occurrences, 12, 16).expect("a containing occurrence");
+    assert_eq!(picked.symbol, "rust-analyzer cargo demo 0.1 `Tight`#", "the tighter span wins");
+
+    // Past the tight span's end, only the enclosing one contains the token.
+    let picked =
+        join::find_containing_occurrence(&occurrences, 50, 60).expect("a containing occurrence");
+    assert_eq!(picked.symbol, "rust-analyzer cargo demo 0.1 `Enclosing`#");
+
+    assert!(
+        join::find_containing_occurrence(&occurrences, 200, 210).is_none(),
+        "nothing contains it"
+    );
+}
+
+/// A namespace WIDER than the token is the module the token sits inside, not the referent, so a
+/// span SCIP has no type or callable occurrence for reports no evidence rather than a disagreement.
+///
+/// Letting such a match be judged turned every span-width mismatch into a contradiction against a
+/// symbol no heuristic arm could produce (#1223). The exactly-bounding case is the referent and is
+/// covered separately.
+#[test]
+fn a_namespace_occurrence_is_never_the_compilers_answer() {
+    let module_only = vec![occurrence(0, 500, "rust-analyzer cargo demo 0.1 commands/clones/")];
+    assert!(
+        join::find_containing_occurrence(&module_only, 100, 122).is_none(),
+        "a module match is the absence of evidence, not the compiler naming a target",
+    );
+
+    // It must not shadow a real occurrence either, even when the namespace is the tighter span.
+    let with_type = vec![
+        occurrence(0, 500, "rust-analyzer cargo demo 0.1 `Wanted`#"),
+        occurrence(90, 130, "rust-analyzer cargo demo 0.1 commands/clones/"),
+    ];
+    let picked =
+        join::find_containing_occurrence(&with_type, 100, 122).expect("the type occurrence");
+    assert_eq!(picked.symbol, "rust-analyzer cargo demo 0.1 `Wanted`#");
+}
+
+/// A namespace that EXACTLY bounds the token is the referent, not the module the token sits in.
+///
+/// TypeScript emits a `references_type` edge for `ns.f()` whose callee range is the receiver node
+/// itself, so for `import * as ns` the occurrence at that token is the namespace symbol — and this
+/// crate indexes those. Width is the discriminator: a module spanning far past the token is
+/// context, a module bounding it exactly is the answer.
+#[test]
+fn a_namespace_bounding_the_token_exactly_is_the_referent() {
+    let receiver = vec![occurrence(100, 102, "scip-typescript npm demo 1.0 `src/m.ts`/ns/")];
+    let picked = join::find_containing_occurrence(&receiver, 100, 102)
+        .expect("a namespace naming the token itself still answers");
+    assert_eq!(picked.symbol, "scip-typescript npm demo 1.0 `src/m.ts`/ns/");
+}
+
+/// A containing REFERENCE outranks a containing definition of any width, so a call site sitting
+/// inside a definition's range is not judged against that definition. Tightest decides only within
+/// a pass.
+#[test]
+fn a_reference_outranks_a_tighter_definition() {
+    let occurrences = vec![
+        occurrence(0, 100, "rust-analyzer cargo demo 0.1 `WideRef`#"),
+        definition(10, 20, "rust-analyzer cargo demo 0.1 `TightDef`#"),
+    ];
+    let picked =
+        join::find_containing_occurrence(&occurrences, 12, 16).expect("a containing occurrence");
+    assert_eq!(
+        picked.symbol, "rust-analyzer cargo demo 0.1 `WideRef`#",
+        "a reference wins on role"
+    );
+
+    // With no reference containing the token, the definition is still selected — the
+    // self-referential edge.
+    let only_definition = vec![definition(10, 20, "rust-analyzer cargo demo 0.1 `TightDef`#")];
+    let picked = join::find_containing_occurrence(&only_definition, 12, 16)
+        .expect("a definition is the fallback, not excluded");
+    assert_eq!(picked.symbol, "rust-analyzer cargo demo 0.1 `TightDef`#");
+}
+
 /// `map_definition_to_symbol` picks the tightest span that REALLY contains the whole definition
 /// range (a method beats its enclosing impl) and returns `None` when no span contains it.
 #[test]


### PR DESCRIPTION
The oracle was reporting about seven times more precision failures than the graph actually has, which is what sent #1223 after the wrong target.

## The defect

`find_containing_occurrence` took the **first** range containing the callee token. But the ranges that contain a token nest — a path segment, the item declaring it, and the module around both — so "first" was decided by iteration order.

The extractor writes the token it saw. For `Type::method` that is the whole path, while SCIP records `Type` and `method` as separate occurrences. Neither segment *contains* the wider span, so the only containing occurrence left is the enclosing module's definition. That module then stood in as the compiler's answer, and since a module is never what any heuristic arm produced, `classify_in_corpus` recorded a **contradiction**.

Worked example — `crates/rag-rat-cli/src/commands/clones.rs`, callee span 14001–14023, which is `IndexDatabase::rebuild`. SCIP's `IndexDatabase` occurrence is 14001–14014, so `token_end <= occ.end_byte` fails. The module occurrence contains it and wins, and the edge is judged against `rust-analyzer cargo rag-rat 0.23.0 commands/clones/`. The heuristic's answer, `IndexDatabase`, was right.

That single name accounted for 1,003 of the contradictions; `Row`/`rusqlite::Row` and `Watcher`/`notify::Watcher` appeared in both bare and qualified form for the same reason.

## The fix

**Tightest containing occurrence wins.** This is what `map_definition_to_symbol` twenty lines below already does for definition ranges — "so a method beats its enclosing impl". The join now applies the same rule to occurrences.

**A namespace occurrence WIDER than the token is not a candidate.** It is the module the token merely sits inside, so matching it is the absence of evidence rather than the compiler naming a different target. Such an edge belongs in `no_occurrence`, alongside the spans SCIP never described.

**One that bounds the token exactly is kept**, because there the namespace *is* the referent. TypeScript emits a `references_type` edge for `ns.f()` whose callee range is the receiver node itself, and for `import * as ns` or `namespace Foo` scip-typescript's occurrence at that token is the namespace symbol — which this crate indexes. Excluding it unconditionally would have turned real verdicts into `no_occurrence` for TS, Java and Go, costing `find_callers` seeds and potentially tripping the ts-rxjs corpus gate. Width is what separates the two cases: rust-analyzer's file-module occurrence spans the whole document against a 22-byte token; a TS namespace receiver occurrence *is* the token.

The predicate is the crate's existing `scip::symbol_is_module`, already used by the moniker pass for the same "not a code entity" reason, rather than a second spelling that could drift from it.

## Measured effect

Same corpus, re-measured after the exact-bounds carve-out (235,017 edges examined; the tree advanced by ~19 edges between runs, which is the small drift in the totals):

| bucket | before | after | Δ |
|---|---|---|---|
| contradicted | 4,336 | **633** | −3,703 |
| confirmed | 53,171 | 54,760 | +1,589 |
| upgraded | 16,969 | 16,992 | +23 |
| resolved_external | 159,146 | 150,799 | −8,347 |
| no_occurrence | 1,376 | 11,833 | +10,457 |

The buckets balance: the fall in contradicted and external is matched by the rise in `no_occurrence` plus the edges that now confirm. Nothing was dropped; edges only moved to the bucket that describes them.

The exact-bounds carve-out is a no-op for Rust — contradicted stays at 633 with or without it — so it protects the other backends without weakening the fix.

Classifying what the compiler names at each surviving contradiction:

| | before | after |
|---|---|---|
| module / namespace | 3,703 | **0** |
| type | 344 | 349 |
| function | 289 | 292 |

Every spurious verdict is gone and every genuine one survives — the survivors are exactly the type and function disagreements, the small rise coming from the edges the tree gained between runs.

The `confirmed` rise is the same defect in the other direction: an edge whose tighter occurrence had been losing to an enclosing one now matches correctly. The `resolved_external` fall is a third face of it — a module occurrence with no in-corpus definition was being read as an external placement.

Reported precision moves from 92.2% to **98.9%**. The graph did not change; only what the oracle was willing to call a disagreement.

## Tests

Four unit tests. The first two were each revert-checked against their own half and confirmed to pass against the other, so neither is carried by the other's fix:

- `containing_occurrence_prefers_the_tightest_span` — fails with `min_by_key` reverted to `find`.
- `a_namespace_occurrence_is_never_the_compilers_answer` — fails with the namespace filter removed. It also pins that a namespace must not shadow a real occurrence even when the namespace is the tighter span.
- `a_namespace_bounding_the_token_exactly_is_the_referent` — pins the TypeScript receiver case, so the exclusion cannot be widened back into a regression for that backend.
- `a_reference_outranks_a_tighter_definition` — pins that tightest decides only within a pass, and that a definition is still selected when it is the only candidate (the self-referential edge). Without it, collapsing the two passes into one `min_by_key` would flip verdicts for call sites inside a definition's range.

Fixes #1223.
