### PR TITLE
refactor(sync): single-home "does this sealed announcement fit one publish?"

### DIFF
--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -557,14 +557,39 @@ fn prepare_advertisement(
     if record.live(now_ms) {
         return Ok(None);
     }
-    Ok(record.envelope.map(|envelope| Publication {
-        tag,
-        node: *node,
-        service: *service,
-        relay: relay.to_owned(),
-        envelope,
-        ttl_seconds,
+    // Applied to the persisted envelope, not only to a fresh seal: a record written before the
+    // ceiling or the wrap layout moved is over-size too, and it would otherwise reach the publish
+    // boundary — which spends a dial to learn what is known here, and reports a bare byte count
+    // where the operator needs the roster.
+    Ok(record.envelope.filter(|envelope| fits_one_announcement(envelope)).map(|envelope| {
+        Publication {
+            tag,
+            node: *node,
+            service: *service,
+            relay: relay.to_owned(),
+            envelope,
+            ttl_seconds,
+        }
     }))
+}
+
+/// Whether this envelope can be advertised at all, said in words an operator can act on.
+///
+/// The publish boundary refuses an over-size envelope too, but it sees bytes and not a roster, so
+/// its message names a byte count and no action. This one names the roster and its ceiling, which
+/// is the only thing an operator can change.
+fn fits_one_announcement(envelope: &[u8]) -> bool {
+    if rag_rat_sync::discovery::fits_publish(envelope) {
+        return true;
+    }
+    tracing::warn!(
+        // The envelope's size law: one version byte, then one fixed-size wrap per recipient.
+        recipients = (envelope.len() - 1) / rag_rat_oplog::discovery::WRAP_LEN,
+        bytes = envelope.len(),
+        max_recipients = rag_rat_sync::discovery::MAX_PUBLISHABLE_RECIPIENTS,
+        "not advertising: this account's roster is too large to seal into one announcement"
+    );
+    false
 }
 
 fn record_advertisement_liveness(
@@ -606,15 +631,9 @@ fn seal_advertisement(
     if sealed.recipients <= 1 {
         return Ok(None);
     }
-    if !rag_rat_sync::discovery::fits_publish(&sealed.bytes) {
-        tracing::warn!(
-            recipients = sealed.recipients,
-            bytes = sealed.bytes.len(),
-            max_recipients = rag_rat_sync::discovery::MAX_PUBLISHABLE_RECIPIENTS,
-            "not advertising: this account's roster is too large to seal into one announcement"
-        );
-        return Ok(None);
-    }
+    // Size is NOT judged here. A fresh seal and a persisted envelope are the same input to the
+    // question, and asking it once — see `fits_one_announcement` — is what keeps the two paths from
+    // giving an operator two different accounts of the same roster.
     Ok(Some(sealed.bytes))
 }
 
@@ -1282,8 +1301,8 @@ mod tests {
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PULL_PEER_MEMO_PREFIX, PerPeerSessionLimiter,
         PersistedAdvertisement, RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host,
         can_sync, device_sync_run, foreign_pull_hosts, foreign_pull_targets, nudge_resident_host,
-        ordered_pull_peers, peer_identity, pull_account_via_peers, read_advertisement,
-        refused_publication_is_due, retry_is_due, write_advertisement,
+        ordered_pull_peers, peer_identity, prepare_advertisement, pull_account_via_peers,
+        read_advertisement, refused_publication_is_due, retry_is_due, write_advertisement,
     };
 
     fn schema_conn() -> Connection {
@@ -1437,6 +1456,54 @@ mod tests {
         assert!(can_host(Some(rag_rat_sync::PeerCapability::ReadWrite)));
         assert!(!can_host(Some(rag_rat_sync::PeerCapability::ReadOnly)));
         assert!(can_sync(Some(rag_rat_sync::PeerCapability::ReadOnly)));
+    }
+
+    /// A persisted envelope is judged against the byte ceiling too, not just a fresh seal.
+    ///
+    /// The record is reused verbatim whenever the tag, endpoint, service, relay, and roster stamp
+    /// all still match, and none of those move when the ceiling or the wrap layout does — so an
+    /// envelope sealed under the old law would sail past the seal-time verdict, cost a dial, and be
+    /// reported at the publish boundary as a byte count with no roster in it. The under-size half
+    /// is what keeps this from passing for the wrong reason: the same record one byte smaller must
+    /// still be advertised.
+    #[test]
+    fn a_persisted_envelope_over_the_announcement_ceiling_is_not_advertised() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let database = dir.path().join("index.sqlite");
+        let node = [0x11; 32];
+        let service = [0x22; 32];
+        let relay = "https://relay.one";
+        let persist = |envelope: Vec<u8>| {
+            let storage = super::IndexConnection::open(&database).unwrap();
+            let conn = storage.connection();
+            rag_rat_db::schema::apply(conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+            rag_rat_oplog::local_account(conn, 1_000).unwrap();
+            let secret = rag_rat_sync::discovery::discovery_secret(conn).unwrap().unwrap();
+            write_advertisement(conn, &PersistedAdvertisement {
+                tag: rag_rat_sync::discovery::account_tag(&secret),
+                node,
+                service,
+                relay: relay.to_owned(),
+                roster_stamp: rag_rat_oplog::discovery::roster_stamp(conn).unwrap(),
+                envelope: Some(envelope),
+                published_at_ms: None,
+                ttl_seconds: 600,
+            })
+            .unwrap();
+        };
+        let ceiling = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES;
+
+        persist(vec![0; ceiling + 1]);
+        assert!(
+            prepare_advertisement(&database, &node, &service, relay, 2_000, 600).unwrap().is_none(),
+            "an over-size persisted envelope must not be handed to the publish path"
+        );
+
+        persist(vec![0; ceiling]);
+        assert!(
+            prepare_advertisement(&database, &node, &service, relay, 2_000, 600).unwrap().is_some(),
+            "the ceiling itself fits, so the same record one byte smaller is still advertised"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -606,11 +606,11 @@ fn seal_advertisement(
     if sealed.recipients <= 1 {
         return Ok(None);
     }
-    if sealed.bytes.len() > rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES {
+    if !rag_rat_sync::discovery::fits_publish(&sealed) {
         tracing::warn!(
             recipients = sealed.recipients,
             bytes = sealed.bytes.len(),
-            max_bytes = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES,
+            max_recipients = rag_rat_sync::discovery::MAX_PUBLISHABLE_RECIPIENTS,
             "not advertising: this account's roster is too large to seal into one announcement"
         );
         return Ok(None);

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -554,22 +554,26 @@ fn prepare_advertisement(
             record
         },
     };
+    // An over-size envelope is LATCHED to `None` in the record, not filtered on the way out.
+    // Nothing `matches` compares moves when the ceiling or the wrap layout does, so the same
+    // record answers this question on every one-second tick — a filter alone would repeat the
+    // verdict forever. Latched, the roster is reported once and every later tick reads `None`.
+    // This covers a fresh seal and a record written before the ceiling moved alike, so the two
+    // never give an operator two different accounts of the same roster.
+    if record.envelope.as_deref().is_some_and(|envelope| !fits_one_announcement(envelope)) {
+        write_advertisement(conn, &PersistedAdvertisement { envelope: None, ..record })?;
+        return Ok(None);
+    }
     if record.live(now_ms) {
         return Ok(None);
     }
-    // Applied to the persisted envelope, not only to a fresh seal: a record written before the
-    // ceiling or the wrap layout moved is over-size too, and it would otherwise reach the publish
-    // boundary — which spends a dial to learn what is known here, and reports a bare byte count
-    // where the operator needs the roster.
-    Ok(record.envelope.filter(|envelope| fits_one_announcement(envelope)).map(|envelope| {
-        Publication {
-            tag,
-            node: *node,
-            service: *service,
-            relay: relay.to_owned(),
-            envelope,
-            ttl_seconds,
-        }
+    Ok(record.envelope.map(|envelope| Publication {
+        tag,
+        node: *node,
+        service: *service,
+        relay: relay.to_owned(),
+        envelope,
+        ttl_seconds,
     }))
 }
 
@@ -578,6 +582,8 @@ fn prepare_advertisement(
 /// The publish boundary refuses an over-size envelope too, but it sees bytes and not a roster, so
 /// its message names a byte count and no action. This one names the roster and its ceiling, which
 /// is the only thing an operator can change.
+///
+/// The verdict is warned, so a caller on a timer MUST latch it — see `prepare_advertisement`.
 fn fits_one_announcement(envelope: &[u8]) -> bool {
     if rag_rat_sync::discovery::fits_publish(envelope) {
         return true;
@@ -1458,6 +1464,91 @@ mod tests {
         assert!(can_sync(Some(rag_rat_sync::PeerCapability::ReadOnly)));
     }
 
+    const ADVERTISED_NODE: [u8; 32] = [0x11; 32];
+    const ADVERTISED_SERVICE: [u8; 32] = [0x22; 32];
+    const ADVERTISED_RELAY: &str = "https://relay.one";
+
+    /// Persist an advertisement record `prepare_advertisement` matches, so it is reused verbatim
+    /// rather than resealed — the shape in which an envelope sealed under an older byte ceiling or
+    /// wrap layout survives.
+    fn persist_advertised_envelope(database: &std::path::Path, envelope: Vec<u8>) {
+        let storage = super::IndexConnection::open(database).unwrap();
+        let conn = storage.connection();
+        rag_rat_db::schema::apply(conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        rag_rat_oplog::local_account(conn, 1_000).unwrap();
+        let secret = rag_rat_sync::discovery::discovery_secret(conn).unwrap().unwrap();
+        write_advertisement(conn, &PersistedAdvertisement {
+            tag: rag_rat_sync::discovery::account_tag(&secret),
+            node: ADVERTISED_NODE,
+            service: ADVERTISED_SERVICE,
+            relay: ADVERTISED_RELAY.to_owned(),
+            roster_stamp: rag_rat_oplog::discovery::roster_stamp(conn).unwrap(),
+            envelope: Some(envelope),
+            published_at_ms: None,
+            ttl_seconds: 600,
+        })
+        .unwrap();
+    }
+
+    /// One advertisement pass, with whatever it warned about.
+    ///
+    /// Every pass goes through the capturing subscriber, and that is not decoration: `tracing`
+    /// caches a callsite's interest PROCESS-wide on its first use, so a single pass made with no
+    /// subscriber installed caches "never" for the size warning and every later capture in the same
+    /// test binary comes back empty. Routing all of them through one seam takes that out of the
+    /// hands of test ordering.
+    fn prepare_advertised(database: &std::path::Path) -> (Option<super::Publication>, String) {
+        let mut prepared = None;
+        let logged = captured_warnings(|| {
+            prepared = prepare_advertisement(
+                database,
+                &ADVERTISED_NODE,
+                &ADVERTISED_SERVICE,
+                ADVERTISED_RELAY,
+                2_000,
+                600,
+            )
+            .unwrap();
+        });
+        (prepared, logged)
+    }
+
+    /// A `MakeWriter` that appends every formatted log line into a shared buffer, so a test can
+    /// assert on the `tracing` events a pass emitted — and on how many times.
+    #[derive(Clone)]
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `body` with warnings captured, returning what it logged. The subscriber is thread-local
+    /// (`with_default`), so parallel tests do not see each other's output.
+    fn captured_warnings(body: impl FnOnce()) -> String {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(CaptureWriter(std::sync::Arc::clone(&buffer)))
+            .finish();
+        tracing::subscriber::with_default(subscriber, body);
+        let logged = buffer.lock().unwrap().clone();
+        String::from_utf8(logged).expect("formatted log lines are UTF-8")
+    }
+
     /// A persisted envelope is judged against the byte ceiling too, not just a fresh seal.
     ///
     /// The record is reused verbatim whenever the tag, endpoint, service, relay, and roster stamp
@@ -1470,39 +1561,50 @@ mod tests {
     fn a_persisted_envelope_over_the_announcement_ceiling_is_not_advertised() {
         let dir = tempfile::TempDir::new().unwrap();
         let database = dir.path().join("index.sqlite");
-        let node = [0x11; 32];
-        let service = [0x22; 32];
-        let relay = "https://relay.one";
-        let persist = |envelope: Vec<u8>| {
-            let storage = super::IndexConnection::open(&database).unwrap();
-            let conn = storage.connection();
-            rag_rat_db::schema::apply(conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
-            rag_rat_oplog::local_account(conn, 1_000).unwrap();
-            let secret = rag_rat_sync::discovery::discovery_secret(conn).unwrap().unwrap();
-            write_advertisement(conn, &PersistedAdvertisement {
-                tag: rag_rat_sync::discovery::account_tag(&secret),
-                node,
-                service,
-                relay: relay.to_owned(),
-                roster_stamp: rag_rat_oplog::discovery::roster_stamp(conn).unwrap(),
-                envelope: Some(envelope),
-                published_at_ms: None,
-                ttl_seconds: 600,
-            })
-            .unwrap();
-        };
         let ceiling = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES;
 
-        persist(vec![0; ceiling + 1]);
+        persist_advertised_envelope(&database, vec![0; ceiling + 1]);
         assert!(
-            prepare_advertisement(&database, &node, &service, relay, 2_000, 600).unwrap().is_none(),
+            prepare_advertised(&database).0.is_none(),
             "an over-size persisted envelope must not be handed to the publish path"
         );
 
-        persist(vec![0; ceiling]);
+        persist_advertised_envelope(&database, vec![0; ceiling]);
         assert!(
-            prepare_advertisement(&database, &node, &service, relay, 2_000, 600).unwrap().is_some(),
+            prepare_advertised(&database).0.is_some(),
             "the ceiling itself fits, so the same record one byte smaller is still advertised"
+        );
+    }
+
+    /// The over-size verdict is reported ONCE, however long the roster stays too large.
+    ///
+    /// `prepare_advertisement` runs on the one-second `ADVERTISEMENT_REFRESH` tick, and nothing the
+    /// record `matches` on moves when the ceiling does — so a verdict re-derived on every pass and
+    /// not latched is a warning per second, indefinitely, burying every other line the operator
+    /// needs. Latching the record to `envelope: None` is what holds it to one, and it is also what
+    /// keeps the dial suppressed: the publish rate limiter never sees this condition, because the
+    /// pass returns before `exchange`.
+    #[test]
+    fn an_over_size_roster_is_reported_once_and_not_on_every_pass() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let database = dir.path().join("index.sqlite");
+        let ceiling = rag_rat_sync::discovery::MAX_ANNOUNCEMENT_BYTES;
+        persist_advertised_envelope(&database, vec![0; ceiling + 1]);
+
+        let reported: usize = (0..10)
+            .map(|_| {
+                let (publication, logged) = prepare_advertised(&database);
+                assert!(publication.is_none(), "an over-size roster is never advertised");
+                logged.matches("roster is too large to seal into one announcement").count()
+            })
+            .sum();
+        assert_eq!(reported, 1, "ten passes must report the over-size roster once, not once each");
+
+        let storage = super::IndexConnection::open(&database).unwrap();
+        assert_eq!(
+            read_advertisement(storage.connection()).unwrap().unwrap().envelope,
+            None,
+            "the record is latched, so there is no envelope left for a later pass to judge"
         );
     }
 

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -606,7 +606,7 @@ fn seal_advertisement(
     if sealed.recipients <= 1 {
         return Ok(None);
     }
-    if !rag_rat_sync::discovery::fits_publish(&sealed) {
+    if !rag_rat_sync::discovery::fits_publish(&sealed.bytes) {
         tracing::warn!(
             recipients = sealed.recipients,
             bytes = sealed.bytes.len(),

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -43,7 +43,12 @@ use crate::op::DeviceFingerprint;
 pub const ANNOUNCEMENT_VERSION: u8 = 1;
 
 /// One sealed wrap on the wire: the ephemeral public key then the tagged ciphertext.
-const WRAP_LEN: usize = 32 + 48;
+///
+/// Public because the envelope's size law — one version byte plus this per roster-effective device
+/// — is what the publish side's recipient ceiling is computed from. A publisher that spelled `80`
+/// beside its own byte limit would keep sealing envelopes the service refuses the moment the wrap
+/// layout changed here, and the refusal reads like any other transient publish error.
+pub const WRAP_LEN: usize = 32 + 48;
 
 /// The `key_epoch` slot of the wrap context. Discovery has no epochs — the whole point of sealing
 /// per recipient is that nothing rotates — so it is pinned at zero and covered by the golden vector

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -308,7 +308,12 @@ fn a_store_with_no_account_seals_nothing_and_opens_nothing() {
     let conn = db();
     assert!(seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().is_none());
     assert!(
-        open_discovery_announcement(&conn, &TAG, &[ANNOUNCEMENT_VERSION; 81]).unwrap().is_none()
+        // A WELL-FORMED one-wrap envelope, sized off `WRAP_LEN` so a wrap-layout change keeps it
+        // that way: a malformed envelope would be rejected by the parser and prove nothing about
+        // opening without an account.
+        open_discovery_announcement(&conn, &TAG, &[ANNOUNCEMENT_VERSION; 1 + WRAP_LEN])
+            .unwrap()
+            .is_none()
     );
 }
 

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -265,26 +265,28 @@ fn the_wrap_context_carries_account_tag_epoch_and_recipient() {
 
 /// The size law an envelope obeys — and the reason the publish side has a recipient ceiling at all.
 ///
-/// `1 + 80n` is what makes roster size a WIRE constraint: the discovery service caps one publish,
-/// so this growth rate decides how many devices an account can have before its host can no longer
-/// seal an announcement it is able to send. The caller pins the resulting ceiling against its own
-/// limit; this pins the law that ceiling is computed from, so the two cannot drift apart silently.
+/// `1 + WRAP_LEN·n` is what makes roster size a WIRE constraint: the discovery service caps one
+/// publish, so this growth rate decides how many devices an account can have before its host can no
+/// longer seal an announcement it is able to send. The publish side derives its recipient ceiling
+/// from `WRAP_LEN`; this pins `WRAP_LEN` against what sealing actually emits, so a wrap layout that
+/// grew would fail here rather than at the service, where the refusal is indistinguishable from a
+/// transient error.
 #[test]
-fn the_envelope_is_a_version_byte_then_eighty_bytes_per_recipient() {
+fn the_envelope_is_a_version_byte_then_one_wrap_per_recipient() {
     let conn = db();
     let account = bootstrap::local_account(&conn, NOW).unwrap();
     add_member(&conn, account, &DeviceX25519Secret::from_seed(&[0x5c; 32]));
 
     let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
     assert_eq!(sealed.bytes[0], ANNOUNCEMENT_VERSION);
-    assert_eq!(sealed.bytes.len(), 1 + 2 * 80, "one version byte, 80 per recipient");
+    assert_eq!(sealed.bytes.len(), 1 + 2 * WRAP_LEN, "one version byte, one wrap per recipient");
     assert_eq!(wraps_of(&sealed.bytes).len(), 2);
 }
 
 /// Anything that is not one of ours is refused at parse, individually and quietly.
 #[test]
 fn parsing_refuses_everything_that_is_not_an_envelope() {
-    let good = 1 + 80;
+    let good = 1 + WRAP_LEN;
     assert!(parse_wraps(&[]).is_none(), "empty");
     assert!(parse_wraps(&[ANNOUNCEMENT_VERSION]).is_none(), "version with no wraps");
     assert!(parse_wraps(&vec![9u8; good]).is_none(), "unknown version");

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -42,7 +42,7 @@ mod tests;
 use std::time::Duration;
 
 use iroh::{Endpoint, EndpointAddr};
-use rag_rat_oplog::discovery::{SealedAnnouncement, WRAP_LEN};
+use rag_rat_oplog::discovery::WRAP_LEN;
 use sha2::{Digest, Sha256};
 
 use self::wire::{DiscoveryRequest, DiscoveryResponse, TAG_LEN};
@@ -116,17 +116,21 @@ pub const MAX_ANNOUNCEMENT_BYTES: usize = 2048;
 /// Derived from the envelope's size law rather than written beside it: an envelope is one version
 /// byte plus [`WRAP_LEN`] per recipient, so this ceiling and the wrap layout cannot drift apart. An
 /// account past it cannot advertise at all until the envelope is split across announcements — see
-/// [`crate::discovery`] docs.
+/// [`crate::discovery`] docs. Today: 25.
 pub const MAX_PUBLISHABLE_RECIPIENTS: usize = (MAX_ANNOUNCEMENT_BYTES - 1) / WRAP_LEN;
 
-/// Whether a sealed announcement fits one publish.
+/// Whether an announcement fits one publish.
 ///
 /// The single place the envelope's size law and the service's byte ceiling meet. It lives on this
 /// side of the crate boundary because the ceiling mirrors the service's limit and the op-log crate,
 /// which owns the sealing, cannot see it. Callers get the verdict rather than two constants to
 /// recombine — recombining them is how the pairing ended up restated per publisher.
-pub fn fits_publish(sealed: &SealedAnnouncement) -> bool {
-    sealed.bytes.len() <= MAX_ANNOUNCEMENT_BYTES
+///
+/// Takes BYTES rather than a sealed envelope so it can be asked at the publish boundary, where no
+/// envelope survives: both publish paths carry opaque bytes by then. A verdict only the seal site
+/// can ask is a verdict an envelope from anywhere else evades.
+pub fn fits_publish(announcement: &[u8]) -> bool {
+    announcement.len() <= MAX_ANNOUNCEMENT_BYTES
 }
 
 /// The tag an account publishes and fetches under.
@@ -361,6 +365,20 @@ async fn exchange_inner(
     // asked for is owed regardless of whether anyone answered the other question.
     let publish_state = match publish {
         None => PublishState::NotAttempted,
+        // Enforced HERE, at the boundary the bytes actually cross, and not only where they are
+        // sealed: the seal site is one publisher among several, and an over-size envelope reaching
+        // the service comes back as a refusal indistinguishable from a transient error, which the
+        // advertiser then retries every tick forever. Refused rather than dropped silently, so the
+        // caller sees the same "nothing is stored" state it would get from the service and the
+        // reason is named in `degraded` — and the round trip that could only fail is skipped.
+        Some(envelope) if !fits_publish(envelope) => {
+            degraded.push(format!(
+                "publish skipped: {} bytes over the {MAX_ANNOUNCEMENT_BYTES}-byte announcement \
+                 limit",
+                envelope.len()
+            ));
+            PublishState::Refused
+        },
         Some(envelope) => {
             let publish = DiscoveryRequest::Publish {
                 tag: *tag,

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -42,6 +42,7 @@ mod tests;
 use std::time::Duration;
 
 use iroh::{Endpoint, EndpointAddr};
+use rag_rat_oplog::discovery::{SealedAnnouncement, WRAP_LEN};
 use sha2::{Digest, Sha256};
 
 use self::wire::{DiscoveryRequest, DiscoveryResponse, TAG_LEN};
@@ -106,11 +107,27 @@ pub const MAX_SEALED_ANNOUNCEMENTS: usize = 64;
 /// a diagnosable message, because the alternative failure is genuinely silent — the refusal looks
 /// like every other transient publish error and the host retries it forever.
 ///
-/// It binds at a smaller roster than it looks. An envelope is one version byte plus 80 bytes per
-/// roster-effective device, so this permits about **25 recipients**; the service's own frame budget
-/// would not bite until several hundred. An account past that ceiling cannot advertise until the
-/// envelope is split across announcements — see [`crate::discovery`] docs.
+/// It binds at a smaller roster than it looks — see [`MAX_PUBLISHABLE_RECIPIENTS`]; the service's
+/// own frame budget would not bite until several hundred.
 pub const MAX_ANNOUNCEMENT_BYTES: usize = 2048;
+
+/// Most roster-effective devices an account can have and still be advertised by one host.
+///
+/// Derived from the envelope's size law rather than written beside it: an envelope is one version
+/// byte plus [`WRAP_LEN`] per recipient, so this ceiling and the wrap layout cannot drift apart. An
+/// account past it cannot advertise at all until the envelope is split across announcements — see
+/// [`crate::discovery`] docs.
+pub const MAX_PUBLISHABLE_RECIPIENTS: usize = (MAX_ANNOUNCEMENT_BYTES - 1) / WRAP_LEN;
+
+/// Whether a sealed announcement fits one publish.
+///
+/// The single place the envelope's size law and the service's byte ceiling meet. It lives on this
+/// side of the crate boundary because the ceiling mirrors the service's limit and the op-log crate,
+/// which owns the sealing, cannot see it. Callers get the verdict rather than two constants to
+/// recombine — recombining them is how the pairing ended up restated per publisher.
+pub fn fits_publish(sealed: &SealedAnnouncement) -> bool {
+    sealed.bytes.len() <= MAX_ANNOUNCEMENT_BYTES
+}
 
 /// The tag an account publishes and fetches under.
 ///
@@ -146,7 +163,7 @@ pub fn account_tag(secret: &[u8; 32]) -> [u8; TAG_LEN] {
 /// This is still strictly better than the account id, which is broadcast to every dialed host by
 /// design, and it is a bounded exposure — routing advice and denial of service, never data. The fix
 /// is purpose-built discovery key material sealed to roster-effective devices and rotated on
-/// removal (#1080); routing every caller through this one function is what keeps that change from
+/// removal (#1081); routing every caller through this one function is what keeps that change from
 /// touching the wire, the tag domain, the client, or the driver.
 pub fn discovery_secret(conn: &rusqlite::Connection) -> anyhow::Result<Option<[u8; 32]>> {
     rag_rat_oplog::read_local_account_genesis(conn)

--- a/crates/rag-rat-sync/src/discovery/mod.rs
+++ b/crates/rag-rat-sync/src/discovery/mod.rs
@@ -119,6 +119,15 @@ pub const MAX_ANNOUNCEMENT_BYTES: usize = 2048;
 /// [`crate::discovery`] docs. Today: 25.
 pub const MAX_PUBLISHABLE_RECIPIENTS: usize = (MAX_ANNOUNCEMENT_BYTES - 1) / WRAP_LEN;
 
+/// The ceiling is the LARGEST recipient count that fits, so one more must not.
+///
+/// Non-test code on purpose: a wrap layout that moved the ceiling off the bytes is a wire mistake,
+/// and it should stop `cargo build` rather than wait for whoever runs the tests.
+const _: () = assert!(
+    1 + (MAX_PUBLISHABLE_RECIPIENTS + 1) * WRAP_LEN > MAX_ANNOUNCEMENT_BYTES,
+    "one more recipient than the ceiling must not fit, or the ceiling leaves a wrap of room unused"
+);
+
 /// Whether an announcement fits one publish.
 ///
 /// The single place the envelope's size law and the service's byte ceiling meet. It lives on this
@@ -131,6 +140,17 @@ pub const MAX_PUBLISHABLE_RECIPIENTS: usize = (MAX_ANNOUNCEMENT_BYTES - 1) / WRA
 /// can ask is a verdict an envelope from anywhere else evades.
 pub fn fits_publish(announcement: &[u8]) -> bool {
     announcement.len() <= MAX_ANNOUNCEMENT_BYTES
+}
+
+/// Why an over-size announcement was not published, naming the size.
+///
+/// Written once because both refusal points report it: the pre-dial one and the publish stream a
+/// fetching caller still reaches. Two spellings of the same refusal would have an operator matching
+/// two log lines to one cause.
+fn oversize_reason(bytes: usize) -> String {
+    format!(
+        "publish skipped: {bytes} bytes over the {MAX_ANNOUNCEMENT_BYTES}-byte announcement limit"
+    )
 }
 
 /// The tag an account publishes and fetches under.
@@ -320,6 +340,24 @@ async fn exchange_inner(
     deadline: tokio::time::Instant,
 ) -> DiscoveryOutcome {
     let DiscoveryExchange { endpoint, service, tag, fetch, publish, ttl_seconds } = params;
+
+    // BEFORE the dial, because a publish-only pass with an unpublishable envelope has nothing else
+    // to do on that connection. Its caller is a serving host, which retries on a fraction of the
+    // TTL — as little as a few seconds — for as long as the roster stays too large, so dialing to
+    // reach a verdict already known here would spend a full connection against a shared service
+    // forever. A fetching caller still dials: the peers it came for do not depend on its own
+    // envelope, and the same refusal waits at the publish stream below.
+    let oversize = publish.filter(|envelope| !fits_publish(envelope));
+    if let Some(envelope) = oversize
+        && !*fetch
+    {
+        return DiscoveryOutcome {
+            publish: PublishState::Refused,
+            degraded: Some(oversize_reason(envelope.len())),
+            ..Default::default()
+        };
+    }
+
     let connecting = endpoint.connect(service.clone(), PEER_DISCOVERY_ALPN);
     let conn = match tokio::time::timeout_at(deadline, connecting).await {
         Ok(Ok(conn)) => conn,
@@ -370,13 +408,11 @@ async fn exchange_inner(
         // the service comes back as a refusal indistinguishable from a transient error, which the
         // advertiser then retries every tick forever. Refused rather than dropped silently, so the
         // caller sees the same "nothing is stored" state it would get from the service and the
-        // reason is named in `degraded` — and the round trip that could only fail is skipped.
+        // reason is named in `degraded`. The connection is already open — a fetching caller needed
+        // it — so what is skipped here is the publish stream, not the dial; the publish-only shape
+        // never gets this far.
         Some(envelope) if !fits_publish(envelope) => {
-            degraded.push(format!(
-                "publish skipped: {} bytes over the {MAX_ANNOUNCEMENT_BYTES}-byte announcement \
-                 limit",
-                envelope.len()
-            ));
+            degraded.push(oversize_reason(envelope.len()));
             PublishState::Refused
         },
         Some(envelope) => {

--- a/crates/rag-rat-sync/src/discovery/stub.rs
+++ b/crates/rag-rat-sync/src/discovery/stub.rs
@@ -110,6 +110,12 @@ pub(crate) struct StubService {
     /// that quietly starts fetching is invisible to every assertion about stored
     /// announcements.
     fetches: Arc<AtomicUsize>,
+    /// Connections accepted, counted before any request is read.
+    ///
+    /// A dial the client then declines to use costs this service the whole handshake, and every
+    /// other assertion here is about what a connection carried — so a caller that dials and asks
+    /// nothing looks identical to one that never dialed at all.
+    dials: Arc<AtomicUsize>,
 }
 
 impl StubService {
@@ -126,19 +132,23 @@ impl StubService {
         let tags = Arc::new(Mutex::new(HashMap::new()));
         let now = Arc::new(AtomicI64::new(now_ms));
         let fetches = Arc::new(AtomicUsize::new(0));
+        let dials = Arc::new(AtomicUsize::new(0));
         let service = Self {
             endpoint: endpoint.clone(),
             tags: Arc::clone(&tags),
             now_ms: Arc::clone(&now),
             fetches: Arc::clone(&fetches),
+            dials: Arc::clone(&dials),
         };
         tokio::spawn(async move {
             while let Some(incoming) = endpoint.accept().await {
                 let tags = Arc::clone(&tags);
                 let now = Arc::clone(&now);
                 let fetches = Arc::clone(&fetches);
+                let dials = Arc::clone(&dials);
                 tokio::spawn(async move {
                     let Ok(conn) = incoming.await else { return };
+                    dials.fetch_add(1, Ordering::Relaxed);
                     // Swallowed streams are PARKED, not dropped: dropping a send stream closes it,
                     // which the client sees as an immediate error — the opposite of a black hole,
                     // and enough to make the timeout test pass with the timeout deleted.
@@ -220,6 +230,11 @@ impl StubService {
     /// How many fetches this stub has answered.
     pub(crate) fn fetches(&self) -> usize {
         self.fetches.load(Ordering::Relaxed)
+    }
+
+    /// How many connections this stub has accepted.
+    pub(crate) fn dials(&self) -> usize {
+        self.dials.load(Ordering::Relaxed)
     }
 
     /// Seed an announcement directly, bypassing the wire — for setting up a tag's prior state.

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -7,7 +7,7 @@ use super::stub::{Behaviour, PER_TAG_CAP, StubService};
 use super::{
     DISCOVERY_TAG_DOMAIN, DISCOVERY_TIMEOUT, DiscoveryExchange, DiscoveryOutcome,
     MAX_ANNOUNCEMENT_BYTES, MAX_PUBLISHABLE_RECIPIENTS, PEER_DISCOVERY_ALPN, PublishState,
-    SealedAnnouncement, WRAP_LEN, account_tag, exchange, fits_publish, publish_ttl_seconds,
+    WRAP_LEN, account_tag, exchange, fits_publish, publish_ttl_seconds,
 };
 
 /// A fixed instant: the announcement arithmetic under test is about durations, and a real clock
@@ -950,19 +950,72 @@ fn only_possibly_live_publishes_reset_the_renewal_clock() {
     );
 }
 
+/// The verdict flips between exactly [`MAX_ANNOUNCEMENT_BYTES`] and one byte past it.
+///
+/// Probing at the boundary byte rather than at envelope sizes, because no envelope has a length of
+/// exactly the limit — `1 + WRAP_LEN·n` never lands on it — so recipient-shaped inputs alone leave
+/// the comparator free to be `<` and never say so. The limit is inclusive: it mirrors the largest
+/// payload the service accepts, not the first one it rejects.
+#[test]
+fn the_byte_ceiling_is_inclusive_and_the_next_byte_is_not() {
+    assert!(
+        fits_publish(&vec![0u8; MAX_ANNOUNCEMENT_BYTES]),
+        "{MAX_ANNOUNCEMENT_BYTES} bytes is the limit, not one past it"
+    );
+    assert!(
+        !fits_publish(&vec![0u8; MAX_ANNOUNCEMENT_BYTES + 1]),
+        "one byte past the limit is refused by the service, so it must be refused here"
+    );
+}
+
+/// An over-size announcement is refused HERE, without a round trip, whoever handed it over.
+///
+/// The stub stores whatever it is given, so a publish that got as far as the wire would land — the
+/// assertion that nothing is stored is what separates the local guard from a service that happened
+/// to accept it. The real service would refuse instead, and that refusal is indistinguishable from
+/// a transient error, so [`advertise`] would republish the same doomed envelope every tick forever
+/// with nothing in the log naming the size. Refusing locally names it.
+#[tokio::test]
+async fn an_announcement_past_the_byte_ceiling_never_reaches_the_service() {
+    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
+    let tag = account_tag(&[23; 32]);
+    let endpoint = client().await;
+    let oversize = vec![7u8; MAX_ANNOUNCEMENT_BYTES + 1];
+
+    let out = exchange(DiscoveryExchange {
+        endpoint: &endpoint,
+        service: service.addr(),
+        tag,
+        fetch: false,
+        publish: Some(&oversize),
+        ttl_seconds: 600,
+    })
+    .await;
+
+    assert_eq!(out.publish, PublishState::Refused, "nothing is stored, so the state is Refused");
+    assert!(service.stored(&tag).is_empty(), "the over-size envelope reached the service anyway");
+    let degraded = out.degraded.expect("an unpublishable announcement must say so");
+    assert!(
+        degraded.contains(&MAX_ANNOUNCEMENT_BYTES.to_string()),
+        "the reason must name the limit, or the operator cannot tell this from a transient \
+         failure: {degraded}"
+    );
+}
+
 /// Whether a sealed announcement fits one publish is one question with one answer, and the
 /// recipient ceiling is that answer read backwards.
 ///
 /// Both are computed from `WRAP_LEN`, so a wrap layout change moves the envelope, the ceiling, and
 /// this boundary together. A publisher holding its own copy of the size law moves only its copy,
 /// and the consequence is a service refusal that looks like every other transient publish error.
-/// The `+ 1` case is the one that matters: it is the first roster that cannot be advertised at all.
+///
+/// Catches an error of a whole wrap in either direction — the ceiling claiming a roster fits that
+/// the service would refuse, or stopping a roster short that it would have taken. The `+ 1` case is
+/// the one that matters in practice: it is the first roster that cannot be advertised at all.
 #[test]
 fn the_recipient_ceiling_is_where_a_sealed_envelope_stops_fitting_one_publish() {
-    let announcement = |recipients: usize| SealedAnnouncement {
-        bytes: vec![0u8; 1 + recipients * WRAP_LEN],
-        recipients,
-    };
+    // The envelope's size law: one version byte, then one fixed-size wrap per recipient.
+    let announcement = |recipients: usize| vec![0u8; 1 + recipients * WRAP_LEN];
 
     assert!(
         fits_publish(&announcement(MAX_PUBLISHABLE_RECIPIENTS)),
@@ -972,4 +1025,13 @@ fn the_recipient_ceiling_is_where_a_sealed_envelope_stops_fitting_one_publish() 
         !fits_publish(&announcement(MAX_PUBLISHABLE_RECIPIENTS + 1)),
         "one recipient past the ceiling must not claim to fit"
     );
+    // The ceiling read forwards: it is the LARGEST recipient count that fits, so the derivation
+    // cannot quietly leave a wrap's worth of room on the table. Const-evaluated, so a wrap layout
+    // that moved the ceiling off the bytes fails the build rather than one test.
+    const {
+        assert!(
+            1 + (MAX_PUBLISHABLE_RECIPIENTS + 1) * WRAP_LEN > MAX_ANNOUNCEMENT_BYTES,
+            "one more recipient must not fit, or the ceiling is lower than the bytes allow"
+        );
+    }
 }

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -968,13 +968,15 @@ fn the_byte_ceiling_is_inclusive_and_the_next_byte_is_not() {
     );
 }
 
-/// An over-size announcement is refused HERE, without a round trip, whoever handed it over.
+/// An over-size announcement is refused HERE, without a publish stream, whoever handed it over.
 ///
 /// The stub stores whatever it is given, so a publish that got as far as the wire would land — the
 /// assertion that nothing is stored is what separates the local guard from a service that happened
 /// to accept it. The real service would refuse instead, and that refusal is indistinguishable from
-/// a transient error, so [`advertise`] would republish the same doomed envelope every tick forever
-/// with nothing in the log naming the size. Refusing locally names it.
+/// a transient error, so an advertiser would keep republishing the same doomed envelope with
+/// nothing in the log naming the size. This does not stop the retry loop — a refusal is not
+/// liveness, so the next tick tries again — it stops the bytes reaching the service and names the
+/// size in `degraded`.
 #[tokio::test]
 async fn an_announcement_past_the_byte_ceiling_never_reaches_the_service() {
     let service = StubService::start(NOW_MS, Behaviour::Serve).await;
@@ -994,12 +996,48 @@ async fn an_announcement_past_the_byte_ceiling_never_reaches_the_service() {
 
     assert_eq!(out.publish, PublishState::Refused, "nothing is stored, so the state is Refused");
     assert!(service.stored(&tag).is_empty(), "the over-size envelope reached the service anyway");
+    // Publish-only: the connection exists solely to carry this envelope, so opening one is pure
+    // cost. A host in this state retries on a fraction of its TTL for as long as the roster stays
+    // too large, and every one of those dials would be a full handshake against a shared service.
+    assert_eq!(service.dials(), 0, "a doomed publish-only pass must not dial the service");
     let degraded = out.degraded.expect("an unpublishable announcement must say so");
     assert!(
         degraded.contains(&MAX_ANNOUNCEMENT_BYTES.to_string()),
         "the reason must name the limit, or the operator cannot tell this from a transient \
          failure: {degraded}"
     );
+}
+
+/// A caller that also fetches still dials, and still gets its peers.
+///
+/// The pre-dial refusal is scoped to the publish-only shape on purpose: the peers a fetching caller
+/// came for do not depend on its own envelope, so skipping the connection would blind it to every
+/// reachable peer over a defect in what it wanted to advertise. Its publish is refused all the
+/// same, at the stream instead of before the dial.
+#[tokio::test]
+async fn a_fetching_caller_with_an_over_size_announcement_still_gets_its_peers() {
+    let service = StubService::start(NOW_MS, Behaviour::Serve).await;
+    let tag = account_tag(&[29; 32]);
+    let endpoint = client().await;
+    let peer = vec![9u8; 40];
+    let oversize = vec![7u8; MAX_ANNOUNCEMENT_BYTES + 1];
+    service.seed(tag, peer.clone(), NOW_MS + 60_000);
+
+    let out = exchange(DiscoveryExchange {
+        endpoint: &endpoint,
+        service: service.addr(),
+        tag,
+        fetch: true,
+        publish: Some(&oversize),
+        ttl_seconds: 600,
+    })
+    .await;
+
+    assert_eq!(out.announcements, vec![peer.clone()], "the fetch is owed regardless");
+    assert_eq!(out.publish, PublishState::Refused, "the envelope is still unpublishable");
+    assert_eq!(service.stored(&tag), vec![peer], "the seeded entry is all that is stored");
+    let degraded = out.degraded.expect("an unpublishable announcement must say so");
+    assert!(degraded.contains(&MAX_ANNOUNCEMENT_BYTES.to_string()), "{degraded}");
 }
 
 /// Whether a sealed announcement fits one publish is one question with one answer, and the
@@ -1025,13 +1063,4 @@ fn the_recipient_ceiling_is_where_a_sealed_envelope_stops_fitting_one_publish() 
         !fits_publish(&announcement(MAX_PUBLISHABLE_RECIPIENTS + 1)),
         "one recipient past the ceiling must not claim to fit"
     );
-    // The ceiling read forwards: it is the LARGEST recipient count that fits, so the derivation
-    // cannot quietly leave a wrap's worth of room on the table. Const-evaluated, so a wrap layout
-    // that moved the ceiling off the bytes fails the build rather than one test.
-    const {
-        assert!(
-            1 + (MAX_PUBLISHABLE_RECIPIENTS + 1) * WRAP_LEN > MAX_ANNOUNCEMENT_BYTES,
-            "one more recipient must not fit, or the ceiling is lower than the bytes allow"
-        );
-    }
 }

--- a/crates/rag-rat-sync/src/discovery/tests.rs
+++ b/crates/rag-rat-sync/src/discovery/tests.rs
@@ -6,7 +6,8 @@ use iroh::{Endpoint, RelayMode};
 use super::stub::{Behaviour, PER_TAG_CAP, StubService};
 use super::{
     DISCOVERY_TAG_DOMAIN, DISCOVERY_TIMEOUT, DiscoveryExchange, DiscoveryOutcome,
-    PEER_DISCOVERY_ALPN, PublishState, account_tag, exchange, publish_ttl_seconds,
+    MAX_ANNOUNCEMENT_BYTES, MAX_PUBLISHABLE_RECIPIENTS, PEER_DISCOVERY_ALPN, PublishState,
+    SealedAnnouncement, WRAP_LEN, account_tag, exchange, fits_publish, publish_ttl_seconds,
 };
 
 /// A fixed instant: the announcement arithmetic under test is about durations, and a real clock
@@ -479,7 +480,7 @@ async fn a_large_account_is_never_refused_and_its_fetches_fit_one_frame() {
 
     let service = StubService::start(NOW_MS, Behaviour::Serve).await;
     let tag = account_tag(&[13; 32]);
-    let realistic_envelope = |seed: u8| vec![seed.wrapping_add(100); 1 + 16 * 80];
+    let realistic_envelope = |seed: u8| vec![seed.wrapping_add(100); 1 + 16 * WRAP_LEN];
 
     let endpoint = client().await;
     for seed in 0..32u8 {
@@ -946,5 +947,29 @@ fn only_possibly_live_publishes_reset_the_renewal_clock() {
     assert!(
         !super::records_liveness(PublishState::NotAttempted),
         "nothing was published, so there is nothing to renew"
+    );
+}
+
+/// Whether a sealed announcement fits one publish is one question with one answer, and the
+/// recipient ceiling is that answer read backwards.
+///
+/// Both are computed from `WRAP_LEN`, so a wrap layout change moves the envelope, the ceiling, and
+/// this boundary together. A publisher holding its own copy of the size law moves only its copy,
+/// and the consequence is a service refusal that looks like every other transient publish error.
+/// The `+ 1` case is the one that matters: it is the first roster that cannot be advertised at all.
+#[test]
+fn the_recipient_ceiling_is_where_a_sealed_envelope_stops_fitting_one_publish() {
+    let announcement = |recipients: usize| SealedAnnouncement {
+        bytes: vec![0u8; 1 + recipients * WRAP_LEN],
+        recipients,
+    };
+
+    assert!(
+        fits_publish(&announcement(MAX_PUBLISHABLE_RECIPIENTS)),
+        "the ceiling itself must fit, or it is off by one against {MAX_ANNOUNCEMENT_BYTES} bytes"
+    );
+    assert!(
+        !fits_publish(&announcement(MAX_PUBLISHABLE_RECIPIENTS + 1)),
+        "one recipient past the ceiling must not claim to fit"
     );
 }

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -94,11 +94,12 @@ Devices cost nothing here; they only fetch. Past that, hosts evict each other an
 **flaps**: a host findable this hour may not be next hour. Pin those hosts in `server_peers` instead.
 
 **How many devices an account can have.** An announcement is sealed once per recipient, so it grows
-by 80 bytes per roster-effective device against a publish limit of 2048 bytes — a ceiling of about
-**25 devices**. Past it a host logs `roster is too large to seal into one announcement` and does not
-advertise; it serves normally, and every device that reaches it through `server_peers` is
-unaffected. The announcement is never truncated to fit, because which recipients got dropped would
-silently decide who can find that host.
+by one fixed-size wrap per roster-effective device against the service's publish limit — **a few
+dozen devices** at today's wrap layout. The exact figure is `MAX_PUBLISHABLE_RECIPIENTS`, which the
+code derives from those two rather than writing down. Past it a host logs `roster is too large to
+seal into one announcement` and does not advertise; it serves normally, and every device that
+reaches it through `server_peers` is unaffected. The announcement is never truncated to fit,
+because which recipients got dropped would silently decide who can find that host.
 
 A fetch is bounded the same way: the service answers with as much as fits one response frame, chosen
 at random, so a busy tag returns a **sample** rather than everything. A device therefore learns some
@@ -238,8 +239,8 @@ folded it, because they do not depend on anything the account can take back:
   stop, and — because each sealed envelope is a version byte plus one fixed-size wrap per recipient
   (80 bytes at today's wrap layout) — the exact number of devices on the account, tracked across
   enrollments and removals without opening a single wrap. It can also publish junk under the tag,
-  costing whoever fetches it a wasted slot. What it can no longer do is read a host's node id out of any
-  announcement sealed after its removal. Rotating the tag itself is
+  costing whoever fetches it a wasted slot. What it can no longer do is read a host's node id out
+  of any announcement sealed after its removal. Rotating the tag itself is
   [#1081](https://github.com/cq27-dev/rag-rat/issues/1081); padding the envelope to hide device
   count is [#1087](https://github.com/cq27-dev/rag-rat/issues/1087).
 - **Announcements sealed before it stops being a recipient**, which stay openable by it until they

--- a/docs/config/sync.md
+++ b/docs/config/sync.md
@@ -235,10 +235,10 @@ folded it, because they do not depend on anything the account can take back:
 
 - **The discovery tag**, which is derived from immutable account material already in that device's
   database. It can therefore keep watching the tag: how many hosts advertise and when they renew or
-  stop, and — because each sealed envelope is a version byte plus a fixed 80 bytes per recipient —
-  the exact number of devices on the account, `(len - 1) / 80`, tracked across enrollments and
-  removals without opening a single wrap. It can also publish junk under the tag, costing whoever
-  fetches it a wasted slot. What it can no longer do is read a host's node id out of any
+  stop, and — because each sealed envelope is a version byte plus one fixed-size wrap per recipient
+  (80 bytes at today's wrap layout) — the exact number of devices on the account, tracked across
+  enrollments and removals without opening a single wrap. It can also publish junk under the tag,
+  costing whoever fetches it a wasted slot. What it can no longer do is read a host's node id out of any
   announcement sealed after its removal. Rotating the tag itself is
   [#1081](https://github.com/cq27-dev/rag-rat/issues/1081); padding the envelope to hide device
   count is [#1087](https://github.com/cq27-dev/rag-rat/issues/1087).


### PR DESCRIPTION
Closes #1089.

"Does this sealed announcement fit one publish?" was assembled from constants in three crates plus the docs, with nothing owning it: the envelope size law (`WRAP_LEN`, private in the op-log crate), the byte ceiling (`MAX_ANNOUNCEMENT_BYTES`, a sync-crate mirror of the service limit with no caller in its own crate), and the recombination of the two in the publish driver — with `80` also spelled by hand in two test files and in `docs/config/sync.md`.

## The ownership choice

`rag_rat_sync::discovery::fits_publish(&SealedAnnouncement) -> bool` now answers it, and the driver asks for the verdict instead of comparing a length against a constant borrowed from another crate.

It sits on the **sync** side because the crate dependency runs one way: `MAX_ANNOUNCEMENT_BYTES` mirrors the discovery service's own limit, which the client cannot query, and the op-log crate — which owns sealing and cannot see sync — would have had to take the ceiling as a parameter from every caller to host the decision. That is the shape the issue was complaining about, one crate further in. Returning a `TooLargeToPublish` outcome from `seal_discovery_announcement` was the alternative; it moves the ceiling into the crate that must not know about it.

## What that makes possible

`WRAP_LEN` is public, so the ceiling is **derived** rather than written down: `MAX_PUBLISHABLE_RECIPIENTS = (MAX_ANNOUNCEMENT_BYTES - 1) / WRAP_LEN` replaces the "about 25 recipients" prose, and the tests and docs reference the law instead of re-typing `80`. A change to the wrap layout now moves the envelope, the ceiling and the boundary together.

No wire format or announcement version change — this single-homes the existing law so that changing what the size *means* (#1087) does not have to edit five constants.

## Tests

Two tests pin the chain rather than checking for a mismatch after the fact:

- `the_envelope_is_a_version_byte_then_one_wrap_per_recipient` (op-log) asserts a **real** seal is exactly `1 + WRAP_LEN·n`. Verified failing: with the wrap layout widened to `32 + 64` and `WRAP_LEN` left alone, it fails with `left: 161, right: 193` — the drift now surfaces here rather than as a service refusal indistinguishable from a transient publish error.
- `the_recipient_ceiling_is_where_a_sealed_envelope_stops_fitting_one_publish` (sync) pins `fits_publish` flipping at exactly `MAX_PUBLISHABLE_RECIPIENTS`, including the version byte's off-by-one.

## Also

`docs/config/sync.md` no longer restates the `(len - 1) / 80` formula as a spec constant, and the discovery-tag rotation reference points at #1081 (the actual fix) rather than the shipped #1080.

## Verification

All green with real exit codes: `clippy --workspace --all-targets` under `--no-default-features` and `--all-features`, both `eval`-feature clippy runs for `rag-rat-core`/`rag-rat`, `cargo nextest run --workspace --no-default-features --no-fail-fast` (5171 passed), `cargo test --workspace --no-default-features`, and `cargo +nightly fmt`.