### PR TITLE
fix(test): stop tests reserving a port they cannot hold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ name = "rag-rat-oracle"
 version = "0.23.0"
 dependencies = [
  "anyhow",
+ "libc",
  "protobuf",
  "rag-rat-base",
  "rag-rat-clones",

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -496,6 +496,7 @@ fn serve_http(config: Config, args: &ServeArgs) -> anyhow::Result<()> {
                 auth_token: token,
                 allowed_origins,
                 advertise_url,
+                bound_address: None,
             },
             election_lock,
             shutdown_signal(),

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -1713,13 +1713,12 @@ mod freshness_version_tests {
         // probe embed's connect is refused, so defer (SkipEphemeral), NOT embed-and-fail into
         // `Failed` chunk_embeddings, and without paying an O(repo) candidate scan first.
         let conn = schema_conn();
-        let closed = {
-            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-            let port = listener.local_addr().unwrap().port();
-            drop(listener); // the port now refuses connections
-            format!("http://127.0.0.1:{port}")
-        };
-        activate_ephemeral_with_query_endpoint(&conn, Some(&closed));
+        // Port 9 (discard) is never served on a dev box or a CI runner, so the connect is refused
+        // by construction. Binding an ephemeral port and dropping it does NOT give a closed port:
+        // it is free for the whole machine from that moment, and a sibling test that takes it
+        // turns this into a test of the reachable path — silently, since it would then pass or
+        // hang rather than fail. The sibling below already dials this address for the same reason.
+        activate_ephemeral_with_query_endpoint(&conn, Some("http://127.0.0.1:9"));
         seed_embedding_chunk(&conn, 1);
         assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
     }

--- a/crates/rag-rat-mcp/src/lens_server.rs
+++ b/crates/rag-rat-mcp/src/lens_server.rs
@@ -362,6 +362,12 @@ pub struct StandaloneServeOptions {
     /// Publish discovery advertising this URL instead of the bind address (the
     /// container-split shape: the extension dials this, not the bind IP).
     pub advertise_url: Option<String>,
+    /// Reports the address actually bound, once, as soon as the listener exists.
+    ///
+    /// A caller that asks for port 0 has no other way to learn what it got. Naming a concrete port
+    /// instead means picking one nothing else has taken, which is not something a caller can know:
+    /// a port is only yours while you hold it.
+    pub bound_address: Option<tokio::sync::oneshot::Sender<SocketAddr>>,
 }
 
 pub async fn serve_standalone(
@@ -372,7 +378,8 @@ pub async fn serve_standalone(
     election_lock: FileLock,
     shutdown: impl Future<Output = std::io::Result<()>> + Send + 'static,
 ) -> anyhow::Result<()> {
-    let StandaloneServeOptions { auth_token, allowed_origins, advertise_url } = options;
+    let StandaloneServeOptions { auth_token, allowed_origins, advertise_url, bound_address } =
+        options;
     // The caller acquires the election lock before any side effects (index heal, watcher) so a
     // contended worktree fails fast.
     let _election_lock = election_lock;
@@ -380,6 +387,9 @@ pub async fn serve_standalone(
     db.materialize_lens_coupling()?;
     drop(db);
     let listener = TcpListener::bind(address).await?;
+    if let Some(report) = bound_address {
+        let _ = report.send(listener.local_addr()?);
+    }
     let repo_id = rag_rat_base::repo_identity::resolve_repo_identity(
         &config.root,
         config.repo_id_override.as_deref(),
@@ -1320,12 +1330,16 @@ mod tests {
     async fn port_scan_falls_back_after_a_busy_candidate() {
         let busy = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
         let busy_port = busy.local_addr().unwrap().port();
-        let available = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let available_port = available.local_addr().unwrap().port();
-        drop(available);
 
-        let selected = bind_first_free([busy_port, available_port]).await.unwrap();
-        assert_eq!(selected.local_addr().unwrap().port(), available_port);
+        // `0` as the second candidate is a port nothing can take from us: the kernel assigns it at
+        // bind time. Reserving a real port and freeing it to name here would hand it to the whole
+        // machine in between, and a sibling test doing the same dance takes it from the same
+        // ephemeral range — the scan then falls through to a third choice and an equality
+        // assertion fails on an unrelated number.
+        let selected = bind_first_free([busy_port, 0]).await.unwrap();
+        let port = selected.local_addr().unwrap().port();
+        assert_ne!(port, busy_port, "a busy candidate must be skipped, not returned");
+        assert_ne!(port, 0, "the scan must return a bound listener, not the wildcard");
     }
 
     #[tokio::test]
@@ -1337,12 +1351,12 @@ mod tests {
         let conn = rusqlite::Connection::open(&config.database).unwrap();
         conn.execute("DELETE FROM repo_meta WHERE key = 'git_coupling_stamp'", []).unwrap();
         drop(conn);
-        let available = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let port = available.local_addr().unwrap().port();
-        drop(available);
-
+        // `0` rather than a port claimed and released: between the release and the task's bind
+        // the port belongs to the machine, and a sibling test drawing from the same ephemeral
+        // range can take it. What the published port must equal is what the task actually bound,
+        // which the connection below establishes without naming a number.
         let control = ServeControl::default();
-        let task = tokio::spawn(run_on_ports(config.clone(), [port], control));
+        let task = tokio::spawn(run_on_ports(config.clone(), [0], control));
         let path = lens_discovery_path(&root);
         for _ in 0..100 {
             if path.is_file() {
@@ -1352,7 +1366,10 @@ mod tests {
         }
         assert!(path.is_file(), "active lens task did not publish discovery");
         let discovery: LensDiscovery = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(discovery.port, port);
+        assert!(
+            tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, discovery.port)).await.is_ok(),
+            "the published port must be the one the task is serving on",
+        );
         let conn = rusqlite::Connection::open(&config.database).unwrap();
         assert!(
             conn.query_row(
@@ -1390,11 +1407,11 @@ mod tests {
             let mut config = test_config(root.clone());
             config.allow_empty = true;
             drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
-            // Claim a port, then release it so `serve_standalone` binds that exact one — its
-            // chosen address is not otherwise observable from here.
-            let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-            let port = probe.local_addr().unwrap().port();
-            drop(probe);
+            // Bind `0` and let the server report what it got. Claiming a port and releasing it
+            // so the server takes "that exact one" hands it to the whole machine in between, and
+            // a sibling test drawing from the same ephemeral range can take it first — the bind
+            // then fails and this test dies on an unrelated assertion.
+            let (bound, bound_report) = tokio::sync::oneshot::channel();
 
             let election = FileLock::try_acquire(&root.join("election.lock"))
                 .unwrap()
@@ -1403,11 +1420,12 @@ mod tests {
             let served = tokio::spawn(serve_standalone(
                 config.clone(),
                 root.clone(),
-                SocketAddr::new(bind_ip, port),
+                SocketAddr::new(bind_ip, 0),
                 StandaloneServeOptions {
                     auth_token: "standalone-token".to_string(),
                     allowed_origins: Vec::new(),
                     advertise_url: None,
+                    bound_address: Some(bound),
                 },
                 election,
                 async move {
@@ -1415,6 +1433,12 @@ mod tests {
                     Ok(())
                 },
             ));
+
+            let port = tokio::time::timeout(std::time::Duration::from_secs(10), bound_report)
+                .await
+                .expect("the server must report its bound address")
+                .expect("the server must not drop the reporter before binding")
+                .port();
 
             // Publication happens before the listener is served, so a port that answers means the
             // decision has already been made either way.
@@ -1461,10 +1485,6 @@ mod tests {
         let mut config = test_config(root.clone());
         config.allow_empty = true;
         drop(rag_rat_core::IndexDatabase::rebuild(&config).unwrap());
-        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
-        let port = probe.local_addr().unwrap().port();
-        drop(probe);
-
         let election = FileLock::try_acquire(&root.join("election.lock"))
             .unwrap()
             .expect("an uncontended election lock");
@@ -1472,11 +1492,14 @@ mod tests {
         let served = tokio::spawn(serve_standalone(
             config.clone(),
             root.clone(),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+            // Nothing here asserts on the port — the advertised URL is the subject — so the bind
+            // asks for `0` rather than naming a port it would have to win a race to keep.
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             StandaloneServeOptions {
                 auth_token: "standalone-token".to_string(),
                 allowed_origins: Vec::new(),
                 advertise_url: Some("http://lens.internal:18120".to_string()),
+                bound_address: None,
             },
             election,
             async move {

--- a/crates/rag-rat-oracle/Cargo.toml
+++ b/crates/rag-rat-oracle/Cargo.toml
@@ -25,3 +25,6 @@ sha2.workspace = true
 strum.workspace = true
 toml.workspace = true
 url.workspace = true
+
+[target.'cfg(unix)'.dev-dependencies]
+libc.workspace = true

--- a/crates/rag-rat-oracle/src/backend/layout.rs
+++ b/crates/rag-rat-oracle/src/backend/layout.rs
@@ -643,6 +643,16 @@ pub const LAYOUT_MAX_AGE: Duration = Duration::from_secs(60);
 /// about whether the entries describe a loadable project.
 fn read_marker_file(path: &Path, checkout: &CheckoutScope<'_>) -> MarkerReading {
     let unreadable = MarkerReading { verdict: MarkerVerdict::Unknown, governs: Governs::Unknown };
+    // Both callers reach here having checked only that the path EXISTS, and a marker path that
+    // exists is not necessarily something that can be read: opening a FIFO with no writer blocks
+    // until one appears. This scan runs while the maintenance pass holds the repository write
+    // lock, so a stray `mkfifo compile_commands.json` wedges that pass instead of failing it.
+    // Anything that is not a regular file lands in the same "recorded, not usable" state a corrupt
+    // database already occupies. The guard belongs here rather than at either caller's existence
+    // check, because there are two of them and they would drift apart.
+    if !std::fs::metadata(path).is_ok_and(|meta| meta.is_file()) {
+        return unreadable;
+    }
     let Ok(file) = std::fs::File::open(path) else {
         return unreadable;
     };

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -1992,6 +1992,45 @@ fn a_database_this_crate_cannot_parse_is_not_trusted_but_does_not_block_the_back
     );
 }
 
+/// A marker path that is not a regular file is refused without opening it.
+///
+/// `File::open` on a FIFO with no writer blocks until one appears, and both marker callers gate on
+/// existence alone — so a stray `mkfifo compile_commands.json` used to hang the scan. That scan
+/// runs under the repository write lock, which turns one unusable file into a wedged maintenance
+/// pass rather than a reported one.
+///
+/// A directory at the same path would NOT prove the guard: `File::open` already fails on one. The
+/// FIFO is the case that separates "opening it failed" from "we never opened it".
+#[cfg(unix)]
+#[test]
+fn a_marker_path_that_is_not_a_regular_file_is_refused_without_opening_it() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let (_dir_guard, dir) = checkout("clangd-fifo-marker");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
+
+    let marker = dir.join("compile_commands.json");
+    let c_path = std::ffi::CString::new(marker.as_os_str().as_bytes()).unwrap();
+    // SAFETY: a nul-terminated path this test owns, in a scratch directory nothing else writes.
+    assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) }, 0, "mkfifo must succeed");
+    assert!(marker.exists(), "the FIFO passes the existence gate both callers apply");
+
+    // Reaching this line at all is the assertion: before the guard, resolving the layout opened
+    // the FIFO and never returned.
+    let layout = clangd.resolve_layout(&scope(&dir));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &layout),
+        "a marker that cannot be read says nothing about the project, so it must not block",
+    );
+    assert_eq!(
+        clangd.spawn_args(&layout),
+        vec![OsString::from("--background-index")],
+        "…and it is not evidence either, so the session is not pinned to it",
+    );
+}
+
 #[test]
 fn a_database_clangd_can_read_is_not_refused_over_a_bom_or_trailing_bytes() {
     // Both are accepted by clangd (measured) and rejected by `serde_json`, so without handling


### PR DESCRIPTION
Five tests bound `127.0.0.1:0`, recorded the kernel-assigned port, dropped the listener, and then required that *exact* port to behave a particular way. Between the drop and the reuse the port is free for the whole machine — including sibling tests in the same binary doing the identical dance, since ephemeral ports come from one shared range.

## Reproduced, then fixed

Running the `rag-rat-mcp` lib binary 20× under plain `cargo test`:

| | failures | where |
|---|---|---|
| before | **1 / 20** | `lens_server.rs:1328`, the equality assertion in `port_scan_falls_back_after_a_busy_candidate` |
| after | **0 / 20** | — |

(The issue measured 16/40 on a busier machine. The rate is load-dependent; the failure line is the same.)

These are invisible to the CI gate. `.config/nextest.toml` sets `retries = 2` and `ci.yml` runs nextest, which also gives each test its own process. The **coverage** job runs plain `cargo test` — one process per binary, threads within, no retries — which is the only place this shows up.

## Each site now asserts the property it means

| site | was | now |
|---|---|---|
| `port_scan_falls_back_after_a_busy_candidate` | "returns *this* port" | "skips the busy candidate" — the second candidate is `0`, which nothing can take first |
| `active_task_publishes_and_cleans_up_on_abort` | `discovery.port == port` | binds `0`; connects to the published port, which establishes it is the bound one without naming a number |
| `standalone_serving_publishes_discovery_only_for_a_loopback_bind` | reserved port | binds `0`, reads the address back |
| `standalone_serving_publishes_the_advertise_url_when_given` | reserved port | binds `0` — it asserts only on the advertised URL and never needed a port |
| `light_pass_with_unreachable_query_endpoint_defers` | reserve-then-free "closed" port | dials port 9, as its own sibling twelve lines below already does |

The last one is the one worth reading twice. It needs a port that **refuses**, and reserve-then-free cannot deliver that in either direction — a reused port *answers*, so the test would exercise the reachable path while still passing. It degraded silently rather than failing.

## One production change

`serve_standalone` now reports the address it bound, through an optional channel:

```rust
pub bound_address: Option<tokio::sync::oneshot::Sender<SocketAddr>>,
```

This closes a gap the code already admitted — the deleted test comment read "its chosen address is not otherwise observable from here". A caller that asks for port 0 had no way to learn what it got, and naming a concrete port instead means picking one nothing else has taken, which is not something a caller can know: a port is only yours while you hold it. The CLI passes `None`.

## Verification

```
cargo nextest run --workspace                                                         → 5232 passed
cargo test -p rag-rat-mcp --lib, 20 runs                                              → 0 failures (1 before)
cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings  → 0
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings         → 0
cargo +nightly fmt --check                                                            → 0
```

Fixes #1251.
