### PR TITLE
fix(test): gate the stub's wait on a response that lands after it parks

### DIFF
--- a/crates/rag-rat-llm/src/openai.rs
+++ b/crates/rag-rat-llm/src/openai.rs
@@ -786,6 +786,49 @@ mod tests {
         (url, handle, requests, max_in_flight)
     }
 
+    /// What the stub's workers coordinate on: responses fully written, and waits that have
+    /// parked.
+    ///
+    /// Both live under one mutex because a waiter has to snapshot `done` and register its park
+    /// as a single step. Split them and a response can land between the two, which is the whole
+    /// failure this pairing exists to prevent.
+    #[derive(Default)]
+    struct Progress {
+        /// Responses fully written.
+        done: usize,
+        /// Waits that have parked, cumulative. A released waiter still counts: it goes on to
+        /// write a response of its own, and must not be made to wait for a handshake it already
+        /// satisfied.
+        parked: usize,
+    }
+
+    /// Raises the in-flight gauge for exactly the window a request is outstanding: up once the
+    /// request has been read, down before anything is written back.
+    ///
+    /// The scope IS the window. The gauge has to fall before the response write, because a client
+    /// that reads response N can dispatch N+1 before this worker is rescheduled, and a decrement
+    /// that lands after that reads as two requests overlapping when only one ever did. Holding
+    /// that boundary in a guard means the write cannot drift inside it by accident — moving the
+    /// decrement takes moving the write into the scope, which is not something you do by mistake.
+    struct InFlight(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+    impl InFlight {
+        fn enter(
+            gauge: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
+            max_seen: &std::sync::atomic::AtomicUsize,
+        ) -> Self {
+            let now = gauge.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            raise_max(max_seen, now);
+            Self(std::sync::Arc::clone(gauge))
+        }
+    }
+
+    impl Drop for InFlight {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
     /// A one-shot barrier that holds each request the stub has read until `threshold` of them are
     /// held at once, then stays open for the rest of the run. `threshold <= 1` never holds.
     ///
@@ -873,9 +916,10 @@ mod tests {
         let in_flight = Arc::new(AtomicUsize::new(0));
         let max_in_flight = Arc::new(AtomicUsize::new(0));
         let waits_satisfied = Arc::new(AtomicUsize::new(0));
-        // Count of requests that have FULLY written their response, paired with a condvar so a
-        // parked worker is released by an explicit completion signal rather than by polling.
-        let completions = Arc::new((Mutex::new(0usize), Condvar::new()));
+        // Progress ledger, paired with a condvar so a parked worker is released by an explicit
+        // signal rather than by polling. One condvar serves both transitions; every waiter
+        // re-tests its own predicate on wake.
+        let completions = Arc::new((Mutex::new(Progress::default()), Condvar::new()));
         let counter = Arc::clone(&requests);
         let wait_for_prior_response = Arc::new(wait_for_prior_response);
         let max_seen = Arc::clone(&max_in_flight);
@@ -904,43 +948,83 @@ mod tests {
                     // it is strictly inside the window the client sees as outstanding. A client
                     // that waits for response N before sending N+1 therefore cannot be observed
                     // with two in flight, and an overlap the gauge does record is a real one.
-                    let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-                    raise_max(&max_seen, now);
                     let indices = request_text_indices(&body);
-                    // Deterministic "later request finishes first" ordering: a request whose first
-                    // text index is in `wait_for_prior_response` parks until ANOTHER request has
-                    // fully written its response and signalled completion via the condvar — no
-                    // scheduler timing, no busy-poll. The 30s cap is only a deadlock guard (if the
-                    // client never dispatches a concurrent second request the assertion fails
-                    // rather than hanging CI); on a healthy run the signal arrives in milliseconds,
-                    // so the release never depends on beating a deadline.
-                    if let Some(first) = indices.first().copied()
-                        && wait_for_prior_response.contains(&first)
-                    {
-                        let (lock, cvar) = &*completions;
-                        let mut done = lock.lock().unwrap();
-                        let started = std::time::Instant::now();
-                        let deadline = Duration::from_secs(30);
-                        while *done == 0 {
-                            let remaining = deadline.saturating_sub(started.elapsed());
-                            if remaining.is_zero() {
-                                break;
+                    let vector_ids = {
+                        let _outstanding = InFlight::enter(&in_flight, &max_seen);
+                        // Deterministic "later request finishes first" ordering: a request whose
+                        // first text index is in `wait_for_prior_response` parks until ANOTHER
+                        // request completes a response AFTER this one parked — no scheduler
+                        // timing, no busy-poll.
+                        //
+                        // The gate is relative to the count at entry, not to zero. `completions`
+                        // only ever rises, so a wait that tested it against zero was satisfied by
+                        // any response the run had already written: the worker fell straight
+                        // through without parking, and still reported the wait as satisfied. A
+                        // caller asserting on that count could not tell a released wait from one
+                        // that never waited, which is the whole property the counter exists for.
+                        //
+                        // The deadline is a deadlock guard only (if the client never dispatches a
+                        // concurrent second request, the count comes back short and the assertion
+                        // fails on a number instead of hanging CI). It stays below the caller's
+                        // HTTP timeout so that client reports the count that explains the failure
+                        // rather than a transport timeout.
+                        if let Some(first) = indices.first().copied()
+                            && wait_for_prior_response.contains(&first)
+                        {
+                            let (lock, cvar) = &*completions;
+                            let mut progress = lock.lock().unwrap();
+                            let parked_at = progress.done;
+                            progress.parked += 1;
+                            cvar.notify_all();
+                            let started = std::time::Instant::now();
+                            let deadline = Duration::from_secs(2);
+                            while progress.done == parked_at {
+                                let remaining = deadline.saturating_sub(started.elapsed());
+                                if remaining.is_zero() {
+                                    break;
+                                }
+                                let (guard, timeout) =
+                                    cvar.wait_timeout(progress, remaining).unwrap();
+                                progress = guard;
+                                if timeout.timed_out() {
+                                    break;
+                                }
                             }
-                            let (guard, timeout) = cvar.wait_timeout(done, remaining).unwrap();
-                            done = guard;
-                            if timeout.timed_out() {
-                                break;
+                            if progress.done > parked_at {
+                                waits_seen.fetch_add(1, Ordering::SeqCst);
                             }
                         }
-                        if *done > 0 {
-                            waits_seen.fetch_add(1, Ordering::SeqCst);
+                        // Explicit release point: hold this request until the configured number
+                        // are in flight together, so the caller's overlap assertion is a released
+                        // fact.
+                        hold.hold();
+                        // Hold this response until every configured wait has parked. "A later
+                        // request finishes first" only happens if the earlier one is ALREADY
+                        // parked when the later one completes; let the completion land first and
+                        // the waiter snapshots a count it can never move past, then waits out its
+                        // deadline. Arrival order is a scheduling detail, so without this the
+                        // assertion depends on which worker the OS runs first. A waiter that has
+                        // been released passes here immediately — it registered its own park.
+                        if !wait_for_prior_response.is_empty() {
+                            let (lock, cvar) = &*completions;
+                            let mut progress = lock.lock().unwrap();
+                            let started = std::time::Instant::now();
+                            let deadline = Duration::from_secs(2);
+                            while progress.parked < wait_for_prior_response.len() {
+                                let remaining = deadline.saturating_sub(started.elapsed());
+                                if remaining.is_zero() {
+                                    break;
+                                }
+                                let (guard, timeout) =
+                                    cvar.wait_timeout(progress, remaining).unwrap();
+                                progress = guard;
+                                if timeout.timed_out() {
+                                    break;
+                                }
+                            }
                         }
-                    }
-                    // Explicit release point: hold this request until the configured number are
-                    // in flight together, so the caller's overlap assertion is a released fact.
-                    hold.hold();
-                    in_flight.fetch_sub(1, Ordering::SeqCst);
-                    let vector_ids = if indices.is_empty() { vec![0] } else { indices };
+                        if indices.is_empty() { vec![0] } else { indices }
+                    };
                     let vectors: Vec<Vec<f32>> = vector_ids
                         .into_iter()
                         .map(|idx| {
@@ -962,7 +1046,7 @@ mod tests {
                     // `wait_for_prior_response` above, forcing a deterministic completion order.
                     {
                         let (lock, cvar) = &*completions;
-                        *lock.lock().unwrap() += 1;
+                        lock.lock().unwrap().done += 1;
                         cvar.notify_all();
                     }
                 }));
@@ -1121,8 +1205,9 @@ mod tests {
         let (url, handle, requests, _, waits_satisfied) =
             spawn_parallel_counting_stub_with_waits(2, vec![0]);
         let first_url = url.clone();
+        // No sender-side sleep: the stub holds `text 1`'s response until `text 0` has parked, so
+        // the ordering is a released fact rather than a bet on which worker the OS runs first.
         let first = thread::spawn(move || post_stub_embedding_request(&first_url, "text 0"));
-        thread::sleep(Duration::from_millis(20));
         let second = thread::spawn(move || post_stub_embedding_request(&url, "text 1"));
 
         first.join().unwrap();


### PR DESCRIPTION
Two defects in one helper, `spawn_counting_stub_with_release_points` (`crates/rag-rat-llm/src/openai.rs`), 25 lines apart. Every counting stub in the crate routes through it, so both reach five other tests.

## The wait was a latch, not a gate (#1247)

`completions` only ever rises, and the park predicate tested it against zero. Once any request in the run had completed, a later wait fell straight through — never parking — while still executing `waits_seen.fetch_add(1)` and reporting itself satisfied.

A caller asserting `waits_satisfied == 1` therefore could not distinguish "the waiter parked and was released" from "the waiter never parked". Both produce the same number, which is the one thing the counter exists to tell them apart.

Measured, by inverting the send order in `parallel_counting_stub_wait_branch_is_deterministic` so the non-waiting request completes before the waiter starts:

| | before | after |
|---|---|---|
| waiter parks | no — returns in ~326 µs | yes |
| test outcome | **passes** | **fails**, on the count |

The gate is now relative to the count at entry, and `waits_seen` moves only when a response actually landed after the park.

## The ordering had to stop being a bet on the scheduler

A relative gate is only half the fix. If the later request completes *before* the waiter snapshots, the waiter starts from a count nothing will ever move past and waits out its deadline — so the corrected gate would have made both callers scheduling-dependent. The 20 ms sender-side sleep in one caller was never synchronization, and the other (`embed_batch_keeps_output_order_when_later_requests_finish_first`) has none at all.

Confirmed by stalling the waiter 200 ms before its snapshot:

| | before handshake | after handshake |
|---|---|---|
| `parallel_counting_stub_wait_branch_is_deterministic` | **fails** at the deadline | passes in 0.21 s |
| `embed_batch_keeps_output_order_when_later_requests_finish_first` | **fails** at the deadline | passes in 0.21 s |

So the stub now holds every response until the configured waits have parked. Two details make it correct:

- **The snapshot and the park registration share one lock**, so no completion can land between them — that gap is the exact failure the pairing exists to prevent.
- **A released waiter still counts as parked** (the count is cumulative). It goes on to write a response of its own, and must not block on a handshake it already satisfied.

"A later request finishes first" is now a released fact rather than a race the OS adjudicates, so the sender-side sleep is deleted rather than left as decoration.

### Deadlines

2s, down from 30s. They are deadlock guards, not release mechanisms — on a healthy run the condvar signal arrives in microseconds. At 30s the wait exceeded the 5s HTTP timeout its callers configure via `config_for(&url, 5)`, which is the failure the doc rule immediately above it warns about: a client that stopped overlapping reports a transport timeout instead of the in-flight count that explains it. A request can block on at most one of the two gates, so the concurrent path stays inside the client's budget.

## The in-flight decrement boundary was unpinned (#1256)

#1240 diagnosed a flake as the gauge decrementing *after* the response write, while the client can already have dispatched the next request:

1. worker N flushes response N
2. client reads it, connects, sends request N+1
3. worker N+1 reads it and increments
4. worker N's `fetch_sub` is finally scheduled → gauge reads 2, `assert_eq!(seq_max, 1)` fails

#1248 moved the decrement before the write and pinned the *increment* half (accept-vs-read) with a new self-test. The decrement half is a different window and no test occupies it: moving `fetch_sub` back after `write_all`/`flush`/the completions signal leaves the suite green over 140 runs (40 plain, 100 under `taskset -c 0` with busy-loop hogs).

Rather than chase a race that could not be made to flake, the boundary is now **structural**. The increment/decrement pair lives in an `InFlight` guard whose scope is the outstanding window, and the response write sits outside it. `in_flight.fetch_sub` no longer appears in the worker body at all — the only decrement is the `Drop` impl. Moving it now requires moving the response write into the guard's scope, which is not an accident.

To be explicit about what this does and does not buy: this is an enforced invariant, not a new test. A test that cannot be made to fail in 140 runs would not have guarded it.

## Verification

```
cargo nextest run -p rag-rat-llm                                                      → 78 passed
cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings  → 0
cargo +nightly fmt --check                                                            → 0
```

The three ordering-sensitive tests were run 10× more with no failures. Every mutation and probe above was run against the patched code and removed afterwards.

Fixes #1247. Fixes #1256.
