### PR TITLE
test: avoid ephemeral port reuse races

### DIFF
--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -1709,17 +1709,11 @@ mod freshness_version_tests {
 
     #[test]
     fn light_pass_with_unreachable_query_endpoint_defers() {
-        // Ephemeral watcher pass, `query_endpoint` set but the server is DOWN (a closed port) → the
-        // probe embed's connect is refused, so defer (SkipEphemeral), NOT embed-and-fail into
+        // Ephemeral watcher pass, `query_endpoint` set to port zero (which no server listens on) →
+        // the probe embed's connect is refused, so defer (SkipEphemeral), NOT embed-and-fail into
         // `Failed` chunk_embeddings, and without paying an O(repo) candidate scan first.
         let conn = schema_conn();
-        let closed = {
-            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-            let port = listener.local_addr().unwrap().port();
-            drop(listener); // the port now refuses connections
-            format!("http://127.0.0.1:{port}")
-        };
-        activate_ephemeral_with_query_endpoint(&conn, Some(&closed));
+        activate_ephemeral_with_query_endpoint(&conn, Some("http://127.0.0.1:0"));
         seed_embedding_chunk(&conn, 1);
         assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
     }

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -372,19 +372,31 @@ pub async fn serve_standalone(
     election_lock: FileLock,
     shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
 ) -> anyhow::Result<()> {
-    let listener = TcpListener::bind(address).await?;
-    serve_standalone_on_listener(config, workspace_root, listener, options, election_lock, shutdown)
-        .await
+    serve_standalone_with_binder(
+        config,
+        workspace_root,
+        address,
+        options,
+        election_lock,
+        shutdown,
+        TcpListener::bind,
+    )
+    .await
 }
 
-async fn serve_standalone_on_listener(
+async fn serve_standalone_with_binder<Bind, BindFuture>(
     config: Config,
     workspace_root: PathBuf,
-    listener: TcpListener,
+    address: SocketAddr,
     options: StandaloneServeOptions,
     election_lock: FileLock,
     shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
-) -> anyhow::Result<()> {
+    bind: Bind,
+) -> anyhow::Result<()>
+where
+    Bind: FnOnce(SocketAddr) -> BindFuture,
+    BindFuture: Future<Output = std::io::Result<TcpListener>>,
+{
     let StandaloneServeOptions { auth_token, allowed_origins, advertise_url } = options;
     // The caller acquires the election lock before any side effects (index heal, watcher) so a
     // contended worktree fails fast.
@@ -392,6 +404,7 @@ async fn serve_standalone_on_listener(
     let db = rag_rat_core::IndexDatabase::open_config(&config)?;
     db.materialize_lens_coupling()?;
     drop(db);
+    let listener = bind(address).await?;
     let repo_id = rag_rat_base::repo_identity::resolve_repo_identity(
         &config.root,
         config.repo_id_override.as_deref(),
@@ -1437,10 +1450,10 @@ mod tests {
             let bound_address = listener.local_addr().unwrap();
             let (started, wait_for_start) = tokio::sync::oneshot::channel::<()>();
             let (stop, wait_for_stop) = tokio::sync::oneshot::channel::<()>();
-            let served = tokio::spawn(serve_standalone_on_listener(
+            let served = tokio::spawn(serve_standalone_with_binder(
                 config.clone(),
                 root.clone(),
-                listener,
+                bound_address,
                 StandaloneServeOptions {
                     auth_token: "standalone-token".to_string(),
                     allowed_origins: Vec::new(),
@@ -1451,6 +1464,10 @@ mod tests {
                     let _ = started.send(());
                     let _ = wait_for_stop.await;
                     Ok(())
+                },
+                move |address| {
+                    assert_eq!(address, bound_address);
+                    std::future::ready(Ok(listener))
                 },
             ));
 

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -523,9 +523,7 @@ fn path_has_case_alias(path: &Path) -> bool {
 }
 
 async fn bind_first_free(ports: impl IntoIterator<Item = u16>) -> anyhow::Result<TcpListener> {
-    bind_first_free_with(ports, |address| TcpListener::bind(address))
-        .await
-        .context("binding a loopback lens port")
+    bind_first_free_with(ports, TcpListener::bind).await.context("binding a loopback lens port")
 }
 
 async fn bind_first_free_with<T, Bind, BindFuture>(

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -372,6 +372,19 @@ pub async fn serve_standalone(
     election_lock: FileLock,
     shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
 ) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(address).await?;
+    serve_standalone_on_listener(config, workspace_root, listener, options, election_lock, shutdown)
+        .await
+}
+
+async fn serve_standalone_on_listener(
+    config: Config,
+    workspace_root: PathBuf,
+    listener: TcpListener,
+    options: StandaloneServeOptions,
+    election_lock: FileLock,
+    shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
+) -> anyhow::Result<()> {
     let StandaloneServeOptions { auth_token, allowed_origins, advertise_url } = options;
     // The caller acquires the election lock before any side effects (index heal, watcher) so a
     // contended worktree fails fast.
@@ -379,7 +392,6 @@ pub async fn serve_standalone(
     let db = rag_rat_core::IndexDatabase::open_config(&config)?;
     db.materialize_lens_coupling()?;
     drop(db);
-    let listener = TcpListener::bind(address).await?;
     let repo_id = rag_rat_base::repo_identity::resolve_repo_identity(
         &config.root,
         config.repo_id_override.as_deref(),
@@ -511,20 +523,30 @@ fn path_has_case_alias(path: &Path) -> bool {
 }
 
 async fn bind_first_free(ports: impl IntoIterator<Item = u16>) -> anyhow::Result<TcpListener> {
+    bind_first_free_with(ports, |address| TcpListener::bind(address))
+        .await
+        .context("binding a loopback lens port")
+}
+
+async fn bind_first_free_with<T, Bind, BindFuture>(
+    ports: impl IntoIterator<Item = u16>,
+    mut bind: Bind,
+) -> Result<T, std::io::Error>
+where
+    Bind: FnMut(SocketAddr) -> BindFuture,
+    BindFuture: Future<Output = Result<T, std::io::Error>>,
+{
     let mut last_error = None;
     for port in ports {
         let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-        match TcpListener::bind(address).await {
+        match bind(address).await {
             Ok(listener) => return Ok(listener),
             Err(error) => last_error = Some(error),
         }
     }
-    TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+    bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .await
-        .map_err(|error| {
-            last_error.map(anyhow::Error::from).unwrap_or_else(|| anyhow::Error::from(error))
-        })
-        .context("binding a loopback lens port")
+        .map_err(|error| last_error.unwrap_or(error))
 }
 
 pub fn ownership_token() -> anyhow::Result<String> {
@@ -1317,16 +1339,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn port_scan_falls_back_after_a_busy_candidate() {
-        let busy = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let busy_port = busy.local_addr().unwrap().port();
+    async fn port_scan_continues_after_a_busy_candidate() {
+        let mut attempted_ports = Vec::new();
+        let selected = bind_first_free_with([18120, 18121], |address| {
+            attempted_ports.push(address.port());
+            std::future::ready(if address.port() == 18120 {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    "deterministically occupied candidate",
+                ))
+            } else {
+                Ok(address.port())
+            })
+        })
+        .await
+        .unwrap();
 
-        let selected = bind_first_free([busy_port]).await.unwrap();
-        assert_ne!(
-            selected.local_addr().unwrap().port(),
-            busy_port,
-            "fallback must skip a candidate while its listener is held"
-        );
+        assert_eq!(selected, 18121, "the scan must select the next configured candidate");
+        assert_eq!(attempted_ports, [18120, 18121], "the scan must not jump to port zero");
     }
 
     #[tokio::test]
@@ -1384,9 +1414,20 @@ mod tests {
     /// credential there would be pure exposure. Both branches serve either way.
     #[tokio::test]
     async fn standalone_serving_publishes_discovery_only_for_a_loopback_bind() {
-        for (bind_ip, publishes) in
-            [(IpAddr::V4(Ipv4Addr::LOCALHOST), true), (IpAddr::V4(Ipv4Addr::UNSPECIFIED), false)]
-        {
+        for (bind_ip, connect_ip, publishes) in [
+            (IpAddr::V4(Ipv4Addr::UNSPECIFIED), IpAddr::V4(Ipv4Addr::LOCALHOST), false),
+            (IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V4(Ipv4Addr::LOCALHOST), true),
+            (
+                IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+                false,
+            ),
+            (
+                IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+                IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+                true,
+            ),
+        ] {
             let root = temp_dir();
             let mut config = test_config(root.clone());
             config.allow_empty = true;
@@ -1394,12 +1435,14 @@ mod tests {
             let election = FileLock::try_acquire(&root.join("election.lock"))
                 .unwrap()
                 .expect("an uncontended election lock");
+            let listener = TcpListener::bind(SocketAddr::new(bind_ip, 0)).await.unwrap();
+            let bound_address = listener.local_addr().unwrap();
             let (started, wait_for_start) = tokio::sync::oneshot::channel::<()>();
             let (stop, wait_for_stop) = tokio::sync::oneshot::channel::<()>();
-            let served = tokio::spawn(serve_standalone(
+            let served = tokio::spawn(serve_standalone_on_listener(
                 config.clone(),
                 root.clone(),
-                SocketAddr::new(bind_ip, 0),
+                listener,
                 StandaloneServeOptions {
                     auth_token: "standalone-token".to_string(),
                     allowed_origins: Vec::new(),
@@ -1418,6 +1461,16 @@ mod tests {
                 .expect("standalone serve must reach its shutdown future")
                 .expect("standalone serve must not exit before serving");
 
+            let accepted =
+                tokio::net::TcpStream::connect(SocketAddr::new(connect_ip, bound_address.port()))
+                    .await;
+            assert!(
+                accepted.is_ok(),
+                "{bind_ip} bind must accept connections through {connect_ip}:{}",
+                bound_address.port()
+            );
+            drop(accepted);
+
             let discovery_path = lens_discovery_path(&root);
             assert_eq!(
                 discovery_path.is_file(),
@@ -1431,7 +1484,8 @@ mod tests {
                 assert_eq!(published.ownership_token, "standalone-token");
                 assert!(published.url.contains(&published.port.to_string()));
                 let published_listener =
-                    tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, published.port)).await;
+                    tokio::net::TcpStream::connect(SocketAddr::new(connect_ip, published.port))
+                        .await;
                 assert!(published_listener.is_ok(), "discovery must name the active listener");
                 drop(published_listener);
             }

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -1320,12 +1320,13 @@ mod tests {
     async fn port_scan_falls_back_after_a_busy_candidate() {
         let busy = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
         let busy_port = busy.local_addr().unwrap().port();
-        let available = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let available_port = available.local_addr().unwrap().port();
-        drop(available);
 
-        let selected = bind_first_free([busy_port, available_port]).await.unwrap();
-        assert_eq!(selected.local_addr().unwrap().port(), available_port);
+        let selected = bind_first_free([busy_port]).await.unwrap();
+        assert_ne!(
+            selected.local_addr().unwrap().port(),
+            busy_port,
+            "fallback must skip a candidate while its listener is held"
+        );
     }
 
     #[tokio::test]
@@ -1337,12 +1338,8 @@ mod tests {
         let conn = rusqlite::Connection::open(&config.database).unwrap();
         conn.execute("DELETE FROM repo_meta WHERE key = 'git_coupling_stamp'", []).unwrap();
         drop(conn);
-        let available = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let port = available.local_addr().unwrap().port();
-        drop(available);
-
         let control = ServeControl::default();
-        let task = tokio::spawn(run_on_ports(config.clone(), [port], control));
+        let task = tokio::spawn(run_on_ports(config.clone(), [0], control));
         let path = lens_discovery_path(&root);
         for _ in 0..100 {
             if path.is_file() {
@@ -1352,7 +1349,11 @@ mod tests {
         }
         assert!(path.is_file(), "active lens task did not publish discovery");
         let discovery: LensDiscovery = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(discovery.port, port);
+        assert_ne!(discovery.port, 0, "discovery must publish the kernel-selected port");
+        let published_listener =
+            tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, discovery.port)).await;
+        assert!(published_listener.is_ok(), "discovery must name the active listener");
+        drop(published_listener);
         let conn = rusqlite::Connection::open(&config.database).unwrap();
         assert!(
             conn.query_row(
@@ -1390,20 +1391,15 @@ mod tests {
             let mut config = test_config(root.clone());
             config.allow_empty = true;
             drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
-            // Claim a port, then release it so `serve_standalone` binds that exact one — its
-            // chosen address is not otherwise observable from here.
-            let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-            let port = probe.local_addr().unwrap().port();
-            drop(probe);
-
             let election = FileLock::try_acquire(&root.join("election.lock"))
                 .unwrap()
                 .expect("an uncontended election lock");
+            let (started, wait_for_start) = tokio::sync::oneshot::channel::<()>();
             let (stop, wait_for_stop) = tokio::sync::oneshot::channel::<()>();
             let served = tokio::spawn(serve_standalone(
                 config.clone(),
                 root.clone(),
-                SocketAddr::new(bind_ip, port),
+                SocketAddr::new(bind_ip, 0),
                 StandaloneServeOptions {
                     auth_token: "standalone-token".to_string(),
                     allowed_origins: Vec::new(),
@@ -1411,22 +1407,16 @@ mod tests {
                 },
                 election,
                 async move {
+                    let _ = started.send(());
                     let _ = wait_for_stop.await;
                     Ok(())
                 },
             ));
 
-            // Publication happens before the listener is served, so a port that answers means the
-            // decision has already been made either way.
-            let mut serving = false;
-            for _ in 0..200 {
-                if tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, port)).await.is_ok() {
-                    serving = true;
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-            assert!(serving, "standalone serve never accepted on {bind_ip}:{port}");
+            tokio::time::timeout(std::time::Duration::from_secs(10), wait_for_start)
+                .await
+                .expect("standalone serve must reach its shutdown future")
+                .expect("standalone serve must not exit before serving");
 
             let discovery_path = lens_discovery_path(&root);
             assert_eq!(
@@ -1437,9 +1427,13 @@ mod tests {
             if publishes {
                 let published: LensDiscovery =
                     serde_json::from_slice(&fs::read(&discovery_path).unwrap()).unwrap();
-                assert_eq!(published.port, port);
+                assert_ne!(published.port, 0, "discovery must publish the kernel-selected port");
                 assert_eq!(published.ownership_token, "standalone-token");
-                assert!(published.url.contains(&port.to_string()));
+                assert!(published.url.contains(&published.port.to_string()));
+                let published_listener =
+                    tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, published.port)).await;
+                assert!(published_listener.is_ok(), "discovery must name the active listener");
+                drop(published_listener);
             }
 
             let _ = stop.send(());
@@ -1461,18 +1455,15 @@ mod tests {
         let mut config = test_config(root.clone());
         config.allow_empty = true;
         drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
-        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let port = probe.local_addr().unwrap().port();
-        drop(probe);
-
         let election = FileLock::try_acquire(&root.join("election.lock"))
             .unwrap()
             .expect("an uncontended election lock");
+        let (started, wait_for_start) = tokio::sync::oneshot::channel::<()>();
         let (stop, wait_for_stop) = tokio::sync::oneshot::channel::<()>();
         let served = tokio::spawn(serve_standalone(
             config.clone(),
             root.clone(),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             StandaloneServeOptions {
                 auth_token: "standalone-token".to_string(),
                 allowed_origins: Vec::new(),
@@ -1480,18 +1471,17 @@ mod tests {
             },
             election,
             async move {
+                let _ = started.send(());
                 let _ = wait_for_stop.await;
                 Ok(())
             },
         ));
 
+        tokio::time::timeout(std::time::Duration::from_secs(10), wait_for_start)
+            .await
+            .expect("advertise-url serve must reach its shutdown future")
+            .expect("advertise-url serve must not exit before serving");
         let discovery_path = lens_discovery_path(&root);
-        for _ in 0..200 {
-            if discovery_path.is_file() {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
         let published: LensDiscovery = serde_json::from_slice(
             &fs::read(&discovery_path).expect("an advertise-url serve must publish discovery"),
         )


### PR DESCRIPTION
**Summary**
Removes test assumptions that a released ephemeral port remains reserved while preserving the production port-scan, standalone reachability, discovery, lifecycle, and failure-path invariants.

**Related Issues and Pull Requests**
Fixes #1251

**Changes**
- Kept the first port-scan candidate occupied and added a deterministic production-connected binder seam that proves scanning continues to the next configured port before the port-zero fallback
- Updated standalone lifecycle tests to retain kernel-selected listeners and prove real TCP acceptance for IPv4 and IPv6 loopback and wildcard binds
- Preserved non-loopback discovery suppression, advertised URL fields, cleanup, election-lock behavior, and startup ordering
- Made the unreachable query-endpoint test use literal loopback port zero instead of a released ephemeral port

**Testing**
- Proved the port-scan assertion fails when the implementation jumps to port zero after the first occupied candidate
- Proved the standalone assertion fails when the wildcard listener is dropped while the shutdown future still reports startup
- Ran focused `rag-rat-mcp` port-scan and standalone-serving tests locally; all passed
- Ran fork CI at exact SHA `9281d88565d1c0655f6658d50a46692484bd470b`: 5,229 tests passed, clippy passed with warnings denied, and rustfmt passed

**Follow-ups / Known Limitations**
The focused IPv6 cases require IPv6 wildcard and loopback support on the test host; the required Ubuntu runner supports both and executed them successfully.

**Footer**
Generated by GPT-5.6 Sol (brief, implementation, review, testing, verification)
