### PR TITLE
fix(build): decode fixed-size chunks as arrays, drop a redundant glob

### DIFF
--- a/crates/rag-rat-base/src/hash.rs
+++ b/crates/rag-rat-base/src/hash.rs
@@ -29,12 +29,12 @@ pub fn hex_nibble(byte: u8) -> Option<u8> {
 /// Decode an even-length hex string. `None` on an odd length or any non-hex byte; callers that
 /// need the failing position iterate [`hex_nibble`] themselves for the precise error.
 pub fn hex_decode(text: &str) -> Option<Vec<u8>> {
-    let bytes = text.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len() / 2);
-    for pair in bytes.chunks_exact(2) {
-        out.push(hex_nibble(pair[0])? << 4 | hex_nibble(pair[1])?);
+    let (pairs, remainder) = text.as_bytes().as_chunks::<2>();
+    let mut out = Vec::with_capacity(pairs.len());
+    for &[high, low] in pairs {
+        out.push(hex_nibble(high)? << 4 | hex_nibble(low)?);
     }
-    bytes.chunks_exact(2).remainder().is_empty().then_some(out)
+    remainder.is_empty().then_some(out)
 }
 
 /// Hex SHA-256 of a byte slice. This is the hash space of `files.sha256` (the indexer writes
@@ -43,4 +43,26 @@ pub fn hex_decode(text: &str) -> Option<Vec<u8>> {
 /// this function to stay in the same space.
 pub fn hex_sha256(bytes: &[u8]) -> String {
     hex_lower(&Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hex_decode, hex_lower};
+
+    /// Both halves of the round trip, plus the rejections the doc promises. `hex_decode` consumes
+    /// whole pairs and reports the leftover separately, so an odd length and a bad nibble must
+    /// both come back `None` rather than a short read.
+    #[test]
+    fn hex_decode_reads_whole_pairs_and_rejects_anything_else() {
+        assert_eq!(hex_decode("0a1bff"), Some(vec![0x0a, 0x1b, 0xff]));
+        assert_eq!(hex_decode(""), Some(vec![]));
+        assert_eq!(hex_decode("0A1BFF"), Some(vec![0x0a, 0x1b, 0xff]), "upper case decodes too");
+
+        assert_eq!(hex_decode("abc"), None, "an odd length is not a short read");
+        assert_eq!(hex_decode("zz"), None, "a non-hex byte fails the whole decode");
+        assert_eq!(hex_decode("00zz"), None, "including after a valid pair");
+
+        let bytes = [0x00, 0x7f, 0x80, 0xff];
+        assert_eq!(hex_decode(&hex_lower(&bytes)), Some(bytes.to_vec()));
+    }
 }

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -1158,8 +1158,8 @@ fn decode_node_secret(hex: &str) -> anyhow::Result<Zeroizing<[u8; 32]>> {
         bail!("persisted sync node secret is {} hex chars, expected 64", hex.len());
     }
     let mut out = Zeroizing::new([0u8; 32]);
-    for (i, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
-        match ((pair[0] as char).to_digit(16), (pair[1] as char).to_digit(16)) {
+    for (i, &[high, low]) in hex.as_bytes().as_chunks::<2>().0.iter().enumerate() {
+        match ((high as char).to_digit(16), (low as char).to_digit(16)) {
             (Some(hi), Some(lo)) => out[i] = ((hi << 4) | lo) as u8,
             _ => bail!("persisted sync node secret is not valid hex"),
         }

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -169,8 +169,8 @@ const INT8_QUANT_LEVELS: f32 = 127.0;
 pub(crate) fn decode_vector(blob: &[u8], dim: usize) -> Option<Vec<f32>> {
     if blob.len() == dim.checked_mul(4)? {
         let mut out = Vec::with_capacity(dim);
-        for bytes in blob.chunks_exact(4) {
-            out.push(f32::from_le_bytes(bytes.try_into().ok()?));
+        for &bytes in blob.as_chunks::<4>().0 {
+            out.push(f32::from_le_bytes(bytes));
         }
         return Some(out);
     }

--- a/crates/rag-rat-core/src/index/languages/c_family/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/edges.rs
@@ -1,5 +1,4 @@
 //! C and C++ graph-edge extraction for the shared structural edge walk.
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn c_like_edges(

--- a/crates/rag-rat-core/src/index/languages/go/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/go/edges.rs
@@ -22,7 +22,6 @@ use std::path::Path;
 use tree_sitter::Node;
 
 use super::super::{ReceiverFallback, ResolutionPolicy};
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn go_edges(

--- a/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
@@ -1,5 +1,4 @@
 //! Kotlin graph-edge extraction for the shared structural edge walk.
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn kotlin_edges(

--- a/crates/rag-rat-core/src/index/languages/python/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/python/edges.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn python_edges(

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -3,7 +3,6 @@
 use tree_sitter::Node;
 
 use super::{binders, dispatch};
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn rust_edges(

--- a/crates/rag-rat-core/src/index/languages/swift/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/edges.rs
@@ -3,7 +3,6 @@
 use tree_sitter::Node;
 
 use super::syntax;
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn swift_edges(

--- a/crates/rag-rat-core/src/index/languages/typescript/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/edges.rs
@@ -1,5 +1,4 @@
 //! TypeScript graph-edge extraction for the shared structural edge walk.
-use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(in crate::index::languages) fn typescript_edges(

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -1293,7 +1293,7 @@ fn decode_secret(encoded: &str) -> anyhow::Result<Zeroizing<[u8; 32]>> {
         ));
     }
     let mut secret = Zeroizing::new([0; 32]);
-    for (index, pair) in encoded.as_bytes().chunks_exact(2).enumerate() {
+    for (index, pair) in encoded.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         secret[index] = u8::from_str_radix(std::str::from_utf8(pair)?, 16)
             .map_err(|_| anyhow!("persisted sync node secret is not valid hex"))?;
     }

--- a/crates/rag-rat-db/src/content_digest.rs
+++ b/crates/rag-rat-db/src/content_digest.rs
@@ -114,11 +114,11 @@ pub fn decode_state(hex: &str) -> Result<DigestState, MalformedDigestState> {
         return Err(MalformedDigestState(format!("expected 64 hex chars, got {}", bytes.len())));
     }
     let mut raw = [0u8; 32];
-    for (out, chunk) in raw.iter_mut().zip(bytes.chunks_exact(2)) {
-        let hi = rag_rat_base::hash::hex_nibble(chunk[0])
-            .ok_or_else(|| MalformedDigestState(format!("non-hex byte {:#04x}", chunk[0])))?;
-        let lo = rag_rat_base::hash::hex_nibble(chunk[1])
-            .ok_or_else(|| MalformedDigestState(format!("non-hex byte {:#04x}", chunk[1])))?;
+    for (out, &[high, low]) in raw.iter_mut().zip(bytes.as_chunks::<2>().0) {
+        let hi = rag_rat_base::hash::hex_nibble(high)
+            .ok_or_else(|| MalformedDigestState(format!("non-hex byte {high:#04x}")))?;
+        let lo = rag_rat_base::hash::hex_nibble(low)
+            .ok_or_else(|| MalformedDigestState(format!("non-hex byte {low:#04x}")))?;
         *out = (hi << 4) | lo;
     }
     let mut lanes = [0u64; 4];

--- a/crates/rag-rat-oplog/src/account/discovery/mod.rs
+++ b/crates/rag-rat-oplog/src/account/discovery/mod.rs
@@ -214,7 +214,9 @@ fn parse_wraps(envelope: &[u8]) -> Option<Vec<SealedKeyWrap>> {
         return None;
     }
     Some(
-        rest.chunks_exact(WRAP_LEN)
+        rest.as_chunks::<WRAP_LEN>()
+            .0
+            .iter()
             .map(|chunk| {
                 let mut ephemeral_pubkey = [0u8; 32];
                 let mut ciphertext = [0u8; 48];

--- a/crates/rag-rat-oplog/src/account/id.rs
+++ b/crates/rag-rat-oplog/src/account/id.rs
@@ -45,11 +45,11 @@ impl AccountId {
             value.len()
         );
         let mut bytes = [0u8; 32];
-        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
-            let high = rag_rat_base::hash::hex_nibble(pair[0]).ok_or_else(|| {
+        for (index, &[hi, lo]) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
+            let high = rag_rat_base::hash::hex_nibble(hi).ok_or_else(|| {
                 anyhow::anyhow!("account id has invalid hex at position {}", index * 2)
             })?;
-            let low = rag_rat_base::hash::hex_nibble(pair[1]).ok_or_else(|| {
+            let low = rag_rat_base::hash::hex_nibble(lo).ok_or_else(|| {
                 anyhow::anyhow!("account id has invalid hex at position {}", index * 2 + 1)
             })?;
             bytes[index] = high << 4 | low;

--- a/crates/rag-rat-oplog/src/op.rs
+++ b/crates/rag-rat-oplog/src/op.rs
@@ -133,10 +133,10 @@ impl FromStr for DeviceFingerprint {
             return Err(ParseDeviceFingerprintError::Length { actual: value.len() });
         }
         let mut bytes = [0u8; 32];
-        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
-            let high = rag_rat_base::hash::hex_nibble(pair[0])
+        for (index, &[hi, lo]) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
+            let high = rag_rat_base::hash::hex_nibble(hi)
                 .ok_or(ParseDeviceFingerprintError::InvalidHex { index: index * 2 })?;
-            let low = rag_rat_base::hash::hex_nibble(pair[1])
+            let low = rag_rat_base::hash::hex_nibble(lo)
                 .ok_or(ParseDeviceFingerprintError::InvalidHex { index: index * 2 + 1 })?;
             bytes[index] = high << 4 | low;
         }

--- a/crates/rag-rat-sync/src/enrollment.rs
+++ b/crates/rag-rat-sync/src/enrollment.rs
@@ -1289,8 +1289,7 @@ fn replay_receipt(
                 .map(|entry| (entry.entry_hash, entry.signed_bytes))
                 .collect();
         let mut account_entries = Vec::with_capacity(manifest.len() / 32);
-        for hash in manifest.chunks_exact(32) {
-            let hash: [u8; 32] = hash.try_into().expect("chunked by 32");
+        for &hash in manifest.as_chunks::<32>().0 {
             let bytes = signed_by_hash.remove(&hash).ok_or_else(|| {
                 InviteError::Storage(anyhow::anyhow!(
                     "receipt entry missing from the candidate DAG"


### PR DESCRIPTION
Rust 1.98 (released 2026-08-18) fails the workspace on two new lints. `dtolnay/rust-toolchain@stable` picks it up automatically, so **every open branch is red** regardless of what it changes — `clippy`, `clippy (all features)`, and `eval (search-quality)` all fail on `main`'s code.

## `chunks_exact_to_as_chunks`

Nine call sites split a slice into fixed-width pieces with a constant width. `as_chunks::<N>()` returns `(&[[T; N]], &[T])`, so each piece arrives as an array with its length known statically, and the leftover is a separate value rather than something to ask for afterwards.

Three sites carried a fallible conversion back to an array that the new form makes unnecessary:

| site | went away |
|---|---|
| `rag-rat-sync/src/enrollment.rs` | `hash.try_into().expect("chunked by 32")` |
| `rag-rat-core/src/index/ai/helpers.rs` | `bytes.try_into().ok()?` per f32 lane |
| `rag-rat-db/src/content_digest.rs` | index-per-nibble, now a destructured pair |

The remaining sites destructure the pair (`&[high, low]`) instead of indexing it. `rag-rat-base`'s `hex_decode` also stops walking the input twice — it previously iterated `chunks_exact(2)` once for the pairs and again for `.remainder()`.

Behavior is unchanged at every site: each loop already ran behind an exact length check, so the whole-chunks half is the same set it iterated before.

## `unused_imports` through a re-export

All seven language extractors carry `use crate::index::edges::extract::*;`. Each also globs `crate::index::edges::*`, and `edges/mod.rs` line 12 is `pub(crate) use extract::*;` — so the second import re-exports the module wholesale and the direct one contributes no name that is not already in scope. 1.98 now sees this. The names still resolve after removal.

## Test

`hex_decode` had no direct test — it was covered only through its two callers, neither of which exercises a malformed input. Since this rewrites it, it lands with one that pins what the doc comment promises: an odd length and a non-hex byte both fail the whole decode rather than returning a short read. Verified to fail when the remainder check is dropped.

## Verification

All four CI clippy invocations, under 1.98:

```
cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings   → 0
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings          → 0
cargo clippy -p rag-rat-core -p rag-rat --no-default-features --features eval …         → 0
cargo clippy -p rag-rat-core -p rag-rat --features eval …                               → 0
cargo nextest run --workspace   → 5214 passed, 7 skipped
cargo +nightly fmt --check      → 0
```

MSRV is unaffected: `slice::as_chunks` stabilized in 1.88, well under the declared `rust-version = "1.96"`.
