### PR TITLE
perf(sync): load the discovery opener state once per fetch pass

### DIFF
--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -819,6 +819,12 @@ async fn reconcile(
     let tag = rag_rat_sync::discovery::discovery_secret(conn)?
         .map(|secret| rag_rat_sync::discovery::account_tag(&secret));
     let discovery = discovery_addr(config, &relay);
+    // Built before the fetch, not inside the per-payload closure: the account and this device's key
+    // are the same for the whole pass. A failure to load them leaves discovery unopenable and falls
+    // back to the configured peers, the same as a payload that will not open.
+    let opener = tag.and_then(|tag| {
+        rag_rat_oplog::discovery::AnnouncementOpener::load(conn, &tag).ok().flatten()
+    });
     let resolved = rag_rat_sync::discover_peers(
         &config.sync.server_peers,
         &relay,
@@ -832,13 +838,7 @@ async fn reconcile(
                 config.sync.push_interval_secs,
             ),
         }),
-        &|payload| {
-            tag.and_then(|tag| {
-                rag_rat_oplog::discovery::open_discovery_announcement(conn, &tag, payload)
-                    .ok()
-                    .flatten()
-            })
-        },
+        &|payload| opener.as_ref().and_then(|opener| opener.open(payload)),
     )
     .await;
     // Scope the DEVICE-sync phases to peers that can serve this account. A peer memoized as a

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -816,31 +816,27 @@ async fn reconcile(
     account: rag_rat_oplog::AccountId,
 ) -> anyhow::Result<(usize, usize, usize)> {
     let relay = relay_url(config);
-    let tag = rag_rat_sync::discovery::discovery_secret(conn)?
-        .map(|secret| rag_rat_sync::discovery::account_tag(&secret));
-    let discovery = discovery_addr(config, &relay);
-    // Built before the fetch, not inside the per-payload closure: the account and this device's key
-    // are the same for the whole pass. A failure to load them leaves discovery unopenable and falls
-    // back to the configured peers, the same as a payload that will not open.
-    let opener = tag.and_then(|tag| {
-        rag_rat_oplog::discovery::AnnouncementOpener::load(conn, &tag).ok().flatten()
-    });
-    let resolved = rag_rat_sync::discover_peers(
-        &config.sync.server_peers,
-        &relay,
-        tag.zip(discovery).map(|(tag, service)| rag_rat_sync::discovery::DiscoveryExchange {
-            endpoint,
-            service,
-            tag,
-            fetch: true,
-            publish: None,
-            ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
-                config.sync.push_interval_secs,
-            ),
-        }),
-        &|payload| opener.as_ref().and_then(|opener| opener.open(payload)),
-    )
-    .await;
+    let (exchange, opener) = match discovery_fetch(config, conn, &relay)? {
+        Some(fetch) => (
+            Some(rag_rat_sync::discovery::DiscoveryExchange {
+                endpoint,
+                service: fetch.service,
+                tag: fetch.tag,
+                fetch: true,
+                publish: None,
+                ttl_seconds: rag_rat_sync::discovery::publish_ttl_seconds(
+                    config.sync.push_interval_secs,
+                ),
+            }),
+            fetch.opener,
+        ),
+        None => (None, None),
+    };
+    let resolved =
+        rag_rat_sync::discover_peers(&config.sync.server_peers, &relay, exchange, &|payload| {
+            opener.as_ref().and_then(|opener| opener.open(payload))
+        })
+        .await;
     // Scope the DEVICE-sync phases to peers that can serve this account. A peer memoized as a
     // FOREIGN-account host serves only its own account by construction, so dialing it here would
     // fail the account-scope handshake, log a device-sync failure, and count an error on every
@@ -1216,6 +1212,49 @@ fn discovery_addr(config: &Config, relay: &str) -> Option<rag_rat_sync::Endpoint
     }).ok()
 }
 
+/// What one discovery fetch needs: where to ask, under which tag, and what opens the answers.
+struct DiscoveryFetch {
+    tag: [u8; 32],
+    service: rag_rat_sync::EndpointAddr,
+    /// `None` when this store cannot open announcements at all — no account, no local device, or a
+    /// failed read. Discovery then finds nothing and the pass falls back to the configured peers.
+    opener: Option<rag_rat_oplog::discovery::AnnouncementOpener>,
+}
+
+/// Resolve that state once, before the fetch, or `None` when there will be no fetch: discovery is
+/// off, or the configured service node id is unusable, or this store has no discovery secret.
+///
+/// The opener is loaded here rather than in the per-payload closure because the account and this
+/// device's key are the same for every announcement in a pass. **The service gate comes before
+/// every read** so a pass that will not fetch pays for none of them: the opener costs an account
+/// read plus a device load that re-derives and validates the stored keys, and with no exchange to
+/// pass on, `discover_peers` returns before it ever calls the opening closure.
+fn discovery_fetch(
+    config: &Config,
+    conn: &Connection,
+    relay: &str,
+) -> anyhow::Result<Option<DiscoveryFetch>> {
+    let Some(service) = discovery_addr(config, relay) else {
+        return Ok(None);
+    };
+    let Some(secret) = rag_rat_sync::discovery::discovery_secret(conn)? else {
+        return Ok(None);
+    };
+    let tag = rag_rat_sync::discovery::account_tag(&secret);
+    // A failed load leaves discovery unopenable and falls back to the configured peers, the same as
+    // a payload that will not open — the rest of the pass has work to do and should not fail with
+    // it. It is wider than the per-payload failure it stands in for, though: one bad read costs the
+    // whole pass rather than one announcement, so a persistent one would otherwise look like
+    // discovery quietly finding nobody. Log it.
+    let opener = rag_rat_oplog::discovery::AnnouncementOpener::load(conn, &tag)
+        .inspect_err(|error| {
+            tracing::warn!(%error, "discovery announcements are unopenable this pass");
+        })
+        .ok()
+        .flatten();
+    Ok(Some(DiscoveryFetch { tag, service, opener }))
+}
+
 fn sync_due(conn: &Connection, interval_secs: u64) -> anyhow::Result<bool> {
     if interval_secs == 0 {
         return Ok(true);
@@ -1313,9 +1352,10 @@ mod tests {
     use super::{
         DISCOVERY_ADVERTISEMENT, DeviceSyncOutcome, PULL_PEER_MEMO_PREFIX, PerPeerSessionLimiter,
         PersistedAdvertisement, RESIDENT_NUDGE, RefusedPublication, account_is_public_kb, can_host,
-        can_sync, device_sync_run, foreign_pull_hosts, foreign_pull_targets, nudge_resident_host,
-        ordered_pull_peers, peer_identity, prepare_advertisement, pull_account_via_peers,
-        read_advertisement, refused_publication_is_due, retry_is_due, write_advertisement,
+        can_sync, device_sync_run, discovery_fetch, foreign_pull_hosts, foreign_pull_targets,
+        nudge_resident_host, ordered_pull_peers, peer_identity, prepare_advertisement,
+        pull_account_via_peers, read_advertisement, refused_publication_is_due, retry_is_due,
+        write_advertisement,
     };
 
     fn schema_conn() -> Connection {
@@ -1462,6 +1502,46 @@ mod tests {
         );
 
         assert_eq!(device_sync_run(&config, &conn).unwrap(), DeviceSyncOutcome::Disabled);
+    }
+
+    /// A pass that will not fetch reads nothing to fetch with. The opener costs an account read
+    /// plus a device load that re-derives and validates this device's keys, and with no
+    /// discovery service `discover_peers` returns before it ever calls the opening closure.
+    ///
+    /// Pinned by poisoning the reads so any of them fails loudly: with discovery off the call still
+    /// succeeds, and turning discovery back on surfaces the failure, so the silence is the gate and
+    /// not a store with nothing to read.
+    #[test]
+    fn discovery_off_reads_nothing_the_pass_cannot_use() {
+        let poisoned = schema_conn();
+        poisoned.execute("DROP TABLE oplog_local_account", []).unwrap();
+        let mut config = Config::minimal_for_database(
+            PathBuf::from("/nonexistent/sync.sqlite"),
+            PathBuf::from("/nonexistent"),
+        );
+
+        config.sync.discovery = false;
+        assert!(
+            discovery_fetch(&config, &poisoned, "https://relay.one").unwrap().is_none(),
+            "no service to fetch from, so nothing is read to open with"
+        );
+
+        config.sync.discovery = true;
+        assert!(
+            discovery_fetch(&config, &poisoned, "https://relay.one").is_err(),
+            "the reads do happen once there is a fetch to open for"
+        );
+
+        // A healthy store loads exactly one opener, carried for the whole pass.
+        let conn = schema_conn();
+        rag_rat_oplog::local_account(&conn, 1_000).unwrap();
+        let fetch = discovery_fetch(&config, &conn, "https://relay.one")
+            .unwrap()
+            .expect("an account plus a valid service node id is a fetch");
+        assert!(
+            fetch.opener.is_some(),
+            "a founder is a device that can open its own account's tag"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -1508,13 +1508,16 @@ mod tests {
     /// plus a device load that re-derives and validates this device's keys, and with no
     /// discovery service `discover_peers` returns before it ever calls the opening closure.
     ///
-    /// Pinned by poisoning the reads so any of them fails loudly: with discovery off the call still
-    /// succeeds, and turning discovery back on surfaces the failure, so the silence is the gate and
-    /// not a store with nothing to read.
+    /// Pinned by dropping BOTH tables the opener reads, so either one fails loudly wherever it is
+    /// read from: with discovery off the call still succeeds, and turning discovery back on
+    /// surfaces the failure, so the silence is the gate and not a store with nothing to read.
+    /// Leaving `oplog_device_identity` present but empty would not pin the device load — it
+    /// answers `None` on an empty table, so a read hoisted above the gate would stay silent.
     #[test]
     fn discovery_off_reads_nothing_the_pass_cannot_use() {
         let poisoned = schema_conn();
         poisoned.execute("DROP TABLE oplog_local_account", []).unwrap();
+        poisoned.execute("DROP TABLE oplog_device_identity", []).unwrap();
         let mut config = Config::minimal_for_database(
             PathBuf::from("/nonexistent/sync.sqlite"),
             PathBuf::from("/nonexistent"),
@@ -1529,7 +1532,7 @@ mod tests {
         config.sync.discovery = true;
         assert!(
             discovery_fetch(&config, &poisoned, "https://relay.one").is_err(),
-            "the reads do happen once there is a fetch to open for"
+            "either read failing is enough — the reads do happen once there is a fetch to open for"
         );
 
         // A healthy store loads exactly one opener, carried for the whole pass.

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -25,8 +25,8 @@ use sha2::{Digest, Sha256};
 
 use super::keywrap::{self, ContentKey, SealedKeyWrap, WrapContext};
 use super::{bootstrap, storage};
-use crate::device::DeviceX25519Public;
-use crate::identity::{self, LocalDevice};
+use crate::device::{DeviceX25519Public, DeviceX25519Secret};
+use crate::identity;
 use crate::op::DeviceFingerprint;
 
 /// The envelope's leading byte. Bumping it is a wire break; the fetch side drops what it does not
@@ -151,10 +151,14 @@ fn stamp_of(recipients: &[(DeviceFingerprint, DeviceX25519Public)]) -> RosterSta
 /// context are the same answer each time, so they are paid for once and carried.
 ///
 /// It holds no connection, so a loaded opener cannot reach the database again. That is the point:
-/// hold one for the length of a fetch pass and drop it after, since a roster or identity change
-/// mid-pass is not something the pass is expected to observe.
+/// the sync pass that builds one holds it until the pass ends, and a roster or identity change
+/// while it is held is not something that pass is expected to observe.
+///
+/// It keeps the X25519 secret alone rather than the whole
+/// [`LocalDevice`](crate::identity::LocalDevice) it was loaded from, so the ed25519 signing key is
+/// not carried through the peer dials and sync sessions that outlive the opening itself.
 pub struct AnnouncementOpener {
-    device: LocalDevice,
+    x25519_secret: DeviceX25519Secret,
     ctx: WrapContext,
 }
 
@@ -169,7 +173,7 @@ impl AnnouncementOpener {
             return Ok(None);
         };
         let ctx = wrap_context(account, tag, &device.x25519_public().to_bytes());
-        Ok(Some(Self { device, ctx }))
+        Ok(Some(Self { x25519_secret: device.into_x25519_secret(), ctx }))
     }
 
     /// Recover the node id from an announcement sealed to this device, or `None`.
@@ -185,8 +189,7 @@ impl AnnouncementOpener {
         parse_wraps(envelope)?.iter().find_map(|wrap| {
             // Failure here is the expected case, not an error: this device matches at most one
             // wrap.
-            let opened =
-                keywrap::unwrap_content_key(wrap, self.device.x25519_secret(), &self.ctx).ok()?;
+            let opened = keywrap::unwrap_content_key(wrap, &self.x25519_secret, &self.ctx).ok()?;
             let mut node_id = [0u8; 32];
             node_id.copy_from_slice(opened.as_slice());
             Some(node_id)

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -155,7 +155,7 @@ fn stamp_of(recipients: &[(DeviceFingerprint, DeviceX25519Public)]) -> RosterSta
 /// while it is held is not something that pass is expected to observe.
 ///
 /// It keeps the X25519 secret alone rather than the whole
-/// [`LocalDevice`](crate::identity::LocalDevice) it was loaded from, so the ed25519 signing key is
+/// [`LocalDevice`](crate::LocalDevice) it was loaded from, so the ed25519 signing key is
 /// not carried through the peer dials and sync sessions that outlive the opening itself.
 pub struct AnnouncementOpener {
     x25519_secret: DeviceX25519Secret,

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -26,7 +26,7 @@ use sha2::{Digest, Sha256};
 use super::keywrap::{self, ContentKey, SealedKeyWrap, WrapContext};
 use super::{bootstrap, storage};
 use crate::device::DeviceX25519Public;
-use crate::identity;
+use crate::identity::{self, LocalDevice};
 use crate::op::DeviceFingerprint;
 
 /// The envelope's leading byte. Bumping it is a wire break; the fetch side drops what it does not
@@ -141,42 +141,57 @@ fn stamp_of(recipients: &[(DeviceFingerprint, DeviceX25519Public)]) -> RosterSta
     hasher.finalize().into()
 }
 
-/// Recover the node id from an announcement sealed to this device, or `None`.
+/// Everything opening an announcement needs that does not vary with the announcement: this
+/// device's X25519 key and the wrap context the account and tag determine.
 ///
-/// `None` covers every "not for us, or not ours to read" case: no local account or device, an
-/// unrecognised version, a malformed length, and — the ordinary case — no wrap that opens under
-/// this device's key.
+/// **Why the state is loaded up front rather than per announcement.** One fetch returns up to the
+/// service's per-response cap of payloads, and a payload that does not open spends no peer budget,
+/// so the opening path runs for every one of them. Only the unwrap depends on the envelope; the
+/// account read, the device load — which re-derives and re-validates the stored keys — and the
+/// context are the same answer each time, so they are paid for once and carried.
 ///
-/// **Silent when a wrap fails its tag.** Every announcement carries one wrap per roster device, so
-/// all but one are expected to fail here. The content path records unwrap failures as security
-/// events; doing that here would write a security event per foreign wrap per announcement per
-/// discovery pass, burying the real ones.
-pub fn open_discovery_announcement(
-    conn: &Connection,
-    tag: &[u8; 32],
-    envelope: &[u8],
-) -> anyhow::Result<Option<[u8; 32]>> {
-    let Some(wraps) = parse_wraps(envelope) else {
-        return Ok(None);
-    };
-    let Some(account) = bootstrap::read_local_account(conn)? else {
-        return Ok(None);
-    };
-    let Some(device) = identity::load_local_device(conn)? else {
-        return Ok(None);
-    };
-    let secret = device.x25519_secret();
-    let ctx = wrap_context(account, tag, &device.x25519_public().to_bytes());
+/// It holds no connection, so a loaded opener cannot reach the database again. That is the point:
+/// hold one for the length of a fetch pass and drop it after, since a roster or identity change
+/// mid-pass is not something the pass is expected to observe.
+pub struct AnnouncementOpener {
+    device: LocalDevice,
+    ctx: WrapContext,
+}
 
-    for wrap in wraps {
-        // Failure here is the expected case, not an error: this device matches at most one wrap.
-        if let Ok(opened) = keywrap::unwrap_content_key(&wrap, secret, &ctx) {
+impl AnnouncementOpener {
+    /// Load the per-pass state, or `None` when this store has no account or no local device — in
+    /// which case nothing it fetches under `tag` is openable, for the whole pass.
+    pub fn load(conn: &Connection, tag: &[u8; 32]) -> anyhow::Result<Option<Self>> {
+        let Some(account) = bootstrap::read_local_account(conn)? else {
+            return Ok(None);
+        };
+        let Some(device) = identity::load_local_device(conn)? else {
+            return Ok(None);
+        };
+        let ctx = wrap_context(account, tag, &device.x25519_public().to_bytes());
+        Ok(Some(Self { device, ctx }))
+    }
+
+    /// Recover the node id from an announcement sealed to this device, or `None`.
+    ///
+    /// `None` covers every "not for us, or not ours to read" case: an unrecognised version, a
+    /// malformed length, and — the ordinary case — no wrap that opens under this device's key.
+    ///
+    /// **Silent when a wrap fails its tag.** Every announcement carries one wrap per roster device,
+    /// so all but one are expected to fail here. The content path records unwrap failures as
+    /// security events; doing that here would write a security event per foreign wrap per
+    /// announcement per discovery pass, burying the real ones.
+    pub fn open(&self, envelope: &[u8]) -> Option<[u8; 32]> {
+        parse_wraps(envelope)?.iter().find_map(|wrap| {
+            // Failure here is the expected case, not an error: this device matches at most one
+            // wrap.
+            let opened =
+                keywrap::unwrap_content_key(wrap, self.device.x25519_secret(), &self.ctx).ok()?;
             let mut node_id = [0u8; 32];
             node_id.copy_from_slice(opened.as_slice());
-            return Ok(Some(node_id));
-        }
+            Some(node_id)
+        })
     }
-    Ok(None)
 }
 
 /// The AAD every wrap is bound to.

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -132,8 +132,8 @@ fn a_sealed_announcement_opens_on_the_sealing_device() {
     assert_eq!(open_one(&conn, &TAG, &sealed.bytes), Some(NODE_ID));
 }
 
-/// The state an opener holds is fixed at load, so a fetch pass pays for the account read and the
-/// device load once however many announcements come back.
+/// The state an opener holds is fixed at load: opening reads nothing further from the store, so a
+/// pass pays for the account read and the device load once however many announcements come back.
 ///
 /// Pinned by emptying both single-row tables under a live opener: anything that reloaded them per
 /// announcement would stop opening here.

--- a/crates/rag-rat-oplog/src/account/discovery/tests.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/tests.rs
@@ -110,6 +110,12 @@ fn wraps_of(envelope: &[u8]) -> Vec<SealedKeyWrap> {
     parse_wraps(envelope).expect("a sealed envelope parses")
 }
 
+/// Open a single announcement against freshly loaded state — `None` when there is no account or
+/// device to open it with, as well as when the envelope does not open.
+fn open_one(conn: &Connection, tag: &[u8; 32], envelope: &[u8]) -> Option<[u8; 32]> {
+    AnnouncementOpener::load(conn, tag).unwrap()?.open(envelope)
+}
+
 // ---------------------------------------------------------------- round trip
 
 /// The sealing device is among the recipients, so it opens its own announcement. A publisher is
@@ -123,8 +129,29 @@ fn a_sealed_announcement_opens_on_the_sealing_device() {
     let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
     assert_eq!(sealed.recipients, 1, "a lone founder is the whole roster");
 
-    let opened = open_discovery_announcement(&conn, &TAG, &sealed.bytes).unwrap();
-    assert_eq!(opened, Some(NODE_ID));
+    assert_eq!(open_one(&conn, &TAG, &sealed.bytes), Some(NODE_ID));
+}
+
+/// The state an opener holds is fixed at load, so a fetch pass pays for the account read and the
+/// device load once however many announcements come back.
+///
+/// Pinned by emptying both single-row tables under a live opener: anything that reloaded them per
+/// announcement would stop opening here.
+#[test]
+fn a_loaded_opener_reads_nothing_further_from_the_store() {
+    let conn = db();
+    bootstrap::local_account(&conn, NOW).unwrap();
+    let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
+    let opener = AnnouncementOpener::load(&conn, &TAG).unwrap().expect("a founder is a device");
+
+    conn.execute("DELETE FROM oplog_local_account", []).unwrap();
+    conn.execute("DELETE FROM oplog_device_identity", []).unwrap();
+
+    assert_eq!(opener.open(&sealed.bytes), Some(NODE_ID));
+    assert!(
+        AnnouncementOpener::load(&conn, &TAG).unwrap().is_none(),
+        "a fresh load sees the emptied store, so the open above used state loaded earlier"
+    );
 }
 
 /// Every roster-effective device is a recipient, not just the publisher.
@@ -239,9 +266,9 @@ fn a_wrap_does_not_open_under_another_tag() {
     bootstrap::local_account(&conn, NOW).unwrap();
     let sealed = seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().unwrap();
 
-    assert_eq!(open_discovery_announcement(&conn, &TAG, &sealed.bytes).unwrap(), Some(NODE_ID));
+    assert_eq!(open_one(&conn, &TAG, &sealed.bytes), Some(NODE_ID));
     assert_eq!(
-        open_discovery_announcement(&conn, &OTHER_TAG, &sealed.bytes).unwrap(),
+        open_one(&conn, &OTHER_TAG, &sealed.bytes),
         None,
         "the tag is AAD; a different tag must not open the wrap"
     );
@@ -307,14 +334,10 @@ fn parsing_refuses_everything_that_is_not_an_envelope() {
 fn a_store_with_no_account_seals_nothing_and_opens_nothing() {
     let conn = db();
     assert!(seal_discovery_announcement(&conn, &TAG, &NODE_ID).unwrap().is_none());
-    assert!(
-        // A WELL-FORMED one-wrap envelope, sized off `WRAP_LEN` so a wrap-layout change keeps it
-        // that way: a malformed envelope would be rejected by the parser and prove nothing about
-        // opening without an account.
-        open_discovery_announcement(&conn, &TAG, &[ANNOUNCEMENT_VERSION; 1 + WRAP_LEN])
-            .unwrap()
-            .is_none()
-    );
+    assert!(AnnouncementOpener::load(&conn, &TAG).unwrap().is_none());
+    // A well-formed one-wrap envelope, sized off `WRAP_LEN` so a wrap-layout change keeps it that
+    // way: the `None` must come from the absent account, not from a parser rejection.
+    assert!(open_one(&conn, &TAG, &[ANNOUNCEMENT_VERSION; 1 + WRAP_LEN]).is_none());
 }
 
 /// Opening is silent when a wrap is not ours — the ordinary case, once per foreign recipient per
@@ -334,7 +357,7 @@ fn opening_a_foreign_wrap_records_no_security_event() {
     envelope.extend_from_slice(&sealed.ephemeral_pubkey);
     envelope.extend_from_slice(&sealed.ciphertext);
 
-    assert_eq!(open_discovery_announcement(&conn, &TAG, &envelope).unwrap(), None);
+    assert_eq!(open_one(&conn, &TAG, &envelope), None);
 
     let events: i64 = conn
         .query_row("SELECT COUNT(*) FROM sync_security_events", [], |row| row.get(0))

--- a/crates/rag-rat-oplog/src/identity.rs
+++ b/crates/rag-rat-oplog/src/identity.rs
@@ -83,6 +83,13 @@ impl LocalDevice {
     pub(super) fn x25519_secret(&self) -> &DeviceX25519Secret {
         &self.x25519_secret
     }
+
+    /// Consume the identity for its X25519 secret alone, dropping the signing key with the rest.
+    /// For a caller that decrypts but never signs and outlives the load — holding the whole
+    /// identity there would keep the ed25519 secret alive for no reason.
+    pub(super) fn into_x25519_secret(self) -> DeviceX25519Secret {
+        self.x25519_secret
+    }
 }
 
 /// Read this store's local device fingerprint WITHOUT minting one — `None` when no identity has


### PR DESCRIPTION
Fixes #1088.

## Problem

`open_discovery_announcement` reloaded every piece of its invariant state on each payload: `read_local_account` (two indexed reads), `load_local_device` (a read plus an ed25519 secret→public derive, a fingerprint hash, and an X25519 derive, all re-validated against the stored columns), and a rebuilt `WrapContext`. None of that varies within a discovery pass.

A fetch returns up to the service's per-response cap of payloads, and a payload that does not open spends no peer budget, so the opener runs for all of them — roughly 192 reads and 128 key derivations per pass, every one producing the same answer.

## Change

`AnnouncementOpener` replaces the free function: `load(conn, tag)` does the reads and derives once and returns `None` when there is no account or device, `open(envelope)` does only the X25519 unwrap. It holds no connection, so a loaded opener cannot reach the database again.

`sync_driver::reconcile` builds one before `discover_peers` and the per-payload closure captures it. `discover_peers` keeps its `&dyn Fn(&[u8]) -> Option<[u8; 32]>` parameter and stays opening-agnostic; the crypto and roster knowledge stay in the op-log crate.

Per-payload behaviour is unchanged: the same silent skip for a wrap this device cannot open, the same tolerance of a failed load (discovery falls back to the configured peers rather than failing the pass), and the exchange's de-dupe by payload bytes is untouched.

## Verification

`a_loaded_opener_reads_nothing_further_from_the_store` pins the reuse by emptying `oplog_local_account` and `oplog_device_identity` under a live opener and asserting it still opens, with a fresh `load` confirming the store really is empty. Reintroducing a per-payload reload behind the same API fails that test and nothing else.

Full workspace clippy (default, no-default-features, all-features, and the `eval` feature sets) and both test runners pass.