### PR TITLE
feat(memory): demote a synced memory whose anchored text this checkout no longer holds

### DIFF
--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -416,10 +416,19 @@ pub(crate) fn memory_render_item(m: memory::RepoMemory) -> RenderItem {
     };
     let gist_part = if gist.is_empty() { String::new() } else { format!(" — {gist}") };
     let verdict_part = m.verdict.as_deref().map(|v| format!(" {v}")).unwrap_or_default();
+    // A synced memory anchored to text this checkout no longer holds reads in the status slot,
+    // which is where a reader looks to decide how far to trust the line. These surfaces render a
+    // raw list and never partition it, so without this the divergence would be computed and then
+    // dropped on the way out.
+    let status = if m.synced_anchor_drifted {
+        format!("{} · anchor drifted", m.status)
+    } else {
+        m.status.clone()
+    };
     RenderItem {
         line: format!(
             "- [{} | {}] {}{}{} (rag-rat: memory_search)",
-            m.kind, m.status, m.title, gist_part, verdict_part,
+            m.kind, status, m.title, gist_part, verdict_part,
         ),
         memory_id: Some(m.memory_id),
         symbol_key: None,
@@ -776,6 +785,40 @@ mod tests {
 
     /// A memory reachable ONLY through the FTS lane: bound to the seeded file's path, which
     /// `compose` never consults here because these tests pass `search_path: None`.
+    #[test]
+    fn a_drifted_memory_renders_its_drift_in_the_status_slot() {
+        // grep- and read-augment render a raw list without partitioning it, so the status slot is
+        // the only place a reader learns the anchor moved on. Kept next to the persisted status
+        // rather than replacing it: the row really is active, and this says what is untrustworthy.
+        let memory = memory::RepoMemory {
+            memory_id: "m1".to_string(),
+            kind: "Invariant".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            summary: None,
+            verdict: None,
+            confidence: "high".to_string(),
+            status: "active".to_string(),
+            created_by: None,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            source: "agent".to_string(),
+            payload_json: None,
+            source_text_hash: None,
+            input_hash: None,
+            memory_version: "v1".to_string(),
+            synced_anchor_drifted: true,
+            bindings: Vec::new(),
+            call_paths: Vec::new(),
+            tags: Vec::new(),
+        };
+        let rendered = memory_render_item(memory).line;
+        assert!(
+            rendered.contains("anchor drifted"),
+            "the drift must reach the rendered line: {rendered}"
+        );
+    }
+
     fn seed_fts_memory(conn: &Connection, title: &str, body: &str) -> memory::RepoMemory {
         crate::memory_write::create_memory(conn, RepoMemoryCreate {
             kind: "Invariant".to_string(),

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -323,6 +323,11 @@ pub fn compose(
     }
     // Apply session-level dedupe filter last (after insertion-order dedup above).
     memories.retain(|m| !dedupe.memory_ids.contains(&m.memory_id));
+    // The lexical lane hydrates through plain `memory_by_id`, so a memory that reached this list
+    // by matching prose carries no drift verdict while the same memory reached by path or symbol
+    // does. Mark the assembled list, so one rendered lane cannot present a drifted anchor as
+    // current just because of how the pattern happened to find it.
+    memory::mark_drive_by_drift(conn, &mut memories)?;
     // Honor `[memory] surface`: under `Summary` each memory renders its dream summary + verdict
     // marker (title-only fallback) instead of the clamped body — the hook context stays terse and
     // the full body is one `memory show` away.
@@ -816,6 +821,47 @@ mod tests {
         assert!(
             rendered.contains("anchor drifted"),
             "the drift must reach the rendered line: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_memory_found_only_by_prose_still_renders_its_anchor_drift() {
+        // The lexical lane hydrates through plain `memory_by_id`, so a memory the pattern reaches
+        // by prose alone arrives unmarked. Rendering it beside the path/symbol lanes would present
+        // the same memory as current or drifted purely by how it was found.
+        let conn = seeded_conn();
+        let memory = seed_fts_memory(
+            &conn,
+            "Zebraglyph routing pins quokkaform",
+            "zebraglyph quokkaform lorikeetwise — the zebraglyph router pins quokkaform.",
+        );
+        // Make it a synced memory whose stamped text this checkout no longer holds. The pattern
+        // below matches its prose only: nothing names `src/watch.rs` or a symbol in it.
+        conn.execute(
+            "UPDATE repo_memories SET origin = 'synced', source_text_hash = 'stamped-then' WHERE \
+             id = ?1",
+            rusqlite::params![memory.memory_id],
+        )
+        .unwrap();
+
+        let out = compose(
+            &conn,
+            "zebraglyph quokkaform lorikeetwise",
+            None,
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
+        assert!(
+            out.context.contains("Zebraglyph routing pins quokkaform"),
+            "the prose match surfaces: {}",
+            out.context
+        );
+        assert!(
+            out.context.contains("anchor drifted"),
+            "and carries its drift, though no drive-by reader hydrated it: {}",
+            out.context
         );
     }
 

--- a/crates/rag-rat-query/src/memory/api.rs
+++ b/crates/rag-rat-query/src/memory/api.rs
@@ -208,7 +208,10 @@ pub fn memories_for_symbol(
     }
     let mut memories = Vec::new();
     for id in candidate_ids.into_iter().take(usize::try_from(limit).unwrap_or(usize::MAX)) {
-        if let Some(memory) = memory_by_id(conn, &id)? {
+        // `drive_by_memory`, not `memory_by_id`: this reader collects ids into a set rather than
+        // going through `ids_to_memories`, so it has to ask for the drive-by hydration explicitly
+        // or it would be the one `memories_for_*` surface that never marks anchor drift (#1236).
+        if let Some(memory) = drive_by_memory(conn, &id)? {
             memories.push(memory);
         }
     }

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -281,42 +281,46 @@ pub(crate) fn mark_drifted_synced_anchor(
     if !synced {
         return Ok(());
     }
-    // Only rows THIS checkout currently serves may price an anchor. Without the live-generation
-    // and `deleted` filters a superseded staging row or a tombstone could answer, and the memory
-    // would be judged against text no reader can see; without the worktree filter a sibling
-    // checkout's copy of the file could answer for this one. `worktree_id = ''` is the shared base
-    // row, which belongs to every checkout — see `path_is_live_in_another_scope`.
-    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
-    let live_generation = rag_rat_db::schema::live_files_generation(conn, &repo_id)?;
-    let active_worktree =
-        rag_rat_db::schema::connection_context_value(conn, "worktree_id").unwrap_or_default();
+    // Every anchor is priced by the SAME quantity its resolver stamped: `chunks.text_hash` for a
+    // chunk/symbol anchor, `files.sha256` for an edge anchor, and `files.sha256` by path for a
+    // `path` anchor (spanned or bare — `resolve_path_binding` stamps both from the file). Omitting
+    // the path branch would leave a peer's path-anchored memory permanently unpriced, and so
+    // permanently presented as current however far its file had moved on.
+    //
+    // Reads go through the SCOPED `files` view, never `main.files`. The view is what this checkout
+    // actually serves: it applies the live generation, drops tombstones, keeps a sibling
+    // checkout's rows out, and — the part a hand-rolled predicate gets wrong — SHADOWS a base row
+    // whose path a linked worktree overrides. Selecting from `main.files` retains both rows, so a
+    // stamp matching the hidden base hash would read as current while the checkout serves changed
+    // overlay text.
     let (candidates, matches): (i64, i64) = conn.query_row(
         "
-        WITH live_files AS (
-            SELECT id, sha256 FROM main.files
-            WHERE repo_id = ?3 AND kind != 'deleted' AND generation = ?4
-              AND (worktree_id = '' OR worktree_id = ?5)
-        )
         SELECT COUNT(*), COALESCE(SUM(current_hash = ?2), 0)
         FROM (
             SELECT chunks.text_hash AS current_hash
             FROM repo_memory_bindings
             JOIN chunks ON chunks.id = repo_memory_bindings.chunk_id
-            JOIN live_files ON live_files.id = chunks.file_id
+            JOIN files ON files.id = chunks.file_id
             WHERE repo_memory_bindings.memory_id = ?1
             UNION ALL
-            SELECT live_files.sha256 AS current_hash
+            SELECT files.sha256 AS current_hash
             FROM repo_memory_bindings
             JOIN edges ON edges.id = repo_memory_bindings.edge_id
-            JOIN live_files ON live_files.id = edges.source_file_id
+            JOIN files ON files.id = edges.source_file_id
             WHERE repo_memory_bindings.memory_id = ?1
+            UNION ALL
+            SELECT files.sha256 AS current_hash
+            FROM repo_memory_bindings
+            JOIN files ON files.path = repo_memory_bindings.path
+            WHERE repo_memory_bindings.memory_id = ?1
+              AND repo_memory_bindings.binding_kind = 'path'
         )
         ",
-        params![&memory.memory_id, stamp, repo_id, live_generation, active_worktree],
+        params![&memory.memory_id, stamp],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
-    // No candidate anchors this checkout can price (a bare `path` binding, or an anchor whose
-    // chunk is gone) leaves the memory unmarked: absence of evidence, not evidence of drift.
+    // An anchor this checkout cannot price at all — its file shadowed, tombstoned, or never
+    // indexed here — leaves the memory unmarked: absence of evidence, not evidence of drift.
     memory.synced_anchor_drifted = candidates > 0 && matches == 0;
     Ok(())
 }
@@ -547,6 +551,7 @@ mod drift_tests {
         let conn = db();
         // The checkout now holds `now`; the author stamped `then`.
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", Some("then"), chunk);
 
         let found = memories_for_chunk(&conn, chunk, 10).unwrap();
@@ -564,6 +569,7 @@ mod drift_tests {
         // What a content-confirmed relocation leaves behind: the anchor moved, the text did not,
         // so the stamp still names what is there.
         let chunk = seed_chunk(&conn, "src/a.rs", "same");
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", Some("same"), chunk);
 
         let found = memories_for_chunk(&conn, chunk, 10).unwrap();
@@ -576,6 +582,7 @@ mod drift_tests {
         let conn = db();
         // Every pre-carrier row is NULL. Absence of a stamp is not evidence of drift.
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", None, chunk);
 
         let found = memories_for_chunk(&conn, chunk, 10).unwrap();
@@ -589,6 +596,7 @@ mod drift_tests {
         // Same divergence as the marked case, authored locally. Local drift is relocation's job;
         // marking it here would demote most of a living repo's own memories.
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "local", Some("then"), chunk);
 
         let found = memories_for_chunk(&conn, chunk, 10).unwrap();
@@ -597,17 +605,77 @@ mod drift_tests {
     }
 
     #[test]
-    fn an_anchor_this_checkout_cannot_price_leaves_the_memory_unmarked() {
+    fn a_path_anchor_is_priced_by_its_files_hash() {
         let conn = db();
-        // A bare `path` binding names no span, so nothing here holds a comparable hash. Silence is
-        // not divergence.
-        seed_chunk(&conn, "src/a.rs", "now");
+        // `resolve_path_binding` stamps a path anchor from `files.sha256`, so this checkout can
+        // price it — and must. Leaving path anchors out of the candidate set would keep a peer's
+        // path-anchored memory presenting as current however far its file had moved on.
+        seed_chunk(&conn, "src/a.rs", "irrelevant");
+        install_files_view(&conn, "");
         conn.execute(
             "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
              created_at_ms, updated_at_ms, source, memory_version, repo_id, origin, \
              source_text_hash) VALUES \
-             ('m1','Invariant','t','b','high','active','agent',1,1,'agent','v1',?1,'synced','then'\
-             )",
+             ('m1','Invariant','t','b','high','active','agent',1,1,'agent','v1',?1,'synced','\
+             stamped-then')",
+            params![REPO],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             start_line, end_line, anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','path','src/a.rs:1-5','src/a.rs',1,5,'current',0,?1)",
+            params![REPO],
+        )
+        .unwrap();
+
+        let found = memories_for_path(&conn, "src/a.rs", 10).unwrap();
+        assert_eq!(found.len(), 1, "still surfaces");
+        assert!(found[0].synced_anchor_drifted, "the file's hash is not what the author stamped");
+    }
+
+    #[test]
+    fn an_anchor_this_checkout_does_not_serve_leaves_the_memory_unmarked() {
+        let conn = db();
+        // The anchored file is not in this checkout's view at all, so nothing here can speak to
+        // the memory either way. Absence of evidence is not evidence of drift.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+        conn.execute_batch(
+            "DROP VIEW IF EXISTS temp.files;
+             CREATE TEMP VIEW temp.files AS SELECT * FROM main.files WHERE 0",
+        )
+        .unwrap();
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(!memory.synced_anchor_drifted, "an unserved anchor yields no verdict");
+    }
+
+    #[test]
+    fn an_overlay_shadows_the_base_row_it_overrides() {
+        let conn = db();
+        // A linked worktree overrides the path. The scoped view hides the base row, so the stamp
+        // must be judged against the OVERLAY text this checkout serves — matching the hidden base
+        // hash is exactly the false "current" a `main.files` read would produce.
+        seed_chunk_in(&conn, "src/a.rs", "base-text", "");
+        conn.execute("UPDATE main.files SET sha256 = 'stamped-base' WHERE worktree_id = ''", [])
+            .unwrap();
+        seed_chunk_in(&conn, "src/a.rs", "overlay-text", "wt-active");
+        conn.execute(
+            "UPDATE main.files SET sha256 = 'moved-on' WHERE worktree_id = 'wt-active'",
+            [],
+        )
+        .unwrap();
+        set_active_worktree(&conn, "wt-active");
+        install_files_view(&conn, "wt-active");
+
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id, origin, \
+             source_text_hash) VALUES \
+             ('m1','Invariant','t','b','high','active','agent',1,1,'agent','v1',?1,'synced','\
+             stamped-base')",
             params![REPO],
         )
         .unwrap();
@@ -619,15 +687,19 @@ mod drift_tests {
         )
         .unwrap();
 
-        let found = memories_for_path(&conn, "src/a.rs", 10).unwrap();
-        assert_eq!(found.len(), 1);
-        assert!(!found[0].synced_anchor_drifted, "no priceable anchor means no verdict");
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(
+            memory.synced_anchor_drifted,
+            "the shadowed base hash must not certify a memory as current"
+        );
     }
 
     #[test]
     fn every_drive_by_reader_marks_including_the_one_that_hydrates_its_own_ids() {
         let conn = db();
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", Some("then"), chunk);
         // `memories_for_symbol` collects ids into a set and hydrates them itself rather than going
         // through `ids_to_memories`, so it is the reader a seam-only fix would silently miss.
@@ -690,6 +762,29 @@ mod drift_tests {
         .unwrap();
     }
 
+    /// The scoped `files` view a real connection carries, in the shape `lifecycle.rs` installs:
+    /// the active checkout's own rows, plus base rows for paths that checkout does not override.
+    /// Reads under test must see exactly what this checkout serves, shadowing included.
+    fn install_files_view(conn: &Connection, active_worktree: &str) {
+        conn.execute_batch(&format!(
+            "DROP VIEW IF EXISTS temp.files;
+             CREATE TEMP VIEW temp.files AS
+             SELECT * FROM main.files
+              WHERE repo_id = '{REPO}' AND generation = 0 AND kind != 'deleted'
+                AND worktree_id = '{active_worktree}' AND worktree_id != ''
+             UNION ALL
+             SELECT * FROM main.files
+              WHERE repo_id = '{REPO}' AND generation = 0 AND kind != 'deleted'
+                AND worktree_id = ''
+                AND path NOT IN (
+                    SELECT path FROM main.files
+                     WHERE repo_id = '{REPO}' AND generation = 0 AND kind != 'deleted'
+                       AND worktree_id = '{active_worktree}' AND worktree_id != ''
+                )"
+        ))
+        .unwrap();
+    }
+
     #[test]
     fn a_sibling_checkouts_chunk_never_prices_this_checkouts_anchor() {
         let conn = db();
@@ -698,6 +793,7 @@ mod drift_tests {
         // it must not decide this checkout's verdict; the memory simply goes unpriced here.
         let theirs = seed_chunk_in(&conn, "src/a.rs", "their-text", "wt-sibling");
         set_active_worktree(&conn, "wt-active");
+        install_files_view(&conn, "wt-active");
         seed_memory(&conn, "m1", "synced", Some("stamped"), theirs);
 
         let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
@@ -716,6 +812,7 @@ mod drift_tests {
         // the filter above would turn every linked worktree into a blanket exemption.
         let base = seed_chunk_in(&conn, "src/a.rs", "now", "");
         set_active_worktree(&conn, "wt-active");
+        install_files_view(&conn, "wt-active");
         seed_memory(&conn, "m1", "synced", Some("then"), base);
 
         let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
@@ -730,6 +827,7 @@ mod drift_tests {
         // It is not what any reader is served, so it must not answer for the anchor either.
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
         conn.execute("UPDATE main.files SET generation = 7 WHERE path = 'src/a.rs'", []).unwrap();
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", Some("then"), chunk);
 
         let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
@@ -745,6 +843,7 @@ mod drift_tests {
         let conn = db();
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
         conn.execute("UPDATE main.files SET kind = 'deleted' WHERE path = 'src/a.rs'", []).unwrap();
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", Some("then"), chunk);
 
         let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
@@ -753,9 +852,54 @@ mod drift_tests {
     }
 
     #[test]
+    fn an_edge_anchor_is_priced_by_its_source_files_hash() {
+        let conn = db();
+        // An edge anchor is stamped from the source file's `sha256` (`edge_by_id`), so that is
+        // what prices it. Without this branch a peer's edge-anchored memory would go unpriced and
+        // present as current no matter how far the file holding the call had moved on.
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES \
+             ('src/a.rs','rust','source','moved-on',0,0,'','',?1,0)",
+            params![REPO],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO edges_data(source_file_id, to_name_id, resolution_id, edge_kind_id, \
+             confidence_id) VALUES (?1, 0, 0, 0, 0)",
+            params![file_id],
+        )
+        .unwrap();
+        let edge_id = conn.last_insert_rowid();
+        install_files_view(&conn, "");
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id, origin, \
+             source_text_hash) VALUES \
+             ('m1','Invariant','t','b','high','active','agent',1,1,'agent','v1',?1,'synced','\
+             stamped-then')",
+            params![REPO],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, edge_id, \
+             anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','edge','fp','src/a.rs',?1,'current',0,?2)",
+            params![edge_id, REPO],
+        )
+        .unwrap();
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(memory.synced_anchor_drifted, "the edge's source file is not what was stamped");
+    }
+
+    #[test]
     fn a_by_id_read_never_marks() {
         let conn = db();
         let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
         seed_memory(&conn, "m1", "synced", Some("then"), chunk);
         // `memory_by_id` backs `memory_get` and `memory_search`. Drift is a drive-by presentation
         // rule, so those surfaces must be untouched by it.

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -169,6 +169,10 @@ pub(crate) fn memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoMemory
         source_text_hash: row.get("source_text_hash")?,
         input_hash: row.get("input_hash")?,
         memory_version: row.get("memory_version")?,
+        // Drift is a property of the reading surface, not of the row: only the drive-by readers
+        // mark it (`mark_drifted_synced_anchor`). The mechanical hydration leaves it clear so
+        // `memory_get`, `memory_search`, dream, distill and doctor are unaffected.
+        synced_anchor_drifted: false,
         bindings: Vec::new(),
         call_paths: Vec::new(),
         tags: Vec::new(),
@@ -248,13 +252,94 @@ pub fn tags_for_memory(conn: &Connection, memory_id: &str) -> anyhow::Result<Vec
         .collect::<Result<Vec<_>, _>>()
         .map_err(Into::into)
 }
+/// Mark a synced memory whose anchored text this checkout no longer holds (#1236).
+///
+/// The stamp is not a bespoke hash: `resolve.rs` takes it from `chunks.text_hash` for a
+/// chunk/symbol anchor and from `files.sha256` for an edge anchor, so the current value is the
+/// same column read back — a join, not a recomputation, and no filesystem read on a drive-by
+/// surface. Comparing anything else (a fresh span read, or `files.sha256` for a chunk anchor)
+/// would compare against a quantity the author never stamped.
+///
+/// Drift is "the stamp matches nothing this checkout currently holds at the memory's anchors": the
+/// memory carries candidate hashes and none of them equals the stamp. A content-confirmed
+/// relocation therefore passes by construction — it moved the anchor to text that hashes the same.
+/// A moniker- or name-matched relocation onto changed text does mark, which is the honest reading
+/// of a pure hash comparison and costs a mark rather than a disappearance.
+pub(crate) fn mark_drifted_synced_anchor(
+    conn: &Connection,
+    memory: &mut RepoMemory,
+) -> anyhow::Result<()> {
+    // An absent stamp is not evidence of drift — every pre-carrier row is NULL.
+    let Some(stamp) = memory.source_text_hash.as_deref() else { return Ok(()) };
+    // Scoped to synced rows. A local memory's stamp is its own authoring snapshot, and local
+    // drift already has a mechanism: relocation stamps `anchor_status`, which demotes on its own.
+    let synced: bool = conn.query_row(
+        "SELECT origin = 'synced' FROM repo_memories WHERE id = ?1",
+        [&memory.memory_id],
+        |row| row.get(0),
+    )?;
+    if !synced {
+        return Ok(());
+    }
+    // Only rows THIS checkout currently serves may price an anchor. Without the live-generation
+    // and `deleted` filters a superseded staging row or a tombstone could answer, and the memory
+    // would be judged against text no reader can see; without the worktree filter a sibling
+    // checkout's copy of the file could answer for this one. `worktree_id = ''` is the shared base
+    // row, which belongs to every checkout — see `path_is_live_in_another_scope`.
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let live_generation = rag_rat_db::schema::live_files_generation(conn, &repo_id)?;
+    let active_worktree =
+        rag_rat_db::schema::connection_context_value(conn, "worktree_id").unwrap_or_default();
+    let (candidates, matches): (i64, i64) = conn.query_row(
+        "
+        WITH live_files AS (
+            SELECT id, sha256 FROM main.files
+            WHERE repo_id = ?3 AND kind != 'deleted' AND generation = ?4
+              AND (worktree_id = '' OR worktree_id = ?5)
+        )
+        SELECT COUNT(*), COALESCE(SUM(current_hash = ?2), 0)
+        FROM (
+            SELECT chunks.text_hash AS current_hash
+            FROM repo_memory_bindings
+            JOIN chunks ON chunks.id = repo_memory_bindings.chunk_id
+            JOIN live_files ON live_files.id = chunks.file_id
+            WHERE repo_memory_bindings.memory_id = ?1
+            UNION ALL
+            SELECT live_files.sha256 AS current_hash
+            FROM repo_memory_bindings
+            JOIN edges ON edges.id = repo_memory_bindings.edge_id
+            JOIN live_files ON live_files.id = edges.source_file_id
+            WHERE repo_memory_bindings.memory_id = ?1
+        )
+        ",
+        params![&memory.memory_id, stamp, repo_id, live_generation, active_worktree],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    // No candidate anchors this checkout can price (a bare `path` binding, or an anchor whose
+    // chunk is gone) leaves the memory unmarked: absence of evidence, not evidence of drift.
+    memory.synced_anchor_drifted = candidates > 0 && matches == 0;
+    Ok(())
+}
+
+/// Hydrate ids into memories for a DRIVE-BY surface — the five `memories_for_*` readers. Unlike
+/// bare `memory_by_id`, this marks anchor drift (#1236), which is why the drive-by readers must
+/// route through here rather than looping `memory_by_id` themselves.
+pub(crate) fn drive_by_memory(
+    conn: &Connection,
+    memory_id: &str,
+) -> anyhow::Result<Option<RepoMemory>> {
+    let Some(mut memory) = memory_by_id(conn, memory_id)? else { return Ok(None) };
+    mark_drifted_synced_anchor(conn, &mut memory)?;
+    Ok(Some(memory))
+}
+
 pub(crate) fn ids_to_memories(
     conn: &Connection,
     rows: rusqlite::MappedRows<'_, impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<String>>,
 ) -> anyhow::Result<Vec<RepoMemory>> {
     let mut memories = Vec::new();
     for row in rows {
-        if let Some(memory) = memory_by_id(conn, &row?)? {
+        if let Some(memory) = drive_by_memory(conn, &row?)? {
             memories.push(memory);
         }
     }
@@ -374,6 +459,10 @@ pub fn split_active_stale(memories: Vec<RepoMemory>) -> (Vec<RepoMemory>, Vec<Re
         // oracle runs. A real problem with the anchored code shows on the primary
         // symbol/logical_symbol binding, which still demotes.
         if memory.status == "stale"
+            // A synced memory anchored to text this checkout no longer holds (#1236). It still
+            // surfaces — in the demoted lane, like any other weakened anchor — because a hash
+            // divergence cannot distinguish a peer running ahead from a local edit after a pull.
+            || memory.synced_anchor_drifted
             || memory.bindings.iter().any(|binding| {
                 binding.binding_kind != SCIP_MONIKER_BINDING_KIND
                     && matches!(
@@ -391,4 +480,286 @@ pub fn split_active_stale(memories: Vec<RepoMemory>) -> (Vec<RepoMemory>, Vec<Re
         }
     }
     (direct, stale)
+}
+
+#[cfg(test)]
+mod drift_tests {
+    use super::*;
+    use crate::memory::api::{memories_for_chunk, memories_for_path, memories_for_symbol};
+
+    const REPO: &str = "r";
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [REPO],
+        )
+        .unwrap();
+        conn
+    }
+
+    /// A file with one chunk whose current text hashes to `text_hash`.
+    fn seed_chunk(conn: &Connection, path: &str, text_hash: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES \
+             (?1,'rust','source',?2,0,0,'','',?3,0)",
+            params![path, format!("sha-{path}"), REPO],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO chunks(file_id, chunk_kind, start_byte, end_byte, start_line, end_line, \
+             text_hash) VALUES (?1,'code',0,10,1,5,?2)",
+            params![file_id, text_hash],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    /// A memory carrying `stamp` as its author-stamped hash, anchored to `chunk_id`.
+    fn seed_memory(conn: &Connection, id: &str, origin: &str, stamp: Option<&str>, chunk_id: i64) {
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id, origin, \
+             source_text_hash) VALUES \
+             (?1,'Invariant','t','b','high','active','agent',1,1,'agent','v1',?2,?3,?4)",
+            params![id, REPO, origin, stamp],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             chunk_id, anchor_status, created_at_ms, repo_id) VALUES \
+             (?1,'chunk',?2,'src/a.rs',?3,'current',0,?4)",
+            params![id, chunk_id.to_string(), chunk_id, REPO],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn a_synced_memory_whose_anchor_text_moved_on_is_demoted_but_still_surfaces() {
+        let conn = db();
+        // The checkout now holds `now`; the author stamped `then`.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+
+        let found = memories_for_chunk(&conn, chunk, 10).unwrap();
+        assert_eq!(found.len(), 1, "drift must never hide a memory");
+        assert!(found[0].synced_anchor_drifted, "a diverged stamp marks");
+
+        let (direct, stale) = split_active_stale(found);
+        assert!(direct.is_empty(), "a drifted anchor does not present as confidently current");
+        assert_eq!(stale.len(), 1, "it is demoted into the stale lane, not dropped");
+    }
+
+    #[test]
+    fn a_synced_memory_still_anchored_to_its_stamped_text_is_untouched() {
+        let conn = db();
+        // What a content-confirmed relocation leaves behind: the anchor moved, the text did not,
+        // so the stamp still names what is there.
+        let chunk = seed_chunk(&conn, "src/a.rs", "same");
+        seed_memory(&conn, "m1", "synced", Some("same"), chunk);
+
+        let found = memories_for_chunk(&conn, chunk, 10).unwrap();
+        assert!(!found[0].synced_anchor_drifted, "a matching stamp is not drift");
+        assert_eq!(split_active_stale(found).0.len(), 1, "and it stays in the direct lane");
+    }
+
+    #[test]
+    fn a_synced_memory_carrying_no_stamp_surfaces_unmarked() {
+        let conn = db();
+        // Every pre-carrier row is NULL. Absence of a stamp is not evidence of drift.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        seed_memory(&conn, "m1", "synced", None, chunk);
+
+        let found = memories_for_chunk(&conn, chunk, 10).unwrap();
+        assert!(!found[0].synced_anchor_drifted, "a NULL stamp cannot diverge");
+        assert_eq!(split_active_stale(found).0.len(), 1);
+    }
+
+    #[test]
+    fn a_local_memory_in_identical_drift_is_not_marked() {
+        let conn = db();
+        // Same divergence as the marked case, authored locally. Local drift is relocation's job;
+        // marking it here would demote most of a living repo's own memories.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        seed_memory(&conn, "m1", "local", Some("then"), chunk);
+
+        let found = memories_for_chunk(&conn, chunk, 10).unwrap();
+        assert!(!found[0].synced_anchor_drifted, "the rule is scoped to synced rows");
+        assert_eq!(split_active_stale(found).0.len(), 1);
+    }
+
+    #[test]
+    fn an_anchor_this_checkout_cannot_price_leaves_the_memory_unmarked() {
+        let conn = db();
+        // A bare `path` binding names no span, so nothing here holds a comparable hash. Silence is
+        // not divergence.
+        seed_chunk(&conn, "src/a.rs", "now");
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id, origin, \
+             source_text_hash) VALUES \
+             ('m1','Invariant','t','b','high','active','agent',1,1,'agent','v1',?1,'synced','then'\
+             )",
+            params![REPO],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','path','src/a.rs','src/a.rs','current',0,?1)",
+            params![REPO],
+        )
+        .unwrap();
+
+        let found = memories_for_path(&conn, "src/a.rs", 10).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(!found[0].synced_anchor_drifted, "no priceable anchor means no verdict");
+    }
+
+    #[test]
+    fn every_drive_by_reader_marks_including_the_one_that_hydrates_its_own_ids() {
+        let conn = db();
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+        // `memories_for_symbol` collects ids into a set and hydrates them itself rather than going
+        // through `ids_to_memories`, so it is the reader a seam-only fix would silently miss.
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','path','src/a.rs','src/a.rs','current',0,?1)",
+            params![REPO],
+        )
+        .unwrap();
+
+        let hit = crate::symbol::SymbolHit {
+            symbol_id: 0,
+            logical_symbol_id: None,
+            logical_variant_count: None,
+            logical_group_reason: None,
+            file_id: 0,
+            path: "src/a.rs".to_string(),
+            file_kind: "source".to_string(),
+            language: "rust".to_string(),
+            name: "a".to_string(),
+            symbol_path: "src/a.rs::a".to_string(),
+            qualified_name: "src/a.rs::a".to_string(),
+            kind: "function".to_string(),
+            start_byte: 0,
+            end_byte: 0,
+            signature: None,
+            docs: None,
+            importance: None,
+        };
+        let found = memories_for_symbol(&conn, &hit, 10).unwrap();
+        assert_eq!(found.len(), 1, "the symbol reader still finds it");
+        assert!(found[0].synced_anchor_drifted, "and marks it, like the other four readers");
+    }
+
+    /// Seed a file+chunk owned by a specific checkout, so the active-scope filter can be exercised.
+    fn seed_chunk_in(conn: &Connection, path: &str, text_hash: &str, worktree: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES \
+             (?1,'rust','source',?2,0,0,'',?3,?4,0)",
+            params![path, format!("sha-{path}"), worktree, REPO],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO chunks(file_id, chunk_kind, start_byte, end_byte, start_line, end_line, \
+             text_hash) VALUES (?1,'code',0,10,1,5,?2)",
+            params![file_id, text_hash],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn set_active_worktree(conn: &Connection, worktree: &str) {
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('worktree_id', ?1)",
+            [worktree],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn a_sibling_checkouts_chunk_never_prices_this_checkouts_anchor() {
+        let conn = db();
+        // The anchor names a chunk owned by ANOTHER checkout's file row — the shape a binding
+        // takes when it was resolved over there. That text is not what this checkout serves, so
+        // it must not decide this checkout's verdict; the memory simply goes unpriced here.
+        let theirs = seed_chunk_in(&conn, "src/a.rs", "their-text", "wt-sibling");
+        set_active_worktree(&conn, "wt-active");
+        seed_memory(&conn, "m1", "synced", Some("stamped"), theirs);
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(
+            !memory.synced_anchor_drifted,
+            "a sibling checkout's text is not evidence about this one"
+        );
+    }
+
+    #[test]
+    fn the_shared_base_row_still_prices_an_anchor_inside_a_linked_worktree() {
+        let conn = db();
+        // The `worktree_id = ''` base row belongs to every checkout, so working inside a linked
+        // worktree must not silence drift on files that checkout has not overridden — otherwise
+        // the filter above would turn every linked worktree into a blanket exemption.
+        let base = seed_chunk_in(&conn, "src/a.rs", "now", "");
+        set_active_worktree(&conn, "wt-active");
+        seed_memory(&conn, "m1", "synced", Some("then"), base);
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(memory.synced_anchor_drifted, "the shared base row is this checkout's text too");
+    }
+
+    #[test]
+    fn a_superseded_generation_row_never_prices_an_anchor() {
+        let conn = db();
+        // A staging row from an in-flight rebuild carries a higher generation than the live one.
+        // It is not what any reader is served, so it must not answer for the anchor either.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        conn.execute("UPDATE main.files SET generation = 7 WHERE path = 'src/a.rs'", []).unwrap();
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(
+            !memory.synced_anchor_drifted,
+            "no LIVE row prices this anchor, so there is no verdict to reach"
+        );
+    }
+
+    #[test]
+    fn a_deleted_files_chunk_never_prices_an_anchor() {
+        let conn = db();
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        conn.execute("UPDATE main.files SET kind = 'deleted' WHERE path = 'src/a.rs'", []).unwrap();
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(!memory.synced_anchor_drifted, "a tombstone is not evidence of drift");
+    }
+
+    #[test]
+    fn a_by_id_read_never_marks() {
+        let conn = db();
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+        // `memory_by_id` backs `memory_get` and `memory_search`. Drift is a drive-by presentation
+        // rule, so those surfaces must be untouched by it.
+        let direct = memory_by_id(&conn, "m1").unwrap().unwrap();
+        assert!(!direct.synced_anchor_drifted, "memory_get / memory_search stay unaffected");
+    }
 }

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -295,6 +295,11 @@ pub(crate) fn mark_drifted_synced_anchor(
     // memories first appear. Both are reachable from the portable identity: an edge anchor's
     // `path` IS its source file's, and a symbol anchor's span selects the chunk covering it.
     //
+    // The fallback keys on whether the resolved id is SERVED here, not on whether it is set. A
+    // validated binding inside a linked worktree keeps pointing at the base row the overlay
+    // shadows, so an id that is present but invisible is no more usable than a missing one —
+    // gating on `IS NULL` would leave that memory unpriced while the checkout serves changed text.
+    //
     // Reads go through the SCOPED `files` view, never `main.files`. The view is what this checkout
     // actually serves: it applies the live generation, drops tombstones, keeps a sibling
     // checkout's rows out, and — the part a hand-rolled predicate gets wrong — SHADOWS a base row
@@ -328,7 +333,11 @@ pub(crate) fn mark_drifted_synced_anchor(
             JOIN files ON files.path = repo_memory_bindings.path
             WHERE repo_memory_bindings.memory_id = ?1
               AND repo_memory_bindings.binding_kind = 'edge'
-              AND repo_memory_bindings.edge_id IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM edges
+                  JOIN files AS served ON served.id = edges.source_file_id
+                  WHERE edges.id = repo_memory_bindings.edge_id
+              )
             UNION ALL
             SELECT chunks.text_hash AS current_hash
             FROM repo_memory_bindings
@@ -338,7 +347,11 @@ pub(crate) fn mark_drifted_synced_anchor(
                        AND chunks.end_line >= repo_memory_bindings.end_line
             WHERE repo_memory_bindings.memory_id = ?1
               AND repo_memory_bindings.binding_kind IN ('symbol', 'logical_symbol')
-              AND repo_memory_bindings.chunk_id IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM chunks AS resolved
+                  JOIN files AS served ON served.id = resolved.file_id
+                  WHERE resolved.id = repo_memory_bindings.chunk_id
+              )
               AND repo_memory_bindings.start_line IS NOT NULL
               AND repo_memory_bindings.end_line IS NOT NULL
         )
@@ -349,6 +362,20 @@ pub(crate) fn mark_drifted_synced_anchor(
     // An anchor this checkout cannot price at all — its file shadowed, tombstoned, or never
     // indexed here — leaves the memory unmarked: absence of evidence, not evidence of drift.
     memory.synced_anchor_drifted = candidates > 0 && matches == 0;
+    Ok(())
+}
+
+/// Mark anchor drift across a list a drive-by surface is about to render (#1236).
+///
+/// The augmenters assemble one list from several lanes — symbol, path, and a lexical lane fed by
+/// `memory_search_scored`, which hydrates through plain `memory_by_id`. Rendering that list without
+/// this leaves the same memory marked or unmarked depending on which lane happened to find it,
+/// which is worse than not marking at all: the reader cannot tell a current anchor from an
+/// unpriced one. Idempotent, so lanes already marked at hydration recompute the same answer.
+pub fn mark_drive_by_drift(conn: &Connection, memories: &mut [RepoMemory]) -> anyhow::Result<()> {
+    for memory in memories.iter_mut() {
+        mark_drifted_synced_anchor(conn, memory)?;
+    }
     Ok(())
 }
 
@@ -1029,6 +1056,97 @@ mod drift_tests {
         let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
         mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
         assert!(memory.synced_anchor_drifted, "an unresolved edge is priced by its file");
+    }
+
+    #[test]
+    fn a_validated_anchor_the_overlay_shadows_falls_back_to_the_served_chunk() {
+        let conn = db();
+        // A binding validated in the base checkout keeps that checkout's `chunk_id`. Inside a
+        // linked worktree that overrides the file, the scoped view hides that row — so the id is
+        // present but unusable, and gating the fallback on `IS NULL` would leave the memory
+        // unpriced while this checkout serves changed text.
+        let base_chunk = seed_chunk_in(&conn, "src/a.rs", "stamped-then", "");
+        seed_chunk_in(&conn, "src/a.rs", "moved-on", "wt-active");
+        set_active_worktree(&conn, "wt-active");
+        install_files_view(&conn, "wt-active");
+        seed_bare_memory(&conn, "stamped-then");
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             start_line, end_line, chunk_id, anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','logical_symbol','sym','src/a.rs',1,5,?1,'current',0,?2)",
+            params![base_chunk, REPO],
+        )
+        .unwrap();
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(
+            memory.synced_anchor_drifted,
+            "a resolved id this checkout does not serve must fall back, not go silent"
+        );
+    }
+
+    #[test]
+    fn a_validated_edge_anchor_the_overlay_shadows_falls_back_to_the_served_file() {
+        let conn = db();
+        // The edge mirror of the case above: the edge row hangs off the base file the overlay
+        // shadows, so its resolved id is present but unserved here and the path fallback must
+        // price it against the text this checkout does serve.
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES \
+             ('src/a.rs','rust','source','stamped-then',0,0,'','',?1,0)",
+            params![REPO],
+        )
+        .unwrap();
+        let base_file = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES \
+             ('src/a.rs','rust','source','moved-on',0,0,'','wt-active',?1,0)",
+            params![REPO],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO edges_data(source_file_id, to_name_id, resolution_id, edge_kind_id, \
+             confidence_id) VALUES (?1, 0, 0, 0, 0)",
+            params![base_file],
+        )
+        .unwrap();
+        let edge_id = conn.last_insert_rowid();
+        set_active_worktree(&conn, "wt-active");
+        install_files_view(&conn, "wt-active");
+        seed_bare_memory(&conn, "stamped-then");
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, edge_id, \
+             anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','edge','fp','src/a.rs',?1,'current',0,?2)",
+            params![edge_id, REPO],
+        )
+        .unwrap();
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(
+            memory.synced_anchor_drifted,
+            "an edge id this checkout does not serve must fall back to its path"
+        );
+    }
+
+    #[test]
+    fn marking_a_list_reaches_a_memory_no_drive_by_reader_hydrated() {
+        let conn = db();
+        // The augmenter's lexical lane hydrates through plain `memory_by_id`. Rendering that list
+        // beside path/symbol lanes would present the same memory as current or drifted depending
+        // on which lane found it, so the assembled list is marked as a whole.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+
+        let mut lexical = vec![memory_by_id(&conn, "m1").unwrap().unwrap()];
+        assert!(!lexical[0].synced_anchor_drifted, "a plain by-id hydration carries no verdict");
+        mark_drive_by_drift(&conn, &mut lexical).unwrap();
+        assert!(lexical[0].synced_anchor_drifted, "marking the list reaches it");
     }
 
     #[test]

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -287,6 +287,14 @@ pub(crate) fn mark_drifted_synced_anchor(
     // the path branch would leave a peer's path-anchored memory permanently unpriced, and so
     // permanently presented as current however far its file had moved on.
     //
+    // The last two branches carry the SEEDED state. `seed_node_anchors` writes portable columns
+    // only and leaves `chunk_id`/`edge_id` at their defaults for the validate/relocate loop to
+    // fill, and nothing runs that loop automatically after a drain — so keying solely on the
+    // resolved ids would leave every freshly synced symbol and edge anchor unpriced for as long as
+    // no one happened to run `memory_validate`, which is exactly the window in which a peer's
+    // memories first appear. Both are reachable from the portable identity: an edge anchor's
+    // `path` IS its source file's, and a symbol anchor's span selects the chunk covering it.
+    //
     // Reads go through the SCOPED `files` view, never `main.files`. The view is what this checkout
     // actually serves: it applies the live generation, drops tombstones, keeps a sibling
     // checkout's rows out, and — the part a hand-rolled predicate gets wrong — SHADOWS a base row
@@ -314,6 +322,25 @@ pub(crate) fn mark_drifted_synced_anchor(
             JOIN files ON files.path = repo_memory_bindings.path
             WHERE repo_memory_bindings.memory_id = ?1
               AND repo_memory_bindings.binding_kind = 'path'
+            UNION ALL
+            SELECT files.sha256 AS current_hash
+            FROM repo_memory_bindings
+            JOIN files ON files.path = repo_memory_bindings.path
+            WHERE repo_memory_bindings.memory_id = ?1
+              AND repo_memory_bindings.binding_kind = 'edge'
+              AND repo_memory_bindings.edge_id IS NULL
+            UNION ALL
+            SELECT chunks.text_hash AS current_hash
+            FROM repo_memory_bindings
+            JOIN files ON files.path = repo_memory_bindings.path
+            JOIN chunks ON chunks.file_id = files.id
+                       AND chunks.start_line <= repo_memory_bindings.start_line
+                       AND chunks.end_line >= repo_memory_bindings.end_line
+            WHERE repo_memory_bindings.memory_id = ?1
+              AND repo_memory_bindings.binding_kind IN ('symbol', 'logical_symbol')
+              AND repo_memory_bindings.chunk_id IS NULL
+              AND repo_memory_bindings.start_line IS NOT NULL
+              AND repo_memory_bindings.end_line IS NOT NULL
         )
         ",
         params![&memory.memory_id, stamp],
@@ -922,6 +949,86 @@ mod drift_tests {
             serde_json::to_value(&clean[0]).unwrap().get("synced_anchor_drifted").is_none(),
             "the common case stays off the wire"
         );
+    }
+
+    /// The row shape `seed_node_anchors` writes: portable columns only, resolved ids left NULL.
+    fn seed_unresolved_binding(
+        conn: &Connection,
+        kind: &str,
+        path: &str,
+        span: Option<(i64, i64)>,
+    ) {
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             start_line, end_line, anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1',?1,'portable-id',?2,?3,?4,'unverified',0,?5)",
+            params![kind, path, span.map(|s| s.0), span.map(|s| s.1), REPO],
+        )
+        .unwrap();
+    }
+
+    fn seed_bare_memory(conn: &Connection, stamp: &str) {
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id, origin, \
+             source_text_hash) VALUES \
+             ('m1','Invariant','t','b','high','active','agent',1,1,'agent','v1',?1,'synced',?2)",
+            params![REPO, stamp],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn a_freshly_seeded_symbol_anchor_is_priced_before_validation_resolves_it() {
+        let conn = db();
+        // Straight out of the drain: the seeder writes portable columns only, and nothing runs the
+        // validate/relocate loop for it automatically. Keying on `chunk_id` alone would leave a
+        // peer's symbol-anchored memory unpriced for as long as nobody ran `memory_validate` —
+        // precisely the window in which their memories first show up.
+        seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
+        seed_bare_memory(&conn, "stamped-then");
+        seed_unresolved_binding(&conn, "logical_symbol", "src/a.rs", Some((2, 4)));
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(memory.synced_anchor_drifted, "the covering chunk prices an unresolved symbol");
+    }
+
+    #[test]
+    fn a_freshly_seeded_symbol_anchor_still_matching_is_not_marked() {
+        let conn = db();
+        // The mirror: pricing the seeded state must not manufacture drift for a peer whose text
+        // this checkout genuinely still holds.
+        seed_chunk(&conn, "src/a.rs", "same");
+        install_files_view(&conn, "");
+        seed_bare_memory(&conn, "same");
+        seed_unresolved_binding(&conn, "logical_symbol", "src/a.rs", Some((2, 4)));
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(!memory.synced_anchor_drifted, "a seeded anchor on matching text is current");
+    }
+
+    #[test]
+    fn a_freshly_seeded_edge_anchor_is_priced_by_its_source_file() {
+        let conn = db();
+        // An edge anchor's stamp is its source file's hash, and the seeded row already carries
+        // that file's path — so the portable identity prices it exactly, with no id to resolve.
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation) VALUES \
+             ('src/a.rs','rust','source','moved-on',0,0,'','',?1,0)",
+            params![REPO],
+        )
+        .unwrap();
+        install_files_view(&conn, "");
+        seed_bare_memory(&conn, "stamped-then");
+        seed_unresolved_binding(&conn, "edge", "src/a.rs", None);
+
+        let mut memory = memory_by_id(&conn, "m1").unwrap().unwrap();
+        mark_drifted_synced_anchor(&conn, &mut memory).unwrap();
+        assert!(memory.synced_anchor_drifted, "an unresolved edge is priced by its file");
     }
 
     #[test]

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -896,6 +896,35 @@ mod drift_tests {
     }
 
     #[test]
+    fn a_drifted_memory_carries_the_flag_on_the_wire() {
+        let conn = db();
+        // The augmenters and the raw MCP readers return a list and never partition it, so the
+        // demotion has to survive serialization or those surfaces present a drifted memory as
+        // plainly current. An undrifted memory adds no field.
+        let chunk = seed_chunk(&conn, "src/a.rs", "now");
+        install_files_view(&conn, "");
+        seed_memory(&conn, "m1", "synced", Some("then"), chunk);
+
+        let found = memories_for_chunk(&conn, chunk, 10).unwrap();
+        let json = serde_json::to_value(&found[0]).unwrap();
+        assert_eq!(
+            json.get("synced_anchor_drifted").and_then(serde_json::Value::as_bool),
+            Some(true),
+            "a consumer that never calls split_active_stale still sees the divergence"
+        );
+
+        let conn2 = db();
+        let ok = seed_chunk(&conn2, "src/a.rs", "same");
+        install_files_view(&conn2, "");
+        seed_memory(&conn2, "m2", "synced", Some("same"), ok);
+        let clean = memories_for_chunk(&conn2, ok, 10).unwrap();
+        assert!(
+            serde_json::to_value(&clean[0]).unwrap().get("synced_anchor_drifted").is_none(),
+            "the common case stays off the wire"
+        );
+    }
+
+    #[test]
     fn a_by_id_read_never_marks() {
         let conn = db();
         let chunk = seed_chunk(&conn, "src/a.rs", "now");

--- a/crates/rag-rat-query/src/memory/mod.rs
+++ b/crates/rag-rat-query/src/memory/mod.rs
@@ -81,6 +81,15 @@ pub struct RepoMemory {
     pub input_hash: Option<String>,
     #[serde(skip_serializing)]
     pub memory_version: String,
+    /// A synced memory whose author-stamped `source_text_hash` no longer matches the text this
+    /// checkout holds at any of its anchors (#1236). Set only on the drive-by surfaces, where it
+    /// demotes the memory into the stale lane — it never hides one. Exact-text hashing cannot tell
+    /// "the peer is ahead of my checkout" from "I edited after pulling", so a divergence is a
+    /// reason to mark, never to withhold. Always `false` for a locally authored memory, and for a
+    /// memory carrying no stamp (every pre-carrier row is NULL, and an absent stamp is not
+    /// evidence of drift).
+    #[serde(skip_serializing)]
+    pub synced_anchor_drifted: bool,
     pub bindings: Vec<RepoMemoryBinding>,
     pub call_paths: Vec<RepoMemoryCallPath>,
     pub tags: Vec<String>,
@@ -676,6 +685,7 @@ mod tests {
             source_text_hash: None,
             input_hash: None,
             memory_version: String::new(),
+            synced_anchor_drifted: false,
             bindings,
             call_paths: Vec::new(),
             tags: Vec::new(),
@@ -747,6 +757,7 @@ mod tests {
             source_text_hash: None,
             input_hash: None,
             memory_version: String::new(),
+            synced_anchor_drifted: false,
             bindings: Vec::new(),
             call_paths: Vec::new(),
             tags: Vec::new(),

--- a/crates/rag-rat-query/src/memory/mod.rs
+++ b/crates/rag-rat-query/src/memory/mod.rs
@@ -38,6 +38,12 @@ pub(crate) fn memory_repo_scope_clause(scope: &Option<String>) -> String {
     rag_rat_db::schema::periphery_repo_scope_clause(scope, "repo_memories")
 }
 
+/// Serialize `synced_anchor_drifted` only when it is set, so the common case adds no field and a
+/// drifted memory carries a visible one. A reader that never demotes still sees the divergence.
+fn is_not_drifted(drifted: &bool) -> bool {
+    !*drifted
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoMemory {
     pub memory_id: String,
@@ -88,7 +94,7 @@ pub struct RepoMemory {
     /// reason to mark, never to withhold. Always `false` for a locally authored memory, and for a
     /// memory carrying no stamp (every pre-carrier row is NULL, and an absent stamp is not
     /// evidence of drift).
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "is_not_drifted")]
     pub synced_anchor_drifted: bool,
     pub bindings: Vec<RepoMemoryBinding>,
     pub call_paths: Vec<RepoMemoryCallPath>,


### PR DESCRIPTION
Fixes #1236.

## Problem

A synced memory carries `repo_memories.source_text_hash` — the hash of the text its author anchored to (the carrier landed in #1235). Nothing compared it against what the reader actually holds, so a memory describing code that has since moved on surfaced exactly as confidently as one still anchored to the text it describes.

## Where the current hash comes from

The issue left this open, and it decides whether the comparison means anything. The stamp is not a bespoke span hash: `resolve.rs` takes it from `chunks.text_hash` for a chunk/symbol anchor and from `files.sha256` for an edge anchor. So the current value is **the same column read back** — a join, not a recomputation, and no filesystem read on a drive-by surface. The two alternatives were rejected for the same reason: joining `files.sha256` for a chunk anchor and reading the span live off disk both compare against a quantity the author never stamped, and the second also puts I/O on a drive-by path.

## Behaviour

Divergence **marks and demotes into the stale lane; it never hides.** Exact-text hashing cannot distinguish "the peer is ahead of my checkout" from "I edited after pulling", so a hide-on-divergence rule converges on permanently hiding every synced memory in a living file while local memories in identical drift keep surfacing.

- Absent stamp surfaces unmarked — every pre-carrier row is NULL, and an absent stamp is not evidence of drift.
- Locally authored memories are never marked. Local drift is relocation's job, and `anchor_status` already demotes on it.
- A content-confirmed relocation passes by construction: it moved the anchor onto text that hashes the same. A moniker- or name-matched relocation onto changed text does mark, which is the honest reading of a pure hash comparison and costs a mark rather than a disappearance.

Only rows this checkout serves may price an anchor. A superseded generation, a tombstone, and a sibling checkout's file row all leave the memory **unpriced** rather than judged against text no reader here can see; the shared `worktree_id = ''` base row still prices, so working inside a linked worktree is not a blanket exemption.

## Scope

The five `memories_for_*` readers only — `memory_get`, `memory_search`, dream, distill and doctor are untouched, and a test pins that. `memories_for_symbol` collects ids into a set and hydrates them itself rather than going through `ids_to_memories`, so it asks for the drive-by hydration explicitly; a seam-only change would have left it the one reader that never marks.

## Verification

11 tests. Each was confirmed to fail on the thing it claims to protect, on an assertion rather than a compile error:

| mutation | result |
|---|---|
| marking made a no-op | 2 fail |
| synced gate dropped | local-memory test fails |
| NULL-stamp guard dropped | unmarked-stamp test fails |
| `candidates > 0` guard dropped | unpriceable-anchor test fails |
| `memories_for_symbol` reverted to `memory_by_id` | symbol-reader test fails |
| demotion clause dropped from `split_active_stale` | demotion test fails |
| live-generation filter dropped | superseded-row test fails |
| `deleted` filter dropped | tombstone test fails |
| active-worktree filter dropped | sibling-checkout test fails |
| filter tightened to exclude the shared base row | base-row test fails |

The worktree filter is pinned in both directions deliberately: an earlier version of the sibling test bound the memory to its own chunk, so the join never reached the sibling's row and the filter was never consulted — it passed with the filter removed.

Workspace: **5240 passed, 7 skipped**; `clippy -D warnings` green in all four CI configurations; nightly `rustfmt --check` clean. Under `cargo test` the pre-existing `lens_server::tests::port_scan_falls_back_after_a_busy_candidate` fails (#1251, fix open as #1261) — a different crate, untouched by this diff.