### PR TITLE
fix(oracle): refuse a marker path that is not a regular file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ name = "rag-rat-oracle"
 version = "0.23.0"
 dependencies = [
  "anyhow",
+ "libc",
  "protobuf",
  "rag-rat-base",
  "rag-rat-clones",

--- a/crates/rag-rat-oracle/Cargo.toml
+++ b/crates/rag-rat-oracle/Cargo.toml
@@ -25,3 +25,6 @@ sha2.workspace = true
 strum.workspace = true
 toml.workspace = true
 url.workspace = true
+
+[target.'cfg(unix)'.dev-dependencies]
+libc.workspace = true

--- a/crates/rag-rat-oracle/src/backend/layout.rs
+++ b/crates/rag-rat-oracle/src/backend/layout.rs
@@ -643,6 +643,16 @@ pub const LAYOUT_MAX_AGE: Duration = Duration::from_secs(60);
 /// about whether the entries describe a loadable project.
 fn read_marker_file(path: &Path, checkout: &CheckoutScope<'_>) -> MarkerReading {
     let unreadable = MarkerReading { verdict: MarkerVerdict::Unknown, governs: Governs::Unknown };
+    // Both callers reach here having checked only that the path EXISTS, and a marker path that
+    // exists is not necessarily something that can be read: opening a FIFO with no writer blocks
+    // until one appears. This scan runs while the maintenance pass holds the repository write
+    // lock, so a stray `mkfifo compile_commands.json` wedges that pass instead of failing it.
+    // Anything that is not a regular file lands in the same "recorded, not usable" state a corrupt
+    // database already occupies. The guard belongs here rather than at either caller's existence
+    // check, because there are two of them and they would drift apart.
+    if !std::fs::metadata(path).is_ok_and(|meta| meta.is_file()) {
+        return unreadable;
+    }
     let Ok(file) = std::fs::File::open(path) else {
         return unreadable;
     };

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -1992,6 +1992,45 @@ fn a_database_this_crate_cannot_parse_is_not_trusted_but_does_not_block_the_back
     );
 }
 
+/// A marker path that is not a regular file is refused without opening it.
+///
+/// `File::open` on a FIFO with no writer blocks until one appears, and both marker callers gate on
+/// existence alone — so a stray `mkfifo compile_commands.json` used to hang the scan. That scan
+/// runs under the repository write lock, which turns one unusable file into a wedged maintenance
+/// pass rather than a reported one.
+///
+/// A directory at the same path would NOT prove the guard: `File::open` already fails on one. The
+/// FIFO is the case that separates "opening it failed" from "we never opened it".
+#[cfg(unix)]
+#[test]
+fn a_marker_path_that_is_not_a_regular_file_is_refused_without_opening_it() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let (_dir_guard, dir) = checkout("clangd-fifo-marker");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/main.c"), "int m(void){return 0;}\n").unwrap();
+
+    let marker = dir.join("compile_commands.json");
+    let c_path = std::ffi::CString::new(marker.as_os_str().as_bytes()).unwrap();
+    // SAFETY: a nul-terminated path this test owns, in a scratch directory nothing else writes.
+    assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) }, 0, "mkfifo must succeed");
+    assert!(marker.exists(), "the FIFO passes the existence gate both callers apply");
+
+    // Reaching this line at all is the assertion: before the guard, resolving the layout opened
+    // the FIFO and never returned.
+    let layout = clangd.resolve_layout(&scope(&dir));
+    assert!(
+        clangd.checkout_can_signal_readiness(&scope(&dir), &layout),
+        "a marker that cannot be read says nothing about the project, so it must not block",
+    );
+    assert_eq!(
+        clangd.spawn_args(&layout),
+        vec![OsString::from("--background-index")],
+        "…and it is not evidence either, so the session is not pinned to it",
+    );
+}
+
 #[test]
 fn a_database_clangd_can_read_is_not_refused_over_a_bom_or_trailing_bytes() {
     // Both are accepted by clangd (measured) and rejected by `serde_json`, so without handling


### PR DESCRIPTION
Opening a FIFO with no writer blocks until one appears, and the compilation-database marker scan opened whatever it found. That scan runs while the maintenance pass holds the **repository write lock**, so a stray `mkfifo compile_commands.json` in a checkout wedged the pass rather than reporting an unusable database.

## The guard goes in the reader, not at a caller

The issue points at `record_marker_in`'s existence check. That would leave the bug reachable: there are **two** existence-only gates, and both funnel into the same `File::open`.

| caller | gate | route |
|---|---|---|
| `MarkerSearch::record_marker_in` | `if !candidate.exists()` | direct |
| `ProjectLayout::discoverable_marker_dir` | `if file.exists()` | via `marker_reading`, memoized |

So the check belongs in `read_marker_file`, where they converge — guarding one caller leaves the other able to hang, and leaves the two free to drift apart.

A non-regular path lands in the state a corrupt database already occupies: `MarkerVerdict::Unknown` / `Governs::Unknown` — not evidence, not a reason to declare the backend blocked. That is the same posture #1016 established for a database this reader cannot parse.

## The test plants a real FIFO

This is what makes it a test rather than a restatement. `File::open` **already fails on a directory**, so a directory at the marker path passes with or without the guard — it cannot tell "opening it failed" from "we never opened it". Only a FIFO separates them.

Measured both ways:

| | result |
|---|---|
| with the guard | passes in 0.004 s |
| without the guard | **does not return** — killed at 57 s, "test was not run due to signal" |

`libc` is added as a `cfg(unix)` dev-dependency for `mkfifo`; it is already a workspace dependency, so no new external surface. The test is `#[cfg(unix)]`.

## Verification

```
cargo nextest run -p rag-rat-oracle                                                   → 315 passed
cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings  → 0
cargo +nightly fmt --check                                                            → 0
```

Fixes #1249.
