### PR TITLE
fix(watch): stop the unconfigured warning diagnosing what it cannot know

### DIFF
--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -916,14 +916,18 @@ impl LiveBackendTail {
         }
         self.unconfigured_reported = true;
         if report.database_unreadable {
+            // The marker's name comes from the backend's own declaration, like every other
+            // message that names one. Spelling it out here would let a second checkout-scoped
+            // backend send an operator to a file it does not use, with nothing to catch it.
+            let marker = self.backend.marker_name_hint();
             tracing::warn!(
                 target: "rag_rat_core::watch",
                 tool = self.backend.tool.as_db_str(),
                 skipped = report.skipped_unconfigured,
                 "live oracle: this pass sent the server no requests and skipped candidates because \
                  this checkout's sole compilation database could not be used by this reader. \
-                 Inspect compile_commands.json: it may be unreadable, contain unsupported syntax \
-                 (such as clangd's YAML forms), or contain an unsupported entry key."
+                 Inspect {marker}: it may be unreadable, contain unsupported syntax (such as \
+                 clangd's YAML forms), or contain an unsupported entry key."
             );
             return;
         }
@@ -949,18 +953,27 @@ impl LiveBackendTail {
             );
             return;
         }
+        // TERMINAL branch: it runs for every layout the branches above did not claim, and that
+        // set is defined as the complement of theirs — new verdict/governs combinations join it
+        // silently, so it must not assert a diagnosis. A sole database whose entries parse but
+        // carry a non-string `file` lands here today (#1255), and telling that operator to
+        // consolidate the databases they do not have sends them after the wrong problem
+        // entirely. Adding a branch would narrow the set without closing it. So: state what was
+        // observed, offer the causes, and make each remedy conditional on its own cause.
         tracing::warn!(
             target: "rag_rat_core::watch",
             tool = self.backend.tool.as_db_str(),
             skipped = report.skipped_unconfigured,
             "live oracle: this pass sent the server no requests and skipped candidates because \
-             the session cannot configure their files. A compilation database is pinned for the \
-             server (`--compile-commands-dir`) only when the checkout holds exactly one; \
-             otherwise the server has to find each file's database itself, and a file it cannot \
-             find one for is skipped rather than answered with fallback flags. Those files stay \
-             unresolvable until the checkout's layout changes — leave a single compilation \
-             database, or put each file's database in one of its ancestor directories or that \
-             directory's `build/`."
+             the session cannot configure their files. The layout facts collected do not identify \
+             which cause, so both are worth checking. A compilation database is pinned for the \
+             server (`--compile-commands-dir`) only when the checkout holds exactly one: if it \
+             holds several, the server has to find each file's database itself and skips a file \
+             it finds none for — leave a single compilation database, or put each file's database \
+             in one of its ancestor directories or that directory's `build/`. If it holds exactly \
+             one, that database may parse while still not proving it covers these files — an \
+             entry whose `file` is not a string is the usual shape — so regenerate it with string \
+             `file` fields naming the indexed sources."
         );
     }
 
@@ -1456,14 +1469,23 @@ mod tests {
             captured_warnings(|| tail.note_unconfigured(&report))
         };
 
-        let several_databases =
+        // No database fact set: the terminal branch. It must OFFER its causes rather than pick
+        // one — the set it covers is the complement of the branches above, so it cannot know.
+        let unidentified =
             warning(LivePassReport { skipped_unconfigured: 1, ..LivePassReport::default() });
         assert!(
-            several_databases.contains("leave a single compilation database"),
-            "several databases need the consolidation remedy: {several_databases:?}",
+            unidentified.contains("do not identify which cause"),
+            "the terminal branch must not assert a diagnosis: {unidentified:?}",
         );
-        assert!(!several_databases.contains("names no file this checkout indexes"));
-        assert!(!several_databases.contains("could not be read as JSON"));
+        assert!(
+            unidentified.contains("leave a single compilation database"),
+            "…while still carrying the several-databases remedy: {unidentified:?}",
+        );
+        assert!(
+            unidentified.contains("is not a string"),
+            "…and the sole-database one: {unidentified:?}",
+        );
+        assert!(!unidentified.contains("names no file this checkout indexes"));
 
         let governs_nothing = warning(LivePassReport {
             skipped_unconfigured: 1,
@@ -1475,7 +1497,6 @@ mod tests {
             "a non-governing database needs its own remedy: {governs_nothing:?}",
         );
         assert!(!governs_nothing.contains("leave a single compilation database"));
-        assert!(!governs_nothing.contains("could not be read as JSON"));
 
         let fixture = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(fixture.path().join("src")).unwrap();
@@ -1510,7 +1531,6 @@ mod tests {
             unreadable.contains("compile_commands.json"),
             "a sole unreadable database warning must identify its file: {unreadable:?}",
         );
-        assert!(!unreadable.contains("could not be read as JSON"));
         assert!(unreadable.contains("unsupported syntax"));
         assert!(unreadable.contains("unsupported entry key"));
         assert!(!unreadable.contains("leave a single compilation database"));
@@ -1532,9 +1552,9 @@ mod tests {
             ..LivePassReport::default()
         });
         assert!(
-            !strict_json_unknown_key.contains("could not be read as JSON"),
-            "strict JSON with an unknown key must not be described as unparseable: \
-             {strict_json_unknown_key:?}",
+            strict_json_unknown_key.contains("may be unreadable"),
+            "strict JSON with an unknown key parses, so unreadability may only be OFFERED as a \
+             cause, never asserted: {strict_json_unknown_key:?}",
         );
         assert!(
             strict_json_unknown_key.contains("compile_commands.json"),
@@ -1565,16 +1585,44 @@ mod tests {
             "the warning must identify an unreadable marker path: {unreadable_marker:?}",
         );
         assert!(
-            !unreadable_marker.contains("has syntax or entry fields this reader cannot accept"),
-            "an unopenable marker must not assert a content-level cause: {unreadable_marker:?}",
-        );
-        assert!(
             unreadable_marker.contains("could not be used"),
             "the warning must state the reader could not use the marker: {unreadable_marker:?}",
         );
         assert!(
             unreadable_marker.contains("may be unreadable"),
             "the warning must present unreadability as a possible cause: {unreadable_marker:?}",
+        );
+
+        // The shape that made the terminal branch lie: a SOLE database whose entries parse, so
+        // the unreadable branch declines it, and whose `file` this reader cannot read as a path,
+        // so `Governs::Unknown` makes the governs-nothing branch decline it too. It falls
+        // through — and the fallthrough used to tell an operator with one database to leave a
+        // single one.
+        std::fs::remove_dir(fixture.path().join("compile_commands.json")).unwrap();
+        std::fs::write(
+            fixture.path().join("compile_commands.json"),
+            r#"[{"directory":"/x","file":42,"command":"cc -c a.c"}]"#,
+        )
+        .unwrap();
+        let non_string_file = clangd.resolve_layout(&scope);
+        assert!(
+            !non_string_file.has_unreadable_database(),
+            "entries that parse are not an unreadable database",
+        );
+        assert!(
+            !non_string_file.has_database_governing_nothing_indexed(),
+            "a `file` this reader cannot read is unknown governance, not proven non-governance",
+        );
+        let sole_unreadable_entry = warning(LivePassReport {
+            skipped_unconfigured: 1,
+            database_unreadable: non_string_file.has_unreadable_database(),
+            database_governs_nothing: non_string_file.has_database_governing_nothing_indexed(),
+            ..LivePassReport::default()
+        });
+        assert!(
+            sole_unreadable_entry.contains("do not identify which cause"),
+            "a sole database that reaches the terminal branch must not be diagnosed as several: \
+             {sole_unreadable_entry:?}",
         );
     }
 

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -960,6 +960,12 @@ impl LiveBackendTail {
         // consolidate the databases they do not have sends them after the wrong problem
         // entirely. Adding a branch would narrow the set without closing it. So: state what was
         // observed, offer the causes, and make each remedy conditional on its own cause.
+        //
+        // That includes not claiming the database PARSED. An incomplete scan withholds every sole
+        // database fact on purpose — it cannot prove the marker it saw is the only one — so a
+        // checkout whose single database this reader could not read reaches here with both flags
+        // false, warmable under `Trust::Possible` and skipping every file under `Trust::Proven`.
+        // Whatever this branch asserts, some layout that withheld its facts will contradict.
         tracing::warn!(
             target: "rag_rat_core::watch",
             tool = self.backend.tool.as_db_str(),
@@ -971,9 +977,10 @@ impl LiveBackendTail {
              holds several, the server has to find each file's database itself and skips a file \
              it finds none for — leave a single compilation database, or put each file's database \
              in one of its ancestor directories or that directory's `build/`. If it holds exactly \
-             one, that database may parse while still not proving it covers these files — an \
-             entry whose `file` is not a string is the usual shape — so regenerate it with string \
-             `file` fields naming the indexed sources."
+             one, this reader could not establish a configuration for these files from it — the \
+             file may not have parsed, or may have parsed without describing them. Inspect its \
+             entries against what the server expects: a `file` naming the source, and a `command` \
+             or `arguments` a compiler would accept."
         );
     }
 
@@ -1477,13 +1484,30 @@ mod tests {
             unidentified.contains("do not identify which cause"),
             "the terminal branch must not assert a diagnosis: {unidentified:?}",
         );
+        // Both remedies are present and BOTH are conditional. A terminal branch that named one
+        // cause would drop a conditional, which is what these two read.
+        assert!(
+            unidentified.contains("if it holds several"),
+            "the several-databases remedy must stay conditional: {unidentified:?}",
+        );
+        assert!(
+            unidentified.contains("If it holds exactly one"),
+            "and so must the sole-database one: {unidentified:?}",
+        );
         assert!(
             unidentified.contains("leave a single compilation database"),
             "…while still carrying the several-databases remedy: {unidentified:?}",
         );
         assert!(
-            unidentified.contains("is not a string"),
-            "…and the sole-database one: {unidentified:?}",
+            unidentified.contains("a `command` or `arguments` a compiler would accept"),
+            "…and a sole-database remedy that does not presume which field is wrong: \
+             {unidentified:?}",
+        );
+        // Not even parsing may be asserted: an incomplete scan withholds the unreadable-database
+        // fact, so a checkout whose only database could not be read reaches this branch too.
+        assert!(
+            unidentified.contains("may not have parsed"),
+            "the terminal branch cannot claim the database parsed: {unidentified:?}",
         );
         assert!(!unidentified.contains("names no file this checkout indexes"));
 
@@ -1623,6 +1647,50 @@ mod tests {
             sole_unreadable_entry.contains("do not identify which cause"),
             "a sole database that reaches the terminal branch must not be diagnosed as several: \
              {sole_unreadable_entry:?}",
+        );
+
+        // A sole database that PARSES and is still unusable — a string `file` naming an indexed
+        // source, with an empty `command` — reaches the terminal branch too: entries counted zero
+        // makes it NotLoadable, so the unreadable branch declines it, and NotLoadable is not the
+        // Loadable the governs-nothing branch requires. Nothing about this entry's `file` is
+        // wrong, so a remedy naming that field would send its operator to the wrong line.
+        std::fs::write(
+            fixture.path().join("compile_commands.json"),
+            format!(
+                "[{{\"directory\":\"/x\",\"file\":{:?},\"command\":\"\"}}]",
+                fixture.path().join("src/main.c").display().to_string()
+            ),
+        )
+        .unwrap();
+        let empty_command = clangd.resolve_layout(&scope);
+        assert!(!empty_command.has_unreadable_database());
+        assert!(!empty_command.has_database_governing_nothing_indexed());
+        let unusable_entry = warning(LivePassReport {
+            skipped_unconfigured: 1,
+            database_unreadable: empty_command.has_unreadable_database(),
+            database_governs_nothing: empty_command.has_database_governing_nothing_indexed(),
+            ..LivePassReport::default()
+        });
+        assert!(
+            unusable_entry.contains("do not identify which cause"),
+            "a database whose entries are malformed some other way is still undiagnosed: \
+             {unusable_entry:?}",
+        );
+        assert!(
+            unusable_entry.contains("a `command` or `arguments` a compiler would accept"),
+            "and the remedy must reach the field that IS wrong: {unusable_entry:?}",
+        );
+
+        // A checkout that holds NO database never reaches this warning: it cannot signal
+        // readiness, so it blocks on the prerequisite instead of spawning, and a running session
+        // whose checkout loses every database ends its pass at the layout-refresh check. The
+        // prerequisite already words that remedy; a branch here would be unreachable.
+        std::fs::remove_file(fixture.path().join("compile_commands.json")).unwrap();
+        let no_database = clangd.resolve_layout(&scope);
+        assert!(no_database.has_no_database(), "the checkout holds no database to find");
+        assert!(
+            !clangd.checkout_can_signal_readiness(&scope, &no_database),
+            "so no session spawns against it, and no pass can report it",
         );
     }
 

--- a/crates/rag-rat-oracle/src/backend/layout.rs
+++ b/crates/rag-rat-oracle/src/backend/layout.rs
@@ -1198,6 +1198,53 @@ mod tests {
         }
     }
 
+    /// Both guards on both "sole database" predicates, because the word an operator reads is
+    /// SOLE and neither guard is what makes it true on its own.
+    ///
+    /// A truncated scan may have missed the database that governs half the sources, so it cannot
+    /// establish that the one it saw is the only one. And a second marker means the file the
+    /// warning names is not the only one to look at — the operator is sent to inspect a database
+    /// that may be perfectly fine while the one that matters goes unmentioned.
+    #[test]
+    fn a_sole_database_fact_needs_a_finished_scan_and_exactly_one_marker() {
+        let site = |verdict, governs| MarkerSite {
+            dir: PathBuf::from("x"),
+            reading: MarkerReading { verdict, governs },
+        };
+        let layout = |sites: Vec<MarkerSite>, scan_finished| {
+            ProjectLayout::from_marker_sites("compile_commands.json", MarkerScan {
+                sites,
+                complete: scan_finished,
+            })
+        };
+        let unreadable = site(MarkerVerdict::Unknown, Governs::Unknown);
+        let governs_nothing = site(MarkerVerdict::Loadable, Governs::NothingIndexed);
+        let good = site(MarkerVerdict::Loadable, Governs::IndexedSource);
+
+        assert!(layout(vec![unreadable.clone()], true).has_unreadable_database());
+        assert!(
+            layout(vec![governs_nothing.clone()], true).has_database_governing_nothing_indexed()
+        );
+
+        assert!(
+            !layout(vec![unreadable.clone()], false).has_unreadable_database(),
+            "a truncated scan cannot prove the unreadable marker is the checkout's only database",
+        );
+        assert!(
+            !layout(vec![governs_nothing.clone()], false).has_database_governing_nothing_indexed(),
+            "nor that the non-governing one is",
+        );
+
+        assert!(
+            !layout(vec![unreadable, good.clone()], true).has_unreadable_database(),
+            "a second, readable database means the unreadable one is not the sole database",
+        );
+        assert!(
+            !layout(vec![governs_nothing, good], true).has_database_governing_nothing_indexed(),
+            "and a second database means the non-governing one is not either",
+        );
+    }
+
     #[test]
     fn an_entry_that_cannot_be_enumerated_makes_the_scan_incomplete() {
         // `ReadDir` reports a per-item failure as an `Err` element, and the entry behind it could

--- a/crates/rag-rat-oracle/src/backend/layout.rs
+++ b/crates/rag-rat-oracle/src/backend/layout.rs
@@ -216,6 +216,21 @@ impl ProjectLayout {
             )
     }
 
+    /// Whether this checkout holds NO compilation database at all.
+    ///
+    /// Carries the same finished-scan guard as its siblings, and for the same reason: a truncated
+    /// scan that found nothing has not established that there is nothing to find, and telling an
+    /// operator to generate a database they already have is its own wrong remedy. Unproven falls
+    /// through to the terminal warning, which claims no cause.
+    ///
+    /// A checkout that holds none at SPAWN never reaches a running pass — it blocks on the
+    /// prerequisite. What this covers is the decay: a session that warmed while the checkout held
+    /// several, which have since been removed. Both layouts pin nothing, so the session survives
+    /// the refresh and every path it carries is then skipped as unconfigurable.
+    pub fn has_no_database(&self) -> bool {
+        self.complete && self.markers.is_empty()
+    }
+
     /// Whether this complete layout has exactly one compilation database that this crate could
     /// not read as JSON. An incomplete scan cannot establish that the unreadable marker is the
     /// sole database, so it does not carry this operator-facing fact.
@@ -1221,6 +1236,16 @@ mod tests {
         let governs_nothing = site(MarkerVerdict::Loadable, Governs::NothingIndexed);
         let good = site(MarkerVerdict::Loadable, Governs::IndexedSource);
 
+        assert!(layout(Vec::new(), true).has_no_database());
+        assert!(
+            !layout(Vec::new(), false).has_no_database(),
+            "a truncated scan that found nothing has not established there is nothing to find",
+        );
+        assert!(
+            !layout(vec![good.clone()], true).has_no_database(),
+            "and a database that was found is not an absent one",
+        );
+
         assert!(layout(vec![unreadable.clone()], true).has_unreadable_database());
         assert!(
             layout(vec![governs_nothing.clone()], true).has_database_governing_nothing_indexed()
@@ -1235,6 +1260,14 @@ mod tests {
             "nor that the non-governing one is",
         );
 
+        // Withholding is not free: a truncated scan over a checkout whose only database cannot be
+        // read reports NEITHER fact, so it reaches the terminal warning like any other undiagnosed
+        // layout. That warning therefore cannot claim the database parsed.
+        let truncated_unreadable = layout(vec![unreadable.clone()], false);
+        assert!(!truncated_unreadable.has_unreadable_database());
+        assert!(!truncated_unreadable.has_database_governing_nothing_indexed());
+        assert!(!truncated_unreadable.has_no_database());
+
         assert!(
             !layout(vec![unreadable, good.clone()], true).has_unreadable_database(),
             "a second, readable database means the unreadable one is not the sole database",
@@ -1243,6 +1276,46 @@ mod tests {
             !layout(vec![governs_nothing, good], true).has_database_governing_nothing_indexed(),
             "and a second database means the non-governing one is not either",
         );
+    }
+
+    /// Why a session's layout-refresh check cannot be pin equality alone.
+    ///
+    /// `pins_same_database_as` asks "does the argv already passed to the running server still
+    /// describe this checkout" — and NOTHING is a legitimate answer on both sides. So a checkout
+    /// that held several databases and now holds none reads as unchanged, and a session that has
+    /// not yet signalled ready would warm forever against a project that no longer exists. The
+    /// absence has to be tested for separately.
+    #[test]
+    fn pinning_nothing_is_not_proof_the_layout_is_unchanged() {
+        let site = |verdict, governs| MarkerSite {
+            dir: PathBuf::from("x"),
+            reading: MarkerReading { verdict, governs },
+        };
+        let layout = |sites: Vec<MarkerSite>| {
+            ProjectLayout::from_marker_sites("compile_commands.json", MarkerScan {
+                sites,
+                complete: true,
+            })
+        };
+        let good = site(MarkerVerdict::Loadable, Governs::IndexedSource);
+        let several = layout(vec![good.clone(), good.clone()]);
+        let none = layout(Vec::new());
+
+        assert!(several.sole_marker_dir().is_none(), "several databases pin nothing");
+        assert!(none.sole_marker_dir().is_none(), "and so does no database at all");
+        assert!(
+            none.pins_same_database_as(&several),
+            "so pin equality reads the loss of every database as no change — which is why the \
+             refresh has to ask `has_no_database` as well",
+        );
+        assert!(none.has_no_database() && !several.has_no_database());
+
+        // Losing a SOLE database is both an absence and a pin change, so the two tests overlap
+        // and their order decides what the operator is told. Absence has to win: "points at a
+        // different compilation database" names a database that does not exist.
+        let one = layout(vec![good]);
+        assert!(!one.pins_same_database_as(&none), "a sole database going away moves the pin");
+        assert!(none.has_no_database() && !one.has_no_database(), "and is also an absence");
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/backend/registry.rs
+++ b/crates/rag-rat-oracle/src/backend/registry.rs
@@ -145,6 +145,21 @@ pub(super) enum ProjectScope {
 }
 
 impl LiveBackend {
+    /// The operator-facing name of this backend's project marker, for a diagnostic that has to
+    /// tell someone which file to open.
+    ///
+    /// Every message that names a marker derives it from the declaration rather than spelling it
+    /// out, so a second backend declaring `ProjectScope::Checkout` + `MarkerKind::Parsed` cannot
+    /// inherit another backend's filename with no compile error to catch it.
+    pub fn marker_name_hint(&self) -> String {
+        // The model goes in a binding: `files()` borrows from it, so calling it on a temporary
+        // does not compile — its own rustdoc says as much.
+        match &self.project_model {
+            Some(model) => crate::manifest::hint_marker_names(model.files()),
+            None => crate::manifest::hint_marker_names(&[]),
+        }
+    }
+
     /// The live backend for `tool`, or `None` for a batch tool. Total over the non-batch variants:
     /// [`OracleTool::batch_capable`] is `false` exactly when this returns `Some`.
     pub fn for_tool(tool: OracleTool) -> Option<Self> {

--- a/crates/rag-rat-oracle/src/backend/tests.rs
+++ b/crates/rag-rat-oracle/src/backend/tests.rs
@@ -1822,6 +1822,77 @@ fn a_real_linked_worktree_inside_the_checkout_is_not_this_checkouts_project() {
     );
 }
 
+/// Losing every compilation database is scoped to the checkout that lost it.
+///
+/// A linked worktree and its main checkout share one index in this repository's model, so an
+/// absence read at repository scope would end the main checkout's session over a deletion next
+/// door, and one read only at main would leave the linked worktree warming against a project it
+/// no longer has. The scan answers per `CheckoutScope`, and this pins that from both sides.
+///
+/// The main checkout's own scan is INCOMPLETE here — a nested checkout's `.git` is a file it
+/// cannot classify — which is the second half: an incomplete scan must never report an absence,
+/// because it cannot prove there is nothing left to find.
+#[test]
+fn a_linked_worktree_losing_its_database_does_not_take_the_sibling_with_it() {
+    let clangd = LiveBackend::for_tool(OracleTool::ClangdLsp).unwrap();
+    let (_dir_guard, dir) = checkout("clangd-worktree-database-loss");
+    let main = dir.join("main");
+    std::fs::create_dir_all(main.join("src")).unwrap();
+    rag_rat_base::test_git::run(&main, &["init"]);
+    std::fs::write(main.join("src/main.c"), "int main(void) { return 0; }\n").unwrap();
+    write_database(&main, "build/compile_commands.json", &["src/main.c"]);
+    rag_rat_base::test_git::run(&main, &["add", "."]);
+    rag_rat_base::test_git::run(&main, &["commit", "-m", "seed"]);
+
+    let linked = main.join(".claude/worktrees/feature");
+    std::fs::create_dir_all(main.join(".claude/worktrees")).unwrap();
+    rag_rat_base::test_git::run(&main, &[
+        "worktree",
+        "add",
+        linked.to_str().unwrap(),
+        "-b",
+        "feature",
+    ]);
+    write_database(&linked, "build/compile_commands.json", &["src/main.c"]);
+
+    let main_corpus = crate::test_support::PrefixCorpus::new(&main, &["src"]);
+    let linked_corpus = crate::test_support::PrefixCorpus::new(&linked, &["src"]);
+    let main_layout = || clangd.resolve_layout(&super::CheckoutScope::resolve(&main, &main_corpus));
+    let linked_layout =
+        || clangd.resolve_layout(&super::CheckoutScope::resolve(&linked, &linked_corpus));
+
+    // Control: with both databases present neither side reports an absence, or the assertions
+    // below prove nothing.
+    assert!(!main_layout().has_no_database(), "control: main holds a database");
+    assert!(!linked_layout().has_no_database(), "control: so does the linked worktree");
+
+    // The linked worktree loses its database. Its own layout is the one that says so.
+    std::fs::remove_file(linked.join("build/compile_commands.json")).unwrap();
+    assert!(
+        linked_layout().has_no_database(),
+        "the checkout that lost its database reports the absence, under its own ceiling",
+    );
+    let sibling = main_layout();
+    assert!(
+        !sibling.has_no_database(),
+        "and the sibling, which still holds one, is not ended for a deletion next door",
+    );
+    assert!(!sibling.is_empty(), "its own database is still found");
+
+    // The other direction: main's scan cannot classify the nested checkout, so it is incomplete
+    // and must decline to claim an absence even once its own database is gone.
+    std::fs::remove_file(main.join("build/compile_commands.json")).unwrap();
+    assert!(
+        !main_layout().has_no_database(),
+        "an incomplete scan has not established there is nothing left to find, so it must not \
+         report an absence that would tear a working session down",
+    );
+    assert!(
+        linked_layout().has_no_database(),
+        "while the linked worktree, whose own scan finished, still reports its own absence",
+    );
+}
+
 /// What the scan proves is now "every database that could GOVERN an indexed file", not "every
 /// database under the root" — and both halves of that need pinning, or the redefinition lives only
 /// in a comment.

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -325,17 +325,34 @@ impl LiveOracleSession {
     /// `false` means the checkout now pins a DIFFERENT database (one appeared, moved, or was
     /// removed). That cannot be corrected in place: the server was spawned with an argv derived
     /// from the old layout, so the session has to be replaced.
-    fn layout_still_holds(&mut self, checkout: &CheckoutScope<'_>) -> bool {
+    fn layout_change_ending_the_pass(
+        &mut self,
+        checkout: &CheckoutScope<'_>,
+    ) -> Option<&'static str> {
         if self.layout_resolved_at.elapsed() < backend::LAYOUT_MAX_AGE {
-            return true;
+            return None;
         }
         let fresh = self.backend.resolve_layout(checkout);
         self.layout_resolved_at = Instant::now();
+        // REMOVAL is tested first, because it is also a pin change when the checkout held exactly
+        // one: reported the other way round, an operator whose only database was deleted is told
+        // the checkout points at a different one, which is a database that does not exist.
+        //
+        // And pinning the same database is not holding the same layout. SEVERAL databases and
+        // NONE both pin nothing, so a checkout that lost every database it had passes the pin
+        // test and the session survives against a layout describing no project at all. It cannot
+        // do useful work there: its argv was derived while the databases existed, and a session
+        // that has not yet signalled ready would warm forever with nothing to become ready for.
+        // End the pass so the watcher replaces it — a fresh spawn blocks on the prerequisite,
+        // which is where a checkout with no project belongs and where the remedy is worded.
+        if fresh.has_no_database() && !self.layout.has_no_database() {
+            return Some("the checkout no longer holds a compilation database");
+        }
         if !fresh.pins_same_database_as(&self.layout) {
-            return false;
+            return Some("the checkout now points at a different compilation database");
         }
         self.layout = fresh;
-        true
+        None
     }
 
     /// Whether the checkout's sole database was declined for describing nothing indexed.
@@ -478,11 +495,10 @@ pub fn live_oracle_pass(
     // never reach this check, so a database removed during warm-up would leave it warming forever
     // with no way back. End the pass instead and let the watcher replace the session — its argv
     // was derived from the old layout, so it cannot be corrected in place.
-    if !session.layout_still_holds(input.scope) {
+    if let Some(reason) = session.layout_change_ending_the_pass(input.scope) {
         report.unfinished_paths = input.worklist.to_vec();
         report.abort = Some(LivePassAbort::LayoutChanged);
-        report.status =
-            "Aborted: the checkout now points at a different compilation database".to_string();
+        report.status = format!("Aborted: {reason}");
         return Ok(report);
     }
     match session.readiness_checkpoint() {


### PR DESCRIPTION
## The terminal branch asserted a diagnosis it cannot reach

`note_unconfigured` is a fallthrough chain, and its last branch told the operator:

> A compilation database is pinned … only when the checkout holds exactly one … **leave a single compilation database**

That branch runs for every layout the branches above do not claim. The set is defined as *the complement of theirs*, so it cannot know what is in it — and a sole database whose entries parse but whose `file` is not a string lands there today:

```
compile_commands.json = [{"directory":"/x","file":42,"command":"cc -c a.c"}]

unreadable = false      (entries > 0 → Loadable, so the unreadable branch declines it)
governs_nothing = false (Governs::Unknown, not NothingIndexed, so that branch declines too)
→ terminal branch → "leave a single compilation database"
```

An operator with exactly one database is sent to consolidate the databases they do not have.

Three other layouts land there and must stay undiagnosed. A sole database with a **string** `file` naming an indexed source but an empty `command` counts zero entries, so it is `NotLoadable` — declined by the unreadable branch, and not the `Loadable` the governs-nothing branch requires. Nothing about that entry's `file` is wrong, so the terminal remedy names no field in particular: it points at what the server expects (a `file` naming the source, and a `command` or `arguments` a compiler would accept) and lets the operator find which is missing. A truncated scan reaches it too, and is why the branch cannot even claim the database **parsed**: `has_unreadable_database` withholds its answer for an incomplete scan on purpose, so a checkout whose only database could not be read reports all three facts false while still warming under `Trust::Possible` and skipping every file under `Trust::Proven`.

That is the general shape, and it is worth stating once: **whatever this branch asserts, some layout that withheld its facts will contradict.** Cases arrive here precisely because their facts are unproven, so any positive claim is unsafe by construction.

The shapes are fixture cases, and the test reads the *conditionals* plus the parsing hedge — a branch that picked one cause, or reasserted parsing, would drop one of them. Verified: restoring "that database parsed" fails the test.

**Adding a branch narrows the set without closing it.** New `MarkerVerdict`/`Governs` combinations join it silently and inherit whatever it asserts. #1250 already applied the right discipline to the *new* branch — assert only what is true, offer causes as possibilities — and this carries it back to the terminal one. The sole-database shape is pinned as a regression, and the next combination degrades to under-specific rather than false.

## A checkout that loses every database no longer warms forever

A session refreshes its layout through `pins_same_database_as`, because what that answer protects is the argv already handed to the running server. **Nothing is a legitimate answer on both sides**, so a checkout that lost every database read as unchanged:

| transition | pin before | pin after | caught? |
|---|---|---|---|
| one → zero | `Some(dir)` | `None` | yes |
| several → zero | `None` | `None` | **no** |
| sole unreadable → zero | `None` | `None` | **no** |

The check that guards this sits *before* the readiness gate precisely so a database removed during warm-up cannot leave a session warming forever — but it only ever caught a removal that moved the pin. A session that had not yet signalled ready stayed warming against a project that no longer existed.

Pin equality now carries a companion test for the absence itself. `has_no_database` takes the same finished-scan guard as its siblings: a truncated scan that found nothing has not established there is nothing to find, and tearing down a working session over an unproven absence is the expensive direction to be wrong in.

**Covered against a real linked worktree**, per the repo's worktree-correctness rule. `a_linked_worktree_losing_its_database_does_not_take_the_sibling_with_it` builds a main checkout with its own database and a `git worktree add` sibling with its own, then deletes the sibling's:

- the checkout that lost it reports the absence, under its own ceiling;
- the main checkout does not, and still finds its database — a deletion next door does not end its session.

The second half is the incomplete-scan case in situ: main's scan cannot classify a nested checkout's `.git` file, so it stays incomplete and must decline to claim an absence *even after its own database is deleted too*, while the linked worktree — whose own scan finished — still reports its own. Removing the finished-scan guard fails this test.

**Absence is tested before the pin, and the abort says which happened.** Losing a *sole* database is both an absence and a pin change, so the two overlap and their order decides what the operator reads — `points at a different compilation database` would name a database that does not exist. The refresh now returns the reason rather than a bool.

**Reported through the abort, not as a pass fact.** Ending the pass hands the checkout to the watcher; the replacement spawn cannot signal readiness without a database, so it blocks on the prerequisite — where a checkout with no project belongs, and where the remedy is already worded. Verified empirically that a zero-database checkout returns `false` from `checkout_can_signal_readiness`, so no session exists to observe the state and no `LivePassReport` field is added for it. `live.rs`'s public surface is unchanged.

## Two guards nothing enforced

`has_unreadable_database` documents its contract as "true only for a complete scan with exactly one marker". Both guards were unpinned — the suite passed with either deleted. Verified by running each mutation the issue names:

| mutation | before | now |
|---|---|---|
| drop `self.complete &&` | passes | **fails** |
| `[only]` → `.iter().any(…)` | passes | **fails** |

Both matter to an operator: a truncated scan may have missed the database that governs half the sources, so it cannot prove the one it saw is the only one; and with a second marker, the file the warning names is not the only one to look at — the operator inspects a database that may be fine while the one that matters goes unmentioned.

`has_database_governing_nothing_indexed` carries the identical guards, so the test covers both predicates rather than the one that was reported.

## Five assertions that could not fail

`live_oracle.rs` asserted the *absence* of `"could not be read as JSON"` and `"has syntax or entry fields this reader cannot accept"` — strings that appear in no `warn!` anywhere in `crates/`, surviving only in doc comments and in the assertions themselves. Residue of an earlier wording; every one passed against an empty `note_unconfigured` body.

Deleted, except where the intent still applies. "Strict JSON with an unknown key must not be described as unparseable" is a real property — the message may only *offer* unreadability as a cause. That now reads the hedge which carries it (`may be unreadable`), which an edit to an assertive claim would remove. The whole test now fails against an empty function body; verified.

## Minor: the marker name is derived, not spelled

The unreadable branch hardcoded `Inspect compile_commands.json:` while its sibling `prerequisite_blocked_with` derives the name from `backend.project_model`. Unreachable today — only `ClangdLsp` declares `ProjectScope::Checkout` + `MarkerKind::Parsed` — but it was the first message in the chain to name a filename rather than a concept, so a second such backend would name the wrong file with no compile error. It now goes through a `LiveBackend::marker_name_hint` accessor.

## Verification

```
cargo nextest run --workspace                                                         → 5233 passed
cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings  → 0
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings         → 0
cargo +nightly fmt --check                                                            → 0
```

Every mutation above was run against the patched code and reverted.

Fixes #1255.
