### PR TITLE
test(oracle): separate the end edge from the start edge in the namespace pin

### DIFF
--- a/crates/rag-rat-oracle/src/tests/resolution.rs
+++ b/crates/rag-rat-oracle/src/tests/resolution.rs
@@ -399,4 +399,10 @@ fn a_namespace_occurrence_answers_only_when_it_bounds_the_token() {
         verdict_for(0, 29).0.is_none(),
         "a namespace merely containing the token yields no evidence at all",
     );
+    // Starting at the token is not bounding it. `ns.f()` is the shape an `import x.y` receiver
+    // produces, and only the END edge separates it from the exact match above.
+    assert!(
+        verdict_for(20, 26).0.is_none(),
+        "a namespace starting at the token but running past it is still context",
+    );
 }


### PR DESCRIPTION
`a_namespace_occurrence_answers_only_when_it_bounds_the_token` drove two occurrences: the token exactly (`20..22`) and the whole statement (`0..29`). Those differ on **both** edges at once, so four different rules satisfy them equally — exact bounds, start equality, end equality, or a width threshold. The rule the test names was pinned only up to that set.

Measured: weakening the carve-out at `join.rs:206` from

```rust
occ.start_byte == token_start && occ.end_byte == token_end
```

to `occ.start_byte == token_start` alone leaves **all 313 oracle tests green** — the run-level fixture and both selector unit tests from #1232 included. Width being the whole rule was unpinned on the end edge.

A third occurrence, `20..26`, starts at the receiver token and runs past it over `ns.f()`. Only the end edge separates it from the exact match, so admitting it requires exactly the weakening above.

| rule | `20..22` exact | `0..29` wider both sides | `20..26` starts at token |
|---|---|---|---|
| shipped (exact bounds) | admit | decline | **decline** |
| start equality only | admit | decline | **admit** ← now fails |

That third input is not hypothetical: it is the shape an `import x.y` receiver produces, which is the case the module carve-out exists for — #1234 names it as the same class.

## Verification

- With the rule weakened to start-equality: the test **fails** on its own diagnostic.
- With the shipped rule: 313 oracle tests pass, `cargo +nightly fmt --check` exit 0.

## Not addressed

Two cosmetic sub-points from the issue are left as they are. The SCIP symbol string spells the file `` `src/m.ts` `` while the document and `files` row use `m.ts` — inert, since only the trailing `/` descriptor is read. And `verdict(edge).is_none()` means "no row for this content key", where a `verdict_count() == 0` would additionally catch a row written against a shifted key; no such helper exists on the harness today.

The issue's other gap — that the resolved-symbol assertion cannot fail — was already closed in 12c97816, which adds a second symbol spanning the declaring block so a wrong mapping has something wrong to pick.

Fixes #1254.
