### PR TITLE
test(oracle): pin that a namespace answers only when it bounds the token

### DIFF
--- a/crates/rag-rat-oracle/src/join.rs
+++ b/crates/rag-rat-oracle/src/join.rs
@@ -9,9 +9,10 @@
 //!
 //! Containment alone is too generous to decide by, though, because the ranges that contain a token
 //! nest: a segment, the item declaring it, and the module around both. The join takes the TIGHTEST
-//! containing occurrence and never considers a namespace one at all — a module is not something a
-//! call or a type reference can resolve to, so matching one means SCIP had no answer here, not that
-//! it named a different target.
+//! containing occurrence, and admits a namespace one only where it bounds the token exactly — a
+//! module merely spanning the token is what the token sits inside, not something a call or a type
+//! reference resolves to, so matching one means SCIP had no answer here rather than that it named a
+//! different target.
 
 use super::scip::{ScipIndex, ScipOccurrence};
 use super::store::SymbolSpan;

--- a/crates/rag-rat-oracle/src/tests/resolution.rs
+++ b/crates/rag-rat-oracle/src/tests/resolution.rs
@@ -315,3 +315,88 @@ fn decl_and_def_of_same_logical_symbol_is_confirm_not_contradiction() {
     assert_eq!(report.confirmed, 1);
     assert_eq!(report.contradicted, 0, "same logical symbol is not a contradiction");
 }
+
+/// A namespace occurrence answers for an edge when it BOUNDS the callee token, and is ignored when
+/// it merely contains it.
+///
+/// Width is the whole rule. A module spanning far past the token is the thing the token sits
+/// inside, and judging an edge against it manufactured a disagreement with a symbol no heuristic
+/// arm could produce. But a namespace CAN be the referent: TypeScript emits a `references_type`
+/// edge for `ns.f()` whose callee range is the receiver node itself, so a DECLARED `namespace ns`
+/// — which carries a definition occurrence over its own name — answers for that receiver.
+///
+/// The `import * as ns` variant is deliberately NOT modelled here. Its per-file symbol carries a
+/// synthetic zero-width `0..0` definition, which resolves by containment to whichever symbol
+/// happens to span byte 0 — a defect downstream of this rule, in definition mapping rather than
+/// occurrence selection (#1246).
+///
+/// The edge here carries the shape TypeScript emits — name-only, unresolved — so the counterfactual
+/// the wide case rules out is a spurious UPGRADE onto the namespace. The contradictions #1223
+/// measured need an edge the heuristic already resolved; either way the recorded target is a module
+/// no call can reach.
+///
+/// Both halves are pinned at RUN level rather than over the selector alone: no declared corpus
+/// produces a namespace verdict — rxjs's `src/internal` carries namespace imports in one re-export
+/// file and declares no `namespace` block — so a regression in either direction survives the corpus
+/// suite (#1234).
+#[test]
+fn a_namespace_occurrence_answers_only_when_it_bounds_the_token() {
+    // scip-typescript's spelling for a module: the trailing `/` descriptor.
+    const NAMESPACE: &str = "scip-typescript npm demo 1.0 `src/m.ts`/ns/";
+
+    /// One run over `function caller() { ns.f(); }`, with the namespace occurrence at
+    /// `occ_start..occ_end`. Returns the verdict written for the receiver edge and the id of the
+    /// namespace symbol it should have resolved to.
+    fn verdict_for(occ_start: i32, occ_end: i32) -> (Option<(String, Option<i64>, String)>, i64) {
+        let h = Harness::new();
+        let caller = h.add_file("caller.ts", "function caller() { ns.f(); }\n");
+        let defs = h.add_file("m.ts", "namespace ns {}\n");
+        // The declaration's own name spans bytes 10..12 ("ns") in m.ts.
+        let ns_sym = h.add_symbol(defs, "ns", 10, 12);
+        // The whole `namespace ns {}` block contains that definition too. The answer has to be the
+        // name it declares, not the enclosing block that merely spans it.
+        h.add_symbol(defs, "block", 0, 15);
+        // The receiver token `ns` sits at bytes 20..22 — the shape TypeScript emits, where the
+        // callee range is the receiver node rather than the whole path.
+        let edge = h.add_edge_with_kind(caller, "ns", 20, 22, "references_type", "NameOnly", None);
+
+        let bytes =
+            scip_bytes("caller.ts", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+                occurrence(
+                    0,
+                    occ_start,
+                    occ_end,
+                    NAMESPACE,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                ),
+            ]);
+        let mut full = Index::parse_from_bytes(&bytes).unwrap();
+        full.documents.push(Document {
+            relative_path: "m.ts".to_string(),
+            occurrences: vec![occurrence(0, 10, 12, NAMESPACE, SymbolRole::Definition as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        });
+        let bytes = full.write_to_bytes().unwrap();
+
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+        (h.verdict(edge), ns_sym)
+    }
+
+    let (verdict, ns_sym) = verdict_for(20, 22);
+    let (kind, resolved, scip) =
+        verdict.expect("a namespace naming the token itself is the referent");
+    assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
+    assert_eq!(scip, NAMESPACE, "the verdict cites the namespace it resolved through");
+    // Citing the namespace is not enough: a definition-mapping regression can cite it while
+    // resolving to whatever symbol happens to sit at the definition's offset (#1246).
+    assert_eq!(resolved, Some(ns_sym), "and resolves to the declaration itself");
+
+    // The same symbol spanning the whole statement is context, not an answer.
+    assert!(
+        verdict_for(0, 29).0.is_none(),
+        "a namespace merely containing the token yields no evidence at all",
+    );
+}


### PR DESCRIPTION
Width decides whether a SCIP namespace occurrence is the referent of an edge or merely the module the token sits inside:

- **Bounding the token exactly** — it is the answer. TypeScript emits a `references_type` edge for `ns.f()` whose callee range is the receiver node itself, so a declared `namespace ns` — which carries a definition occurrence over its own name — answers for that receiver.
- **Spanning far past the token** — it is context. Judging an edge against it records a module as the compiler's target for a call no module can satisfy, which is what inflated the contradiction counter roughly sevenfold.

Neither direction was covered at run level, and the corpus suite cannot cover it.

## Why the corpora miss it

Measured over both available backends, with `KEEP_CHECKOUT=1` and the verdict rows queried directly:

| corpus | tool | edges | `edge_oracle` rows whose symbol ends in `/` |
|---|---|---|---|
| py-rich | scip-python | 8,383 | **0** |
| ts-rxjs | scip-typescript | 7,875 | **0** |

Both runs are healthy — py-rich precision 0.950 / recall 0.813, ts-rxjs 0.873 / 0.774 with `resolved_external` 2,534 against its 1,000 floor. The gap is coverage, not health.

The TypeScript miss is specific rather than accidental: rxjs's `src/internal` contains namespace imports in exactly one file (`umd.ts`, re-export plumbing) and declares no `namespace` blocks. The binding is `src/internal`, chosen to avoid the re-export surface — which is also where the pattern would live.

An earlier revision of this rule excluded namespace occurrences **unconditionally**. Both corpora pass identically either way, because neither ever admits a namespace occurrence — so no corpus run distinguishes the two rules. The unit tests over `find_containing_occurrence` do; what nothing covered is the rule as it behaves through a full pass.

To be precise about what that establishes: the *cost* of the unconditional rule is unmeasured, since no namespace verdict was observed anywhere. What is measured is the other half — judging edges against wider namespace occurrences inflated the contradiction count roughly sevenfold. The carve-out preserves verdicts the extractor can emit for a namespace receiver; this test is what makes that claim checkable rather than argued.

## The fixture

`a_namespace_occurrence_answers_only_when_it_bounds_the_token` drives a hand-written SCIP index through a full `run_oracle` pass — no toolchain, no clone, no network — and asserts both halves:

- a namespace bounding the callee token yields an `Upgrade` citing that symbol **and resolving to the declaration itself**;
- the same symbol widened to the whole statement yields **no verdict** at all.

The edge carries the shape TypeScript emits — name-only, unresolved — so the counterfactual the second assertion rules out is a spurious *upgrade* onto the namespace. The contradictions #1223 measured need an edge the heuristic already resolved; either way the recorded target is a module no call can reach.

Asserting the resolved symbol, not only the cited one, is load-bearing: a definition-mapping regression can cite the namespace while resolving to whatever symbol happens to sit at the definition's offset. That is not hypothetical — `import * as ns` does exactly that today, via scip-typescript's synthetic zero-width definition, which is why the fixture models a declared `namespace ns {}` and the import variant is tracked separately as #1246. The declaring block is indexed alongside the name it declares, so that assertion fails on its own rather than riding on the kind assertion above it.

It fails in both directions, each with its own diagnostic. Removing the exact-bounds carve-out loses the first assertion (`a namespace naming the token itself is the referent`); removing the module exclusion loses the second (`a namespace merely containing the token yields no evidence at all`). So neither half is carried by the other's implementation.

Run level rather than over the selector alone, because the unit tests on `find_containing_occurrence` already pin the selection rule — what was missing is that a namespace receiver survives the whole pipeline into a persisted verdict.

The module doc on the join still described the unconditional exclusion this rule replaced; it now states the exact-bounds carve-out, so the header and the predicate no longer disagree.

Fixes #1234.

