### PR TITLE
fix(dispatch): decide a method chain on its root through `?`, `.await` and parens

### DIFF
--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -41,133 +41,76 @@ fn is_screaming_const_identifier(name: &str) -> bool {
         && characters.all(|character| is_xid_continue(character) && !character.is_lowercase())
 }
 
-/// A method identifier may carry leading underscores, but its first non-underscore character must
-/// be lowercase and the rest must remain within Rust's identifier boundaries. The field token
-/// comes directly from tree-sitter, so comments/whitespace around the member-access dot never
-/// affect this check.
-fn is_lowercase_method_identifier(name: &str) -> bool {
-    let name = name.strip_prefix("r#").unwrap_or(name).trim_start_matches('_');
-    let mut characters = name.chars();
-    characters.next().is_some_and(char::is_lowercase) && characters.all(is_xid_continue)
-}
-
-/// The innermost receiver of a method chain glued onto a call's callee — what the whole chain
-/// ultimately reads — plus whether every field crossed on the way was a lowercase METHOD. Both
-/// halves of the constant-chain decision need the same walk, and doing it once is what keeps them
-/// from disagreeing about the same expression (#1124 maintainer feedback).
-struct MethodChainRoot<'tree> {
-    receiver: Node<'tree>,
-    all_methods: bool,
+/// Peel the wrappers that sit between a method-chain link and the value it reads WITHOUT changing
+/// that value's identity: a turbofish (`generic_function`), a `?`, an `.await`, and redundant
+/// parentheses. A chain's role must not depend on which of these the source happens to spell —
+/// `POOL.get()?.execute(sql)`, `POOL.get().await.execute(sql)` and `POOL.get().execute(sql)` all
+/// glue `execute` onto the same produced value, so a guard that recognizes only the bare form
+/// hands the other two to the delegate fall-through and records the adapter (#1124).
+fn unwrap_transparent(node: Node<'_>) -> Node<'_> {
+    let mut current = unwrap_generic_function(node);
+    while matches!(
+        current.kind(),
+        "try_expression" | "await_expression" | "parenthesized_expression"
+    ) {
+        let Some(inner) = current.named_child(0) else {
+            return current;
+        };
+        current = unwrap_generic_function(inner);
+    }
+    current
 }
 
 /// Walk the Rust AST's nested `field_expression` nodes from the call's callee inward, following an
 /// intermediate `call_expression` only when its own callee is another field expression — a
 /// constructor/function-call root ends the walk there, because that call's RESULT is the value the
 /// rest of the chain adapts. `None` when the callee is not a method chain at all (a bare name, a
-/// path, a `Type::assoc` call). Insensitive to trivia and turbofish wrappers, so comments and
-/// generic arguments around the member-access dot cannot move a verdict.
-fn method_chain_root<'tree>(function: Node<'tree>, text: &str) -> Option<MethodChainRoot<'tree>> {
-    let mut current = unwrap_generic_function(function);
+/// path, a `Type::assoc` call). Insensitive to trivia and to every [`unwrap_transparent`] wrapper,
+/// so comments, generic arguments, `?` and `.await` around the member-access dot cannot move a
+/// verdict.
+fn method_chain_root(function: Node<'_>) -> Option<Node<'_>> {
+    let mut current = unwrap_transparent(function);
     if current.kind() != "field_expression" {
         return None;
     }
-    let mut all_methods = true;
     while current.kind() == "field_expression" {
-        let field = current.child_by_field_name("field")?;
-        all_methods &= is_lowercase_method_identifier(field.utf8_text(text.as_bytes()).ok()?);
-        let value = unwrap_generic_function(current.child_by_field_name("value")?);
+        let value = unwrap_transparent(current.child_by_field_name("value")?);
         if value.kind() != "call_expression" {
             current = value;
             continue;
         }
-        let inner_function = unwrap_generic_function(value.child_by_field_name("function")?);
+        let inner_function = unwrap_transparent(value.child_by_field_name("function")?);
         current = if inner_function.kind() == "field_expression" { inner_function } else { value };
     }
-    Some(MethodChainRoot { receiver: current, all_methods })
+    Some(current)
 }
 
-/// What a method chain's root receiver is, when it is a SCREAMING_SNAKE constant.
-enum ConstantReceiver {
-    /// Owned by a named TYPE — `Handler::DEFAULT`, `crate::ml::Handler::DEFAULT`,
-    /// `<Handler as Runner>::_DEFAULT`. Naming the owner is what makes the chained method the
-    /// dispatch, so the call delegates to that method.
-    TypeOwned,
-    /// Named on its own or through the MODULE it lives in — `LIMIT`, `crate::config::LIMIT`,
-    /// `self::LIMIT`, `super::config::LIMIT`, an aliased `cfg::LIMIT`. A module is not a receiver,
-    /// so the chained method adapts the constant's VALUE and is never the handler.
-    Unowned,
-}
-
-fn constant_receiver(receiver: Node<'_>, text: &str) -> Option<ConstantReceiver> {
-    match receiver.kind() {
-        "identifier" => is_screaming_const_identifier(receiver.utf8_text(text.as_bytes()).ok()?)
-            .then_some(ConstantReceiver::Unowned),
-        "scoped_identifier" => {
-            let name = receiver.child_by_field_name("name")?;
-            if !is_screaming_const_identifier(name.utf8_text(text.as_bytes()).ok()?) {
-                return None;
-            }
-            // A leading `::` names the crate root — a module, and never a type.
-            let Some(path) = receiver.child_by_field_name("path") else {
-                return Some(ConstantReceiver::Unowned);
-            };
-            Some(if qualifier_names_a_type(path, text) {
-                ConstantReceiver::TypeOwned
-            } else {
-                ConstantReceiver::Unowned
-            })
-        },
-        _ => None,
-    }
-}
-
-/// Whether a constant's qualifier names the TYPE that owns it rather than the MODULE it lives in.
-/// Rust's naming convention is the only extraction-time signal there is — type names begin with an
-/// uppercase character, module names do not, and `crate`/`self`/`super` are modules by definition —
-/// so the test is on the qualifier's LAST segment, which keeps the verdict independent of how long
-/// the path to it is (`Handler::DEFAULT` and `crate::a::b::Handler::DEFAULT` agree, as do `LIMIT`
-/// and `crate::a::b::LIMIT`). A bracketed UFCS qualifier (`<Handler as Runner>::DEFAULT`) names its
-/// type outright.
-fn qualifier_names_a_type(path: Node<'_>, text: &str) -> bool {
-    let Ok(raw) = path.utf8_text(text.as_bytes()) else {
+/// Whether the callee is a method chain whose ROOT receiver is a SCREAMING_SNAKE constant —
+/// `LIMIT.min(cap).max(..)`, `crate::config::BASE.to_string()`, `Handler::DEFAULT.run(..)`,
+/// `<Handler as Runner>::DEFAULT.run(..)`. Such a chain adapts the constant's VALUE, so it is never
+/// the handler.
+///
+/// The verdict is read off the root and nothing else. Whether the qualifier names the OWNING TYPE
+/// or the MODULE the constant lives in cannot be told apart at extraction time except by the case
+/// of a path segment, and that guess is wrong for an uppercase module, a type alias, and a
+/// bracketed UFCS qualifier — so making the two spellings disagree only moves the error around.
+/// It also would not help: `Resp::DEFAULT.with_body(handle(cap))` and
+/// `Handler::DEFAULT.run(normalize(input))` are the same expression modulo identifier spelling, so
+/// nothing in the AST distinguishes a builder from a dispatch. Under the false-edge-is-a-bug
+/// contract an undecidable case emits nothing (#1124).
+fn chain_root_is_constant(function: Node<'_>, text: &str) -> bool {
+    let Some(root) = method_chain_root(function) else {
         return false;
     };
-    let raw = raw.trim();
-    if raw.starts_with('<') {
-        return true;
-    }
-    let stripped = degeneric_path(raw);
-    scope_grammar::segments(&stripped)
-        .into_iter()
-        .map(str::trim)
-        .rfind(|segment| !segment.is_empty())
-        .is_some_and(|segment| {
-            let segment = segment.strip_prefix("r#").unwrap_or(segment);
-            segment.chars().next().is_some_and(char::is_uppercase)
-        })
-}
-
-/// Where a method chain glued onto a SCREAMING constant lands, or `None` when the callee is not
-/// such a chain.
-enum ConstantChain {
-    /// The chain adapts the constant's value — emit nothing.
-    AdapterTail,
-    /// The chain calls a method ON the constant — record that method.
-    Dispatch,
-}
-
-/// The ONE decision about a constant-rooted method chain, taken on the chain's ROOT (#1124
-/// maintainer feedback). The adapter verdict is read off the same root as the dispatch verdict, so
-/// there is no order in which one can claim an expression before the other, and no spelling of the
-/// root can route otherwise identical expressions to different verdicts.
-fn constant_method_chain(function: Node<'_>, text: &str) -> Option<ConstantChain> {
-    let root = method_chain_root(function, text)?;
-    match constant_receiver(root.receiver, text)? {
-        ConstantReceiver::Unowned => Some(ConstantChain::AdapterTail),
-        // A PascalCase field is a variant/constructor spelling, not a method call, so it is left to
-        // the qualifier fallbacks below rather than billed as a dispatch.
-        ConstantReceiver::TypeOwned => root.all_methods.then_some(ConstantChain::Dispatch),
-    }
+    let name = match root.kind() {
+        "identifier" => root,
+        "scoped_identifier" => match root.child_by_field_name("name") {
+            Some(name) => name,
+            None => return false,
+        },
+        _ => return false,
+    };
+    name.utf8_text(text.as_bytes()).is_ok_and(is_screaming_const_identifier)
 }
 
 /// The `Enum::Variant` dispatch key from a scoped path node — its last two `::`-segments when BOTH
@@ -706,19 +649,18 @@ fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<Strin
 
 /// How `result_handler_calls` treats a `call_expression` (#200/#208 — one classifier so the
 /// delegate/wrapper decision can't disagree with itself, as it did across review rounds):
-/// - `Delegate`: RECORD it as the handler (a free fn `run`, a method `self.embed`, a module-pathed
-///   fn `crate::ml::embed::embed_text`, or a method chain on a constant a TYPE owns
-///   (`Handler::DEFAULT.run(..)`) — the constant is the chained method's receiver).
+/// - `Delegate`: RECORD it as the handler (a free fn `run`, a method `self.embed`, or a
+///   module-pathed fn `crate::ml::embed::embed_text`).
 /// - `Wrapper`: a TRANSPARENT wrapper / variant constructor whose single argument IS the response —
 ///   `Ok`/`Some`, or ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`).
 ///   Trace its lone payload argument.
 /// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
 ///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), a
 ///   UFCS associated call (`<Resp as Default>::default()`), or an adapter tail glued onto another
-///   call's result or onto a SCREAMING constant no type owns — `LIMIT.min(cap).max(..)`,
-///   `crate::config::BASE.to_string()`, and every other spelling of that root — since it adapts a
-///   value, and recording the trailing method would bind it to an unrelated same-named symbol
-///   (#1124 maintainer feedback).
+///   call's result or onto a SCREAMING constant — `LIMIT.min(cap).max(..)`,
+///   `crate::config::BASE.to_string()`, `Handler::DEFAULT.with_body(..)`, and every other spelling
+///   of those roots — since it adapts a value, and recording the trailing method would bind it to
+///   an unrelated same-named symbol (#1124).
 ///
 /// Classification is by the path TAIL (constructor names are PascalCase; fns/methods are
 /// snake_case), which is receiver-agnostic — so `dto::Wrapped` and `Resp::Embedded` are both
@@ -754,22 +696,14 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
     let Some(tail) = segments.last() else {
         return CallRole::Delegate;
     };
-    // A method chain rooted at a SCREAMING constant is decided by that ROOT, in one place, before
-    // BOTH qualifier fallbacks: the leading-`<` UFCS early return and the PascalCase-receiver
-    // `Skip` below would otherwise bill `Handler::DEFAULT.run(..)` /
-    // `<Handler as Runner>::DEFAULT.run(..)` as an associated/constructor call (#1124 held
-    // feedback), and a separate later adapter guard let the module-pathed spelling of an adapter
-    // tail reach a different verdict than the bare one (#1124 maintainer feedback).
-    //
-    // When a TYPE owns the constant, the chained method is called ON it and delegates
-    // UNCONDITIONALLY: the argument shape says nothing, since
-    // `Resp::DEFAULT.with_body(handle(cap))` and `Handler::DEFAULT.run(normalize(input))` are the
-    // same expression modulo identifier spelling, so a nested-argument test cannot tell a builder
-    // from a dispatch and only picks which of the two loses its handler.
-    match constant_method_chain(function, text) {
-        Some(ConstantChain::AdapterTail) => return CallRole::Skip,
-        Some(ConstantChain::Dispatch) => return CallRole::Delegate,
-        None => {},
+    // A method chain rooted at a SCREAMING constant is decided by that ROOT, in one place, so no
+    // spelling of the path to the constant can route otherwise identical expressions to different
+    // verdicts. It runs before the segment fallbacks below because those read the callee's TEXT,
+    // where a chained method glued onto the constant lands in the tail segment
+    // (`crate::config::BASE.to_string` → tail `BASE.to_string`, receiver `config`) and reaches the
+    // bare-callee delegate fall-through (#1124).
+    if chain_root_is_constant(function, text) {
+        return CallRole::Skip;
     }
     // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
     // associated/constructor call — never a handler, and its arg (if any) isn't the response.
@@ -806,17 +740,18 @@ fn classify_call(call: Node<'_>, text: &str) -> CallRole {
 ///
 /// A method on a plain binding/`self`/field receiver (`worker.run`, `self.embed`) is a bare callee:
 /// that receiver holds the handler. A chain rooted at a SCREAMING constant never reaches here —
-/// [`constant_method_chain`] decides it earlier, on the root, so that `LIMIT.min(cap).max(..)` and
-/// `crate::config::LIMIT.min(cap).max(..)` cannot be answered differently.
+/// [`chain_root_is_constant`] decides it earlier, on the root, so that `LIMIT.min(cap).max(..)` and
+/// `crate::config::LIMIT.min(cap).max(..)` cannot be answered differently. The receiver is read
+/// through [`unwrap_transparent`], so `make_worker()?.run(x)` and `make_worker().run(x)` agree too.
 fn is_chained_adapter_tail(function: Node<'_>) -> bool {
-    let function = unwrap_generic_function(function);
+    let function = unwrap_transparent(function);
     if function.kind() != "field_expression" {
         return false;
     }
     let Some(value) = function.child_by_field_name("value") else {
         return false;
     };
-    unwrap_generic_function(value).kind() == "call_expression"
+    unwrap_transparent(value).kind() == "call_expression"
 }
 
 /// Whether a `scoped_identifier` sits in an expression VALUE position where a unit enum-variant is
@@ -1047,17 +982,31 @@ mod classify_call_tests {
             // The iterator-adapter chain the classifier was first written for.
             "TOOL_NAMES.iter().map(|name| describe(name))",
             "crate::tools::TOOL_NAMES.iter().map(|name| describe(name))",
-        ];
-        let delegate_forms = [
-            // A qualifier that names the OWNING TYPE is not a module path: the chained method is
-            // the dispatch, at any path depth and through a UFCS qualifier.
+            // A qualifier that names the OWNING TYPE is not distinguishable from a module path
+            // except by the case of a segment, and the case guess is wrong for an uppercase
+            // module, a type alias, and a bracketed UFCS qualifier. Both spellings skip.
             "Handler::DEFAULT.run(input)",
             "crate::ml::Handler::DEFAULT.run(input)",
             "crate::a::b::Handler::DEFAULT.build().run(input)",
             "<Handler as Runner>::DEFAULT.run(input)",
+            "<u32 as Bounded>::MAX.min(cap)",
+            "u32::MAX.min(cap)",
+            // A `?`, an `.await` or a paren between the links wraps a value without changing its
+            // identity — the same adapter, so the same verdict.
+            "LIMIT.min(cap)?.max(1)",
+            "crate::config::LIMIT.min(cap)?.max(1)",
+            "POOL.get(url).await.text()",
+            "(LIMIT.min(cap)).max(1)",
+            "(LIMIT).wrapping_mul(cap)",
+            "make_worker()?.run(input)",
+            "make_worker().await.run(input)",
+            "(make_worker()).run(input)",
+        ];
+        let delegate_forms = [
             // A bare callee keeps delegating whatever the receiver is called.
             "worker.run(input)",
             "self.embed(input)",
+            "self.worker.run(input)",
         ];
         let mut misclassified = Vec::new();
         misclassified
@@ -1068,36 +1017,17 @@ mod classify_call_tests {
         assert!(misclassified.is_empty(), "misclassified root spellings: {misclassified:?}");
     }
 
-    /// An associated-constant method chain is the dispatch itself, whatever its arguments hold
-    /// (#1124 maintainer feedback): the constant is the chained method's receiver, so the call
-    /// delegates to that method. Reading the ARGUMENT SHAPE to tell a dispatch from a builder
-    /// cannot work — `Resp::DEFAULT.with_body(handle(cap))` and
-    /// `Handler::DEFAULT.run(normalize(input))` are the same expression modulo spelling — so a
-    /// nested argument call no longer diverts the classification to `Wrapper`.
+    /// A method chain glued onto an ASSOCIATED CONSTANT records no handler (#1124), and no
+    /// spelling around the member-access dot changes that. Whether the qualifier names the owning
+    /// TYPE (`Handler::DEFAULT`) or the MODULE the constant lives in (`crate::config::LIMIT`) is
+    /// not decidable at extraction time except by the case of a path segment, and a builder
+    /// (`Resp::DEFAULT.with_body(handle(cap))`) is not decidable from a dispatch
+    /// (`Handler::DEFAULT.run(normalize(input))`) at all — the two are the same expression modulo
+    /// identifier spelling. Under the false-edge-is-a-bug contract an undecidable case emits
+    /// nothing. The verdicts are collected before asserting, so one failure names EVERY
+    /// misclassified form.
     #[test]
-    fn an_associated_constant_method_chain_always_delegates() {
-        assert!(matches!(role_of("Handler::DEFAULT.run(input)"), CallRole::Delegate));
-        assert!(matches!(role_of("<Handler as Runner>::DEFAULT.run(input)"), CallRole::Delegate));
-        // A nested argument call is argument shape, not classification evidence.
-        assert!(matches!(role_of("Handler::DEFAULT.run(normalize(input))"), CallRole::Delegate));
-        assert!(matches!(role_of("Resp::DEFAULT.with_body(handle(cap))"), CallRole::Delegate));
-        assert!(matches!(
-            role_of("<Resp as Build>::DEFAULT.with_body(handle(cap))"),
-            CallRole::Delegate
-        ));
-        // An intermediate call inside the chain still delegates to the final chained method.
-        assert!(matches!(role_of("Handler::DEFAULT.build().run(input)"), CallRole::Delegate));
-    }
-
-    /// A method chain glued onto an ASSOCIATED CONSTANT delegates to the chained method (#1124
-    /// held feedback): `Handler::DEFAULT.run(input)` calls `run` on the `DEFAULT` constant — the
-    /// constant is the receiver, not a constructor — so neither the PascalCase receiver (`Handler`)
-    /// nor a UFCS qualifier (`<Handler as Runner>`) may bill the call as an associated/constructor
-    /// call. The guards stay: an associated FN (`Handler::new`) configures rather than responds,
-    /// and a bare UFCS associated call (`<Resp as Default>::default()`) is a constructor. The
-    /// verdicts are collected before asserting, so one failure names EVERY misclassified form.
-    #[test]
-    fn an_associated_constant_method_chain_delegates_to_the_chained_method() {
+    fn an_associated_constant_method_chain_records_no_handler() {
         // Trivia is not part of Rust's token identity. Generate the same four semantic forms
         // through several legal spellings around the member-access dot, including comments and a
         // line break. The leading underscore is part of the SCREAMING_SNAKE convention, not a
@@ -1109,14 +1039,14 @@ mod classify_call_tests {
             "<Handler as Runner>::_DEFAULT",
         ];
         let trivia = [".", " . ", "\n .\n", " /* receiver */ . ", "\n /* receiver */\n .\t"];
-        let mut delegate_forms = Vec::new();
+        let mut chain_forms = Vec::new();
         for qualifier in qualifiers {
             for separator in trivia {
-                delegate_forms.push(format!("{qualifier}{separator}run(input)"));
+                chain_forms.push(format!("{qualifier}{separator}run(input)"));
             }
         }
         // A nested field chain and a turbofish must use the same token structure, too.
-        delegate_forms.extend([
+        chain_forms.extend([
             "Handler::DEFAULT . build.ship(input)".to_string(),
             "<Handler as Runner>::_DEFAULT /* receiver */ . run::<u8>(input)".to_string(),
             // A leading underscore is valid on a lowercase method as well as on the associated
@@ -1130,6 +1060,17 @@ mod classify_call_tests {
             "Handler::DEFAULT.build::<u8>().run::<u8>(input)".to_string(),
             "Handler::DEFAULT.combine(Other::DEFAULT).run(input)".to_string(),
             "<Handler as Runner>::DEFAULT.build().configure()._run::<u8>(input)".to_string(),
+            // A `?`, an `.await` or a paren between the links wraps a value without changing its
+            // identity, so it cannot hand the chain to the delegate fall-through.
+            "Handler::DEFAULT.build()?.run(input)".to_string(),
+            "Handler::DEFAULT.build().await.run(input)".to_string(),
+            "(Handler::DEFAULT.build()).run(input)".to_string(),
+            "Handler::DEFAULT.build()?.configure().await.run::<u8>(input)".to_string(),
+            // An argument that nests a produced call is argument shape, not evidence: a builder
+            // and a dispatch are indistinguishable here, so neither records anything.
+            "Handler::DEFAULT.run(normalize(input))".to_string(),
+            "Resp::DEFAULT.with_body(handle(cap))".to_string(),
+            "<Resp as Build>::DEFAULT.with_body(handle(cap))".to_string(),
             "<Handler as Runner>::_DEFAULT /* receiver */ . build /* call */ () /* between */ . \
              run::<u8>(input)"
                 .to_string(),
@@ -1154,9 +1095,9 @@ mod classify_call_tests {
         let wrapper_forms = ["Ok(body)", "Some(body)"];
         let mut misclassified = Vec::new();
         misclassified.extend(
-            delegate_forms
+            chain_forms
                 .iter()
-                .filter(|expression| !matches!(role_of(expression), CallRole::Delegate))
+                .filter(|expression| !matches!(role_of(expression), CallRole::Skip))
                 .map(String::as_str),
         );
         misclassified.extend(

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -407,14 +407,13 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // 17: a same-file declared return types a `let` binding under ANY callee name, not only
 // `new`/`default`, and a declared return carrying generic arguments declines instead of naming
 // itself; re-extract `receiver_type_hint_id` so deployed indexes gain the one and drop the other.
-// Also #1124 — dispatch handler classification reads only a segment's leading identifier with
-// Unicode XID continuation semantics, a method chain on a constant a TYPE owns
-// (`Handler::DEFAULT.run(..)`, `<Handler as Runner>::DEFAULT.run(..)`) delegates to its chained
-// method, and an adapter tail glued onto another call's result or onto a constant no type owns
-// records no handler at all — `LIMIT.min(cap).max(1)` and `crate::config::BASE.to_string()` alike,
-// since the chain's ROOT decides and its spelling does not; re-extract facts so existing indexes do
-// not retain the old wrapper/delegate decision.
-const GRAPH_INDEX_VERSION: &str = "17";
+// 18: #1124 — dispatch handler classification reads only a segment's leading identifier with
+// Unicode XID continuation semantics, and a method chain glued onto another call's result or onto
+// a SCREAMING constant records no handler at all — `LIMIT.min(cap).max(1)`,
+// `crate::config::BASE.to_string()` and `Handler::DEFAULT.with_body(..)` alike, since the chain's
+// ROOT decides and neither its spelling nor an intervening `?`/`.await` moves the verdict;
+// re-extract facts so existing indexes do not retain the old wrapper/delegate decision.
+const GRAPH_INDEX_VERSION: &str = "18";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag
 // on next open. Incremental discovery only rewrites a file row when its sha/language/kind changes —

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -1459,140 +1459,6 @@ pub mod b {
 }
 
 #[test]
-fn dispatch_persists_handle_facts_for_associated_constant_method_chains() {
-    // #1124 held feedback: a match arm delegating through an ASSOCIATED CONSTANT's method chain —
-    // `Handler::DEFAULT.run(input)` or the UFCS `<Handler as Runner>::DEFAULT.run(input)` — calls
-    // the chained METHOD: the constant is the receiver, not a constructor. Each form must persist
-    // a `dispatch_handle` fact to `run`; previously the first read as a PascalCase-receiver
-    // constructor and the second as a UFCS associated call, so neither fact existed.
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(root.join("src")).unwrap();
-    fs::write(
-        root.join("src/lib.rs"),
-        r#"
-pub enum Msg {
-    AssocConst { input: u8 },
-    AssocConstSpaced { input: u8 },
-    AssocConstCommented { input: u8 },
-    AssocConstUnderscore { input: u8 },
-    AssocConstLeadingMethod { input: u8 },
-    AssocConstCallInterrupted { input: u8 },
-    UfcsConst { input: u8 },
-    UfcsConstCommented { input: u8 },
-    UfcsConstUnderscore { input: u8 },
-}
-
-pub struct Handler;
-pub trait Runner {
-    const DEFAULT: Handler;
-    const _DEFAULT: Handler;
-    fn run(&self, input: u8);
-    fn _run(&self, input: u8);
-}
-impl Runner for Handler {
-    const DEFAULT: Handler = Handler;
-    const _DEFAULT: Handler = Handler;
-    fn run(&self, _input: u8) {}
-    fn _run(&self, _input: u8) {}
-}
-impl Handler {
-    pub const DEFAULT: Handler = Handler;
-    pub const _DEFAULT: Handler = Handler;
-    fn build(&self) -> Self { Self }
-    fn combine(&self, _other: Handler) -> Self { Self }
-}
-
-pub fn enqueue() {
-    send(Msg::AssocConst { input: 1 });
-    send(Msg::AssocConstSpaced { input: 2 });
-    send(Msg::AssocConstCommented { input: 3 });
-    send(Msg::AssocConstUnderscore { input: 4 });
-    send(Msg::AssocConstLeadingMethod { input: 5 });
-    send(Msg::AssocConstCallInterrupted { input: 6 });
-    send(Msg::UfcsConst { input: 5 });
-    send(Msg::UfcsConstCommented { input: 7 });
-    send(Msg::UfcsConstUnderscore { input: 8 });
-}
-fn send(_m: Msg) {}
-
-pub fn handle(m: Msg) {
-    match m {
-        Msg::AssocConst { input } => Handler::DEFAULT.run(input),
-        Msg::AssocConstSpaced { input } => Handler::DEFAULT
-            .run(input),
-        Msg::AssocConstCommented { input } => Handler::DEFAULT /* receiver */
-            .run(input),
-        Msg::AssocConstUnderscore { input } => Handler::_DEFAULT
-            .run(input),
-        Msg::AssocConstLeadingMethod { input } => Handler::DEFAULT._run(input),
-        Msg::AssocConstCallInterrupted { input } => Handler::DEFAULT
-            .build()
-            .run(input),
-        Msg::UfcsConst { input } => <Handler as Runner>::DEFAULT.run(input),
-        Msg::UfcsConstCommented { input } => <Handler as Runner>::DEFAULT /* receiver */
-            .run(input),
-        Msg::UfcsConstUnderscore { input } => <Handler as Runner>::_DEFAULT /* receiver */
-            .run(input),
-    }
-}
-"#,
-    )
-    .unwrap();
-    let config = source_config(root.clone(), Language::Rust);
-    let db = IndexDatabase::rebuild(&config).unwrap();
-    let conn = db.storage.connection();
-
-    let mut statement = conn
-        .prepare(
-            "SELECT tn.value, d.evidence FROM edges_data d
-             JOIN name_strings ek ON ek.id = d.edge_kind_id
-             JOIN name_strings tn ON tn.id = d.to_name_id
-             WHERE ek.value = 'dispatch_handle'",
-        )
-        .unwrap();
-    let handle_facts: Vec<(String, Option<String>)> = statement
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
-        .unwrap()
-        .collect::<Result<_, _>>()
-        .unwrap();
-
-    // Each associated-constant method-chain form persists a `dispatch_handle` edge to `run`,
-    // keyed by its own variant. Keep the row count independent from the per-variant assertions so
-    // deleting one assertion cannot make the regression test vacuously pass.
-    let expected_facts = [
-        ("Msg::AssocConst", "run"),
-        ("Msg::AssocConstSpaced", "run"),
-        ("Msg::AssocConstCommented", "run"),
-        ("Msg::AssocConstUnderscore", "run"),
-        ("Msg::AssocConstLeadingMethod", "_run"),
-        ("Msg::AssocConstCallInterrupted", "run"),
-        ("Msg::UfcsConst", "run"),
-        ("Msg::UfcsConstCommented", "run"),
-        ("Msg::UfcsConstUnderscore", "run"),
-    ];
-    let associated_chain_facts = handle_facts
-        .iter()
-        .filter(|(target, _)| expected_facts.iter().any(|(_, expected)| target == expected))
-        .count();
-    assert_eq!(
-        associated_chain_facts,
-        expected_facts.len(),
-        "every associated-constant form must persist exactly one dispatch_handle edge: \
-         {handle_facts:?}"
-    );
-    for (variant, target) in expected_facts {
-        assert!(
-            handle_facts.iter().any(|(actual_target, evidence)| actual_target == target
-                && evidence.as_deref() == Some(variant)),
-            "{variant} must persist a dispatch_handle edge to `{target}`: {handle_facts:?}"
-        );
-    }
-
-    let _ = fs::remove_dir_all(&root);
-}
-
-#[test]
 fn dispatch_suppresses_adapter_tails_end_to_end() {
     // #1124 maintainer feedback (HIGH): a standard-adapter tail computes a value — it is never the
     // dispatch handler. That covers a method glued onto ANOTHER CALL'S RESULT
@@ -1604,14 +1470,22 @@ fn dispatch_suppresses_adapter_tails_end_to_end() {
     // `rag-rat-core/src/index/consolidate.rs`).
     //
     // The role is fixed by the chain's ROOT, so every SPELLING of that root behaves the same: bare,
-    // `crate::`-qualified, `self::`/`super::`-relative, aliased, and an arbitrarily long module
-    // path each get their own arm and their own trailing method. A qualifier that names the OWNING
-    // TYPE is not a module path — `Handler::DEFAULT.run_handler(input)` is a real dispatch and is
-    // the second positive control, so a fix cannot pass by skipping everything.
+    // `crate::`-qualified, `self::`/`super::`-relative, aliased, an arbitrarily long module path,
+    // and a qualifier naming the OWNING TYPE (`Handler::DEFAULT.run_handler(input)`,
+    // `<Handler as Runner>::DEFAULT.run_handler(input)`) each get their own arm and their own
+    // trailing method. Type-owned and module-pathed cannot be told apart at extraction time except
+    // by the case of a path segment, and a builder (`Resp::DEFAULT.with_body(make_body(cap))`)
+    // cannot be told from a dispatch at all, so under the false-edge-is-a-bug contract both emit
+    // nothing.
+    //
+    // Nor may an intervening `?`, `.await`, or paren move a verdict: those wrap a value without
+    // changing its identity, so `LIMIT.min(cap)?.checked_shl(1)` adapts exactly what
+    // `LIMIT.min(cap).max(1)` does, and a guard that recognizes only the bare form hands the rest
+    // to the delegate fall-through.
     //
     // This fixture defines a same-named in-repo helper for EVERY adapter method, so a false edge
-    // cannot hide behind an unresolved name, and the two delegate arms prove the fixture CAN
-    // synthesize edges — the negative assertions are not vacuous.
+    // cannot hide behind an unresolved name, and the delegate arms prove the fixture CAN synthesize
+    // edges — the negative assertions are not vacuous.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -1630,9 +1504,16 @@ pub enum Msg {
     SuperRelative { cap: usize },
     RelativeDirect,
     TypeOwned { input: u8 },
+    UfcsTypeOwned { input: u8 },
+    TypeOwnedNested { cap: usize },
+    Fallible { cap: usize },
+    Awaited { cap: usize },
+    Parenthesized { cap: usize },
+    FallibleCall { cap: usize },
 }
 pub enum Resp { Wrap(usize), Text(String), Empty }
 const LIMIT: usize = 8;
+const POOL: usize = 4;
 const BASE: &str = "SELECT id FROM repo_memories";
 
 pub mod config {
@@ -1644,9 +1525,14 @@ pub mod config {
 use crate::config as cfg;
 
 pub struct Handler;
+pub trait Runner { const DEFAULT: Handler; }
 impl Handler {
     pub const DEFAULT: Handler = Handler;
     fn run_handler(&self, _input: u8) -> usize { 0 }
+    fn with_body(&self, _body: usize) -> usize { 0 }
+}
+impl Runner for Handler {
+    const DEFAULT: Handler = Handler;
 }
 
 pub fn enqueue() {
@@ -1661,6 +1547,12 @@ pub fn enqueue() {
     send(Msg::SuperRelative { cap: 7 });
     send(Msg::RelativeDirect);
     send(Msg::TypeOwned { input: 8 });
+    send(Msg::UfcsTypeOwned { input: 9 });
+    send(Msg::TypeOwnedNested { cap: 10 });
+    send(Msg::Fallible { cap: 11 });
+    send(Msg::Awaited { cap: 12 });
+    send(Msg::Parenthesized { cap: 13 });
+    send(Msg::FallibleCall { cap: 14 });
 }
 fn send(_m: Msg) {}
 
@@ -1677,6 +1569,14 @@ pub fn handle(m: Msg) {
         Msg::SelfRelative { cap } => Ok(Resp::Wrap(self::LIMIT.wrapping_mul(cap))),
         Msg::Aliased { cap } => Ok(Resp::Wrap(cfg::LIMIT.pow(cap))),
         Msg::TypeOwned { input } => Ok(Resp::Wrap(Handler::DEFAULT.run_handler(input))),
+        Msg::UfcsTypeOwned { input } => {
+            Ok(Resp::Wrap(<Handler as Runner>::DEFAULT.run_handler(input)))
+        }
+        Msg::TypeOwnedNested { cap } => Ok(Resp::Wrap(Handler::DEFAULT.with_body(make_body(cap)))),
+        Msg::Fallible { cap } => Ok(Resp::Wrap(LIMIT.min(cap)?.checked_shl(1))),
+        Msg::Awaited { cap } => Ok(Resp::Wrap(POOL.min(cap).await.count_ones())),
+        Msg::Parenthesized { cap } => Ok(Resp::Wrap((LIMIT.min(cap)).leading_zeros())),
+        Msg::FallibleCall { cap } => Ok(Resp::Wrap(batch_items(cap).len()?.trailing_zeros())),
         _ => Ok(Resp::Empty),
     }
 }
@@ -1703,6 +1603,11 @@ fn repeat(_value: &str, _times: usize) -> String { String::new() }
 fn wrapping_mul(_a: usize, _b: usize) -> usize { 0 }
 fn pow(_a: usize, _b: usize) -> usize { 0 }
 fn rotate_left(_a: usize, _b: usize) -> usize { 0 }
+fn checked_shl(_a: usize, _b: usize) -> usize { 0 }
+fn count_ones(_a: usize) -> usize { 0 }
+fn leading_zeros(_a: usize) -> usize { 0 }
+fn trailing_zeros(_a: usize) -> usize { 0 }
+fn make_body(_cap: usize) -> usize { 0 }
 "#,
     )
     .unwrap();
@@ -1719,14 +1624,10 @@ fn rotate_left(_a: usize, _b: usize) -> usize { 0 }
             .any(|from| from.ends_with("enqueue"))
     };
 
-    // Positive controls: a plain delegate and a TYPE-owned associated-constant chain both
-    // synthesize their resolved edge, so the negative assertions below exercise a working
-    // synthesis pipeline and cannot be satisfied by suppressing every edge.
+    // Positive control: a plain delegate synthesizes its resolved edge, so the negative assertions
+    // below exercise a working synthesis pipeline and cannot be satisfied by suppressing every
+    // edge.
     assert!(dispatches_from_enqueue("run_direct"), "the plain delegate arm must dispatch");
-    assert!(
-        dispatches_from_enqueue("run_handler"),
-        "a type-owned associated-constant chain must still dispatch"
-    );
     // The `super::`-relative arm lives in a submodule, so its own match must be proven extracted —
     // otherwise its negative assertion below would pass vacuously.
     assert!(
@@ -1745,6 +1646,13 @@ fn rotate_left(_a: usize, _b: usize) -> usize { 0 }
         "wrapping_mul",
         "pow",
         "rotate_left",
+        "run_handler",
+        "with_body",
+        "make_body",
+        "checked_shl",
+        "count_ones",
+        "leading_zeros",
+        "trailing_zeros",
     ] {
         assert!(
             !dispatches_from_enqueue(non_handler),
@@ -1777,6 +1685,13 @@ fn rotate_left(_a: usize, _b: usize) -> usize { 0 }
         "wrapping_mul",
         "pow",
         "rotate_left",
+        "run_handler",
+        "with_body",
+        "make_body",
+        "checked_shl",
+        "count_ones",
+        "leading_zeros",
+        "trailing_zeros",
     ] {
         assert!(
             handle_facts.iter().all(|(target, _)| target != chained_method),
@@ -1793,119 +1708,17 @@ fn rotate_left(_a: usize, _b: usize) -> usize { 0 }
         "Msg::SelfRelative",
         "Msg::Aliased",
         "Msg::SuperRelative",
+        "Msg::TypeOwned",
+        "Msg::UfcsTypeOwned",
+        "Msg::TypeOwnedNested",
+        "Msg::Fallible",
+        "Msg::Awaited",
+        "Msg::Parenthesized",
+        "Msg::FallibleCall",
     ] {
         assert!(
             handle_facts.iter().all(|(_, evidence)| evidence.as_deref() != Some(adapter_variant)),
             "the adapter arm {adapter_variant} must persist no dispatch_handle fact: \
-             {handle_facts:?}"
-        );
-    }
-
-    let _ = fs::remove_dir_all(&root);
-}
-
-#[test]
-fn dispatch_records_the_chained_method_of_an_associated_constant_chain() {
-    // #1124 maintainer feedback (MEDIUM): `Resp::DEFAULT.with_body(make_body(cap))` and
-    // `Handler::DEFAULT.run(normalize(input))` are the same expression modulo identifier spelling,
-    // so no argument-shape heuristic can tell a builder from a dispatch. An associated-constant
-    // method chain therefore delegates to its chained method unconditionally: the chained method
-    // is recorded even when an argument nests a produced value, and the nested producer is NOT
-    // traced through. Both methods and the nested producer exist in-repo, so every assertion is
-    // about a resolvable name rather than a name that could never bind.
-    let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(root.join("src")).unwrap();
-    fs::write(
-        root.join("src/lib.rs"),
-        r#"
-pub enum Msg { Build { cap: usize }, Run { input: u8 }, Plain { input: u8 } }
-pub struct Resp;
-impl Resp {
-    pub const DEFAULT: Resp = Resp;
-    fn with_body(&self, _body: usize) -> Resp { Resp }
-}
-pub struct Handler;
-impl Handler {
-    pub const DEFAULT: Handler = Handler;
-    fn run(&self, _input: u8) {}
-}
-
-pub fn enqueue() {
-    send(Msg::Build { cap: 1 });
-    send(Msg::Run { input: 2 });
-    send(Msg::Plain { input: 3 });
-}
-fn send(_m: Msg) {}
-
-pub fn handle(m: Msg) {
-    match m {
-        Msg::Build { cap } => Resp::DEFAULT.with_body(make_body(cap)),
-        Msg::Run { input } => Handler::DEFAULT.run(normalize(input)),
-        Msg::Plain { input } => Handler::DEFAULT.run(input),
-    }
-}
-fn make_body(_cap: usize) -> usize { 0 }
-fn normalize(_input: u8) -> u8 { 0 }
-"#,
-    )
-    .unwrap();
-    let config = source_config(root.clone(), Language::Rust);
-    let db = IndexDatabase::rebuild(&config).unwrap();
-    let conn = db.storage.connection();
-
-    let dispatches_from_enqueue = |symbol: &str| -> bool {
-        db.find_callers(symbol, 50)
-            .unwrap()
-            .into_iter()
-            .filter(|hop| hop.edge_kind == "dispatches")
-            .filter_map(|hop| hop.from_symbol)
-            .any(|from| from.ends_with("enqueue"))
-    };
-
-    // Every associated-constant chain reaches its chained method, whether or not an argument
-    // nests a produced value.
-    for chained_method in ["with_body", "run"] {
-        assert!(
-            dispatches_from_enqueue(chained_method),
-            "the associated-constant dispatch must reach `{chained_method}`"
-        );
-    }
-    // A nested argument call is not descended into, so the producer gains no edge of its own.
-    for nested_producer in ["make_body", "normalize"] {
-        assert!(
-            !dispatches_from_enqueue(nested_producer),
-            "{nested_producer} must NOT be a dispatch handler (an argument is not the dispatch)"
-        );
-    }
-
-    // Fact level: each arm's fact names the chained method, never the nested argument call.
-    let mut statement = conn
-        .prepare(
-            "SELECT tn.value, d.evidence FROM edges_data d
-             JOIN name_strings ek ON ek.id = d.edge_kind_id
-             JOIN name_strings tn ON tn.id = d.to_name_id
-             WHERE ek.value = 'dispatch_handle'",
-        )
-        .unwrap();
-    let handle_facts: Vec<(String, Option<String>)> = statement
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
-        .unwrap()
-        .collect::<Result<_, _>>()
-        .unwrap();
-    for (variant, chained_method) in
-        [("Msg::Build", "with_body"), ("Msg::Run", "run"), ("Msg::Plain", "run")]
-    {
-        assert!(
-            handle_facts.iter().any(|(target, evidence)| target == chained_method
-                && evidence.as_deref() == Some(variant)),
-            "{variant} must persist a dispatch_handle fact to `{chained_method}`: {handle_facts:?}"
-        );
-    }
-    for nested_producer in ["make_body", "normalize"] {
-        assert!(
-            handle_facts.iter().all(|(target, _)| target != nested_producer),
-            "no dispatch_handle fact may name the nested argument call `{nested_producer}`: \
              {handle_facts:?}"
         );
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_heal_robustness.rs
@@ -193,40 +193,43 @@ fn delete_dispatch_handle_facts(db: &IndexDatabase, file_id: i64) {
         .unwrap();
 }
 
+fn current_graph_version() -> i64 {
+    GRAPH_INDEX_VERSION.parse().expect("GRAPH_INDEX_VERSION is an integer")
+}
+
+/// The stamp a deployed index carries when the newest `GRAPH_INDEX_VERSION` ladder entry is the one
+/// that must re-extract it. DERIVED from the constant, never written out: a hardcoded pair of
+/// literals keeps passing when a change forgets to bump the ladder, because the staged version and
+/// the expected one then describe a step that already happened rather than this one.
+fn previous_graph_version() -> i64 {
+    current_graph_version() - 1
+}
+
 /// Stage the graph-only part of the version upgrade while leaving the logical-key derivation at
-/// its current value. Version 16 is the persisted stamp immediately before this classifier change;
-/// version 17 is the first graph version that must re-extract it.
-fn stage_graph_version_16(db: &IndexDatabase) {
-    db.set_repo_meta("graph_index_version", "16").unwrap();
+/// its current value.
+fn stage_previous_graph_version(db: &IndexDatabase) {
+    let previous = previous_graph_version();
+    db.set_repo_meta("graph_index_version", &previous.to_string()).unwrap();
     db.storage
         .connection()
         .execute(
-            "UPDATE main.files SET graph_version = 16
+            "UPDATE main.files SET graph_version = ?3
              WHERE repo_id = ?1 AND generation = ?2 AND kind != 'deleted'",
-            params![&db.active_repo_id, db.active_generation],
+            params![&db.active_repo_id, db.active_generation, previous],
         )
         .unwrap();
     *db.drift_snapshot.lock().expect("drift snapshot lock") = None;
 }
 
-/// The handler vehicle is an associated-constant method chain owned by a TYPE, which is the shape
-/// that delegates to its chained method. A constant reached through a MODULE path
-/// (`tools::TOOL_NAMES.iter().map(..)`) is an adapter tail and records no handler at all, so it
-/// cannot carry a dispatch fact for these upgrade assertions to watch (#1124 maintainer feedback).
+/// The handler vehicle is a plain in-file free function — the shape whose delegate verdict no
+/// classifier rule is contested over, so these upgrade assertions watch the version ladder rather
+/// than the classifier. A chain glued onto a constant (`Handler::DEFAULT.run(..)`,
+/// `tools::TOOL_NAMES.iter().map(..)`) is an adapter tail and records no handler at all, so it
+/// cannot carry a dispatch fact for them to watch (#1124).
 fn dispatch_fixture_body(handler_expression: &str) -> String {
     format!(
         r#"
 pub enum Msg {{ Work }}
-pub struct Handler;
-impl Handler {{
-    pub const DEFAULT: Handler = Handler;
-    fn run(&self, _input: usize) -> usize {{ 0 }}
-}}
-pub struct Clock;
-impl Clock {{
-    pub const NOW: Clock = Clock;
-    fn elapsed(&self) -> usize {{ 0 }}
-}}
 
 pub fn enqueue() {{ send(Msg::Work); }}
 fn send(_msg: Msg) {{}}
@@ -236,18 +239,20 @@ pub fn handle(msg: Msg) {{
         Msg::Work => {handler_expression},
     }}
 }}
+
+fn run(_input: usize) -> usize {{ 0 }}
+fn elapsed() -> usize {{ 0 }}
 "#
     )
 }
 
 #[test]
-fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
-    let (root, config) =
-        indexed_root(&[("lib.rs", &dispatch_fixture_body("Handler::DEFAULT.run(1)"))]);
+fn a_previous_version_database_reextracts_the_corrected_dispatch_handle_fact() {
+    let (root, config) = indexed_root(&[("lib.rs", &dispatch_fixture_body("run(1)"))]);
     let db = IndexDatabase::rebuild(&config).unwrap();
     let file_id = scoped_file_id(&db, "src/lib.rs", &db.active_worktree_id);
 
-    // Simulate the deployed v16 row after the old classifier omitted this handle fact.
+    // Simulate the deployed row after the old classifier omitted this handle fact.
     let initial_handles = edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle");
     assert!(
         initial_handles.iter().any(|(name, _, evidence)| {
@@ -257,7 +262,7 @@ fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
     );
     delete_dispatch_handle_facts(&db, file_id);
     assert!(edge_kind_rows_with_resolution(&db, file_id, "dispatch_handle").is_empty());
-    stage_graph_version_16(&db);
+    stage_previous_graph_version(&db);
 
     db.ensure_graph_index_current().unwrap();
 
@@ -270,10 +275,10 @@ fn a_v16_database_reextracts_the_corrected_dispatch_handle_fact() {
                 && resolution == "target_name_fallback"
                 && evidence.as_deref() == Some("Msg::Work")
         }),
-        "the v16 row must be re-extracted with the corrected handle fact: {handles:?}"
+        "the stale row must be re-extracted with the corrected handle fact: {handles:?}"
     );
-    assert_eq!(file_graph_version(&db, file_id), 17);
-    assert_eq!(db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
+    assert_eq!(file_graph_version(&db, file_id), current_graph_version());
+    assert_eq!(db.repo_meta("graph_index_version").unwrap().as_deref(), Some(GRAPH_INDEX_VERSION));
 
     let _ = fs::remove_dir_all(&root);
 }
@@ -283,7 +288,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let main = unique_temp_root();
     let _ = fs::remove_dir_all(&main);
     fs::create_dir_all(main.join("src")).unwrap();
-    fs::write(main.join("src/lib.rs"), dispatch_fixture_body("Handler::DEFAULT.run(1)")).unwrap();
+    fs::write(main.join("src/lib.rs"), dispatch_fixture_body("run(1)")).unwrap();
     init_git_repo(&main);
     run_git(&main, &["add", "."]);
     run_git(&main, &["commit", "-q", "-m", "base"]);
@@ -295,7 +300,7 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
     // A TYPE-owned constant chain like the active checkout's, naming a different method so the
     // sibling's fact is distinguishable from the active checkout's.
-    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("Clock::NOW.elapsed()")).unwrap();
+    fs::write(linked.join("src/lib.rs"), dispatch_fixture_body("elapsed()")).unwrap();
     run_git(&linked, &["add", "."]);
     run_git(&linked, &["commit", "-q", "-m", "branch body"]);
     db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
@@ -326,9 +331,9 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
     let overlay_all_before = edge_targets_with_resolution(&db, overlay_id);
     let overlay_edge_ids_before = edge_ids(&db, overlay_id);
 
-    // Remove only the active checkout's corrected fact, then present both rows as v16 data.
+    // Remove only the active checkout's corrected fact, then present both rows as stale data.
     delete_dispatch_handle_facts(&db, base_id);
-    stage_graph_version_16(&db);
+    stage_previous_graph_version(&db);
     db.ensure_graph_index_current().unwrap();
 
     let base_handles = edge_kind_rows_with_resolution(&db, base_id, "dispatch_handle");
@@ -338,12 +343,12 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
         }),
         "the active checkout receives the corrected dispatch fact: {base_handles:?}"
     );
-    assert_eq!(file_graph_version(&db, base_id), 17);
-    assert_eq!(file_graph_version(&db, overlay_id), 16);
+    assert_eq!(file_graph_version(&db, base_id), current_graph_version());
+    assert_eq!(file_graph_version(&db, overlay_id), previous_graph_version());
     assert_eq!(edge_ids(&db, overlay_id), overlay_edge_ids_before);
     assert_eq!(edge_targets_with_resolution(&db, overlay_id), overlay_all_before);
     assert_eq!(edge_kind_rows_with_resolution(&db, overlay_id, "dispatch_handle"), overlay_before);
-    assert_ne!(db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
+    assert_ne!(db.repo_meta("graph_index_version").unwrap().as_deref(), Some(GRAPH_INDEX_VERSION));
 
     let mut linked_config = source_config(linked.to_path_buf(), Language::Rust);
     linked_config.database = config.database.clone();
@@ -356,10 +361,13 @@ fn a_graph_upgrade_isolated_to_the_active_linked_checkout() {
         }),
         "the sibling later re-extracts its own fact: {overlay_handles:?}"
     );
-    assert_eq!(file_graph_version(&linked_db, base_id), 17);
-    assert_eq!(file_graph_version(&linked_db, overlay_id), 17);
+    assert_eq!(file_graph_version(&linked_db, base_id), current_graph_version());
+    assert_eq!(file_graph_version(&linked_db, overlay_id), current_graph_version());
     assert_eq!(edge_kind_rows_with_resolution(&linked_db, base_id, "dispatch_handle")[0].0, "run");
-    assert_eq!(linked_db.repo_meta("graph_index_version").unwrap().as_deref(), Some("17"));
+    assert_eq!(
+        linked_db.repo_meta("graph_index_version").unwrap().as_deref(),
+        Some(GRAPH_INDEX_VERSION)
+    );
 
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);


### PR DESCRIPTION
Follow-up to #1170 (issue #1124). Three spellings of a method chain reached the wrong verdict, and the version ladder entry that would have pushed the corrected facts to deployed indexes was folded into an existing entry rather than added.

## A transparent wrapper between the links hid the chain

`method_chain_root` and `is_chained_adapter_tail` both tested the receiver node's kind directly, so a `try_expression`, `await_expression` or `parenthesized_expression` between the links made the chain invisible and the call fell through to the bare-callee delegate arm:

| expression | before | after |
|---|---|---|
| `POOL.get()?.execute(sql)` | records `execute` | no handler |
| `CLIENT.get(url).await.text()` | records `text` | no handler |
| `(LIMIT).wrapping_mul(cap)` | records `wrapping_mul` | no handler |
| `LIMIT.min(cap).max(1)` | no handler | no handler |

A recorded trailing method name goes through bare-name fallback, so each of those bound to an unrelated same-named repository symbol and persisted a false `dispatches` edge. Both guards now read the receiver through a single `unwrap_transparent` helper, so every spelling of one chain reaches one verdict. The same helper settles the mirror case on the recall side: `make_worker().run(x)` and `make_worker()?.run(x)` no longer disagree.

## A chain rooted at a constant records no handler, whichever qualifier names the root

The classifier split on whether a constant's qualifier named the owning TYPE (`Handler::DEFAULT.run(..)`, delegate) or the MODULE it lives in (`crate::config::LIMIT.min(..)`, skip). That distinction rested on the case of a path segment, which is wrong for an uppercase module, a type alias, and a bracketed UFCS qualifier — `<u32 as Bounded>::MAX.min(cap)` delegated while `u32::MAX.min(cap)` skipped.

It also cannot settle the case it existed for. `Resp::DEFAULT.with_body(handle(cap))` and `Handler::DEFAULT.run(normalize(input))` are the same expression modulo identifier spelling, so nothing in the AST tells a builder from a dispatch, and reading the argument shape only picks which of the two loses its handler. Under the recognizer's false-edge-is-a-bug contract an undecidable case emits nothing.

Every occurrence of the shape in this repository is a value adapter (`OracleTool::ALL.to_vec()`, `OutcomeStatus::VARIANTS.iter()`, `ProtocolVersion::LATEST.as_str()`, `StatusCode::NO_CONTENT.into_response()`), so the arm was admitting a hypothetical dispatch at the cost of a corpus-wide false-edge population. Collapsing both spellings to skip removes `ConstantReceiver`, `qualifier_names_a_type`, `ConstantChain`, `constant_method_chain` and the chain's method-token scan.

## Re-extraction

`GRAPH_INDEX_VERSION` gains entry 18. The #1124 classification change had been described in entry 17, which belongs to #1239 and is already the stamp on indexes built from `main` — the gate is `graph_version < GRAPH_INDEX_VERSION`, so those indexes would have kept the old wrapper/delegate decision indefinitely.

The two graph upgrade tests staged `16` and asserted `17` as literals, which passes whether or not a change bumps the ladder. They now stage `GRAPH_INDEX_VERSION - 1` and assert against the constant, matching the idiom already used by `an_older_binary_does_not_downgrade_future_row_provenance` in the same file. Their handler vehicle is a plain free function so they exercise the version ladder rather than the classifier.

## Verification

- `cargo nextest run -p rag-rat-core --no-default-features --locked` — 2086 passed.
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` — nothing in the touched files.
- `cargo +nightly fmt --all`.
- `dispatch_suppresses_adapter_tails_end_to_end` gains arms for the `?`, `.await` and parenthesized spellings, the UFCS and nested-argument constant chains, and a same-named in-repo helper for every new adapter method so a false edge cannot hide behind an unresolved name. Reverting `unwrap_transparent` to its old behavior fails it.
- `a_graph_upgrade_isolated_to_the_active_linked_checkout` covers active-checkout scope and sibling preservation.

Fixes #1124