### PR TITLE
feat(sync): mirror a published owner's memories read-only with sync subscribe (#1156)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -397,14 +397,15 @@ pub(crate) enum SyncCommand {
                             back. This store's own memories keep being authored onto its own \
                             stream and are never removed by the mirror. What IS removed: exactly \
                             one stream materializes a repo, so while subscribed this repo stops \
-                            mirroring its own account and the next drain DELETES every memory \
-                            this account's other devices had synced here — they do not go stale, \
-                            they go away. `sync unsubscribe` restores them, EXCEPT for local \
-                            binding work: a `memory rebind` you made on a synced memory is lost \
-                            with the row, because a re-drain seeds only the anchors its author \
-                            published. The owner's log must reach this store before anything \
-                            materializes: automatic sync pulls it once the owner's host is in \
-                            [sync] server_peers, or run `rag-rat sync pull <owner>`.")]
+                            mirroring its own account and the drain DELETES every memory this \
+                            account's other devices had synced here — they do not go stale, they \
+                            go away. `sync unsubscribe` restores them, EXCEPT for local binding \
+                            work: a `memory rebind` you made on a synced memory, and any local \
+                            edge onto it, go with the row, because a re-drain seeds only the \
+                            anchors its author published. The owner's log must reach this store \
+                            before anything materializes: automatic sync pulls it once the \
+                            owner's host is in [sync] server_peers, or run `rag-rat sync pull \
+                            <owner>`.")]
     Subscribe {
         /// The owner's 64-hex account id, from the owner's `rag-rat sync whoami`.
         #[arg(value_name = "OWNER_ACCOUNT_ID")]
@@ -412,23 +413,28 @@ pub(crate) enum SyncCommand {
     },
     /// Stop mirroring a subscribed identity's memories.
     #[command(long_about = "Clears this repo's `sync subscribe` configuration: its memories \
-                            materialize from its OWN account's stream again. The next drain \
-                            restores the memories this account's other devices had synced here \
-                            (the subscription deleted them) and removes the owner's in turn — \
+                            materialize from its OWN account's stream again. Drains immediately, \
+                            restoring the memories this account's other devices had synced here \
+                            (the subscription deleted them) and removing the owner's in turn — \
                             each side is re-materialized from its stream's projection, so the \
                             round trip is lossless EXCEPT for checkout-local binding work: a \
-                            `memory rebind` made on a synced memory is not restored, because the \
-                            re-drain seeds only the anchors the memory's author published.")]
+                            `memory rebind` made on a synced memory, and any local edge onto it, \
+                            are not restored, because the re-drain seeds only the anchors the \
+                            memory's author published.")]
     Unsubscribe,
     /// Stop contributing this repo's memories to a configured owner.
     #[command(long_about = "Clears this repo's `sync contribute` configuration: memory authoring \
                             targets this store's own stream again, which is also the stream the \
-                            repo's memories materialize from, so the next drain restores what \
-                            this account's own devices synced here and removes the owner's. \
-                            Nothing is withdrawn from the owner: the contributions already \
-                            authored onto its stream stay, this store keeps its own copies of \
-                            them, and the Writer grant remains open until the owner runs `sync \
-                            revoke`.")]
+                            repo's memories materialize from, so this drains immediately, \
+                            restoring what this account's own devices synced here and removing \
+                            the owner's. Nothing is withdrawn from the owner: the contributions \
+                            already authored onto its stream stay, this store keeps its own \
+                            copies of them, and the Writer grant remains open until the owner \
+                            runs `sync revoke`. Because those contributions stay fetchable only \
+                            while this account owns no private stream, memory authoring in a \
+                            repo of this index that would need one keeps refusing after the \
+                            unset — publish that repo, index it separately, or re-run `sync \
+                            contribute`.")]
     Uncontribute,
     /// Fetch ANOTHER account's memories from a peer that serves them.
     #[command(long_about = "Syncs a DIFFERENT account's log and memories from a peer, then \

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -395,16 +395,41 @@ pub(crate) enum SyncCommand {
                             nothing is authored onto the owner's stream, so no Writer grant is \
                             needed — use `sync contribute` instead if you also intend to write \
                             back. This store's own memories keep being authored onto its own \
-                            stream and are never removed by the mirror, but while subscribed \
-                            this repo stops mirroring its own account, so its other devices' \
-                            memories stop arriving. The owner's log must reach this store before \
-                            anything materializes: automatic sync pulls it once the owner's host \
-                            is in [sync] server_peers, or run `rag-rat sync pull <owner>`.")]
+                            stream and are never removed by the mirror. What IS removed: exactly \
+                            one stream materializes a repo, so while subscribed this repo stops \
+                            mirroring its own account and the next drain DELETES every memory \
+                            this account's other devices had synced here — they do not go stale, \
+                            they go away. `sync unsubscribe` restores them, EXCEPT for local \
+                            binding work: a `memory rebind` you made on a synced memory is lost \
+                            with the row, because a re-drain seeds only the anchors its author \
+                            published. The owner's log must reach this store before anything \
+                            materializes: automatic sync pulls it once the owner's host is in \
+                            [sync] server_peers, or run `rag-rat sync pull <owner>`.")]
     Subscribe {
         /// The owner's 64-hex account id, from the owner's `rag-rat sync whoami`.
         #[arg(value_name = "OWNER_ACCOUNT_ID")]
         account: String,
     },
+    /// Stop mirroring a subscribed identity's memories.
+    #[command(long_about = "Clears this repo's `sync subscribe` configuration: its memories \
+                            materialize from its OWN account's stream again. The next drain \
+                            restores the memories this account's other devices had synced here \
+                            (the subscription deleted them) and removes the owner's in turn — \
+                            each side is re-materialized from its stream's projection, so the \
+                            round trip is lossless EXCEPT for checkout-local binding work: a \
+                            `memory rebind` made on a synced memory is not restored, because the \
+                            re-drain seeds only the anchors the memory's author published.")]
+    Unsubscribe,
+    /// Stop contributing this repo's memories to a configured owner.
+    #[command(long_about = "Clears this repo's `sync contribute` configuration: memory authoring \
+                            targets this store's own stream again, which is also the stream the \
+                            repo's memories materialize from, so the next drain restores what \
+                            this account's own devices synced here and removes the owner's. \
+                            Nothing is withdrawn from the owner: the contributions already \
+                            authored onto its stream stay, this store keeps its own copies of \
+                            them, and the Writer grant remains open until the owner runs `sync \
+                            revoke`.")]
+    Uncontribute,
     /// Fetch ANOTHER account's memories from a peer that serves them.
     #[command(long_about = "Syncs a DIFFERENT account's log and memories from a peer, then \
                             materializes them locally. This is how a contributor gets the \
@@ -1205,6 +1230,24 @@ mod tests {
                 assert_eq!(account, "ef".repeat(32)),
             other => panic!("expected sync subscribe, got {other:?}"),
         }
+    }
+
+    /// Both unsets take no argument — a repo configures at most one owner, so there is nothing to
+    /// name — and neither accepts one, so a pasted account id is a parse error rather than a
+    /// silently ignored word.
+    #[test]
+    fn sync_unsubscribe_and_uncontribute_parse_without_an_account() {
+        let cli = Cli::try_parse_from(["rag-rat", "sync", "unsubscribe"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            Command::Sync(SyncArgs { command: SyncCommand::Unsubscribe })
+        ));
+        let cli = Cli::try_parse_from(["rag-rat", "sync", "uncontribute"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            Command::Sync(SyncArgs { command: SyncCommand::Uncontribute })
+        ));
+        assert!(Cli::try_parse_from(["rag-rat", "sync", "unsubscribe", &"ef".repeat(32)]).is_err());
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -389,6 +389,22 @@ pub(crate) enum SyncCommand {
         #[arg(value_name = "TICKET_OR_OWNER_ACCOUNT_ID")]
         account: String,
     },
+    /// Mirror another identity's published memories into this repo, read-only.
+    #[command(long_about = "Configures this repo's memories to materialize from ANOTHER \
+                            account's published owner stream instead of its own. Read-only: \
+                            nothing is authored onto the owner's stream, so no Writer grant is \
+                            needed — use `sync contribute` instead if you also intend to write \
+                            back. This store's own memories keep being authored onto its own \
+                            stream and are never removed by the mirror, but while subscribed \
+                            this repo stops mirroring its own account, so its other devices' \
+                            memories stop arriving. The owner's log must reach this store before \
+                            anything materializes: automatic sync pulls it once the owner's host \
+                            is in [sync] server_peers, or run `rag-rat sync pull <owner>`.")]
+    Subscribe {
+        /// The owner's 64-hex account id, from the owner's `rag-rat sync whoami`.
+        #[arg(value_name = "OWNER_ACCOUNT_ID")]
+        account: String,
+    },
     /// Fetch ANOTHER account's memories from a peer that serves them.
     #[command(long_about = "Syncs a DIFFERENT account's log and memories from a peer, then \
                             materializes them locally. This is how a contributor gets the \
@@ -1175,6 +1191,19 @@ mod tests {
             Command::Sync(SyncArgs { command: SyncCommand::Contribute { account } }) =>
                 assert_eq!(account, "cd".repeat(32)),
             other => panic!("expected sync contribute, got {other:?}"),
+        }
+    }
+
+    /// `sync subscribe` takes an owner ACCOUNT ID only — deliberately not a ticket, which exists to
+    /// carry a writer grant a read-only mirror never needs.
+    #[test]
+    fn sync_subscribe_parses() {
+        let cli =
+            Cli::try_parse_from(["rag-rat", "sync", "subscribe", &"ef".repeat(32)]).expect("parse");
+        match cli.command {
+            Command::Sync(SyncArgs { command: SyncCommand::Subscribe { account } }) =>
+                assert_eq!(account, "ef".repeat(32)),
+            other => panic!("expected sync subscribe, got {other:?}"),
         }
     }
 

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -51,7 +51,9 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
         | SyncCommand::Revoke { .. }
         | SyncCommand::Grants
         | SyncCommand::Contribute { .. }
-        | SyncCommand::Subscribe { .. } => {},
+        | SyncCommand::Subscribe { .. }
+        | SyncCommand::Unsubscribe
+        | SyncCommand::Uncontribute => {},
     }
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
@@ -179,7 +181,23 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "repo_id": db.active_repo_id,
                 "owner_account_id": account,
                 "read_only": true,
-                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched, but its other devices' memories stop arriving while subscribed. This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
+                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except that a local `memory rebind` on a synced memory is lost with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
+            }))
+        },
+        SyncCommand::Unsubscribe => {
+            let cleared = db.sync_unsubscribe()?;
+            print_output(&serde_json::json!({
+                "status": if cleared { "unsubscribed" } else { "not_subscribed" },
+                "repo_id": db.active_repo_id,
+                "note": "this repo's memories materialize from its own account's stream again: the next drain restores what its other devices had synced here and removes the owner's. A local `memory rebind` made on a memory the subscription removed is not restored with it",
+            }))
+        },
+        SyncCommand::Uncontribute => {
+            let cleared = db.sync_uncontribute()?;
+            print_output(&serde_json::json!({
+                "status": if cleared { "uncontributed" } else { "not_contributing" },
+                "repo_id": db.active_repo_id,
+                "note": "memory changes for this repo target this store's own stream again, and the next drain materializes it in the owner's place. Contributions already authored onto the owner's stream stay there, and the owner's grant stays open until it runs `sync revoke`",
             }))
         },
         SyncCommand::Serve { .. }
@@ -761,6 +779,18 @@ fn contribute_with_ticket(config: &Config, ticket: &str) -> anyhow::Result<()> {
     )?
     .ok_or_else(|| anyhow!("the index write lock is busy (another writer is mid-pass); retry"))?;
     let db = crate::open_index(config)?;
+    // Refuse a subscribed repo HERE, before the redemption. `sync_contribute` refuses it too, but
+    // that call is the last step of this flow: by then the owner has authored a grant for this
+    // account, and bailing would leave it live for a store that will never contribute. Same
+    // reasoning as the repo-mismatch refusal below — stop while nothing is burned.
+    if let Some(subscribed) = db.sync_owner_config()?.subscription_owner_account_id {
+        bail!(
+            "this repo already subscribes to account {subscribed} — subscription and contribution \
+             both re-point the ONE stream that materializes this repo's memories, so only one can \
+             be configured. Run `sync unsubscribe` first, or redeem this ticket in a separate \
+             index"
+        );
+    }
     let (node_key, contributor) = {
         let conn = db.connection();
         // Mint the contributor identity if absent — a fresh store can redeem an invite as its

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -165,39 +165,59 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 })).collect::<Vec<_>>(),
             }))
         },
+        // Every arm that RE-POINTS the repo's authoritative stream drains before reporting, the way
+        // `contribute_with_ticket` already does: the re-point is only a configuration write, the
+        // memories move in the drain, and no read path runs one. Reporting the new configuration
+        // while `memory search` still shows the old contents reads as a failed command.
         SyncCommand::Contribute { account } => {
             db.sync_contribute(account)?;
+            let effects = rag_rat_core::drain_synced_memory(db.connection())?;
+            db.fold_wal();
             print_output(&serde_json::json!({
                 "status": "contributing",
                 "repo_id": db.active_repo_id,
                 "owner_account_id": account,
+                "memories_added": effects.nodes_written,
+                "memories_removed": effects.nodes_removed,
                 "note": "memory changes for this repo now target the owner's stream; the owner must `sync grant` this account, and this store needs the owner's log — automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
             }))
         },
         SyncCommand::Subscribe { account } => {
             db.sync_subscribe(account)?;
+            let effects = rag_rat_core::drain_synced_memory(db.connection())?;
+            db.fold_wal();
             print_output(&serde_json::json!({
                 "status": "subscribed",
                 "repo_id": db.active_repo_id,
                 "owner_account_id": account,
                 "read_only": true,
-                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except that a local `memory rebind` on a synced memory is lost with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
+                "memories_added": effects.nodes_written,
+                "memories_removed": effects.nodes_removed,
+                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
             }))
         },
         SyncCommand::Unsubscribe => {
             let cleared = db.sync_unsubscribe()?;
+            let effects = rag_rat_core::drain_synced_memory(db.connection())?;
+            db.fold_wal();
             print_output(&serde_json::json!({
                 "status": if cleared { "unsubscribed" } else { "not_subscribed" },
                 "repo_id": db.active_repo_id,
-                "note": "this repo's memories materialize from its own account's stream again: the next drain restores what its other devices had synced here and removes the owner's. A local `memory rebind` made on a memory the subscription removed is not restored with it",
+                "memories_restored": effects.nodes_written,
+                "memories_removed": effects.nodes_removed,
+                "note": "this repo's memories materialize from its own account's stream again: what its other devices had synced here is restored and the owner's goes in turn. Local binding work is not restored — a `memory rebind` made on a memory the subscription removed, and any local edge onto it, went with the row",
             }))
         },
         SyncCommand::Uncontribute => {
             let cleared = db.sync_uncontribute()?;
+            let effects = rag_rat_core::drain_synced_memory(db.connection())?;
+            db.fold_wal();
             print_output(&serde_json::json!({
                 "status": if cleared { "uncontributed" } else { "not_contributing" },
                 "repo_id": db.active_repo_id,
-                "note": "memory changes for this repo target this store's own stream again, and the next drain materializes it in the owner's place. Contributions already authored onto the owner's stream stay there, and the owner's grant stays open until it runs `sync revoke`",
+                "memories_restored": effects.nodes_written,
+                "memories_removed": effects.nodes_removed,
+                "note": "memory changes for this repo target this store's own stream again, and its own stream materializes it in the owner's place. Contributions already authored onto the owner's stream stay there, and the owner's grant stays open until it runs `sync revoke` — so this index still may not hold a private memory stream in any repo, or those contributions become unfetchable. Publish this repo, or re-run `sync contribute`, if memory authoring here starts refusing",
             }))
         },
         SyncCommand::Serve { .. }

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -50,7 +50,8 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
         | SyncCommand::Grant { .. }
         | SyncCommand::Revoke { .. }
         | SyncCommand::Grants
-        | SyncCommand::Contribute { .. } => {},
+        | SyncCommand::Contribute { .. }
+        | SyncCommand::Subscribe { .. } => {},
     }
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
@@ -100,9 +101,12 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
         },
         SyncCommand::Whoami => {
             let account_id = db.sync_whoami()?;
+            let owner = db.sync_owner_config()?;
             print_output(&serde_json::json!({
                 "account_id": account_id,
                 "repo_id": db.active_repo_id,
+                "contribution_owner_account_id": owner.contribution_owner_account_id,
+                "subscription_owner_account_id": owner.subscription_owner_account_id,
                 "note": "share this account id with an owner so they can `sync grant` it write access to their repo's memories",
             }))
         },
@@ -166,6 +170,16 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "repo_id": db.active_repo_id,
                 "owner_account_id": account,
                 "note": "memory changes for this repo now target the owner's stream; the owner must `sync grant` this account, and this store needs the owner's log — automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
+            }))
+        },
+        SyncCommand::Subscribe { account } => {
+            db.sync_subscribe(account)?;
+            print_output(&serde_json::json!({
+                "status": "subscribed",
+                "repo_id": db.active_repo_id,
+                "owner_account_id": account,
+                "read_only": true,
+                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched, but its other devices' memories stop arriving while subscribed. This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
             }))
         },
         SyncCommand::Serve { .. }
@@ -941,11 +955,12 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
         };
 
         // Materialize what landed, and MEASURE the result rather than asserting it. The drain
-        // mirrors exactly ONE authoritative stream per repo: the configured contribution owner's,
-        // or this store's own. Those cover the two directions contribution needs — a contributor
-        // pulling its owner, and an owner pulling a contributor (whose entries sit on the owner's
-        // own stream). A standalone reader pulling some third account it neither owns nor
-        // contributes to has nowhere to put the content, and must not be told otherwise.
+        // mirrors exactly ONE authoritative stream per repo: a configured contribution owner's, a
+        // subscribed owner's, or this store's own. Those cover a contributor pulling its owner, an
+        // owner pulling a contributor (whose entries sit on the owner's own stream), and a
+        // read-only subscriber pulling the owner it mirrors. A pull of some third account this repo
+        // neither owns, contributes to, nor subscribes to has nowhere to put the content, and must
+        // not be told otherwise.
         let effects = rag_rat_core::drain_synced_memory(conn)?;
         rag_rat_core::resolve_synced_distill_anchors(conn)?;
         db.fold_wal();
@@ -953,15 +968,20 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
         // A successful pull implies convergence — the shared helper only reports a peer after
         // both legs converged, so there is no "incomplete success" to describe.
         let note = if effects.nodes_written > 0 || effects.edges_written > 0 {
-            "these memories are searchable locally; their code anchors do not cross an account \
-             boundary, so they will not attach as drive-by context"
+            "these memories are searchable locally, and the code anchors their author published \
+             are seeded here, so they attach as drive-by context wherever they resolve against \
+             this index — a symbol, path, or commit this checkout does not have stays unresolved \
+             and simply attaches nowhere. Call-path and chunk bindings are not carried across an \
+             account boundary, and anchors are seeded only for a memory this store holds none for"
         } else if !effects.is_empty() {
             "the authority this pull brought RETRACTED memories here — the drain removed what the \
              owner's log no longer accepts; nothing new was added"
         } else if content_entries > 0 {
             "content arrived but nothing materialized into this repo's memories: a repo mirrors \
-             ONE stream — its own, or a configured contribution owner's. Run `sync contribute \
-             <this account>` to mirror it, or pull from a store that owns or contributes to it"
+             ONE stream — its own, a subscribed owner's, or a configured contribution owner's. Run \
+             `sync subscribe <this account>` to mirror it read-only, `sync contribute <this \
+             account>` if you also intend to author back (that one needs a Writer grant from the \
+             owner), or pull from a store that already mirrors it"
         } else {
             "already up to date with this account"
         };

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -193,7 +193,7 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "read_only": true,
                 "memories_added": effects.nodes_written,
                 "memories_removed": effects.nodes_removed,
-                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
+                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
             }))
         },
         SyncCommand::Unsubscribe => {
@@ -217,7 +217,7 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "repo_id": db.active_repo_id,
                 "memories_restored": effects.nodes_written,
                 "memories_removed": effects.nodes_removed,
-                "note": "memory changes for this repo target this store's own stream again, and its own stream materializes it in the owner's place. Contributions already authored onto the owner's stream stay there, and the owner's grant stays open until it runs `sync revoke` — so this index still may not hold a private memory stream in any repo, or those contributions become unfetchable. Publish this repo, or re-run `sync contribute`, if memory authoring here starts refusing",
+                "note": "memory changes for this repo target this store's own stream again, and its own stream materializes it in the owner's place. Contributions already authored onto the owner's stream stay there, and the owner's grant stays open until it runs `sync revoke` — so until then this index still may not hold a private memory stream in any repo, or those contributions become unfetchable. What that blocks is memory AUTHORING (`memory create`/`update`/`rebind`, and `sync enable`) in any repo of this index that is not published: those refuse, naming the conflict, and write nothing. Indexing, search and reconcile are unaffected. Publish the repo with `sync publish`, re-run `sync contribute`, or index it in a separate database",
             }))
         },
         SyncCommand::Serve { .. }

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -67,6 +67,41 @@ fn memory_titles(conn: &Connection) -> Vec<String> {
         .unwrap()
 }
 
+/// The memory titles this store holds for the repo as `origin='synced'` rows — the ones the drain
+/// materialized from a stream, and the only ones its removal anti-joins condemn.
+fn synced_memory_titles(conn: &Connection) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT title FROM repo_memories WHERE repo_id = ?1 AND origin = 'synced' ORDER BY \
+             title",
+        )
+        .unwrap();
+    stmt.query_map([REPO], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+}
+
+/// Put one node into `stream`'s projection directly — the shape a peer's accepted entry folds into,
+/// without needing that peer's device key. What the drain reads is the projection, so this is the
+/// state a sibling device's memory arrives in.
+fn plant_projected_node(conn: &Connection, stream: rag_rat_oplog::StreamId, id: &str, title: &str) {
+    conn.execute(
+        "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+         VALUES (?1, ?2, ?3, 'active')",
+        params![
+            stream.to_bytes().as_slice(),
+            id,
+            serde_json::json!({
+                "kind": "Concept", "title": title, "body": "b",
+                "confidence": "high", "source": "agent", "tags": [], "payload": null,
+            })
+            .to_string(),
+        ],
+    )
+    .unwrap();
+}
+
 /// Replicate `src`'s account log (roster/ownership/grant) + content into `dst` — the state a
 /// contributor gains by syncing the owner's log.
 fn sync_account_into(dst: &Connection, src: &Connection, account: rag_rat_oplog::AccountId) {
@@ -168,20 +203,7 @@ fn the_contributors_own_stream_is_not_a_rival_authority_over_the_repo() {
     // If the drain still treated it as an authority it would materialize `local-stream-ghost` and
     // condemn `owner-note` (absent from this projection) on the very next pass.
     let own_stream = rag_rat_oplog::owned_stream_v2_id(&contributor, REPO).unwrap().unwrap();
-    contributor
-        .execute(
-            "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
-             VALUES (?1, 'ghost', ?2, 'active')",
-            params![
-                own_stream.to_bytes().as_slice(),
-                serde_json::json!({
-                    "kind": "Concept", "title": "local-stream-ghost", "body": "b",
-                    "confidence": "high", "source": "agent", "tags": [], "payload": null,
-                })
-                .to_string(),
-            ],
-        )
-        .unwrap();
+    plant_projected_node(&contributor, own_stream, "ghost", "local-stream-ghost");
     let tx = contributor.unchecked_transaction().unwrap();
     rag_rat_oplog::clear_content_drain_watermark(&tx, own_stream).unwrap();
     tx.commit().unwrap();
@@ -254,6 +276,33 @@ fn the_import_reconcile_refuses_in_contribution_mode_instead_of_half_applying() 
     assert_eq!(owned, 0, "no stream established for the contributor");
 }
 
+/// A SUBSCRIBER owns its stream, so the import reconcile would happily sign onto it — and the next
+/// drain, reading the OWNER's stream, would condemn every `origin='synced'` row the import brought
+/// in. The guard covers both configurations for that reason, not just the one that owns no stream.
+#[test]
+fn the_import_reconcile_refuses_while_subscribed() {
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+    let err = crate::memory_write::reconcile_owner_stream_for_repo(&subscriber, REPO, NOW)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("while subscribed"), "refuses with an actionable message: {err}");
+    assert!(err.contains("sync unsubscribe"), "and hands over the escape: {err}");
+}
+
+/// The drain resolves the subscription owner LAZILY — a contributing repo never consults the key,
+/// so a corrupt value there must not error the drain of a repo whose authority is already decided.
+#[test]
+fn a_corrupt_subscription_owner_does_not_break_a_contributing_repos_drain() {
+    let (_owner, contributor, _owner_account) = contribution_pair();
+    rag_rat_db::meta::set_repo_meta(&contributor, REPO, "memory_subscription_owner", "not-hex")
+        .unwrap();
+    crate::drain_synced_memory(&contributor).unwrap();
+    assert!(
+        memory_titles(&contributor).contains(&"owner-note".to_string()),
+        "the contribution owner decides the authority without reading the subscription key",
+    );
+}
+
 /// A configured owner is not yet an AUTHORITY. `sync contribute` succeeds before the owner's log
 /// is synced (configure, then sync), and a mistyped owner id derives a stream that never exists —
 /// both leave an EMPTY projection. Draining it would let the removal anti-joins condemn every
@@ -265,8 +314,8 @@ fn an_unsynced_or_mistyped_owner_never_becomes_removal_authority() {
     assert!(memory_titles(&contributor).contains(&"owner-note".to_string()));
 
     // Re-point at an owner whose log was never synced (the mistyped-id / configure-before-sync
-    // case): `set_contribution_owner` clears the incoming stream's watermark, so the next drain
-    // would otherwise make a FULL pass over an empty projection.
+    // case): `set_contribution_owner` forgets the OUTGOING stream's drain watermark, so the next
+    // drain would otherwise make a FULL pass over the new owner's empty projection.
     crate::memory_write::set_contribution_owner(&contributor, &"ab".repeat(32), NOW).unwrap();
     crate::drain_synced_memory(&contributor).unwrap();
 
@@ -274,6 +323,41 @@ fn an_unsynced_or_mistyped_owner_never_becomes_removal_authority() {
     assert!(
         titles.contains(&"owner-note".to_string()),
         "an unverified owner stream removes nothing: {titles:?}",
+    );
+}
+
+/// `sync contribute` is re-pointable too, and by the same one-stream rule the owner's memories are
+/// REMOVED when it is cleared — so the unset carries the same watermark discipline: the repo's own
+/// stream becomes the authority again and a full pass re-materializes it. What the contributor
+/// authored keeps its `origin='local'` and never depended on the mirror.
+#[test]
+fn uncontributing_re_points_the_repo_back_at_its_own_stream() {
+    let (_owner, contributor, _owner_account) = contribution_pair();
+    create_memory(&contributor, concept("contributor-note")).unwrap();
+    crate::drain_synced_memory(&contributor).unwrap();
+    assert_eq!(
+        synced_memory_titles(&contributor),
+        vec!["owner-note".to_string()],
+        "the owner's memory is the mirrored row",
+    );
+
+    assert!(
+        crate::memory_write::clear_contribution_owner(&contributor).unwrap(),
+        "a contribution was configured",
+    );
+    crate::drain_synced_memory(&contributor).unwrap();
+    let titles = memory_titles(&contributor);
+    assert!(
+        !titles.contains(&"owner-note".to_string()),
+        "the owner's stream stops materializing this repo: {titles:?}",
+    );
+    assert!(
+        titles.contains(&"contributor-note".to_string()),
+        "what this store authored is its own, not the mirror's: {titles:?}",
+    );
+    assert!(
+        !crate::memory_write::clear_contribution_owner(&contributor).unwrap(),
+        "clearing an absent contribution reports it rather than re-pointing anything",
     );
 }
 
@@ -506,7 +590,10 @@ fn a_contributing_store_refuses_to_establish_a_private_stream_later() {
 
 /// A published owner plus a SUBSCRIBER of it: the owner's log + content are synced in, and the
 /// subscriber is configured read-only. Deliberately no grant and no `enable_public_authoring` on
-/// the subscriber — a read-only mirror needs neither. Returns `(owner, subscriber, owner_account)`.
+/// the subscriber — a read-only mirror needs neither. The subscriber authors one memory FIRST, so
+/// it owns a PRIVATE stream of its own before it subscribes: that is what makes the two absent
+/// guards observable (an account that owns nothing is vacuously fully-public and holds no rival
+/// stream at all). Returns `(owner, subscriber, owner_account)`.
 fn subscription_pair() -> (Connection, Connection, rag_rat_oplog::AccountId) {
     let owner = scoped_conn();
     let owner_account = local_account(&owner, NOW).unwrap();
@@ -516,6 +603,12 @@ fn subscription_pair() -> (Connection, Connection, rag_rat_oplog::AccountId) {
     let subscriber = scoped_conn();
     let subscriber_account = local_account(&subscriber, NOW).unwrap();
     assert_ne!(owner_account, subscriber_account, "separate identities");
+    create_memory(&subscriber, concept("subscriber-note")).unwrap();
+    assert!(
+        !rag_rat_oplog::account_is_fully_public(&subscriber, subscriber_account).unwrap(),
+        "the subscriber owns a private stream — the guard `sync contribute` carries would refuse \
+         it",
+    );
     sync_account_into(&subscriber, &owner, owner_account);
 
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
@@ -543,6 +636,10 @@ fn a_subscriber_mirrors_a_published_owner_without_a_grant_or_a_public_account() 
         .unwrap()
         .is_none(),
         "the subscriber holds no writer grant",
+    );
+    assert!(
+        !rag_rat_oplog::account_is_fully_public(&subscriber, subscriber_account).unwrap(),
+        "and its own account is not fully public",
     );
 
     crate::drain_synced_memory(&subscriber).unwrap();
@@ -603,9 +700,9 @@ fn an_unsynced_or_mistyped_subscription_owner_never_becomes_removal_authority() 
     crate::drain_synced_memory(&subscriber).unwrap();
     assert!(memory_titles(&subscriber).contains(&"owner-note".to_string()));
 
-    // Re-point at an owner whose log was never synced. `set_subscription_owner` clears the incoming
-    // stream's watermark, so the next drain would otherwise make a FULL pass over an empty
-    // projection.
+    // Re-point at an owner whose log was never synced. `set_subscription_owner` forgets the
+    // OUTGOING stream's drain watermark, so the next drain would otherwise make a FULL pass over
+    // the new owner's empty projection.
     crate::memory_write::set_subscription_owner(&subscriber, &"ab".repeat(32), NOW).unwrap();
     crate::drain_synced_memory(&subscriber).unwrap();
     let titles = memory_titles(&subscriber);
@@ -631,6 +728,101 @@ fn subscription_and_contribution_refuse_to_coexist() {
         .unwrap_err()
         .to_string();
     assert!(err.contains("already subscribes"), "contribute names the conflict: {err}");
+}
+
+/// The subscriber's OWN account is the rival authority the contribution half never has: a
+/// contributor's own stream is empty by construction, but a subscriber's is actively authored — and
+/// it is also where this account's OTHER DEVICES' memories arrive, materialized `origin='synced'`.
+/// Re-pointing the repo at the owner condemns every one of them (absent from the owner's
+/// projection), which is correct — exactly one stream materializes a repo — but must not be a
+/// one-way door. `sync unsubscribe` re-points back and the rows come home, the owner's going in
+/// turn, each side re-materialized from its own stream's projection.
+///
+/// The fixture: a subscriber that already held sibling-device rows when it subscribed, drained
+/// once. Returns the subscriber connection; the assertions about what the subscription removed are
+/// made here, so both recovery routes below start from the same verified state.
+fn subscribed_store_that_held_sibling_device_memories() -> Connection {
+    let owner = scoped_conn();
+    let owner_account = local_account(&owner, NOW).unwrap();
+    assert!(enable_public_authoring(&owner, NOW).unwrap());
+    create_memory(&owner, concept("owner-note")).unwrap();
+
+    // A store of a DIFFERENT account holding two memories of its own account's: one this device
+    // authored (`origin='local'`) and one a SIBLING DEVICE authored, which reaches this device as a
+    // row in the shared stream's projection and materializes `origin='synced'`.
+    let subscriber = scoped_conn();
+    local_account(&subscriber, NOW).unwrap();
+    create_memory(&subscriber, concept("my-own-note")).unwrap();
+    let own_stream = rag_rat_oplog::owned_stream_v2_id(&subscriber, REPO).unwrap().unwrap();
+    plant_projected_node(&subscriber, own_stream, "sibling", "sibling-device-note");
+    crate::drain_synced_memory(&subscriber).unwrap();
+    assert_eq!(
+        synced_memory_titles(&subscriber),
+        vec!["sibling-device-note".to_string()],
+        "the sibling device's memory is materialized as a synced row",
+    );
+
+    // Subscribe. The owner's stream becomes the one authority, so the sibling's row is condemned.
+    sync_account_into(&subscriber, &owner, owner_account);
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    crate::memory_write::set_subscription_owner(&subscriber, &owner_hex, NOW).unwrap();
+    crate::drain_synced_memory(&subscriber).unwrap();
+    let titles = memory_titles(&subscriber);
+    assert!(
+        !titles.contains(&"sibling-device-note".to_string()),
+        "the subscription REMOVES the sibling device's memories, it does not leave them stale: \
+         {titles:?}",
+    );
+    assert!(titles.contains(&"owner-note".to_string()), "the owner's arrived: {titles:?}");
+    assert!(titles.contains(&"my-own-note".to_string()), "own work is spared: {titles:?}");
+    subscriber
+}
+
+/// The recovery route the operator has: `sync unsubscribe`.
+#[test]
+fn unsubscribing_restores_the_sibling_device_memories_the_subscription_removed() {
+    let subscriber = subscribed_store_that_held_sibling_device_memories();
+
+    // Unsubscribe: the own stream is the authority again, and only a FULL pass restores what the
+    // re-point condemned — which is why the re-point forgets both streams' drain watermarks.
+    assert!(
+        crate::memory_write::clear_subscription_owner(&subscriber).unwrap(),
+        "a subscription was configured",
+    );
+    crate::drain_synced_memory(&subscriber).unwrap();
+    let titles = memory_titles(&subscriber);
+    assert!(
+        titles.contains(&"sibling-device-note".to_string()),
+        "unsubscribing re-materializes the sibling device's memories: {titles:?}",
+    );
+    assert!(
+        !titles.contains(&"owner-note".to_string()),
+        "and the owner's go in turn — one stream materializes the repo: {titles:?}",
+    );
+    assert!(titles.contains(&"my-own-note".to_string()), "own work is spared again: {titles:?}");
+
+    assert!(
+        !crate::memory_write::clear_subscription_owner(&subscriber).unwrap(),
+        "clearing an absent subscription reports it rather than re-pointing anything",
+    );
+}
+
+/// The other route back is not a command at all: the operator (or a future write path) drops the
+/// `memory_subscription_owner` row directly. That bypasses the unsetter entirely, so recovery rests
+/// on what the SETTER did — it forgot the outgoing (own) stream's drain watermark on the way out,
+/// and nothing has drained that stream since, so the next pass is still a full one.
+#[test]
+fn dropping_the_subscription_meta_row_also_re_materializes_the_repo() {
+    let subscriber = subscribed_store_that_held_sibling_device_memories();
+    rag_rat_db::meta::delete_repo_meta(&subscriber, REPO, "memory_subscription_owner").unwrap();
+
+    crate::drain_synced_memory(&subscriber).unwrap();
+    let titles = memory_titles(&subscriber);
+    assert!(
+        titles.contains(&"sibling-device-note".to_string()),
+        "the own stream drains in full again: {titles:?}",
+    );
+    assert!(!titles.contains(&"owner-note".to_string()), "and the owner's go in turn: {titles:?}",);
 }
 
 /// Subscribing to your OWN account would persist a configuration the drain ignores

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -327,9 +327,13 @@ fn an_unsynced_or_mistyped_owner_never_becomes_removal_authority() {
 }
 
 /// `sync contribute` is re-pointable too, and by the same one-stream rule the owner's memories are
-/// REMOVED when it is cleared — so the unset carries the same watermark discipline: the repo's own
-/// stream becomes the authority again and a full pass re-materializes it. What the contributor
-/// authored keeps its `origin='local'` and never depended on the mirror.
+/// REMOVED when it is cleared: the repo's own stream becomes the authority again and the owner's
+/// projection stops materializing here. What the contributor authored keeps its `origin='local'`
+/// and never depended on the mirror. (The unset's watermark discipline is exercised on the
+/// SUBSCRIPTION side —
+/// `unsubscribing_restores_the_sibling_device_memories_the_subscription_removed` — where the repo
+/// has an own stream that was drained to a current watermark before the re-point; a contributor
+/// owns no stream at all, so there is no watermark here to be wrong about.)
 #[test]
 fn uncontributing_re_points_the_repo_back_at_its_own_stream() {
     let (_owner, contributor, _owner_account) = contribution_pair();
@@ -586,6 +590,74 @@ fn a_contributing_store_refuses_to_establish_a_private_stream_later() {
     assert!(err.contains("PRIVATE memory stream"), "the refusal names the conflict: {err}");
     assert!(err.contains("separate database"), "and hands over an escape: {err}");
     assert!(err.contains("sync publish"), "and the other escape: {err}");
+}
+
+/// The guard keys on EVIDENCE, not configuration. `sync uncontribute` empties the configured
+/// targets, but the entries this store already authored onto the owner's stream stay there and the
+/// owner can fetch them only while this account owns no private stream. Keyed on configuration, the
+/// unset would let the very next memory write author a `Private` `StreamOwn` — append-only, never
+/// un-authorable — permanently un-serving the account and stranding those contributions.
+#[test]
+fn an_ex_contributor_still_refuses_to_establish_a_private_stream() {
+    let (_owner, contributor, _owner_account) = contribution_pair();
+    let contributor_account = local_account(&contributor, NOW).unwrap();
+    create_memory(&contributor, concept("contributor-note")).unwrap();
+
+    assert!(
+        crate::memory_write::clear_contribution_owner(&contributor).unwrap(),
+        "a contribution was configured",
+    );
+    assert!(
+        crate::memory_write::contribution_targets(&contributor).unwrap().is_empty(),
+        "nothing is configured any more — the authored entries are all that is left",
+    );
+
+    let err = create_memory(&contributor, concept("post-unset-note")).unwrap_err().to_string();
+    assert!(err.contains("PRIVATE memory stream"), "the refusal names the conflict: {err}");
+    assert!(err.contains("already authored"), "and cites the evidence, not the config: {err}");
+    assert!(err.contains("sync publish"), "and hands over the escape: {err}");
+    assert!(
+        rag_rat_oplog::account_is_fully_public(&contributor, contributor_account).unwrap(),
+        "and nothing private was authored, so the owner can still fetch the contributions",
+    );
+}
+
+/// Both unsetters must work in the state the drain's LAZY owner resolution was made tolerant of: a
+/// `memory_subscription_owner` value that will not parse. Resolving it strictly on the re-point
+/// would bail and roll back, leaving the recovery commands unusable in precisely the state they are
+/// for. A side that cannot resolve had no stream to drain, so best-effort loses nothing.
+#[test]
+fn clearing_a_foreign_owner_tolerates_an_unparseable_owner_key() {
+    // OUTGOING side: the corrupt key is the one being cleared, so the FIRST resolution meets it.
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+    rag_rat_db::meta::set_repo_meta(&subscriber, REPO, "memory_subscription_owner", "not-hex")
+        .unwrap();
+    assert!(
+        crate::memory_write::clear_subscription_owner(&subscriber).unwrap(),
+        "the corrupt subscription is cleared rather than defended",
+    );
+    assert!(
+        rag_rat_db::meta::repo_meta(&subscriber, REPO, "memory_subscription_owner")
+            .unwrap()
+            .is_none(),
+        "and the row is gone, not rolled back",
+    );
+
+    // INCOMING side: the contribution resolves fine on the way out, and the corrupt subscription
+    // key is what the repo falls back to once it is gone.
+    let (_owner2, contributor, _owner_account2) = contribution_pair();
+    rag_rat_db::meta::set_repo_meta(&contributor, REPO, "memory_subscription_owner", "not-hex")
+        .unwrap();
+    assert!(
+        crate::memory_write::clear_contribution_owner(&contributor).unwrap(),
+        "the contribution clears even though the fallback owner key is corrupt",
+    );
+    assert!(
+        rag_rat_db::meta::repo_meta(&contributor, REPO, "memory_contribution_owner")
+            .unwrap()
+            .is_none(),
+        "and the row is gone, not rolled back",
+    );
 }
 
 /// A published owner plus a SUBSCRIBER of it: the owner's log + content are synced in, and the

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -622,10 +622,81 @@ fn an_ex_contributor_still_refuses_to_establish_a_private_stream() {
     );
 }
 
+/// The refusal is a stream-establishment POLICY and belongs where a user is asking for a write.
+/// INDEX MAINTENANCE reaches the very same reconcile — `rag-rat reconcile`, every watcher
+/// incremental pass and `rag-rat index` all route the idle-repo ghost heal through
+/// `heal_memory_oplog_ghosts` — and there the refusal must be SKIPPED. Propagated, an ordinary
+/// `sync uncontribute` would break all three on the next pass, with no ghost to heal, while the
+/// `uncontribute` itself still reported success.
+#[test]
+fn index_maintenance_survives_the_ex_contributors_private_stream_refusal() {
+    let (_owner, contributor, _owner_account) = contribution_pair();
+    let contributor_account = local_account(&contributor, NOW).unwrap();
+    create_memory(&contributor, concept("contributor-note")).unwrap();
+    assert!(crate::memory_write::clear_contribution_owner(&contributor).unwrap());
+
+    // Authoring — where a user asked for a write — still refuses.
+    assert!(
+        create_memory(&contributor, concept("post-unset-note"))
+            .unwrap_err()
+            .to_string()
+            .contains("PRIVATE memory stream"),
+        "the authoring path keeps the refusal",
+    );
+
+    // Maintenance does not. Twice, because the pass runs on every reconcile and must not become
+    // sticky on the first refusal.
+    for pass in 1..=2 {
+        crate::memory_write::heal_memory_oplog_ghosts(&contributor, NOW)
+            .unwrap_or_else(|err| panic!("the ghost heal must survive pass {pass}: {err:#}"));
+    }
+    assert!(
+        rag_rat_oplog::account_is_fully_public(&contributor, contributor_account).unwrap(),
+        "and it skipped rather than established the private stream it refused",
+    );
+}
+
+/// The guard must block on exactly what the SERVING side would still serve. Once the owner runs
+/// `sync revoke`, its own pull already cannot reach this account for that stream, so establishing a
+/// private stream here strands nothing — and refusing anyway would be permanent, with no recourse
+/// the store can take. The authorship evidence itself survives the revoke (the entries stay
+/// `accepted = 1`), so only the servability filter can tell the two apart.
+#[test]
+fn a_revoked_ex_contributor_may_establish_its_private_stream() {
+    // A DEPARTED revoke, whose chain-tail cut vouches the contribution the owner already accepted:
+    // the grant goes, the accepted entry stays.
+    let (owner, contributor, owner_account, contributor_account) = revocable_pair();
+    revoke_repo_writer(
+        &owner,
+        &rag_rat_base::hash::hex_lower(&contributor_account.to_bytes()),
+        rag_rat_oplog::RevokeReason::Departed,
+        None,
+        NOW,
+    )
+    .unwrap();
+    sync_account_into(&contributor, &owner, owner_account);
+    assert!(crate::memory_write::clear_contribution_owner(&contributor).unwrap());
+    assert!(
+        !rag_rat_oplog::authored_foreign_streams(&contributor, contributor_account)
+            .unwrap()
+            .is_empty(),
+        "the authorship evidence outlives the revoke — an unfiltered guard would still block",
+    );
+
+    create_memory(&contributor, concept("post-revoke-note"))
+        .expect("a revoked authorship strands nothing, so the private stream is allowed");
+    assert!(
+        memory_titles(&contributor).contains(&"post-revoke-note".to_string()),
+        "and the memory is really there",
+    );
+}
+
 /// Both unsetters must work in the state the drain's LAZY owner resolution was made tolerant of: a
 /// `memory_subscription_owner` value that will not parse. Resolving it strictly on the re-point
 /// would bail and roll back, leaving the recovery commands unusable in precisely the state they are
-/// for. A side that cannot resolve had no stream to drain, so best-effort loses nothing.
+/// for. A side that cannot resolve had no stream to drain, so tolerating THAT loses nothing — and
+/// the tolerance stops there, see
+/// `clearing_a_foreign_owner_propagates_a_resolution_failure_that_is_not_a_parse`.
 #[test]
 fn clearing_a_foreign_owner_tolerates_an_unparseable_owner_key() {
     // OUTGOING side: the corrupt key is the one being cleared, so the FIRST resolution meets it.
@@ -657,6 +728,33 @@ fn clearing_a_foreign_owner_tolerates_an_unparseable_owner_key() {
             .unwrap()
             .is_none(),
         "and the row is gone, not rolled back",
+    );
+}
+
+/// The unsetters' tolerance covers the unparseable owner key and nothing else. A real read failure
+/// means the outgoing stream is UNKNOWN, not absent — swallowing it skips a watermark clear the
+/// command's own promise depends on, and reports success for a repo whose memories will not come
+/// back. Break the ownership read the resolution goes through and require the command to say so.
+#[test]
+fn clearing_a_foreign_owner_propagates_a_resolution_failure_that_is_not_a_parse() {
+    let (_owner, contributor, _owner_account) = contribution_pair();
+    contributor
+        .execute_batch("ALTER TABLE account_stream_ownership RENAME TO ownership_moved_away")
+        .unwrap();
+
+    let err = crate::memory_write::clear_contribution_owner(&contributor).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("account_stream_ownership"),
+        "the read failure surfaces instead of being swallowed: {err:#}",
+    );
+    contributor
+        .execute_batch("ALTER TABLE ownership_moved_away RENAME TO account_stream_ownership")
+        .unwrap();
+    assert!(
+        rag_rat_db::meta::repo_meta(&contributor, REPO, "memory_contribution_owner")
+            .unwrap()
+            .is_some(),
+        "and the configuration is rolled back, not half-cleared",
     );
 }
 

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -3,6 +3,9 @@
 //! (modelled by ingesting the owner's account log + content); the contributor is configured with
 //! `set_contribution_owner`; and its live authoring folds accepted on the owner's `/2` stream — not
 //! on any stream of its own.
+//!
+//! Plus the read-only half (#1156): a SUBSCRIBER mirrors the same published owner's stream without
+//! a grant and without publishing itself, and keeps authoring its own memories onto its own stream.
 
 use rag_rat_oplog::{
     AccessMode, ContentRefoldBudget, account_entries_for_sync, account_ingest,
@@ -499,4 +502,146 @@ fn a_contributing_store_refuses_to_establish_a_private_stream_later() {
     assert!(err.contains("PRIVATE memory stream"), "the refusal names the conflict: {err}");
     assert!(err.contains("separate database"), "and hands over an escape: {err}");
     assert!(err.contains("sync publish"), "and the other escape: {err}");
+}
+
+/// A published owner plus a SUBSCRIBER of it: the owner's log + content are synced in, and the
+/// subscriber is configured read-only. Deliberately no grant and no `enable_public_authoring` on
+/// the subscriber — a read-only mirror needs neither. Returns `(owner, subscriber, owner_account)`.
+fn subscription_pair() -> (Connection, Connection, rag_rat_oplog::AccountId) {
+    let owner = scoped_conn();
+    let owner_account = local_account(&owner, NOW).unwrap();
+    assert!(enable_public_authoring(&owner, NOW).unwrap());
+    create_memory(&owner, concept("owner-note")).unwrap();
+
+    let subscriber = scoped_conn();
+    let subscriber_account = local_account(&subscriber, NOW).unwrap();
+    assert_ne!(owner_account, subscriber_account, "separate identities");
+    sync_account_into(&subscriber, &owner, owner_account);
+
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    crate::memory_write::set_subscription_owner(&subscriber, &owner_hex, NOW).unwrap();
+    (owner, subscriber, owner_account)
+}
+
+/// The read-only half of cross-account mirroring (#1156): the two guards `sync contribute` carries
+/// (an effective Writer grant, a fully-public local account) exist only because a contributor
+/// AUTHORS onto the owner's stream. A subscriber writes nothing there and is never pulled from, so
+/// it mirrors the same published stream with neither.
+#[test]
+fn a_subscriber_mirrors_a_published_owner_without_a_grant_or_a_public_account() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let subscriber_account = local_account(&subscriber, NOW).unwrap();
+    let owner_stream =
+        owner_stream_v2_id_for_account(REPO, owner_account, AccessMode::PublicRead).unwrap();
+    assert!(
+        rag_rat_oplog::effective_writer_grant(
+            &subscriber,
+            owner_account,
+            owner_stream,
+            subscriber_account,
+        )
+        .unwrap()
+        .is_none(),
+        "the subscriber holds no writer grant",
+    );
+
+    crate::drain_synced_memory(&subscriber).unwrap();
+    let titles = memory_titles(&subscriber);
+    assert!(
+        titles.contains(&"owner-note".to_string()),
+        "the owner's memories materialize here: {titles:?}",
+    );
+}
+
+/// The re-point is DRAIN-side only. A subscriber's own memories keep being authored onto its OWN
+/// stream (never the owner's — it holds no grant and would be rejected), and they stay
+/// `origin='local'`, which the drain's synced-only removal anti-joins spare even though they are
+/// absent from the mirrored owner's projection.
+#[test]
+fn a_subscribers_own_memories_go_to_its_own_stream_and_survive_the_mirror() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let subscriber_account = local_account(&subscriber, NOW).unwrap();
+    create_memory(&subscriber, concept("my-own-note")).unwrap();
+
+    // Authored on a stream the SUBSCRIBER owns, not on the owner's.
+    let owner_stream =
+        owner_stream_v2_id_for_account(REPO, owner_account, AccessMode::PublicRead).unwrap();
+    let on_owner_stream: i64 = subscriber
+        .query_row(
+            "SELECT COUNT(*) FROM content_entries WHERE stream_id = ?1 AND author_account_id = ?2",
+            params![owner_stream.to_bytes().as_slice(), subscriber_account.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(on_owner_stream, 0, "a subscriber authors nothing onto the owner's stream");
+    let owned: i64 = subscriber
+        .query_row(
+            "SELECT COUNT(*) FROM account_stream_ownership WHERE account_id = ?1",
+            [subscriber_account.to_bytes().as_slice()],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(owned, 1, "it established and authored a stream of its own");
+
+    // Draining the owner's stream must not condemn it: it is `origin='local'`, not synced.
+    crate::drain_synced_memory(&subscriber).unwrap();
+    let titles = memory_titles(&subscriber);
+    assert!(
+        titles.contains(&"my-own-note".to_string()),
+        "own work survives the mirror: {titles:?}"
+    );
+    assert!(titles.contains(&"owner-note".to_string()), "and the owner's arrived: {titles:?}");
+}
+
+/// A configured owner is not yet an AUTHORITY — the subscription twin of the contribution case.
+/// `sync subscribe` succeeds before the owner's log is synced, and a mistyped id derives a stream
+/// that never exists; both leave an EMPTY projection, and draining it would let the removal
+/// anti-joins condemn every synced row the repo currently reads.
+#[test]
+fn an_unsynced_or_mistyped_subscription_owner_never_becomes_removal_authority() {
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+    crate::drain_synced_memory(&subscriber).unwrap();
+    assert!(memory_titles(&subscriber).contains(&"owner-note".to_string()));
+
+    // Re-point at an owner whose log was never synced. `set_subscription_owner` clears the incoming
+    // stream's watermark, so the next drain would otherwise make a FULL pass over an empty
+    // projection.
+    crate::memory_write::set_subscription_owner(&subscriber, &"ab".repeat(32), NOW).unwrap();
+    crate::drain_synced_memory(&subscriber).unwrap();
+    let titles = memory_titles(&subscriber);
+    assert!(
+        titles.contains(&"owner-note".to_string()),
+        "an unverified owner stream removes nothing: {titles:?}",
+    );
+}
+
+/// Contribution and subscription both RE-POINT the one stream that materializes a repo's memories,
+/// so configuring the second would make which one the drain honors ambiguous. Both setters refuse,
+/// rather than silently superseding the other's setup.
+#[test]
+fn subscription_and_contribution_refuse_to_coexist() {
+    let (_owner, contributor, _owner_account) = contribution_pair();
+    let err = crate::memory_write::set_subscription_owner(&contributor, &"ab".repeat(32), NOW)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("already contributes"), "subscribe names the conflict: {err}");
+
+    let (_owner2, subscriber, _owner_account2) = subscription_pair();
+    let err = crate::memory_write::set_contribution_owner(&subscriber, &"ab".repeat(32), NOW)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("already subscribes"), "contribute names the conflict: {err}");
+}
+
+/// Subscribing to your OWN account would persist a configuration the drain ignores
+/// (`authoritative_content_stream` falls through when the configured owner is this store), so it
+/// is refused rather than stored as a lie.
+#[test]
+fn subscribing_to_your_own_account_is_refused() {
+    let store = scoped_conn();
+    let account = local_account(&store, NOW).unwrap();
+    let own_hex = rag_rat_base::hash::hex_lower(&account.to_bytes());
+    let err =
+        crate::memory_write::set_subscription_owner(&store, &own_hex, NOW).unwrap_err().to_string();
+    assert!(err.contains("your own account"), "the refusal names the cause: {err}");
 }

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -656,6 +656,26 @@ fn index_maintenance_survives_the_ex_contributors_private_stream_refusal() {
     );
 }
 
+/// The maintenance tolerance covers the private-stream refusal and nothing else. A real failure in
+/// the ghost heal means the reconcile did NOT run, and swallowing it would hide that on every
+/// `rag-rat reconcile` and every watcher pass — silently, forever, since maintenance is the only
+/// caller that could report it. Break a table the heal reads and require the call to say so.
+#[test]
+fn the_ghost_heal_propagates_a_failure_that_is_not_the_private_stream_refusal() {
+    let conn = scoped_conn();
+    local_account(&conn, NOW).unwrap();
+    create_memory(&conn, concept("note")).unwrap();
+    conn.execute_batch("ALTER TABLE account_stream_ownership RENAME TO ownership_moved_away")
+        .unwrap();
+
+    let err = crate::memory_write::heal_memory_oplog_ghosts(&conn, NOW)
+        .expect_err("a non-refusal failure must fail the pass rather than be skipped");
+    assert!(
+        format!("{err:#}").contains("account_stream_ownership"),
+        "and the read failure surfaces instead of being swallowed: {err:#}",
+    );
+}
+
 /// The guard must block on exactly what the SERVING side would still serve. Once the owner runs
 /// `sync revoke`, its own pull already cannot reach this account for that stream, so establishing a
 /// private stream here strands nothing — and refusing anyway would be permanent, with no recourse

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -90,7 +90,13 @@ use crate::index::{self, IndexDatabase, schema};
 ///        0 is load-bearing — A6), `clone_graph_live_generation`, `shallow_boundary` (adoption
 ///        proof for the legacy file's own registry), `source_root` (re-recorded by registration);
 ///      * derived/re-derivable caches: `local_crate_roots` (re-read from manifests),
-///        `embedding_throughput_tune_v1` (a tuning cache, re-derived).
+///        `embedding_throughput_tune_v1` (a tuning cache, re-derived);
+///      * `memory_contribution_owner` / `memory_subscription_owner` — the accounts whose stream
+///        materializes the repo. Not copied and never needed:
+///        `ensure_not_mirroring_another_account` REFUSES the whole run when the TARGET carries
+///        either key, and a legacy source that carries one has nowhere to put it (the target's own
+///        key must stay authoritative — it is what the target's drain already acted on). A repo
+///        consolidates only while it owns its own stream.
 const CARRIED_META_KEYS: &[&str] = &[
     "active_embedding_model",
     "embedding_active_model_version",
@@ -301,14 +307,16 @@ fn run_inner(config: &Config, config_path: Option<&Path>) -> anyhow::Result<Cons
         &crate::index::migration_hooks(),
     )?;
 
-    // Refuse a contribution-configured target BEFORE any import side effect. The reconcile that
-    // signs the imported rows onto an owned stream cannot run for a contributor (it owns none), and
-    // it is reached only AFTER `import_from_source` has committed — so failing there would leave
-    // exactly the half-applied state it exists to prevent: persisted rows and FTS children with no
-    // `NodeCreate`, re-imported and re-failed on every retry. Stopping here leaves the legacy file
-    // unrenamed and the target untouched, so the run is retryable once the repo is no longer
-    // configured to contribute.
-    crate::memory_write::ensure_not_contributing(
+    // Refuse a target whose memories materialize from ANOTHER account's stream, BEFORE any import
+    // side effect. The reconcile that signs the imported rows onto an owned stream cannot run for a
+    // contributor (it owns none), and it is reached only AFTER `import_from_source` has committed —
+    // so failing there would leave exactly the half-applied state it exists to prevent: persisted
+    // rows and FTS children with no `NodeCreate`, re-imported and re-failed on every retry. A
+    // SUBSCRIBER owns its stream but the drain does not honor it, so the import's `origin='synced'`
+    // rows (it carries both origins) are condemned by the next drain instead. Stopping here leaves
+    // the legacy file unrenamed and the target untouched, so the run is retryable once the repo is
+    // no longer configured to mirror another account.
+    crate::memory_write::ensure_not_mirroring_another_account(
         target_conn,
         &repo_id,
         "consolidating a legacy index",

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -84,8 +84,11 @@ impl IndexDatabase {
     /// a no-op under an absent/unstable scope. Runs after the embedding reconcile has
     /// committed, so its authored write (a durable `IMMEDIATE` txn only when a ghost exists)
     /// never nests inside it.
+    ///
+    /// Maintenance, not authoring: the memory-write helper skips the stream-establishment refusal
+    /// an ex-contributor's repo raises rather than take the reconcile down with it.
     pub(crate) fn heal_memory_oplog_ghosts(&self) -> anyhow::Result<()> {
-        crate::memory_write::backfill_memory_oplog(
+        crate::memory_write::heal_memory_oplog_ghosts(
             self.storage.connection(),
             rag_rat_base::time::now_ms(),
         )

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -58,7 +58,11 @@ impl IndexDatabase {
         // one-way ratchet, but a contributor's writes target the CONFIGURED owner's stream, so the
         // seeded rows would have nowhere to be authored and the fresh public stream would stay
         // empty while the CLI reported them seeded. Refuse while nothing irreversible has happened.
-        crate::memory_write::ensure_not_contributing(conn, &repo_id, "`sync publish --seed`")?;
+        crate::memory_write::ensure_not_mirroring_another_account(
+            conn,
+            &repo_id,
+            "`sync publish --seed`",
+        )?;
         let published =
             crate::memory_write::enable_public_authoring(conn, rag_rat_base::time::now_ms())?;
         let imported_memories = crate::index::consolidate::seed_from_index(
@@ -159,6 +163,24 @@ impl IndexDatabase {
             owner_account_hex,
             rag_rat_base::time::now_ms(),
         )
+    }
+
+    /// Stop mirroring a subscribed owner (`sync unsubscribe`): the active repo's memories
+    /// materialize from its OWN stream again. Returns whether a subscription was configured.
+    ///
+    /// The subscription REMOVED this account's other devices' memories (absent from the owner's
+    /// projection, which the drain reads as condemned); clearing it makes the next drain
+    /// re-materialize them, and removes the owner's in turn.
+    pub fn sync_unsubscribe(&self) -> anyhow::Result<bool> {
+        crate::memory_write::clear_subscription_owner(self.storage.connection())
+    }
+
+    /// Stop contributing to a configured owner (`sync uncontribute`): memory authoring for the
+    /// active repo targets this store's own stream again. Returns whether a contribution was
+    /// configured. The owner's Writer grant and the contributions already authored onto its stream
+    /// are untouched.
+    pub fn sync_uncontribute(&self) -> anyhow::Result<bool> {
+        crate::memory_write::clear_contribution_owner(self.storage.connection())
     }
 
     /// The active repo's configured foreign memory owner, if any — what `sync whoami` reports

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -148,6 +148,25 @@ impl IndexDatabase {
         )
     }
 
+    /// Configure the active repo to MIRROR `owner_account_hex`'s published memories, read-only
+    /// (#1156): this repo's memory tables materialize from the owner's stream instead of its own.
+    /// No Writer grant is involved — a subscriber authors nothing onto the owner's stream — but the
+    /// owner's log must reach this store (automatic sync pulls it once the owner's host is in
+    /// `[sync] server_peers`, or `sync pull <owner>`) before anything materializes.
+    pub fn sync_subscribe(&self, owner_account_hex: &str) -> anyhow::Result<()> {
+        crate::memory_write::set_subscription_owner(
+            self.storage.connection(),
+            owner_account_hex,
+            rag_rat_base::time::now_ms(),
+        )
+    }
+
+    /// The active repo's configured foreign memory owner, if any — what `sync whoami` reports
+    /// alongside this store's account id.
+    pub fn sync_owner_config(&self) -> anyhow::Result<crate::memory_write::RepoOwnerConfig> {
+        crate::memory_write::repo_owner_config(self.storage.connection())
+    }
+
     /// Re-wrap the active repo stream's existing live keys to an already-effective enrolled device.
     /// This authors same-key siblings only; it does not enroll, pair, transport, or rotate keys.
     pub fn sync_catch_up(

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -218,6 +218,59 @@ pub(super) fn contribution_owner_account(
     Ok(Some(rag_rat_oplog::AccountId::from_hex(&hex)?))
 }
 
+/// The `repo_meta` key holding the account this repo MIRRORS read-only (set by `sync subscribe`,
+/// #1156). Absent = this repo mirrors its own account's stream.
+///
+/// Read-only is the whole difference from [`CONTRIBUTION_OWNER_META_KEY`]: a subscriber authors
+/// nothing onto the owner's stream, so it needs no Writer grant, and it is never pulled FROM, so
+/// its own streams may stay private. Its own memories keep going to its OWN stream — only the drain
+/// re-points.
+const SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
+
+pub(super) fn subscription_owner_account(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<Option<rag_rat_oplog::AccountId>> {
+    let Some(hex) = rag_rat_db::meta::repo_meta(conn, repo_id, SUBSCRIPTION_OWNER_META_KEY)? else {
+        return Ok(None);
+    };
+    Ok(Some(rag_rat_oplog::AccountId::from_hex(&hex)?))
+}
+
+/// Every owner account this store SUBSCRIBES to. Unlike [`contribution_targets`] the repo id is not
+/// carried: a subscription authors nothing and is never served, so the account is all the
+/// foreign-pull enumeration — its only consumer — needs.
+pub(crate) fn subscription_owners(
+    conn: &Connection,
+) -> anyhow::Result<Vec<rag_rat_oplog::AccountId>> {
+    let mut out = Vec::new();
+    for repo_id in rag_rat_db::schema::real_repo_ids(conn)? {
+        out.extend(subscription_owner_account(conn, &repo_id)?);
+    }
+    Ok(out)
+}
+
+/// The active repo's configured FOREIGN memory owner, for `sync whoami`. At most one field is set —
+/// contribution and subscription both re-point the repo's one authoritative stream, so configuring
+/// the second is refused.
+#[derive(Debug, Default)]
+pub struct RepoOwnerConfig {
+    pub contribution_owner_account_id: Option<String>,
+    pub subscription_owner_account_id: Option<String>,
+}
+
+pub(crate) fn repo_owner_config(conn: &Connection) -> anyhow::Result<RepoOwnerConfig> {
+    let Some(repo_id) = memory_repo_scope(conn)? else {
+        return Ok(RepoOwnerConfig::default());
+    };
+    let hex =
+        |account: rag_rat_oplog::AccountId| rag_rat_base::hash::hex_lower(&account.to_bytes());
+    Ok(RepoOwnerConfig {
+        contribution_owner_account_id: contribution_owner_account(conn, &repo_id)?.map(hex),
+        subscription_owner_account_id: subscription_owner_account(conn, &repo_id)?.map(hex),
+    })
+}
+
 /// Whether this repo authors as a granted CONTRIBUTOR — an owner is configured and it is not this
 /// store's own account. A light check (no grant lookup) so `backfill_memory_oplog` can cheaply skip
 /// the owner-only establish/reconcile path; the grant is required (and its absence errors) later,
@@ -306,6 +359,14 @@ pub(crate) fn set_contribution_owner(
     {
         anyhow::bail!("sync contribute requires a stable repo identity (not legacy or local-only)");
     }
+    if let Some(subscribed) = subscription_owner_account(conn, &repo_id)? {
+        anyhow::bail!(
+            "repo `{repo_id}` already subscribes to account {} — subscription and contribution \
+             both re-point the ONE stream that materializes this repo's memories, so only one can \
+             be configured. Contribute from a separate index",
+            rag_rat_base::hash::hex_lower(&subscribed.to_bytes()),
+        );
+    }
     let owner = rag_rat_oplog::AccountId::from_hex(owner_account_hex)?;
     let local = rag_rat_oplog::local_account(conn, now_ms)?;
     anyhow::ensure!(
@@ -347,6 +408,75 @@ pub(crate) fn set_contribution_owner(
     // removal anti-joins that clear whatever the OUTGOING stream materialized. Re-pointing back
     // at a previously-drained owner would otherwise short-circuit on a watermark that is still
     // current and leave the other owner's memories in place.
+    let stream = rag_rat_oplog::owner_stream_v2_id_for_account(
+        &repo_id,
+        owner,
+        rag_rat_oplog::AccessMode::PublicRead,
+    )?;
+    rag_rat_oplog::clear_content_drain_watermark(&tx, stream)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Configure the ACTIVE repo to MIRROR `owner_account_hex`'s published memories, read-only
+/// (`sync subscribe`, #1156): record the owner id so this repo's memory tables materialize from the
+/// owner's stream instead of its own.
+///
+/// The two guards `sync contribute` carries deliberately do NOT apply here, because both exist only
+/// because a contributor AUTHORS content the owner must later fetch. A subscriber writes nothing to
+/// the owner's stream, so it needs no Writer grant; and it is only ever the puller, never pulled
+/// from, so whether its own streams are private is irrelevant. What it shares with contribution is
+/// the re-point itself: the owner's stream REPLACES this repo's own as its one authoritative
+/// content stream (see `drain::authoritative_content_stream`), so while subscribed this repo stops
+/// draining its own account's stream and sibling-device sync for it pauses. This store's own
+/// memories keep being authored onto its OWN stream and stay `origin='local'`, which the drain's
+/// synced-only removal anti-joins spare.
+pub(crate) fn set_subscription_owner(
+    conn: &Connection,
+    owner_account_hex: &str,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let repo_id =
+        memory_repo_scope(conn)?.context("sync subscribe requires an active repo scope")?;
+    if repo_id == rag_rat_base::repo_identity::LEGACY_REPO_ID
+        || repo_id.starts_with(rag_rat_base::repo_identity::LOCAL_ONLY_ID_PREFIX)
+    {
+        anyhow::bail!("sync subscribe requires a stable repo identity (not legacy or local-only)");
+    }
+    // Refuse rather than supersede: silently clearing a contribution would discard the Writer-grant
+    // setup behind it and leave already-authored contributions looking unconfigured, which the
+    // operator has to notice rather than have decided for them.
+    if let Some(contributing) = contribution_owner_account(conn, &repo_id)? {
+        anyhow::bail!(
+            "repo `{repo_id}` already contributes its memories to account {} — contribution and \
+             subscription both re-point the ONE stream that materializes this repo's memories, so \
+             only one can be configured. A contributor already reads the owner's memories back; \
+             subscribe from a separate index to mirror a different one",
+            rag_rat_base::hash::hex_lower(&contributing.to_bytes()),
+        );
+    }
+    let owner = rag_rat_oplog::AccountId::from_hex(owner_account_hex)?;
+    let local = rag_rat_oplog::local_account(conn, now_ms)?;
+    anyhow::ensure!(
+        owner != local,
+        "cannot subscribe to your own account — this repo already mirrors its own stream (the \
+         owner is a SEPARATE identity, its id from the owner's `sync whoami`)"
+    );
+
+    let canonical = rag_rat_base::hash::hex_lower(&owner.to_bytes());
+
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    anyhow::ensure!(
+        memory_repo_scope(&tx)?.as_deref() == Some(repo_id.as_str()),
+        "active repo scope changed while starting sync subscribe; retry"
+    );
+    rag_rat_db::meta::set_repo_meta(&tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)?;
+    // This repo's AUTHORITATIVE content stream just changed — forget the incoming stream's drain
+    // watermark so the next drain makes a FULL pass, for the same reason `set_contribution_owner`
+    // does: only a full pass runs the removal anti-joins that clear what the OUTGOING stream
+    // materialized, and re-subscribing to a previously-drained owner would otherwise short-circuit
+    // on a watermark that is still current.
     let stream = rag_rat_oplog::owner_stream_v2_id_for_account(
         &repo_id,
         owner,

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -362,8 +362,10 @@ fn grantee_context(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<Gr
 /// Run TWICE by each setter: once before the transaction, so this specific conflict is what the
 /// operator is told about rather than a later, blunter guard; and again INSIDE it, because the two
 /// setters read what the other writes — checked only outside, two concurrent configures each
-/// observe the other's absence and commit, leaving BOTH keys set. Nothing could then clear that:
-/// each setter refuses on account of the other, and the drain silently prefers contribution.
+/// observe the other's absence and commit, leaving BOTH keys set, which neither setter could then
+/// correct (each refuses on account of the other) and which the drain resolves silently in
+/// contribution's favor. Both setters open `BEGIN IMMEDIATE`, so the in-transaction read serializes
+/// them; the outside one only buys the better message.
 fn ensure_no_subscription_configured(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
     if let Some(subscribed) = subscription_owner_account(conn, repo_id)? {
         anyhow::bail!(
@@ -420,24 +422,7 @@ pub(crate) fn set_contribution_owner(
         "cannot contribute to your own account — the owner is a SEPARATE identity (its id from \
          the owner's `sync whoami`)"
     );
-    // A contributor is reachable only while its account is publicly servable: content is served by
-    // its AUTHOR account and the owner is not enrolled here, so if this account holds ANY private
-    // stream the owner can never pull what this store authors — the contributions would be
-    // authored, accepted on the owner's stream, and permanently unreachable.
-    //
-    // Refuse at configure time rather than let it fail invisibly later. A control log cannot be
-    // served as a subset (it is one hash chain), so there is no way to expose the roster while
-    // withholding the private stream metadata; a dedicated store is the only correct answer.
-    // `sync publish` guards the same property for OWNERS, but a contributor never publishes, so
-    // that check never runs on this path.
-    anyhow::ensure!(
-        rag_rat_oplog::account_is_fully_public(conn, local)?,
-        "this account owns private memory streams (from other repos in this index), so a granted \
-         owner could never fetch what you contribute — an account is servable to a peer only when \
-         all of its streams are public, and a control log cannot be served in part. Contribute \
-         from a dedicated index instead: `rag-rat init --database <path-to-a-fresh-index>` in \
-         this checkout, then run `sync contribute` there"
-    );
+    ensure_contributor_account_is_servable(conn, local)?;
 
     let canonical = rag_rat_base::hash::hex_lower(&owner.to_bytes());
 
@@ -448,7 +433,13 @@ pub(crate) fn set_contribution_owner(
         "active repo scope changed while starting sync contribute; retry"
     );
     ensure_no_subscription_configured(&tx, &repo_id)?;
-    repoint_authoritative_content_stream(&tx, &repo_id, |tx| {
+    // Re-read UNDER the write lock, like the conflict guard above and for the same reason: read
+    // only outside, a memory write in a SECOND repo of this index can establish that repo's
+    // private stream (`ensure_owner_stream` takes its own IMMEDIATE lock) between this check and
+    // the commit, and contribute would win the race into exactly the contributing-plus-private
+    // state `ensure_owner_stream` exists to forbid.
+    ensure_contributor_account_is_servable(&tx, local)?;
+    repoint_authoritative_content_stream(&tx, &repo_id, StreamResolution::Strict, |tx| {
         rag_rat_db::meta::set_repo_meta(tx, &repo_id, CONTRIBUTION_OWNER_META_KEY, &canonical)
             .map_err(Into::into)
     })?;
@@ -456,7 +447,42 @@ pub(crate) fn set_contribution_owner(
     Ok(())
 }
 
-/// Apply `repoint` — the write that changes which stream
+/// A contributor is reachable only while its account is publicly servable: content is served by its
+/// AUTHOR account and the owner is not enrolled here, so if this account holds ANY private stream
+/// the owner can never pull what this store authors — the contributions would be authored, accepted
+/// on the owner's stream, and permanently unreachable.
+///
+/// Refuse at configure time rather than let it fail invisibly later. A control log cannot be served
+/// as a subset (it is one hash chain), so there is no way to expose the roster while withholding
+/// the private stream metadata; a dedicated store is the only correct answer. `sync publish` guards
+/// the same property for OWNERS, but a contributor never publishes, so that check never runs on
+/// this path.
+fn ensure_contributor_account_is_servable(
+    conn: &Connection,
+    local: rag_rat_oplog::AccountId,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        rag_rat_oplog::account_is_fully_public(conn, local)?,
+        "this account owns private memory streams (from other repos in this index), so a granted \
+         owner could never fetch what you contribute — an account is servable to a peer only when \
+         all of its streams are public, and a control log cannot be served in part. Contribute \
+         from a dedicated index instead: `rag-rat init --database <path-to-a-fresh-index>` in \
+         this checkout, then run `sync contribute` there"
+    );
+    Ok(())
+}
+
+/// How a re-point resolves the streams whose drain watermarks it forgets.
+enum StreamResolution {
+    /// A SETTER: an unreadable owner key is a state the configure must not write over silently.
+    Strict,
+    /// A CLEAR: the unreadable owner key is precisely what is being removed, and a side that
+    /// cannot resolve had no stream to drain in the first place. Best-effort resolution is what
+    /// keeps the recovery command usable in the one state that needs it.
+    BestEffort,
+}
+
+/// Apply `repoint` — the CONFIGURATION write that changes which stream
 /// [`super::drain::authoritative_content_stream`] names for `repo_id` — and forget the drain
 /// watermark of the stream on BOTH sides of it.
 ///
@@ -469,16 +495,29 @@ pub(crate) fn set_contribution_owner(
 ///
 /// Both sides resolve through the drain's own helper, so the two can never disagree about which
 /// stream the re-point moved away from.
+///
+/// [`enable_public_authoring`] also moves the repo's authoritative stream (Private ⇒ PublicRead)
+/// without coming through here. That path is watermark-safe on its own: it refuses unless the
+/// account is fully public, so the outgoing Private stream is one nothing was ever authored or
+/// ingested onto and it holds no synced rows to condemn.
 fn repoint_authoritative_content_stream(
     tx: &Transaction<'_>,
     repo_id: &str,
+    resolution: StreamResolution,
     repoint: impl FnOnce(&Transaction<'_>) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
-    if let Some(outgoing) = super::drain::authoritative_content_stream(tx, repo_id)? {
+    let resolve = |tx: &Transaction<'_>| -> anyhow::Result<Option<StreamId>> {
+        let resolved = super::drain::authoritative_content_stream(tx, repo_id);
+        match resolution {
+            StreamResolution::Strict => resolved,
+            StreamResolution::BestEffort => Ok(resolved.ok().flatten()),
+        }
+    };
+    if let Some(outgoing) = resolve(tx)? {
         rag_rat_oplog::clear_content_drain_watermark(tx, outgoing)?;
     }
     repoint(tx)?;
-    if let Some(incoming) = super::drain::authoritative_content_stream(tx, repo_id)? {
+    if let Some(incoming) = resolve(tx)? {
         rag_rat_oplog::clear_content_drain_watermark(tx, incoming)?;
     }
     Ok(())
@@ -527,7 +566,7 @@ pub(crate) fn set_subscription_owner(
         "active repo scope changed while starting sync subscribe; retry"
     );
     ensure_no_contribution_configured(&tx, &repo_id)?;
-    repoint_authoritative_content_stream(&tx, &repo_id, |tx| {
+    repoint_authoritative_content_stream(&tx, &repo_id, StreamResolution::Strict, |tx| {
         rag_rat_db::meta::set_repo_meta(tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)
             .map_err(Into::into)
     })?;
@@ -545,8 +584,12 @@ pub(crate) fn set_subscription_owner(
 /// removal recoverable: the own stream's watermark is forgotten, so the next drain makes a full
 /// pass and re-materializes them from its projection. What does NOT come back is checkout-local
 /// binding work — `drain::seed_node_anchors` seeds only the author's published anchors, and only
-/// for a memory this store holds no bindings for, so a local `memory rebind` on a synced memory is
-/// lost with the row.
+/// for a memory this store holds no bindings for, so a `memory rebind` made here is lost with the
+/// row, as is any `origin='local'` edge that FK'd it.
+///
+/// Stream resolution here is BEST-EFFORT, unlike the setters': an owner key that will not parse is
+/// exactly what this command removes, and a side that cannot resolve had no stream to drain — a
+/// strict resolution would make the recovery command unusable in the state that most needs it.
 fn clear_foreign_owner(conn: &Connection, meta_key: &str, command: &str) -> anyhow::Result<bool> {
     let repo_id = memory_repo_scope(conn)?
         .with_context(|| format!("{command} requires an active repo scope"))?;
@@ -560,7 +603,7 @@ fn clear_foreign_owner(conn: &Connection, meta_key: &str, command: &str) -> anyh
     if rag_rat_db::meta::repo_meta(&tx, &repo_id, meta_key)?.is_none() {
         return Ok(false);
     }
-    repoint_authoritative_content_stream(&tx, &repo_id, |tx| {
+    repoint_authoritative_content_stream(&tx, &repo_id, StreamResolution::BestEffort, |tx| {
         rag_rat_db::meta::delete_repo_meta(tx, &repo_id, meta_key).map_err(Into::into)
     })?;
     tx.commit()?;
@@ -1134,24 +1177,54 @@ fn ensure_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow:
     // where the conflict is actually created, inside the same transaction that would create it.
     //
     // Yes, this means memory authoring in an unrelated private repo fails while this index
-    // contributes. That is the honest ordering: the alternative is authoring memories nobody can
-    // ever fetch and discovering it much later. The error names both escapes.
-    if mode != rag_rat_oplog::AccessMode::PublicRead {
-        let contributing = contribution_targets(&tx)?;
-        if let Some((contributing_repo, owner)) = contributing.first() {
-            anyhow::bail!(
-                "repo `{repo_id}` would need a PRIVATE memory stream, but this index contributes \
-                 repo `{contributing_repo}`'s memories to account {} — and an account is \
-                 fetchable by a peer only while all of its streams are public, so this would \
-                 strand those contributions unreachable. Index `{repo_id}` in a separate \
-                 database, or publish it with `rag-rat sync publish`",
-                rag_rat_base::hash::hex_lower(&owner.to_bytes()),
-            );
-        }
+    // contributes — or has ever contributed, since the authored entries outlive the configuration.
+    // That is the honest ordering: the alternative is authoring memories nobody can ever fetch and
+    // discovering it much later. The error names both escapes, and nothing is committed on the way
+    // out, so re-running `sync contribute` or publishing the repo unblocks it.
+    if mode != rag_rat_oplog::AccessMode::PublicRead
+        && let Some(cause) = private_stream_strands_contributions(&tx)?
+    {
+        anyhow::bail!(
+            "repo `{repo_id}` would need a PRIVATE memory stream, but this index {cause} — and an \
+             account is fetchable by a peer only while all of its streams are public, so this \
+             would strand those contributions unreachable. Index `{repo_id}` in a separate \
+             database, or publish it with `rag-rat sync publish`"
+        );
     }
     let stream = rag_rat_oplog::ensure_owned_stream_v2_with_mode_in_tx(&tx, repo_id, mode, now_ms)?;
     tx.commit()?;
     Ok(stream)
+}
+
+/// Why establishing a PRIVATE stream in this index would strand contributions, phrased as the
+/// middle of the refusal sentence — or `None` when nothing is at stake.
+///
+/// EVIDENCE outranks configuration, the same correction
+/// [`crate::sync_driver::account_is_public_kb`] makes on the serving side: `sync uncontribute` (or
+/// any other path that drops the meta row) clears the configured target, but the entries this
+/// account already authored onto the owner's PublicRead stream stay there, and the owner can fetch
+/// them only while this account owns no private stream. Keying the guard on configuration alone
+/// would let the unset open a door that a `StreamOwn` — append-only, never un-authorable — then
+/// closes forever.
+fn private_stream_strands_contributions(conn: &Connection) -> anyhow::Result<Option<String>> {
+    if let Some((contributing_repo, owner)) = contribution_targets(conn)?.first() {
+        return Ok(Some(format!(
+            "contributes repo `{contributing_repo}`'s memories to account {}",
+            rag_rat_base::hash::hex_lower(&owner.to_bytes()),
+        )));
+    }
+    // No local account ⇒ nothing was ever authored anywhere ⇒ nothing to strand.
+    let Some(account) = rag_rat_oplog::read_local_account(conn)? else {
+        return Ok(None);
+    };
+    let authored = rag_rat_oplog::authored_foreign_streams(conn, account)?;
+    if authored.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format!(
+        "has already authored memories onto {} stream(s) another account owns",
+        authored.len(),
+    )))
 }
 
 fn prepare_owner_authoring(

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -282,21 +282,36 @@ fn is_contribution_mode(conn: &Connection, repo_id: &str) -> anyhow::Result<bool
     Ok(rag_rat_oplog::read_local_account(conn)? != Some(owner))
 }
 
-/// Refuse `operation` when `repo_id` is configured to contribute to another account. Both
-/// operations that reconcile IMPORTED rows (legacy consolidation, `sync publish --seed`) need a
-/// stream this store owns, which a contributor does not have — and both are irreversible enough
-/// that continuing on a half-applied import is worse than stopping.
-pub(crate) fn ensure_not_contributing(
+/// Refuse `operation` when `repo_id`'s memories materialize from ANOTHER account's stream — either
+/// configuration reaches that state. Every operation that reconciles or imports rows into the repo
+/// (legacy consolidation, `sync publish --seed`, memory import) needs the repo's own stream to be
+/// the one [`super::drain::authoritative_content_stream`] honors: a contributor owns no such stream
+/// at all, and a subscriber's is not the authority, so the imported `origin='synced'` rows are
+/// condemned by the very next drain. All of them are irreversible enough that continuing on a
+/// half-applied import is worse than stopping.
+pub(crate) fn ensure_not_mirroring_another_account(
     conn: &Connection,
     repo_id: &str,
     operation: &str,
 ) -> anyhow::Result<()> {
+    let local = rag_rat_oplog::read_local_account(conn)?;
     if let Some(owner) = contribution_owner_account(conn, repo_id)?
-        && rag_rat_oplog::read_local_account(conn)? != Some(owner)
+        && local != Some(owner)
     {
         anyhow::bail!(
             "repo `{repo_id}` is configured to contribute memories to account {}, so it owns no \
              memory stream of its own — {operation} is not supported in contribution mode",
+            rag_rat_base::hash::hex_lower(&owner.to_bytes()),
+        );
+    }
+    if let Some(owner) = subscription_owner_account(conn, repo_id)?
+        && local != Some(owner)
+    {
+        anyhow::bail!(
+            "repo `{repo_id}` mirrors account {}'s memories read-only, so its memory tables \
+             materialize from that account's stream and rows imported here would be removed by \
+             the next drain — {operation} is not supported while subscribed. Run `sync \
+             unsubscribe` first",
             rag_rat_base::hash::hex_lower(&owner.to_bytes()),
         );
     }
@@ -342,6 +357,44 @@ fn grantee_context(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<Gr
     Ok(Some(GranteeContext { owner_account, stream, grant_id }))
 }
 
+/// Refuse a `sync contribute` on a repo that already subscribes.
+///
+/// Run TWICE by each setter: once before the transaction, so this specific conflict is what the
+/// operator is told about rather than a later, blunter guard; and again INSIDE it, because the two
+/// setters read what the other writes — checked only outside, two concurrent configures each
+/// observe the other's absence and commit, leaving BOTH keys set. Nothing could then clear that:
+/// each setter refuses on account of the other, and the drain silently prefers contribution.
+fn ensure_no_subscription_configured(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    if let Some(subscribed) = subscription_owner_account(conn, repo_id)? {
+        anyhow::bail!(
+            "repo `{repo_id}` already subscribes to account {} — subscription and contribution \
+             both re-point the ONE stream that materializes this repo's memories, so only one can \
+             be configured. Run `sync unsubscribe` first, or contribute from a separate index",
+            rag_rat_base::hash::hex_lower(&subscribed.to_bytes()),
+        );
+    }
+    Ok(())
+}
+
+/// Refuse a `sync subscribe` on a repo that already contributes — the twin of
+/// [`ensure_no_subscription_configured`], run at the same two points and for the same reasons.
+///
+/// Refuse rather than supersede: silently clearing a contribution would discard the Writer-grant
+/// setup behind it and leave already-authored contributions looking unconfigured, which the
+/// operator has to notice rather than have decided for them.
+fn ensure_no_contribution_configured(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    if let Some(contributing) = contribution_owner_account(conn, repo_id)? {
+        anyhow::bail!(
+            "repo `{repo_id}` already contributes its memories to account {} — contribution and \
+             subscription both re-point the ONE stream that materializes this repo's memories, so \
+             only one can be configured. Run `sync uncontribute` first, or subscribe from a \
+             separate index to mirror a different owner",
+            rag_rat_base::hash::hex_lower(&contributing.to_bytes()),
+        );
+    }
+    Ok(())
+}
+
 /// Configure the ACTIVE repo to contribute memories to `owner_account_hex` (paste flow, #1164):
 /// record the owner id so subsequent memory authoring targets the owner's stream via this account's
 /// Writer grant. Mints this store's local account (the identity the owner grants). Requires a
@@ -359,14 +412,7 @@ pub(crate) fn set_contribution_owner(
     {
         anyhow::bail!("sync contribute requires a stable repo identity (not legacy or local-only)");
     }
-    if let Some(subscribed) = subscription_owner_account(conn, &repo_id)? {
-        anyhow::bail!(
-            "repo `{repo_id}` already subscribes to account {} — subscription and contribution \
-             both re-point the ONE stream that materializes this repo's memories, so only one can \
-             be configured. Contribute from a separate index",
-            rag_rat_base::hash::hex_lower(&subscribed.to_bytes()),
-        );
-    }
+    ensure_no_subscription_configured(conn, &repo_id)?;
     let owner = rag_rat_oplog::AccountId::from_hex(owner_account_hex)?;
     let local = rag_rat_oplog::local_account(conn, now_ms)?;
     anyhow::ensure!(
@@ -401,20 +447,40 @@ pub(crate) fn set_contribution_owner(
         memory_repo_scope(&tx)?.as_deref() == Some(repo_id.as_str()),
         "active repo scope changed while starting sync contribute; retry"
     );
-    rag_rat_db::meta::set_repo_meta(&tx, &repo_id, CONTRIBUTION_OWNER_META_KEY, &canonical)?;
-    // This repo's AUTHORITATIVE content stream just changed (see
-    // `drain::authoritative_content_stream` — exactly one materializes the repo). Forget the
-    // incoming stream's drain watermark so the next drain makes a FULL pass: only that runs the
-    // removal anti-joins that clear whatever the OUTGOING stream materialized. Re-pointing back
-    // at a previously-drained owner would otherwise short-circuit on a watermark that is still
-    // current and leave the other owner's memories in place.
-    let stream = rag_rat_oplog::owner_stream_v2_id_for_account(
-        &repo_id,
-        owner,
-        rag_rat_oplog::AccessMode::PublicRead,
-    )?;
-    rag_rat_oplog::clear_content_drain_watermark(&tx, stream)?;
+    ensure_no_subscription_configured(&tx, &repo_id)?;
+    repoint_authoritative_content_stream(&tx, &repo_id, |tx| {
+        rag_rat_db::meta::set_repo_meta(tx, &repo_id, CONTRIBUTION_OWNER_META_KEY, &canonical)
+            .map_err(Into::into)
+    })?;
     tx.commit()?;
+    Ok(())
+}
+
+/// Apply `repoint` — the write that changes which stream
+/// [`super::drain::authoritative_content_stream`] names for `repo_id` — and forget the drain
+/// watermark of the stream on BOTH sides of it.
+///
+/// Only a FULL drain pass runs the removal anti-joins, and a watermark that is still current
+/// short-circuits the pass entirely. So the INCOMING stream's watermark must go, or the new
+/// authority materializes nothing; and the OUTGOING one's must go too, or the rows the re-point
+/// condemns are gone for good — re-pointing back would find its watermark current and restore
+/// nothing. Nothing drains a stream while it is not the authority, so clearing its watermark costs
+/// only the one full pass that a re-point back needs anyway.
+///
+/// Both sides resolve through the drain's own helper, so the two can never disagree about which
+/// stream the re-point moved away from.
+fn repoint_authoritative_content_stream(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    repoint: impl FnOnce(&Transaction<'_>) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    if let Some(outgoing) = super::drain::authoritative_content_stream(tx, repo_id)? {
+        rag_rat_oplog::clear_content_drain_watermark(tx, outgoing)?;
+    }
+    repoint(tx)?;
+    if let Some(incoming) = super::drain::authoritative_content_stream(tx, repo_id)? {
+        rag_rat_oplog::clear_content_drain_watermark(tx, incoming)?;
+    }
     Ok(())
 }
 
@@ -443,18 +509,7 @@ pub(crate) fn set_subscription_owner(
     {
         anyhow::bail!("sync subscribe requires a stable repo identity (not legacy or local-only)");
     }
-    // Refuse rather than supersede: silently clearing a contribution would discard the Writer-grant
-    // setup behind it and leave already-authored contributions looking unconfigured, which the
-    // operator has to notice rather than have decided for them.
-    if let Some(contributing) = contribution_owner_account(conn, &repo_id)? {
-        anyhow::bail!(
-            "repo `{repo_id}` already contributes its memories to account {} — contribution and \
-             subscription both re-point the ONE stream that materializes this repo's memories, so \
-             only one can be configured. A contributor already reads the owner's memories back; \
-             subscribe from a separate index to mirror a different one",
-            rag_rat_base::hash::hex_lower(&contributing.to_bytes()),
-        );
-    }
+    ensure_no_contribution_configured(conn, &repo_id)?;
     let owner = rag_rat_oplog::AccountId::from_hex(owner_account_hex)?;
     let local = rag_rat_oplog::local_account(conn, now_ms)?;
     anyhow::ensure!(
@@ -471,20 +526,57 @@ pub(crate) fn set_subscription_owner(
         memory_repo_scope(&tx)?.as_deref() == Some(repo_id.as_str()),
         "active repo scope changed while starting sync subscribe; retry"
     );
-    rag_rat_db::meta::set_repo_meta(&tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)?;
-    // This repo's AUTHORITATIVE content stream just changed — forget the incoming stream's drain
-    // watermark so the next drain makes a FULL pass, for the same reason `set_contribution_owner`
-    // does: only a full pass runs the removal anti-joins that clear what the OUTGOING stream
-    // materialized, and re-subscribing to a previously-drained owner would otherwise short-circuit
-    // on a watermark that is still current.
-    let stream = rag_rat_oplog::owner_stream_v2_id_for_account(
-        &repo_id,
-        owner,
-        rag_rat_oplog::AccessMode::PublicRead,
-    )?;
-    rag_rat_oplog::clear_content_drain_watermark(&tx, stream)?;
+    ensure_no_contribution_configured(&tx, &repo_id)?;
+    repoint_authoritative_content_stream(&tx, &repo_id, |tx| {
+        rag_rat_db::meta::set_repo_meta(tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)
+            .map_err(Into::into)
+    })?;
     tx.commit()?;
     Ok(())
+}
+
+/// Stop mirroring another account (`sync unsubscribe` / `sync uncontribute`): drop the configured
+/// owner so this repo's memories materialize from its OWN stream again. Returns whether a
+/// configuration was actually cleared.
+///
+/// The re-point that configured the owner REMOVED every `origin='synced'` row that arrived from
+/// this account's other devices — they are absent from the owner's projection, and the drain reads
+/// that as condemned. Going through [`repoint_authoritative_content_stream`] is what makes the
+/// removal recoverable: the own stream's watermark is forgotten, so the next drain makes a full
+/// pass and re-materializes them from its projection. What does NOT come back is checkout-local
+/// binding work — `drain::seed_node_anchors` seeds only the author's published anchors, and only
+/// for a memory this store holds no bindings for, so a local `memory rebind` on a synced memory is
+/// lost with the row.
+fn clear_foreign_owner(conn: &Connection, meta_key: &str, command: &str) -> anyhow::Result<bool> {
+    let repo_id = memory_repo_scope(conn)?
+        .with_context(|| format!("{command} requires an active repo scope"))?;
+
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    anyhow::ensure!(
+        memory_repo_scope(&tx)?.as_deref() == Some(repo_id.as_str()),
+        "active repo scope changed while starting {command}; retry"
+    );
+    if rag_rat_db::meta::repo_meta(&tx, &repo_id, meta_key)?.is_none() {
+        return Ok(false);
+    }
+    repoint_authoritative_content_stream(&tx, &repo_id, |tx| {
+        rag_rat_db::meta::delete_repo_meta(tx, &repo_id, meta_key).map_err(Into::into)
+    })?;
+    tx.commit()?;
+    Ok(true)
+}
+
+/// Stop mirroring a subscribed owner (`sync unsubscribe`).
+pub(crate) fn clear_subscription_owner(conn: &Connection) -> anyhow::Result<bool> {
+    clear_foreign_owner(conn, SUBSCRIPTION_OWNER_META_KEY, "sync unsubscribe")
+}
+
+/// Stop contributing to a configured owner (`sync uncontribute`). The owner's Writer grant is
+/// untouched — only this store's routing changes — and the contributions already authored onto the
+/// owner's stream stay there; this store keeps its own `origin='local'` copies of them.
+pub(crate) fn clear_contribution_owner(conn: &Connection) -> anyhow::Result<bool> {
+    clear_foreign_owner(conn, CONTRIBUTION_OWNER_META_KEY, "sync uncontribute")
 }
 
 fn explicit_stream_seal_policy(
@@ -1532,7 +1624,7 @@ pub(crate) fn reconcile_owner_stream_for_repo(
     //
     // (The live-write path skips silently instead, and correctly: `backfill_memory_oplog` has
     // nothing to reconcile because each mutation already authors onto the owner's stream.)
-    ensure_not_contributing(conn, repo_id, "importing memories into this repo")?;
+    ensure_not_mirroring_another_account(conn, repo_id, "importing memories into this repo")?;
     sync_owner_stream(conn, repo_id, now_ms)
 }
 

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -208,6 +208,17 @@ pub(crate) fn contribution_targets(
     Ok(out)
 }
 
+/// A configured owner key that will not parse — the ONE stream-resolution failure
+/// [`repoint_authoritative_content_stream`] tolerates. Attached as context so the parse error's own
+/// message survives in the chain, and so a genuine read failure (which carries no such context)
+/// stays distinguishable from it.
+#[derive(Debug, thiserror::Error)]
+#[error("repo `{repo_id}`'s `{meta_key}` is not a 64-hex account id")]
+struct UnparseableOwnerKey {
+    repo_id: String,
+    meta_key: &'static str,
+}
+
 pub(super) fn contribution_owner_account(
     conn: &Connection,
     repo_id: &str,
@@ -215,7 +226,13 @@ pub(super) fn contribution_owner_account(
     let Some(hex) = rag_rat_db::meta::repo_meta(conn, repo_id, CONTRIBUTION_OWNER_META_KEY)? else {
         return Ok(None);
     };
-    Ok(Some(rag_rat_oplog::AccountId::from_hex(&hex)?))
+    let owner = rag_rat_oplog::AccountId::from_hex(&hex).map_err(|err| {
+        err.context(UnparseableOwnerKey {
+            repo_id: repo_id.to_string(),
+            meta_key: CONTRIBUTION_OWNER_META_KEY,
+        })
+    })?;
+    Ok(Some(owner))
 }
 
 /// The `repo_meta` key holding the account this repo MIRRORS read-only (set by `sync subscribe`,
@@ -234,7 +251,13 @@ pub(super) fn subscription_owner_account(
     let Some(hex) = rag_rat_db::meta::repo_meta(conn, repo_id, SUBSCRIPTION_OWNER_META_KEY)? else {
         return Ok(None);
     };
-    Ok(Some(rag_rat_oplog::AccountId::from_hex(&hex)?))
+    let owner = rag_rat_oplog::AccountId::from_hex(&hex).map_err(|err| {
+        err.context(UnparseableOwnerKey {
+            repo_id: repo_id.to_string(),
+            meta_key: SUBSCRIPTION_OWNER_META_KEY,
+        })
+    })?;
+    Ok(Some(owner))
 }
 
 /// Every owner account this store SUBSCRIBES to. Unlike [`contribution_targets`] the repo id is not
@@ -477,8 +500,9 @@ enum StreamResolution {
     /// A SETTER: an unreadable owner key is a state the configure must not write over silently.
     Strict,
     /// A CLEAR: the unreadable owner key is precisely what is being removed, and a side that
-    /// cannot resolve had no stream to drain in the first place. Best-effort resolution is what
-    /// keeps the recovery command usable in the one state that needs it.
+    /// cannot resolve had no stream to drain in the first place. Tolerating THAT — and only that,
+    /// see [`UnparseableOwnerKey`] — is what keeps the recovery command usable in the one state
+    /// that needs it.
     BestEffort,
 }
 
@@ -507,10 +531,24 @@ fn repoint_authoritative_content_stream(
     repoint: impl FnOnce(&Transaction<'_>) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     let resolve = |tx: &Transaction<'_>| -> anyhow::Result<Option<StreamId>> {
-        let resolved = super::drain::authoritative_content_stream(tx, repo_id);
-        match resolution {
-            StreamResolution::Strict => resolved,
-            StreamResolution::BestEffort => Ok(resolved.ok().flatten()),
+        match super::drain::authoritative_content_stream(tx, repo_id) {
+            Ok(stream) => Ok(stream),
+            // Tolerate the ONE failure the unset is itself the cure for. Every other error is real
+            // and must roll the command back: skipping a watermark clear on a read failure loses
+            // the clear silently, and on the INCOMING side that watermark is the stream the repo
+            // moves BACK to — the clear that makes the memories the re-point removed reappear.
+            Err(err)
+                if matches!(resolution, StreamResolution::BestEffort)
+                    && err.downcast_ref::<UnparseableOwnerKey>().is_some() =>
+            {
+                tracing::warn!(
+                    repo_id,
+                    error = format!("{err:#}"),
+                    "skipping a drain-watermark clear: the configured owner key does not parse",
+                );
+                Ok(None)
+            },
+            Err(err) => Err(err),
         }
     };
     if let Some(outgoing) = resolve(tx)? {
@@ -1184,28 +1222,43 @@ fn ensure_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow:
     if mode != rag_rat_oplog::AccessMode::PublicRead
         && let Some(cause) = private_stream_strands_contributions(&tx)?
     {
-        anyhow::bail!(
+        return Err(PrivateStreamRefusal(format!(
             "repo `{repo_id}` would need a PRIVATE memory stream, but this index {cause} — and an \
              account is fetchable by a peer only while all of its streams are public, so this \
              would strand those contributions unreachable. Index `{repo_id}` in a separate \
              database, or publish it with `rag-rat sync publish`"
-        );
+        ))
+        .into());
     }
     let stream = rag_rat_oplog::ensure_owned_stream_v2_with_mode_in_tx(&tx, repo_id, mode, now_ms)?;
     tx.commit()?;
     Ok(stream)
 }
 
+/// The refusal [`ensure_owner_stream`] raises rather than establish a PRIVATE stream that would
+/// strand contributions. Typed, not a bare `bail!`, because this is a stream-establishment POLICY:
+/// it belongs on the paths where a user is asking for a memory write, and the INDEX-MAINTENANCE
+/// seam that shares the same reconcile ([`heal_memory_oplog_ghosts`]) recognizes it and skips.
+/// Left as an opaque error there, an ordinary `sync uncontribute` would fail `rag-rat reconcile`,
+/// every watcher pass, and `rag-rat index` — with no ghost to heal in the first place.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct PrivateStreamRefusal(String);
+
 /// Why establishing a PRIVATE stream in this index would strand contributions, phrased as the
 /// middle of the refusal sentence — or `None` when nothing is at stake.
 ///
-/// EVIDENCE outranks configuration, the same correction
-/// [`crate::sync_driver::account_is_public_kb`] makes on the serving side: `sync uncontribute` (or
-/// any other path that drops the meta row) clears the configured target, but the entries this
-/// account already authored onto the owner's PublicRead stream stay there, and the owner can fetch
-/// them only while this account owns no private stream. Keying the guard on configuration alone
-/// would let the unset open a door that a `StreamOwn` — append-only, never un-authorable — then
-/// closes forever.
+/// EVIDENCE outranks configuration for the streams this account has ALREADY authored onto: `sync
+/// uncontribute` (or any other path that drops the meta row) clears the configured target, but
+/// those entries stay on the owner's PublicRead stream, and the owner can fetch them only while
+/// this account owns no private stream. Keyed on configuration alone, the unset would open a door
+/// that a `StreamOwn` — append-only, never un-authorable — then closes forever.
+///
+/// Each authored stream is put through the same servability check the serving side applies
+/// ([`crate::sync_driver::contribution_stream_is_servable`]), so the refusal fires exactly when
+/// something real is at stake. Authorship the owner has since revoked strands nothing — its pull
+/// already cannot reach this account for that stream — and blocking on it would be a permanent
+/// refusal with no recourse.
 fn private_stream_strands_contributions(conn: &Connection) -> anyhow::Result<Option<String>> {
     if let Some((contributing_repo, owner)) = contribution_targets(conn)?.first() {
         return Ok(Some(format!(
@@ -1217,13 +1270,21 @@ fn private_stream_strands_contributions(conn: &Connection) -> anyhow::Result<Opt
     let Some(account) = rag_rat_oplog::read_local_account(conn)? else {
         return Ok(None);
     };
-    let authored = rag_rat_oplog::authored_foreign_streams(conn, account)?;
-    if authored.is_empty() {
+    let mut still_servable = 0usize;
+    for stream in rag_rat_oplog::authored_foreign_streams(conn, account)? {
+        let Some(owner) = rag_rat_oplog::stream_owner_account(conn, stream)? else {
+            continue;
+        };
+        if crate::sync_driver::contribution_stream_is_servable(conn, owner, stream, account)? {
+            still_servable += 1;
+        }
+    }
+    if still_servable == 0 {
         return Ok(None);
     }
     Ok(Some(format!(
-        "has already authored memories onto {} stream(s) another account owns",
-        authored.len(),
+        "has already authored memories onto {still_servable} stream(s) another account owns and \
+         can still serve"
     )))
 }
 
@@ -1667,6 +1728,28 @@ pub(crate) fn backfill_memory_oplog(conn: &Connection, now_ms: i64) -> anyhow::R
         return Ok(());
     }
     sync_owner_stream(conn, &repo_id, now_ms)
+}
+
+/// [`backfill_memory_oplog`] as INDEX MAINTENANCE runs it — after an embedding reconcile, on every
+/// watcher pass, on every `rag-rat index` — where nobody asked for a memory write.
+///
+/// The one difference is the stream-establishment refusal ([`PrivateStreamRefusal`]): an
+/// ex-contributor still owes the owner a public account, so it provably has no owner stream and
+/// never will until it publishes or re-contributes. Propagating that here would fail the whole
+/// pass, with zero ghosts required — the refusal belongs on the authoring paths, which keep it.
+/// Any OTHER error is a real failure and still propagates.
+pub(crate) fn heal_memory_oplog_ghosts(conn: &Connection, now_ms: i64) -> anyhow::Result<()> {
+    match backfill_memory_oplog(conn, now_ms) {
+        Err(err) if err.downcast_ref::<PrivateStreamRefusal>().is_some() => {
+            tracing::warn!(
+                error = format!("{err:#}"),
+                "skipping the memory op-log ghost heal; memory authoring in this repo stays \
+                 refused until it is published or contributing again",
+            );
+            Ok(())
+        },
+        other => other,
+    }
 }
 
 /// Reconcile a SPECIFIC repo's owner stream independent of connection scope — the seam

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -97,11 +97,15 @@ impl DrainOutcome {
 /// granted contributor authors nothing onto its own owner stream, which would sit empty and
 /// condemn everything the owner's stream materialized. A read-only subscription (#1156) replaces it
 /// for the same reason, with the extra consequence that a subscribed repo stops draining its own
-/// account's stream — sibling-device sync for it pauses while the subscription is configured.
+/// account's stream: every `origin='synced'` row its SIBLING DEVICES put there is absent from the
+/// owner's projection, so the next drain REMOVES it. That is why both setters (and both unsetters)
+/// clear the OUTGOING stream's watermark as well as the incoming one — re-pointing back must
+/// re-materialize what the re-point condemned rather than short-circuit on a watermark that is
+/// still current.
 ///
 /// Scope-gated the same way the reconcile is — a LEGACY placeholder or a `local:` shallow-clone id
 /// can never root an owner stream, so both yield `None`.
-fn authoritative_content_stream(
+pub(super) fn authoritative_content_stream(
     conn: &Connection,
     repo_id: &str,
 ) -> anyhow::Result<Option<StreamId>> {
@@ -119,8 +123,12 @@ fn authoritative_content_stream(
     // memories live — and a read-only SUBSCRIBER (#1156) mirrors a published owner without
     // authoring onto it. A configured owner that IS this store is neither; fall through to the
     // local derivation.
-    let foreign_owner = super::authoring::contribution_owner_account(conn, repo_id)?
-        .or(super::authoring::subscription_owner_account(conn, repo_id)?);
+    // Lazily: a contributing repo must not pay for the subscription lookup on every drain, and a
+    // corrupt `memory_subscription_owner` value must not error a drain that never consults it.
+    let foreign_owner = match super::authoring::contribution_owner_account(conn, repo_id)? {
+        Some(owner) => Some(owner),
+        None => super::authoring::subscription_owner_account(conn, repo_id)?,
+    };
     if let Some(owner) = foreign_owner
         && rag_rat_oplog::read_local_account(conn)? != Some(owner)
     {

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -12,8 +12,9 @@
 //! ONE AUTHORITATIVE STREAM PER REPO. Which stream that is comes from
 //! [`authoritative_content_stream`] and there is never more than one: the removal anti-joins read
 //! "absent from this stream's projection" as "condemned", so a second stream materializing into the
-//! same repo would delete the first's rows. A granted contributor (#1164) therefore REPLACES its
-//! local derivation with the configured owner's stream rather than draining both.
+//! same repo would delete the first's rows. A granted contributor (#1164) and a read-only
+//! subscriber (#1156) therefore REPLACE the local derivation with the configured owner's stream
+//! rather than draining both — and a repo may hold at most one of those two configurations.
 //!
 //! CONVERGE, DON'T FREEZE. The accepted `/3` projection is the LWW-merged content across ALL of the
 //! account's devices, INCLUDING this one — so when another device updates or removes a memory/edge
@@ -94,7 +95,9 @@ impl DrainOutcome {
 /// then not restore them (each stream's watermark says it is up to date). So contribution mode
 /// (#1164) does not ADD the owner's stream to this repo's drain, it REPLACES the local one: a
 /// granted contributor authors nothing onto its own owner stream, which would sit empty and
-/// condemn everything the owner's stream materialized.
+/// condemn everything the owner's stream materialized. A read-only subscription (#1156) replaces it
+/// for the same reason, with the extra consequence that a subscribed repo stops draining its own
+/// account's stream — sibling-device sync for it pauses while the subscription is configured.
 ///
 /// Scope-gated the same way the reconcile is — a LEGACY placeholder or a `local:` shallow-clone id
 /// can never root an owner stream, so both yield `None`.
@@ -110,29 +113,18 @@ fn authoritative_content_stream(
     {
         return Ok(None);
     }
-    // A granted CONTRIBUTOR reads back the CONFIGURED owner's stream — where its own writes went
-    // and where the owner's and other contributors' memories live. A configured owner that IS this
-    // store is not contribution mode; fall through to the local derivation.
-    if let Some(owner) = super::authoring::contribution_owner_account(conn, repo_id)?
+    // A FOREIGN owner replaces the local derivation. Two configurations reach it, and a repo may
+    // hold at most one (both setters refuse the other): a granted CONTRIBUTOR (#1164) reads back
+    // the owner's stream — where its own writes went, and where the owner's and other contributors'
+    // memories live — and a read-only SUBSCRIBER (#1156) mirrors a published owner without
+    // authoring onto it. A configured owner that IS this store is neither; fall through to the
+    // local derivation.
+    let foreign_owner = super::authoring::contribution_owner_account(conn, repo_id)?
+        .or(super::authoring::subscription_owner_account(conn, repo_id)?);
+    if let Some(owner) = foreign_owner
         && rag_rat_oplog::read_local_account(conn)? != Some(owner)
     {
-        // Contribution targets the owner's PublicRead stream (v1 public only).
-        let stream = rag_rat_oplog::owner_stream_v2_id_for_account(
-            repo_id,
-            owner,
-            rag_rat_oplog::AccessMode::PublicRead,
-        )?;
-        // A DERIVED stream id is not yet an authority. `sync contribute` deliberately succeeds
-        // before the owner's log is synced (configure, then sync), and a mistyped owner id derives
-        // a stream that will never exist at all — in both cases the projection is EMPTY, and
-        // handing that to the drain would make the removal anti-joins condemn every synced row the
-        // repo currently reads. So authority begins only once the ownership fact has folded here.
-        // Until then this repo drains NOTHING: `None` rather than falling through to the local
-        // stream, whose own empty projection would condemn exactly the same rows.
-        if rag_rat_oplog::stream_owner_account(conn, stream)? != Some(owner) {
-            return Ok(None);
-        }
-        return Ok(Some(stream));
+        return verified_owner_stream(conn, repo_id, owner);
     }
     // Forward-derive the owner stream under the repo's access-mode intent — the SAME stream id the
     // live-write authored onto, so a published (PublicRead) repo drains its own public stream
@@ -141,6 +133,33 @@ fn authoritative_content_stream(
     // unstable scope).
     let mode = super::authoring::owner_stream_access_mode(conn, repo_id)?;
     rag_rat_oplog::owned_stream_v2_id_with_mode(conn, repo_id, mode)
+}
+
+/// `owner`'s stream for `repo_id`, but ONLY once the ownership fact has folded here.
+///
+/// A DERIVED stream id is not yet an authority. Both `sync contribute` and `sync subscribe`
+/// deliberately succeed before the owner's log is synced (configure, then sync), and a mistyped
+/// owner id derives a stream that will never exist at all — in both cases the projection is EMPTY,
+/// and handing that to the drain would make the removal anti-joins condemn every synced row the
+/// repo currently reads. So authority begins only once the ownership fact has folded here. Until
+/// then this repo drains NOTHING: `None` rather than falling through to the local stream, whose own
+/// empty projection would condemn exactly the same rows.
+///
+/// Both configurations target the owner's PublicRead stream (v1 public only).
+fn verified_owner_stream(
+    conn: &Connection,
+    repo_id: &str,
+    owner: rag_rat_oplog::AccountId,
+) -> anyhow::Result<Option<StreamId>> {
+    let stream = rag_rat_oplog::owner_stream_v2_id_for_account(
+        repo_id,
+        owner,
+        rag_rat_oplog::AccessMode::PublicRead,
+    )?;
+    if rag_rat_oplog::stream_owner_account(conn, stream)? != Some(owner) {
+        return Ok(None);
+    }
+    Ok(Some(stream))
 }
 
 /// Mirror a repo's accepted synced `/3` content into its local memory tables, from the one stream

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -2158,7 +2158,7 @@ mod tests {
 
         // The reconcile runs: the synced row is excluded from re-authoring (origin gate), and it is
         // also already in the projection, so nothing is appended to the immutable /3 log.
-        crate::memory_write::backfill_memory_oplog(&conn, 6_000).unwrap();
+        crate::memory_write::authoring::backfill_memory_oplog(&conn, 6_000).unwrap();
         assert_eq!(
             content_entry_count(&conn),
             entries_before,

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -17,11 +17,12 @@ mod edges;
 mod oracle_relocation_tests;
 
 pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory};
-// The scope-READING reconcile entry (#541): reconciles the active repo's owner stream, reading
-// the repo id from the connection scope and no-oping under an absent/unstable scope.
-// Re-exported so the index reconcile path (the idle-repo ghost backstop, #583) can name it
-// across the private module.
-pub(crate) use authoring::backfill_memory_oplog;
+// The scope-READING reconcile entry (#541) as index MAINTENANCE runs it: reconciles the active
+// repo's owner stream, reading the repo id from the connection scope, no-oping under an
+// absent/unstable scope, and skipping the stream-establishment refusal that must not fail a
+// maintenance pass. Re-exported so the index reconcile path (the idle-repo ghost backstop,
+// #583) can name it across the private module.
+pub(crate) use authoring::heal_memory_oplog_ghosts;
 pub(crate) use authoring::{
     RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, catch_up_enrolled_device_keys,
     clear_contribution_owner, clear_subscription_owner, enable_public_authoring,

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -23,14 +23,16 @@ pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory}
 // across the private module.
 pub(crate) use authoring::backfill_memory_oplog;
 pub(crate) use authoring::{
-    RepoGrantListing, RepoRevokeReport, catch_up_enrolled_device_keys, enable_public_authoring,
-    enable_sealed_authoring, grant_repo_writer, list_repo_grants, published_grant_target,
-    revoke_repo_writer, set_contribution_owner,
+    RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, catch_up_enrolled_device_keys,
+    enable_public_authoring, enable_sealed_authoring, grant_repo_writer, list_repo_grants,
+    published_grant_target, repo_owner_config, revoke_repo_writer, set_contribution_owner,
+    set_subscription_owner,
 };
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::{
     contribution_targets, ensure_not_contributing, reconcile_owner_stream_for_repo,
+    subscription_owners,
 };
 // The synced-content drain entries (#691 A1): the per-repo drain (consolidate) and the
 // store-global drain (open/migrate) that materialize accepted synced `/3` content into the

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -24,14 +24,14 @@ pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory}
 pub(crate) use authoring::backfill_memory_oplog;
 pub(crate) use authoring::{
     RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, catch_up_enrolled_device_keys,
-    enable_public_authoring, enable_sealed_authoring, grant_repo_writer, list_repo_grants,
-    published_grant_target, repo_owner_config, revoke_repo_writer, set_contribution_owner,
-    set_subscription_owner,
+    clear_contribution_owner, clear_subscription_owner, enable_public_authoring,
+    enable_sealed_authoring, grant_repo_writer, list_repo_grants, published_grant_target,
+    repo_owner_config, revoke_repo_writer, set_contribution_owner, set_subscription_owner,
 };
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::{
-    contribution_targets, ensure_not_contributing, reconcile_owner_stream_for_repo,
+    contribution_targets, ensure_not_mirroring_another_account, reconcile_owner_stream_for_repo,
     subscription_owners,
 };
 // The synced-content drain entries (#691 A1): the per-repo drain (consolidate) and the

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -926,13 +926,16 @@ async fn reconcile(
 /// * each configured contribution owner — this store authors onto the owner's stream and needs the
 ///   owner's log for authority plus the owner's content for read-back;
 /// * each effective writer grantee of this account — the grantee's contributions sit on THIS
-///   account's streams but only a session scoped to the GRANTEE's account carries them.
+///   account's streams but only a session scoped to the GRANTEE's account carries them;
+/// * each subscribed owner (#1156) — a read-only mirror is pull-only, and without its account here
+///   a subscription would be configured but never fetch anything.
 fn foreign_pull_targets(
     conn: &Connection,
     local: rag_rat_oplog::AccountId,
 ) -> anyhow::Result<Vec<rag_rat_oplog::AccountId>> {
     let mut targets: Vec<rag_rat_oplog::AccountId> =
         crate::memory_write::contribution_targets(conn)?.into_iter().map(|(_, o)| o).collect();
+    targets.extend(crate::memory_write::subscription_owners(conn)?);
     targets.extend(rag_rat_oplog::effective_writer_grantees(conn, local)?);
     targets.sort_unstable_by_key(|target| target.to_bytes());
     targets.dedup();
@@ -1685,6 +1688,31 @@ mod tests {
         )
         .unwrap();
         assert_eq!(foreign_pull_targets(&store, local).unwrap().len(), 2);
+    }
+
+    /// A read-only SUBSCRIBER (#1156) is pull-only: it authors nothing and is never served, so
+    /// nothing but this enumeration would ever fetch the owner's account — a subscription missing
+    /// here is configured but permanently empty.
+    #[test]
+    fn a_subscribed_owner_is_a_foreign_pull_target() {
+        let store = schema_conn();
+        let local = rag_rat_oplog::local_account(&store, 1_000).unwrap();
+        store
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+                 ('repo-a','a',0)",
+                [],
+            )
+            .unwrap();
+        let owner = rag_rat_oplog::AccountId::from_bytes([0x55; 32]);
+        rag_rat_db::meta::set_repo_meta(
+            &store,
+            "repo-a",
+            "memory_subscription_owner",
+            &hash::hex_lower(&owner.to_bytes()),
+        )
+        .unwrap();
+        assert_eq!(foreign_pull_targets(&store, local).unwrap(), vec![owner]);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -419,7 +419,11 @@ pub fn account_is_public_kb(
 /// AUTHORED-evidence one: the owner's ownership fact must be synced and declare `PublicRead`
 /// (`stream_access_mode` fails closed to `Private` when it is not), and the grant must still be
 /// effective.
-fn contribution_stream_is_servable(
+///
+/// Shared with [`crate::memory_write`]'s private-stream guard, which must block on exactly the
+/// authorship this predicate says is still reachable — otherwise it refuses a store whose
+/// contributions the owner already cannot pull, permanently and with no recourse.
+pub(crate) fn contribution_stream_is_servable(
     conn: &Connection,
     owner: rag_rat_oplog::AccountId,
     stream: rag_rat_oplog::StreamId,


### PR DESCRIPTION
Adds the read-only half of cross-account memory mirroring.

## Problem

`sync contribute` is the only way to mirror another account's memories today, and it is the write-side flow: it requires a Writer grant from the owner and a fully-public local account. Both guards exist because a contributor authors content the owner must later fetch. Someone who only wants to *read* a published knowledge base had no path — and the `sync pull` help was steering them at `sync contribute`, which needs a grant they may never get.

## What this adds

`rag-rat sync subscribe <owner-account-hex>` records the owner in repo meta and re-points the repo's authoritative content stream at the owner's published stream.

It **replaces** the local derivation rather than adding a second stream, exactly as contribution mode does. `memory_write/drain.rs` documents why: the removal anti-joins read "absent from this stream's projection" as "condemned", and the drain watermark is per-stream, so two streams materializing into one repo would delete each other's rows and then not restore them.

Neither contribution guard applies here, and dropping them is principled rather than a relaxation:

- **No Writer grant** — a subscriber authors nothing onto the owner's stream.
- **No fully-public local account** — a subscriber is only ever the puller, never pulled from, so its own private streams are irrelevant.

Correspondingly, subscribe does **not** re-point authoring: this store's memories keep going to its own stream and stay `origin='local'`, which the drain's synced-only removal anti-joins spare. Covered by `a_subscribers_own_memories_go_to_its_own_stream_and_survive_the_mirror`.

The authority gate is shared with contribution and extracted into `verified_owner_stream`: a derived stream id becomes the drain's authority only once the owner's ownership fact has folded locally. A mistyped owner id or a not-yet-synced owner log drains nothing (`Ok(None)`) rather than handing an empty projection to the anti-joins.

## Trade-off, stated in the UI

While subscribed, a repo no longer drains its own account's stream, so its other devices' memories stop arriving. This is inherent to the one-authoritative-stream-per-repo invariant and already precedented by contribution mode. It is stated in the command's long help and in its output note.

Contribution and subscription both re-point that one stream, so configuring the second is **refused** rather than silently superseding the first — superseding would discard a Writer-grant setup the operator should have to notice. Both directions are tested.

## Wiring

- `foreign_pull_targets` now enumerates subscribed owners, so automatic sync fetches them on the same cadence as contribution owners. Without this a subscription is configured but never fetches anything.
- `sync whoami` reports the configured contribution or subscription owner.

## Also in this change

Two `sync pull` messages that no longer described reality:

- The success note claimed synced memories "will not attach as drive-by context". Anchor snapshots now replicate and `seed_node_anchors` seeds them, so they do attach wherever they resolve locally. The new text says so and names the limits (`call_path` and `chunk` bindings are not seeded; seeding is per-memory and only when this store holds no bindings for it; an anchor that does not resolve against this checkout attaches nowhere).
- The "nothing materialized" note told every reader to run `sync contribute`. It now offers `sync subscribe` for read-only mirroring and keeps `contribute` for people who intend to author back, noting that one needs a grant.

The block comment above the drain call, which enumerated the directions the drain covers, is updated to include subscription.

## Tests

New, each verified by breaking the production code it covers and confirming that test — and only that test — fails:

- `a_subscriber_mirrors_a_published_owner_without_a_grant_or_a_public_account`
- `a_subscribers_own_memories_go_to_its_own_stream_and_survive_the_mirror`
- `an_unsynced_or_mistyped_subscription_owner_never_becomes_removal_authority`
- `subscription_and_contribution_refuse_to_coexist`
- `subscribing_to_your_own_account_is_refused`
- `sync_driver::tests::a_subscribed_owner_is_a_foreign_pull_target`
- `cli::tests::sync_subscribe_parses`

Not an index or worktree-overlay change: it routes repo-scoped memory-stream configuration and the `/3` drain, neither of which reads worktree state, so no worktree regression coverage is added.

Verified: `cargo clippy --workspace --all-targets` with and without default features, the two per-package feature-gated clippy runs, `cargo nextest run --workspace --no-default-features --locked`, `cargo test --workspace --no-default-features --locked`, and `cargo +nightly fmt` — all clean.
