### PR TITLE
fix(oracle): reject empty definition ranges

### DIFF
--- a/crates/rag-rat-oracle/src/join.rs
+++ b/crates/rag-rat-oracle/src/join.rs
@@ -69,6 +69,9 @@ pub(crate) fn classify_edge(input: &JoinInput<'_>) -> Option<EdgeVerdict> {
 
     // Where is this symbol defined?
     let definition = input.index.definitions.get(&scip_symbol);
+    if definition.is_some_and(|def| !definition_has_extent(def.start_byte, def.end_byte)) {
+        return None;
+    }
     let resolved_symbol_id =
         definition.and_then(|def| (input.resolve_symbol)(&def.path, def.start_byte, def.end_byte));
 
@@ -238,7 +241,8 @@ pub fn package_of(scip_symbol: &str) -> Option<String> {
 /// Map a SCIP definition byte-range to one of our symbols in `spans` by REAL containment: the
 /// symbol whose `[start_byte, end_byte]` actually contains the *whole* definition range
 /// (`span.start_byte <= def_start && def_end <= span.end_byte`), preferring the tightest (smallest)
-/// such span (so a method beats its enclosing impl). Returns the symbol id or `None`.
+/// such span (so a method beats its enclosing impl). Empty or inverted definition ranges have no
+/// extent to contain and return `None`, as does a range no symbol contains.
 ///
 /// Containment is over the full def range — NOT just `def_start` — on purpose: a symbol whose span
 /// ends *before* the definition (a short helper preceding the real target) must NOT win. The
@@ -252,6 +256,9 @@ pub(crate) fn map_definition_to_symbol(
     def_start: usize,
     def_end: usize,
 ) -> Option<i64> {
+    if !definition_has_extent(def_start, def_end) {
+        return None;
+    }
     let def_start = i64::try_from(def_start).ok()?;
     let def_end = i64::try_from(def_end).ok()?;
     spans
@@ -259,6 +266,10 @@ pub(crate) fn map_definition_to_symbol(
         .filter(|span| span.start_byte <= def_start && def_end <= span.end_byte)
         .min_by_key(|span| span.end_byte - span.start_byte)
         .map(|span| span.symbol_id)
+}
+
+fn definition_has_extent(start: usize, end: usize) -> bool {
+    start < end
 }
 
 /// Tally one verdict into the report's counters. Returns whether a row should be written

--- a/crates/rag-rat-oracle/src/tests/join_tests.rs
+++ b/crates/rag-rat-oracle/src/tests/join_tests.rs
@@ -133,9 +133,9 @@ fn map_definition_to_symbol_prefers_tightest_span() {
     ];
     // Def 12..16 is contained by both → the tighter (id 2) wins.
     assert_eq!(join::map_definition_to_symbol(&spans, 12, 16), Some(2));
-    // Def 50..50 is past the tight method's end (20) → only the enclosing impl contains it.
-    assert_eq!(join::map_definition_to_symbol(&spans, 50, 50), Some(1));
-    // Def 200..200 is past every span → no containment.
+    // An empty definition has no extent to match, even inside the enclosing impl.
+    assert_eq!(join::map_definition_to_symbol(&spans, 50, 50), None);
+    // Def 200..200 is empty and past every span → no containment either.
     assert_eq!(join::map_definition_to_symbol(&spans, 200, 200), None);
 }
 

--- a/crates/rag-rat-oracle/src/tests/mod.rs
+++ b/crates/rag-rat-oracle/src/tests/mod.rs
@@ -31,3 +31,4 @@ mod status_tests;
 mod store_io;
 mod surfacing;
 mod tool_defaults;
+mod zero_width_definitions;

--- a/crates/rag-rat-oracle/src/tests/zero_width_definitions.rs
+++ b/crates/rag-rat-oracle/src/tests/zero_width_definitions.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+/// A synthetic per-file definition has no extent, so it cannot identify an in-corpus symbol or
+/// prove that the receiver resolves outside the corpus.
+#[test]
+fn zero_width_definition_produces_no_receiver_verdict() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.ts", "function caller() { ns.f(); }\n");
+    let defs = h.add_file("defs.ts", "function other() {}\n");
+    let unrelated = h.add_symbol(defs, "other", 0, 19);
+    let edge = h.add_edge_with_kind(caller, "ns", 20, 22, "references_type", "NameOnly", None);
+
+    let file_symbol = "scip-typescript npm demo 1.0 `defs.ts`/";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.ts".to_string(),
+            occurrences: vec![occurrence(0, 20, 22, file_symbol, SymbolRole::Import as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.ts".to_string(),
+        occurrences: vec![occurrence(0, 0, 0, file_symbol, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+
+    let report = run_oracle(
+        &h.conn,
+        OracleTool::ScipTypescript,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        &index.write_to_bytes().unwrap(),
+        h.root(),
+        None,
+        None,
+    )
+    .unwrap();
+
+    let verdict = h.verdict(edge);
+    assert!(
+        verdict.is_none(),
+        "a 0..0 definition must produce no receiver verdict, not resolve to unrelated symbol \
+         {unrelated}: {verdict:?}"
+    );
+    assert_eq!(report.upgraded, 0, "the unrelated symbol must not become an upgrade");
+    assert_eq!(
+        report.resolved_external, 0,
+        "an in-corpus file's synthetic definition is not evidence of an external target"
+    );
+}


### PR DESCRIPTION
**Summary**
Rejects empty and inverted SCIP definition ranges before symbol mapping or external classification, preventing zero-width synthetic definitions from resolving to unrelated code.

**Related Issues and Pull Requests**
Fixes #1246

**Changes**
- Added a shared positive-extent check for definition ranges
- Applied the check to both definition-to-symbol mapping and edge classification
- Added oracle regression coverage for a serialized scip-typescript `0..0` definition, including verdict and report-counter assertions
- Extended the lower-level mapping tests to cover zero-width definitions away from byte zero

**Testing**
- Ran `cargo test -p rag-rat-oracle --no-default-features --locked zero_width_definition_produces_no_receiver_verdict -- --nocapture` locally: 1 passed
- Ran fork CI at `5737f374348ef221795187b1184ecfc6bc2b0e94`: rustfmt, clippy, and 5,227 workspace tests passed
- Changed the extent predicate from `<` to `<=` on an isolated runner branch; the regression assertions failed as expected, then the probe branch was removed

**Footer**
Generated by GPT-5.6 Sol (brief, implementation, review, testing, verification)
