### PR TITLE
feat(sync): subscribe from a checked-in stream locator, pinned on first use

### DIFF
--- a/crates/rag-rat-base/src/config/discovery.rs
+++ b/crates/rag-rat-base/src/config/discovery.rs
@@ -108,9 +108,17 @@ pub fn worktree_root(path: &Path) -> Option<PathBuf> {
     Some(crate::paths::canonicalize_or_simplified(workdir))
 }
 
+/// The canonical git COMMON directory of the checkout containing `path` — the one directory every
+/// worktree of a repository shares: `<main>/.git` for linked worktrees, the hub itself for sibling
+/// worktrees of a bare repository. It identifies a repository across its checkouts where a checkout
+/// root cannot, including when there is no main checkout to compare. `None` outside git.
+pub fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    let repo = crate::repo_discover::discover_repo(path).ok()?;
+    crate::paths::canonicalize(repo.common_dir()).ok()
+}
+
 pub(crate) fn main_worktree_root(root: &Path) -> Option<PathBuf> {
-    let repo = crate::repo_discover::discover_repo(root).ok()?;
-    let common_dir = crate::paths::canonicalize(repo.common_dir()).ok()?;
+    let common_dir = git_common_dir(root)?;
     // Only the standard `<main>/.git` layout maps cleanly to a main worktree root.
     if common_dir.file_name()?.to_str()? != ".git" {
         return None;

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -194,7 +194,7 @@ pub enum ConfigError {
 }
 
 pub use discovery::{
-    default_database_path, default_legacy_database_path, discover_config_path,
+    default_database_path, default_legacy_database_path, discover_config_path, git_common_dir,
     linked_worktree_main_root, nearest_config_at_or_above, worktree_root,
 };
 pub(crate) use discovery::{main_worktree_root, normalize_existing_dir, resolve_default_database};

--- a/crates/rag-rat-base/src/lib.rs
+++ b/crates/rag-rat-base/src/lib.rs
@@ -19,6 +19,7 @@ pub mod repo_identity;
 pub mod serde_big_id;
 pub mod single_flight;
 pub mod stack;
+pub mod stream_locator;
 pub mod test_git;
 pub mod test_scratch;
 pub mod time;

--- a/crates/rag-rat-base/src/stream_locator.rs
+++ b/crates/rag-rat-base/src/stream_locator.rs
@@ -1,0 +1,148 @@
+//! `.rag-rat-stream` — the checked-in locator that tells a clone which published stream this repo
+//! mirrors, so `rag-rat sync subscribe` needs no hand-carried account id.
+//!
+//! **The file is untrusted input.** It ships inside the repo, so anyone who can land a commit can
+//! edit it. Exactly one field is a trust root — `owner`, the account id — and the caller pins it on
+//! first use and refuses a later change (see the subscribe pin). Everything else is routing:
+//! `peers` and `relay` are followed unauthenticated and deliberately so, because every byte pulled
+//! is verified against the pinned account's signature chain. A hostile peer can stall or withhold;
+//! it cannot forge an entry, and it cannot make this store mirror a different account.
+//!
+//! The owner account id is not merely a name for the key — it commits to it. An `AccountId` is a
+//! hash over the founding payload, which carries the founding device key, and every entry chains
+//! back to that genesis under signature. Pinning the id therefore pins the trust root, which is
+//! what makes a plain 64-hex string sufficient here.
+//!
+//! Routing is not optional. A subscriber cannot discover a foreign account's host — the discovery
+//! tag derives from that account's own secret, which only its own devices hold — so a locator
+//! carrying an account id alone would name a stream nobody can reach.
+//!
+//! Unknown keys are tolerated rather than rejected: this file lives in other people's repos and is
+//! read by whatever rag-rat version they happen to run, so a field added later must not turn every
+//! older binary into a hard failure.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// The locator's name at the repo root. Checked in, and read from the active checkout.
+pub const STREAM_LOCATOR_FILE: &str = ".rag-rat-stream";
+
+/// A parsed, validated `.rag-rat-stream`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamLocator {
+    /// The published owner account whose memories a subscriber mirrors — 64 lowercase hex. The
+    /// only field that carries authority; the pin is taken on this.
+    pub owner: String,
+    /// Node ids to reach the owner's host. Unauthenticated routing hints.
+    pub peers: Vec<String>,
+    /// Relay URL for reaching those peers. Unauthenticated.
+    pub relay: Option<String>,
+    /// Display name for the stream. Never used for identity.
+    pub name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawLocator {
+    owner: String,
+    #[serde(default)]
+    peers: Vec<String>,
+    #[serde(default)]
+    relay: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Read and validate the locator at `repo_root`, or `None` when the repo checks none in.
+///
+/// A malformed file is an error rather than a `None`: a repo that ships a locator meant it to work,
+/// and silently falling back to "no locator configured" would report the wrong problem.
+pub fn load(repo_root: &Path) -> anyhow::Result<Option<StreamLocator>> {
+    let path = repo_root.join(STREAM_LOCATOR_FILE);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(anyhow::anyhow!("reading {}: {err}", path.display())),
+    };
+    parse(&text).map(Some).map_err(|err| anyhow::anyhow!("{}: {err}", path.display()))
+}
+
+/// Parse locator text. Split from [`load`] so the format is testable without a filesystem.
+pub fn parse(text: &str) -> anyhow::Result<StreamLocator> {
+    let raw: RawLocator = toml::from_str(text)?;
+    let owner = raw.owner.trim().to_string();
+    anyhow::ensure!(
+        owner.len() == 64 && owner.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+        "`owner` must be a 64-character lowercase hex account id, got `{owner}`"
+    );
+    Ok(StreamLocator { owner, peers: raw.peers, relay: raw.relay, name: raw.name })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OWNER: &str = "4ddbda7cea3a613136ed6c10f26d3fb02bc0f0efa5ef4e5d87bc2e5c9e9b7d89";
+
+    #[test]
+    fn a_locator_carries_the_owner_and_its_routing() {
+        let parsed = parse(&format!(
+            "owner = \"{OWNER}\"\npeers = [\"node-a\", \"node-b\"]\nrelay = \"https://r\"\nname = \
+             \"demo\"\n"
+        ))
+        .unwrap();
+        assert_eq!(parsed.owner, OWNER);
+        assert_eq!(parsed.peers, ["node-a", "node-b"]);
+        assert_eq!(parsed.relay.as_deref(), Some("https://r"));
+        assert_eq!(parsed.name.as_deref(), Some("demo"));
+    }
+
+    #[test]
+    fn routing_is_optional_at_the_format_level() {
+        // The format does not demand peers: an owner already reachable through configured
+        // `server_peers` needs none, and rejecting that here would refuse a working setup. The
+        // subscribe path is where an unreachable owner is diagnosed, with the peer flag to fix it.
+        let parsed = parse(&format!("owner = \"{OWNER}\"\n")).unwrap();
+        assert!(parsed.peers.is_empty());
+        assert_eq!(parsed.relay, None);
+    }
+
+    #[test]
+    fn an_unknown_key_is_tolerated() {
+        // This file sits in other people's repos and is read by whatever version they run. A field
+        // added in a later release must not turn every older binary into a hard failure.
+        let parsed = parse(&format!("owner = \"{OWNER}\"\nsomething_added_later = 3\n")).unwrap();
+        assert_eq!(parsed.owner, OWNER);
+    }
+
+    #[test]
+    fn a_malformed_owner_is_refused_rather_than_carried() {
+        // The owner is the trust root. Carrying a bad one forward would surface as an obscure
+        // transport failure later instead of naming the file that is wrong.
+        for bad in [
+            "",
+            "not-hex-at-all",
+            "4DDBDA7CEA3A613136ED6C10F26D3FB02BC0F0EFA5EF4E5D87BC2E5C9E9B7D89", // uppercase
+            "4ddbda7c",                                                         // too short
+        ] {
+            let err = parse(&format!("owner = \"{bad}\"\n")).unwrap_err().to_string();
+            assert!(err.contains("64-character lowercase hex"), "for `{bad}`: {err}");
+        }
+    }
+
+    #[test]
+    fn a_locator_without_an_owner_is_refused() {
+        let err = parse("peers = [\"node-a\"]\n").unwrap_err().to_string();
+        assert!(err.contains("owner"), "the error must name the missing field: {err}");
+    }
+
+    #[test]
+    fn an_absent_file_is_not_an_error_but_a_malformed_one_is() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(load(dir.path()).unwrap(), None, "a repo may simply check none in");
+
+        std::fs::write(dir.path().join(STREAM_LOCATOR_FILE), "owner = \"nope\"\n").unwrap();
+        let err = load(dir.path()).unwrap_err().to_string();
+        assert!(err.contains(STREAM_LOCATOR_FILE), "the error names the file: {err}");
+    }
+}

--- a/crates/rag-rat-base/src/stream_locator.rs
+++ b/crates/rag-rat-base/src/stream_locator.rs
@@ -137,6 +137,46 @@ mod tests {
     }
 
     #[test]
+    fn a_linked_worktree_reads_its_own_locator_not_the_main_checkouts() {
+        // `config.root` is main-anchored in a linked worktree, so a caller that loads the locator
+        // from it pins or refuses against the WRONG file while the operator stands in the branch.
+        // `worktree_root` is the session-side root that rebases onto the active checkout.
+        const OTHER: &str = "99ff249f76f43de5497761bde999a7baa902008491e4cd1a6a943bcbf1d1f7b1";
+        let tmp = tempfile::tempdir().unwrap();
+        let main = tmp.path().join("main");
+        std::fs::create_dir_all(&main).unwrap();
+        crate::test_git::run(&main, &["init", "-q", "."]);
+        crate::test_git::run(&main, &["config", "user.email", "t@t"]);
+        crate::test_git::run(&main, &["config", "user.name", "t"]);
+        std::fs::write(main.join(STREAM_LOCATOR_FILE), format!("owner = \"{OWNER}\"\n")).unwrap();
+        crate::test_git::run(&main, &["add", "-A"]);
+        crate::test_git::run(&main, &["commit", "-qm", "main locator"]);
+
+        let linked = tmp.path().join("linked");
+        crate::test_git::run(&main, &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "branch",
+            linked.to_str().unwrap(),
+        ]);
+        std::fs::write(linked.join(STREAM_LOCATOR_FILE), format!("owner = \"{OTHER}\"\n")).unwrap();
+
+        let active = crate::config::worktree_root(&linked).expect("a linked worktree has a root");
+        assert_eq!(
+            load(&active).unwrap().expect("the branch checks one in").owner,
+            OTHER,
+            "the active checkout's locator governs, not the main checkout's",
+        );
+        assert_eq!(
+            load(&main).unwrap().expect("main still has its own").owner,
+            OWNER,
+            "and the main checkout is unaffected by the branch's",
+        );
+    }
+
+    #[test]
     fn an_absent_file_is_not_an_error_but_a_malformed_one_is() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(load(dir.path()).unwrap(), None, "a repo may simply check none in");

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -416,11 +416,20 @@ pub(crate) enum SyncCommand {
                             anchors its author published. The owner's log must reach this store \
                             before anything materializes: automatic sync pulls it once the \
                             owner's host is in [sync] server_peers, or run `rag-rat sync pull \
-                            <owner>`.")]
+                            <owner>`.\n\nWith no argument, the owner comes from the repo's \
+                            checked-in `.rag-rat-stream`, along with any peers and relay it \
+                            names for reaching that owner's host. The FIRST subscribe pins the \
+                            owner; because that file is editable by anyone who can land a \
+                            commit, a later edit naming a DIFFERENT owner is refused rather than \
+                            followed — confirm the new id with the stream's owner and pass it \
+                            explicitly to move the pin. The peers and relay carry no authority \
+                            and are followed as given: every entry pulled is verified against \
+                            the pinned account.")]
     Subscribe {
-        /// The owner's 64-hex account id, from the owner's `rag-rat sync whoami`.
+        /// The owner's 64-hex account id, from the owner's `rag-rat sync whoami`. Omit it to use
+        /// the owner named by the repo's checked-in `.rag-rat-stream`.
         #[arg(value_name = "OWNER_ACCOUNT_ID")]
-        account: String,
+        account: Option<String>,
     },
     /// Stop mirroring a subscribed identity's memories.
     #[command(long_about = "Clears this repo's `sync subscribe` configuration: its memories \
@@ -1263,7 +1272,18 @@ mod tests {
             Cli::try_parse_from(["rag-rat", "sync", "subscribe", &"ef".repeat(32)]).expect("parse");
         match cli.command {
             Command::Sync(SyncArgs { command: SyncCommand::Subscribe { account } }) =>
-                assert_eq!(account, "ef".repeat(32)),
+                assert_eq!(account, Some("ef".repeat(32))),
+            other => panic!("expected sync subscribe, got {other:?}"),
+        }
+    }
+
+    /// The no-argument form is what a clone runs: the owner comes from the checked-in locator.
+    #[test]
+    fn sync_subscribe_parses_without_an_account() {
+        let cli = Cli::try_parse_from(["rag-rat", "sync", "subscribe"]).expect("parse");
+        match cli.command {
+            Command::Sync(SyncArgs { command: SyncCommand::Subscribe { account } }) =>
+                assert_eq!(account, None),
             other => panic!("expected sync subscribe, got {other:?}"),
         }
     }

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -189,8 +189,15 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
             let (owner, source, locator) = match account {
                 Some(account) => (account.clone(), "argument", None),
                 None => {
+                    // The ACTIVE checkout, not `config.root`: in a linked worktree the config is
+                    // main-anchored, so reading the locator from it would pin or reject against
+                    // the main checkout's file while the operator is standing in the branch.
+                    let checkout = std::env::current_dir()
+                        .ok()
+                        .and_then(|cwd| rag_rat_base::config::worktree_root(&cwd))
+                        .unwrap_or_else(|| config.root.clone());
                     let locator =
-                        rag_rat_base::stream_locator::load(&config.root)?.with_context(|| {
+                        rag_rat_base::stream_locator::load(&checkout)?.with_context(|| {
                             format!(
                                 "no owner given and this repo checks in no `{}`. Pass the owner's \
                                  64-hex account id (from their `rag-rat sync whoami`), or add the \
@@ -205,6 +212,16 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 Some(_) => db.sync_subscribe(&owner)?,
                 None => db.sync_subscribe_from_locator(&owner)?,
             }
+            // Persisted, not merely echoed: a clone that subscribed from a locator has no
+            // `[sync] server_peers` — carrying that routing is the locator's whole purpose — and a
+            // foreign account cannot be discovered, so without this the repo would record a
+            // subscription it can never fetch. An operator-named subscribe clears any stale
+            // routing rather than dialing the previous owner's host for a different account.
+            let (peers, relay) = match locator.as_ref() {
+                Some(locator) => (locator.peers.clone(), locator.relay.clone()),
+                None => (Vec::new(), None),
+            };
+            db.set_subscription_routing(&peers, relay.as_deref())?;
             let effects = rag_rat_core::drain_synced_memory(db.connection())?;
             db.fold_wal();
             print_output(&serde_json::json!({
@@ -219,7 +236,11 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "read_only": true,
                 "memories_added": effects.nodes_written,
                 "memories_removed": effects.nodes_removed,
-                "note": "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner>` now",
+                "note": if locator.as_ref().is_some_and(|l| !l.peers.is_empty()) {
+                    "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). The locator's peers are recorded, so automatic sync pulls the owner's log without any [sync] server_peers; run `sync pull` now to fetch it immediately"
+                } else {
+                    "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log and no routing was supplied: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner> --peer <NODE_ID>` now"
+                },
             }))
         },
         SyncCommand::Unsubscribe => {
@@ -979,15 +1000,26 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
     };
     drop(repo_lock);
 
+    // An explicit `--peer` wins; otherwise configured peers PLUS whatever a `.rag-rat-stream`
+    // recorded when this repo subscribed. A clone that subscribed from a locator has no configured
+    // peers by design, and this is the command its own subscribe output tells it to run.
+    let (subscribed_peers, _) = db.subscription_routing()?;
     let peer_ids: Vec<String> = match peer_override {
         Some(peer) => vec![peer.to_string()],
-        None => config.sync.server_peers.clone(),
+        None => {
+            let mut peers = config.sync.server_peers.clone();
+            peers.extend(subscribed_peers);
+            peers.sort_unstable();
+            peers.dedup();
+            peers
+        },
     };
     if peer_ids.is_empty() {
         bail!(
-            "no peer to pull from: pass --peer <NODE_ID> or set [sync] server_peers. Discovery \
-             cannot find a FOREIGN account's host — its discovery tag derives from that account's \
-             own secret, which only its own devices hold"
+            "no peer to pull from: pass --peer <NODE_ID>, set [sync] server_peers, or subscribe \
+             from a `.rag-rat-stream` that names the owner's host. Discovery cannot find a \
+             FOREIGN account's host — its discovery tag derives from that account's own secret, \
+             which only its own devices hold"
         );
     }
     // An invalid entry skips to the next peer rather than aborting: one typo in a configured

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -183,13 +183,39 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
             }))
         },
         SyncCommand::Subscribe { account } => {
-            db.sync_subscribe(account)?;
+            // Two trust paths, not one command with a default. An operator naming the id has
+            // obtained it out of band and may move this repo's pin; the checked-in locator is
+            // untrusted input and may only establish one.
+            let (owner, source, locator) = match account {
+                Some(account) => (account.clone(), "argument", None),
+                None => {
+                    let locator =
+                        rag_rat_base::stream_locator::load(&config.root)?.with_context(|| {
+                            format!(
+                                "no owner given and this repo checks in no `{}`. Pass the owner's \
+                                 64-hex account id (from their `rag-rat sync whoami`), or add the \
+                                 locator file.",
+                                rag_rat_base::stream_locator::STREAM_LOCATOR_FILE,
+                            )
+                        })?;
+                    (locator.owner.clone(), "locator", Some(locator))
+                },
+            };
+            match account {
+                Some(_) => db.sync_subscribe(&owner)?,
+                None => db.sync_subscribe_from_locator(&owner)?,
+            }
             let effects = rag_rat_core::drain_synced_memory(db.connection())?;
             db.fold_wal();
             print_output(&serde_json::json!({
                 "status": "subscribed",
                 "repo_id": db.active_repo_id,
-                "owner_account_id": account,
+                "owner_account_id": owner,
+                "owner_source": source,
+                // The routing the locator supplied, echoed so an operator can see what this store
+                // will dial without opening the file. Neither carries authority.
+                "peers": locator.as_ref().map(|l| l.peers.clone()),
+                "relay": locator.as_ref().and_then(|l| l.relay.clone()),
                 "read_only": true,
                 "memories_added": effects.nodes_written,
                 "memories_removed": effects.nodes_removed,

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -203,20 +203,18 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                     (locator.owner.clone(), "locator", Some(locator))
                 },
             };
-            match account {
-                Some(_) => db.sync_subscribe(&owner)?,
-                None => db.sync_subscribe_from_locator(&owner)?,
+            // The routing is persisted, not merely echoed: a clone that subscribed from a locator
+            // has no `[sync] server_peers` — carrying that routing is the locator's whole purpose —
+            // and a foreign account cannot be discovered. It commits in the same transaction as the
+            // owner and pin, and an operator-named subscribe clears any previous routing there too.
+            match locator.as_ref() {
+                None => db.sync_subscribe(&owner)?,
+                Some(locator) => db.sync_subscribe_from_locator(
+                    &owner,
+                    &locator.peers,
+                    locator.relay.as_deref(),
+                )?,
             }
-            // Persisted, not merely echoed: a clone that subscribed from a locator has no
-            // `[sync] server_peers` — carrying that routing is the locator's whole purpose — and a
-            // foreign account cannot be discovered, so without this the repo would record a
-            // subscription it can never fetch. An operator-named subscribe clears any stale
-            // routing rather than dialing the previous owner's host for a different account.
-            let (peers, relay) = match locator.as_ref() {
-                Some(locator) => (locator.peers.clone(), locator.relay.clone()),
-                None => (Vec::new(), None),
-            };
-            db.set_subscription_routing(&peers, relay.as_deref())?;
             let effects = rag_rat_core::drain_synced_memory(db.connection())?;
             db.fold_wal();
             print_output(&serde_json::json!({

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -290,15 +290,18 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
 /// only speaks for the configured repo when it is one of that repo's worktrees: from repo A with
 /// `--config` naming repo B, the store being written is B's, and A's locator must not choose B's
 /// trust root. Anything that is not the configured repo's own family falls back to its root.
+///
+/// Two checkouts are one repository exactly when they share a git common directory. Keying on the
+/// main checkout's root instead misses sibling worktrees of a BARE repository, which have no main
+/// checkout: each would count as its own repository, and the configured checkout's locator would be
+/// read while the operator stands in a sibling.
 fn locator_checkout(config_root: &Path, cwd: Option<PathBuf>) -> PathBuf {
-    let family = |path: &Path| {
-        rag_rat_base::config::linked_worktree_main_root(path)
-            .or_else(|| rag_rat_base::config::worktree_root(path))
-    };
+    let repository = rag_rat_base::config::git_common_dir;
     let configured = rag_rat_base::config::worktree_root(config_root);
     let session = cwd.as_deref().and_then(|cwd| {
-        let family_matches = family(cwd).is_some() && family(cwd) == family(config_root);
-        family_matches.then(|| rag_rat_base::config::worktree_root(cwd)).flatten()
+        let same_repository =
+            repository(cwd).is_some() && repository(cwd) == repository(config_root);
+        same_repository.then(|| rag_rat_base::config::worktree_root(cwd)).flatten()
     });
     session.or(configured).unwrap_or_else(|| config_root.to_path_buf())
 }
@@ -1035,16 +1038,16 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
     };
     drop(repo_lock);
 
-    // An explicit `--peer` wins; otherwise configured peers PLUS whatever a `.rag-rat-stream`
-    // recorded when this repo subscribed, each dialed through the relay that reaches it. A clone
-    // that subscribed from a locator has no configured peers by design, and this is the command its
-    // own subscribe output tells it to run.
+    // An explicit `--peer` wins; otherwise configured peers PLUS the routes a `.rag-rat-stream`
+    // recorded for a subscription to THIS account, each dialed through the relay that reaches it. A
+    // clone that subscribed from a locator has no configured peers by design, and this is the
+    // command its own subscribe output tells it to run.
     let routes: Vec<(String, String)> = match peer_override {
         Some(peer) => vec![(peer.to_string(), relay.clone())],
         None => rag_rat_core::sync_driver::foreign_pull_peers(
             &config.sync.server_peers,
             &relay,
-            &db.subscription_routing()?,
+            &db.subscription_routing(&hash::hex_lower(&target.to_bytes()))?,
         ),
     };
     if routes.is_empty() {
@@ -1057,7 +1060,7 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
     }
     // An invalid entry skips to the next peer rather than aborting: one typo in a configured
     // peer list must not block a pull another entry could serve.
-    let order: Vec<String> = routes.iter().map(|(peer, _)| peer.clone()).collect();
+    let order = rag_rat_core::sync_driver::distinct_peers(&routes);
     let mut peers = Vec::with_capacity(routes.len());
     let mut resolve_error = None;
     for (peer_id, addr) in rag_rat_core::sync_driver::route_addrs(&order, &routes, &relay) {
@@ -1338,6 +1341,61 @@ mod tests {
         std::fs::create_dir_all(&nested).unwrap();
         assert_eq!(super::locator_checkout(&nested, None), top(&b_main));
         assert_eq!(super::locator_checkout(&nested, Some(b_linked.clone())), top(&b_linked));
+    }
+
+    /// Sibling worktrees of a BARE repository have no main checkout, so a repository keyed on the
+    /// main root sees two unrelated repositories. Their shared git common directory is what makes
+    /// them one.
+    #[test]
+    fn sibling_worktrees_of_a_bare_repository_are_one_repository() {
+        let tmp = tempfile::tempdir().unwrap();
+        let seed = tmp.path().join("seed");
+        init_repo(&seed);
+        let hub = tmp.path().join("hub.git");
+        rag_rat_base::test_git::run(tmp.path(), &[
+            "clone",
+            "-q",
+            "--bare",
+            seed.to_str().unwrap(),
+            hub.to_str().unwrap(),
+        ]);
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        rag_rat_base::test_git::run(&hub, &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "a",
+            a.to_str().unwrap(),
+        ]);
+        rag_rat_base::test_git::run(&hub, &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "b",
+            b.to_str().unwrap(),
+        ]);
+        let other = tmp.path().join("other");
+        init_repo(&other);
+        let top = |path: &std::path::Path| rag_rat_base::config::worktree_root(path).unwrap();
+
+        assert_eq!(
+            rag_rat_base::config::linked_worktree_main_root(&b),
+            None,
+            "a bare hub has no main checkout — the topology a main-keyed comparison misses",
+        );
+        assert_eq!(
+            super::locator_checkout(&a, Some(b.clone())),
+            top(&b),
+            "standing in B with A's config, B's own locator governs",
+        );
+        assert_eq!(
+            super::locator_checkout(&a, Some(other.clone())),
+            top(&a),
+            "an unrelated repository still never chooses",
+        );
     }
 
     /// `sync pull` requires the account id, so a suggestion without it would hand the operator a

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -1,6 +1,7 @@
 //! The `rag-rat sync` command: local memory-stream authoring configuration plus the peer transport
 //! driver (a persisted node identity today; `serve`/pairing land on top).
 
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, anyhow, bail};
@@ -189,13 +190,7 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
             let (owner, source, locator) = match account {
                 Some(account) => (account.clone(), "argument", None),
                 None => {
-                    // The ACTIVE checkout, not `config.root`: in a linked worktree the config is
-                    // main-anchored, so reading the locator from it would pin or reject against
-                    // the main checkout's file while the operator is standing in the branch.
-                    let checkout = std::env::current_dir()
-                        .ok()
-                        .and_then(|cwd| rag_rat_base::config::worktree_root(&cwd))
-                        .unwrap_or_else(|| config.root.clone());
+                    let checkout = locator_checkout(&config.root, std::env::current_dir().ok());
                     let locator =
                         rag_rat_base::stream_locator::load(&checkout)?.with_context(|| {
                             format!(
@@ -237,9 +232,18 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "memories_added": effects.nodes_written,
                 "memories_removed": effects.nodes_removed,
                 "note": if locator.as_ref().is_some_and(|l| !l.peers.is_empty()) {
-                    "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). The locator's peers are recorded, so automatic sync pulls the owner's log without any [sync] server_peers; run `sync pull` now to fetch it immediately"
+                    format!(
+                        "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). The locator's peers are recorded, so automatic sync pulls the \
+                         owner's log without any [sync] server_peers; run `{}` to fetch it now",
+                        subscribe_pull_hint(&owner, false),
+                    )
                 } else {
-                    "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log and no routing was supplied: automatic sync pulls it once the owner's host is in [sync] server_peers, or run `sync pull <owner> --peer <NODE_ID>` now"
+                    format!(
+                        "this repo's memories now mirror the owner's stream instead of its own — nothing is authored back, and this store's own memories are untouched. But exactly one stream materializes a repo, so the next drain REMOVES the memories this account's other devices had synced here; `sync unsubscribe` restores them, except for local binding work — a `memory rebind` you made on a synced memory, and any local edge onto it, go with the row (a re-drain seeds only the anchors its author published). This store needs the owner's log and no routing was supplied: \
+                         automatic sync pulls it once the owner's host is in [sync] server_peers, \
+                         or run `{}` now",
+                        subscribe_pull_hint(&owner, true),
+                    )
                 },
             }))
         },
@@ -278,6 +282,37 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
 
 /// The relay this invocation binds: `RAG_RAT_SYNC_RELAY` (ops/tests) overrides the configured
 /// `[sync] relay_url`, which itself defaults to the shipped relay.
+/// Where a subscribe reads `.rag-rat-stream`: the git root of the ACTIVE checkout, provided that
+/// checkout belongs to the repository the config names.
+///
+/// `config.root` is main-anchored, so in a linked worktree it points at the main checkout and
+/// would pin or reject against the wrong file while the operator stands in the branch. But the cwd
+/// only speaks for the configured repo when it is one of that repo's worktrees: from repo A with
+/// `--config` naming repo B, the store being written is B's, and A's locator must not choose B's
+/// trust root. Anything that is not the configured repo's own family falls back to its root.
+fn locator_checkout(config_root: &Path, cwd: Option<PathBuf>) -> PathBuf {
+    let family = |path: &Path| {
+        rag_rat_base::config::linked_worktree_main_root(path)
+            .or_else(|| rag_rat_base::config::worktree_root(path))
+    };
+    let configured = rag_rat_base::config::worktree_root(config_root);
+    let session = cwd.as_deref().and_then(|cwd| {
+        let family_matches = family(cwd).is_some() && family(cwd) == family(config_root);
+        family_matches.then(|| rag_rat_base::config::worktree_root(cwd)).flatten()
+    });
+    session.or(configured).unwrap_or_else(|| config_root.to_path_buf())
+}
+
+/// The pull a subscribe tells its operator to run. `sync pull` requires the account id, so the
+/// suggestion names the owner rather than handing over a command that fails to parse.
+fn subscribe_pull_hint(owner: &str, needs_peer: bool) -> String {
+    if needs_peer {
+        format!("rag-rat sync pull {owner} --peer <NODE_ID>")
+    } else {
+        format!("rag-rat sync pull {owner}")
+    }
+}
+
 fn effective_relay_url(config: &Config) -> String {
     match std::env::var("RAG_RAT_SYNC_RELAY") {
         Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
@@ -1001,20 +1036,18 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
     drop(repo_lock);
 
     // An explicit `--peer` wins; otherwise configured peers PLUS whatever a `.rag-rat-stream`
-    // recorded when this repo subscribed. A clone that subscribed from a locator has no configured
-    // peers by design, and this is the command its own subscribe output tells it to run.
-    let (subscribed_peers, _) = db.subscription_routing()?;
-    let peer_ids: Vec<String> = match peer_override {
-        Some(peer) => vec![peer.to_string()],
-        None => {
-            let mut peers = config.sync.server_peers.clone();
-            peers.extend(subscribed_peers);
-            peers.sort_unstable();
-            peers.dedup();
-            peers
-        },
+    // recorded when this repo subscribed, each dialed through the relay that reaches it. A clone
+    // that subscribed from a locator has no configured peers by design, and this is the command its
+    // own subscribe output tells it to run.
+    let routes: Vec<(String, String)> = match peer_override {
+        Some(peer) => vec![(peer.to_string(), relay.clone())],
+        None => rag_rat_core::sync_driver::foreign_pull_peers(
+            &config.sync.server_peers,
+            &relay,
+            &db.subscription_routing()?,
+        ),
     };
-    if peer_ids.is_empty() {
+    if routes.is_empty() {
         bail!(
             "no peer to pull from: pass --peer <NODE_ID>, set [sync] server_peers, or subscribe \
              from a `.rag-rat-stream` that names the owner's host. Discovery cannot find a \
@@ -1024,10 +1057,11 @@ fn pull(config: &Config, account_hex: &str, peer_override: Option<&str>) -> anyh
     }
     // An invalid entry skips to the next peer rather than aborting: one typo in a configured
     // peer list must not block a pull another entry could serve.
-    let mut peers = Vec::with_capacity(peer_ids.len());
+    let order: Vec<String> = routes.iter().map(|(peer, _)| peer.clone()).collect();
+    let mut peers = Vec::with_capacity(routes.len());
     let mut resolve_error = None;
-    for peer_id in peer_ids {
-        match rag_rat_sync::peer_addr(&peer_id, &relay) {
+    for (peer_id, addr) in rag_rat_core::sync_driver::route_addrs(&order, &routes, &relay) {
+        match addr {
             Ok(addr) => peers.push((peer_id, addr)),
             Err(error) => {
                 resolve_error = Some(format!("peer `{peer_id}` is not a valid node id: {error}"));
@@ -1258,6 +1292,73 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         conn
+    }
+
+    /// A git repo with one commit, so a linked worktree can branch off it.
+    fn init_repo(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        rag_rat_base::test_git::run(dir, &["init", "-q", "."]);
+        rag_rat_base::test_git::run(dir, &["config", "user.email", "t@t"]);
+        rag_rat_base::test_git::run(dir, &["config", "user.name", "t"]);
+        rag_rat_base::test_git::run(dir, &["commit", "-q", "--allow-empty", "-m", "init"]);
+    }
+
+    /// The locator belongs to the repository the config names, read from whichever of ITS checkouts
+    /// the operator stands in. A cwd outside that repository's worktree family never chooses.
+    #[test]
+    fn a_subscribe_reads_the_locator_of_the_configured_repos_active_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let b_main = tmp.path().join("b");
+        init_repo(&b_main);
+        let b_linked = tmp.path().join("b-linked");
+        rag_rat_base::test_git::run(&b_main, &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "branch",
+            b_linked.to_str().unwrap(),
+        ]);
+        let a = tmp.path().join("a");
+        init_repo(&a);
+        let top = |path: &std::path::Path| rag_rat_base::config::worktree_root(path).unwrap();
+
+        // `config.root` is main-anchored, so standing in B's linked worktree the branch's own
+        // checkout must speak — not the main checkout the config points at.
+        assert_eq!(super::locator_checkout(&b_main, Some(b_linked.clone())), top(&b_linked));
+        // From repo A with `--config` naming B, the store being written is B's: A's locator must
+        // not pin B's trust root.
+        assert_eq!(super::locator_checkout(&b_main, Some(a.clone())), top(&b_main));
+        // With no usable cwd, the configured repo's own checkout.
+        assert_eq!(super::locator_checkout(&b_main, None), top(&b_main));
+
+        // A config whose `[index] root` is a subdirectory still reads the locator from the git root
+        // of the checkout, in the main checkout and a linked one alike.
+        let nested = b_main.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(super::locator_checkout(&nested, None), top(&b_main));
+        assert_eq!(super::locator_checkout(&nested, Some(b_linked.clone())), top(&b_linked));
+    }
+
+    /// `sync pull` requires the account id, so a suggestion without it would hand the operator a
+    /// command that fails to parse instead of one that fetches the stream.
+    #[test]
+    fn the_pull_a_subscribe_suggests_is_a_command_that_parses() {
+        use clap::Parser;
+
+        use crate::cli::{Cli, Command, SyncArgs, SyncCommand};
+
+        let owner = "ab".repeat(32);
+        for needs_peer in [false, true] {
+            let hint = super::subscribe_pull_hint(&owner, needs_peer);
+            let cli = Cli::try_parse_from(hint.split_whitespace())
+                .unwrap_or_else(|err| panic!("`{hint}` must parse: {err}"));
+            match cli.command {
+                Command::Sync(SyncArgs { command: SyncCommand::Pull { account, .. } }) =>
+                    assert_eq!(account, owner, "and it fetches the subscribed owner"),
+                other => panic!("`{hint}` parsed as something other than a pull: {other:?}"),
+            }
+        }
     }
 
     /// A minimal config whose paths are never touched by these gate tests (they all return before

--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -634,3 +634,70 @@ fn consolidate_rebuilds_stale_content_projection_before_reconcile() {
     // CONTENT_PROJECTOR_VERSION bump.
     assert_eq!(stamp, "5", "consolidate upgraded the store-global projector stamp");
 }
+
+/// Two clones of one repository share its repo id but hold separate legacy indexes, each pinned to
+/// a different stream owner. Consolidating the first carries its pin and, once the rename lands,
+/// retires the import marker — so consolidating the second cannot pass for a retry of the first and
+/// silently move the global pin. It is refused, and the first clone's trust root stands.
+#[test]
+fn consolidating_a_second_clone_cannot_replace_the_first_clones_pin() {
+    const KEYLESS: &str = "[index]\nroot = \".\"\n\n[llm.embedding]\nmodel = \
+                           \"none\"\n\n[target_bindings]\nrust = [\"src\"]\n";
+    let first = fixture_repo();
+    let second = unique_dir("repo-second");
+    fs::create_dir_all(&second).unwrap();
+    git(&second, &["clone", "-q", first.to_str().unwrap(), "."]);
+    let data_dir = unique_dir("data");
+    let model_cache = unique_dir("cache");
+    let (owner_first, owner_second) = ("ab".repeat(32), "cd".repeat(32));
+
+    // Each clone builds its own legacy index and pins its own owner there. Unsubscribing keeps the
+    // pin — it is built to outlive the subscription — and consolidation needs an unsubscribed repo.
+    for (root, owner) in [(&first, &owner_first), (&second, &owner_second)] {
+        for args in [
+            &["index", "--full"][..],
+            &["sync", "subscribe", owner.as_str()][..],
+            &["sync", "unsubscribe"][..],
+        ] {
+            let out = run(root, &data_dir, &model_cache, args);
+            assert!(
+                out.status.success(),
+                "`{}` failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        fs::write(root.join("rag-rat.toml"), KEYLESS).unwrap();
+    }
+
+    let global = data_dir.join("rag-rat.sqlite");
+    let meta = |key: &str| -> Option<String> {
+        rusqlite::Connection::open(&global)
+            .unwrap()
+            .query_row("SELECT value FROM repo_meta WHERE key = ?1", [key], |row| row.get(0))
+            .ok()
+    };
+
+    let out = run(&first, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "consolidating the first clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        meta("memory_stream_pin"),
+        Some(owner_first.clone()),
+        "the first clone's pin carried"
+    );
+    assert_eq!(
+        meta("memory_stream_pin_imported"),
+        None,
+        "a completed consolidation retires its import marker",
+    );
+
+    let out = run(&second, &data_dir, &model_cache, &["consolidate"]);
+    assert!(!out.status.success(), "the second clone's conflicting pin must be refused");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("consolidation refused"), "the refusal names the conflict: {stderr}");
+    assert_eq!(meta("memory_stream_pin"), Some(owner_first), "the first clone's trust root stands");
+}

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -802,7 +802,13 @@ fn subscription_pair() -> (Connection, Connection, rag_rat_oplog::AccountId) {
     sync_account_into(&subscriber, &owner, owner_account);
 
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-    crate::memory_write::set_subscription_owner(&subscriber, &owner_hex, NOW).unwrap();
+    crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &owner_hex,
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+    )
+    .unwrap();
     (owner, subscriber, owner_account)
 }
 
@@ -893,7 +899,13 @@ fn an_unsynced_or_mistyped_subscription_owner_never_becomes_removal_authority() 
     // Re-point at an owner whose log was never synced. `set_subscription_owner` forgets the
     // OUTGOING stream's drain watermark, so the next drain would otherwise make a FULL pass over
     // the new owner's empty projection.
-    crate::memory_write::set_subscription_owner(&subscriber, &"ab".repeat(32), NOW).unwrap();
+    crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+    )
+    .unwrap();
     crate::drain_synced_memory(&subscriber).unwrap();
     let titles = memory_titles(&subscriber);
     assert!(
@@ -908,9 +920,14 @@ fn an_unsynced_or_mistyped_subscription_owner_never_becomes_removal_authority() 
 #[test]
 fn subscription_and_contribution_refuse_to_coexist() {
     let (_owner, contributor, _owner_account) = contribution_pair();
-    let err = crate::memory_write::set_subscription_owner(&contributor, &"ab".repeat(32), NOW)
-        .unwrap_err()
-        .to_string();
+    let err = crate::memory_write::set_subscription_owner(
+        &contributor,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+    )
+    .unwrap_err()
+    .to_string();
     assert!(err.contains("already contributes"), "subscribe names the conflict: {err}");
 
     let (_owner2, subscriber, _owner_account2) = subscription_pair();
@@ -955,7 +972,13 @@ fn subscribed_store_that_held_sibling_device_memories() -> Connection {
     // Subscribe. The owner's stream becomes the one authority, so the sibling's row is condemned.
     sync_account_into(&subscriber, &owner, owner_account);
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-    crate::memory_write::set_subscription_owner(&subscriber, &owner_hex, NOW).unwrap();
+    crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &owner_hex,
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+    )
+    .unwrap();
     crate::drain_synced_memory(&subscriber).unwrap();
     let titles = memory_titles(&subscriber);
     assert!(
@@ -1023,7 +1046,106 @@ fn subscribing_to_your_own_account_is_refused() {
     let store = scoped_conn();
     let account = local_account(&store, NOW).unwrap();
     let own_hex = rag_rat_base::hash::hex_lower(&account.to_bytes());
-    let err =
-        crate::memory_write::set_subscription_owner(&store, &own_hex, NOW).unwrap_err().to_string();
+    let err = crate::memory_write::set_subscription_owner(
+        &store,
+        &own_hex,
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+    )
+    .unwrap_err()
+    .to_string();
     assert!(err.contains("your own account"), "the refusal names the cause: {err}");
+}
+
+/// The locator (`.rag-rat-stream`) is checked in, so anyone who can land a commit can edit it. It
+/// may establish this repo's trust root and never move it: the first subscribe pins the owner, and
+/// a later locator naming a different one is refused.
+#[test]
+fn a_locator_may_establish_a_pin_but_never_move_it() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    let repo_id = rag_rat_db::schema::active_repo_id(&subscriber).unwrap();
+    assert_eq!(
+        crate::memory_write::stream_pin(&subscriber, &repo_id).unwrap().as_deref(),
+        Some(owner_hex.as_str()),
+        "subscribing pins the owner it subscribed to",
+    );
+
+    // A locator re-pointing at a different account is the attack: an edited in-repo file silently
+    // moving a subscriber's memory source. Refused.
+    let err = crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Locator,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("pinned to"), "the refusal names the conflict: {err}");
+    assert!(
+        err.contains("rag-rat sync subscribe"),
+        "and routes to an explicit re-subscribe rather than to unsubscribe, which would reset the \
+         pin: {err}",
+    );
+    assert!(
+        !err.contains("unsubscribe"),
+        "the remedy must never be the sequence that defeats the pin: {err}",
+    );
+
+    // The same locator naming the SAME owner is the ordinary case and must stay silent.
+    crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &owner_hex,
+        NOW,
+        crate::memory_write::SubscribeTrust::Locator,
+    )
+    .expect("a locator that agrees with the pin is the ordinary case");
+}
+
+/// An operator naming an id on the command line obtained it out of band, so they may move the pin —
+/// that is what makes the refusal above a trust decision rather than a wall.
+#[test]
+fn an_operator_named_account_moves_the_pin() {
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+    let repo_id = rag_rat_db::schema::active_repo_id(&subscriber).unwrap();
+
+    crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+    )
+    .expect("an operator may re-point");
+    assert_eq!(
+        crate::memory_write::stream_pin(&subscriber, &repo_id).unwrap(),
+        Some("ab".repeat(32)),
+        "and the pin follows them, so the locator is then measured against the new trust root",
+    );
+}
+
+/// The pin outlives `sync unsubscribe`. If it did not, the fail-closed refusal would be defeated by
+/// the very sequence an agent handed that error would try next.
+#[test]
+fn unsubscribing_does_not_reset_the_pin() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    let repo_id = rag_rat_db::schema::active_repo_id(&subscriber).unwrap();
+
+    assert!(crate::memory_write::clear_subscription_owner(&subscriber).unwrap());
+    assert_eq!(
+        crate::memory_write::stream_pin(&subscriber, &repo_id).unwrap().as_deref(),
+        Some(owner_hex.as_str()),
+        "unsubscribe clears the subscription, not the trust root",
+    );
+
+    // So unsubscribe-then-locator-subscribe still cannot move it.
+    let err = crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Locator,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("pinned to"), "the pin survives the unsubscribe dance: {err}");
 }

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -1149,3 +1149,39 @@ fn unsubscribing_does_not_reset_the_pin() {
     .to_string();
     assert!(err.contains("pinned to"), "the pin survives the unsubscribe dance: {err}");
 }
+
+/// A locator exists so a clone needs no `[sync] server_peers`. Recording only the owner would leave
+/// that clone holding a subscription it can never fetch: a foreign account's host cannot be
+/// discovered, because the discovery tag derives from that account's own secret.
+#[test]
+fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+
+    crate::memory_write::set_subscription_routing(
+        &subscriber,
+        &["node-a".to_string(), "node-b".to_string()],
+        Some("https://relay.example"),
+    )
+    .unwrap();
+    let (peers, relay) = crate::memory_write::subscription_routing(&subscriber).unwrap();
+    assert_eq!(peers, ["node-a", "node-b"], "the pull paths read these when nothing is configured");
+    assert_eq!(relay.as_deref(), Some("https://relay.example"));
+}
+
+/// An operator-named subscribe supplies no routing, and must not inherit the previous owner's host:
+/// dialing it for a different account is a wasted connection to a peer that never held the stream.
+#[test]
+fn re_subscribing_without_routing_clears_the_previous_owners_host() {
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+    crate::memory_write::set_subscription_routing(
+        &subscriber,
+        &["node-a".to_string()],
+        Some("https://relay.example"),
+    )
+    .unwrap();
+
+    crate::memory_write::set_subscription_routing(&subscriber, &[], None).unwrap();
+    let (peers, relay) = crate::memory_write::subscription_routing(&subscriber).unwrap();
+    assert!(peers.is_empty(), "stale routing is cleared, not carried onto the new owner");
+    assert_eq!(relay, None);
+}

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -1522,3 +1522,35 @@ fn a_routing_lookup_reads_one_subscription_state() {
         .unwrap();
     assert_eq!(owner_now, other, "the concurrent re-subscribe really committed mid-lookup");
 }
+
+/// A subscribe decides the pin in THIS store, so it stops being a copy an earlier consolidation
+/// left: the marker that lets a retried consolidation replace an imported pin must go with it.
+#[test]
+fn a_subscribe_takes_the_pin_out_of_import_provenance() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    subscriber
+        .execute(
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, 'memory_stream_pin_imported', \
+             ?2)",
+            params![REPO, owner_hex],
+        )
+        .unwrap();
+
+    crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
+    )
+    .unwrap();
+    let marker: Option<String> = subscriber
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'memory_stream_pin_imported'",
+            [REPO],
+            |row| row.get(0),
+        )
+        .ok();
+    assert_eq!(marker, None, "a pin decided here is no longer an imported copy");
+}

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -1155,7 +1155,8 @@ fn unsubscribing_does_not_reset_the_pin() {
 /// discovered, because the discovery tag derives from that account's own secret.
 #[test]
 fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
-    let (_owner, subscriber, _owner_account) = subscription_pair();
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
 
     crate::memory_write::set_subscription_routing(
         &subscriber,
@@ -1165,7 +1166,7 @@ fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
     .unwrap();
     let relay = Some("https://relay.example".to_string());
     assert_eq!(
-        crate::memory_write::subscription_routing(&subscriber).unwrap(),
+        crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap(),
         [("node-a".to_string(), relay.clone()), ("node-b".to_string(), relay)],
         "each recorded peer carries the relay its locator named — the pull paths dial it there",
     );
@@ -1175,7 +1176,8 @@ fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
 /// dialing it for a different account is a wasted connection to a peer that never held the stream.
 #[test]
 fn re_subscribing_without_routing_clears_the_previous_owners_host() {
-    let (_owner, subscriber, _owner_account) = subscription_pair();
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
     crate::memory_write::set_subscription_routing(
         &subscriber,
         &["node-a".to_string()],
@@ -1185,7 +1187,7 @@ fn re_subscribing_without_routing_clears_the_previous_owners_host() {
 
     crate::memory_write::set_subscription_routing(&subscriber, &[], None).unwrap();
     assert!(
-        crate::memory_write::subscription_routing(&subscriber).unwrap().is_empty(),
+        crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap().is_empty(),
         "stale routing is cleared, not carried onto the new owner",
     );
 }
@@ -1237,22 +1239,51 @@ fn unsubscribing_an_upgraded_store_first_still_keeps_its_trust_root() {
 /// drop out of every pull — an obsolete host stalls each pass behind a failing dial.
 #[test]
 fn routing_for_a_repo_that_no_longer_subscribes_is_never_dialed() {
-    let (_owner, subscriber, _owner_account) = subscription_pair();
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
     crate::memory_write::set_subscription_routing(&subscriber, &["node-a".to_string()], None)
         .unwrap();
     assert!(crate::memory_write::clear_subscription_owner(&subscriber).unwrap());
     assert!(
-        crate::memory_write::subscription_routing(&subscriber).unwrap().is_empty(),
+        crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap().is_empty(),
         "unsubscribe takes the routing out of every pull",
     );
 
     // And the reader holds the line on its own: routing rows that outlived their subscription by
     // any other path are not pooled either.
-    let (_owner, stale, _owner_account) = subscription_pair();
+    let (_owner, stale, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
     crate::memory_write::set_subscription_routing(&stale, &["node-b".to_string()], None).unwrap();
     stale.execute("DELETE FROM repo_meta WHERE key = 'memory_subscription_owner'", []).unwrap();
     assert!(
-        crate::memory_write::subscription_routing(&stale).unwrap().is_empty(),
+        crate::memory_write::subscription_routing(&stale, &owner_hex).unwrap().is_empty(),
         "routing without a live subscription is ignored",
+    );
+}
+
+/// A locator describes how to reach ONE owner's host, so its routes belong to that owner. Pooled
+/// across owners, one repository's locator could name another owner's peer through a dead relay and
+/// put that route in front of the live one.
+#[test]
+fn routing_reaches_only_the_owner_its_locator_describes() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    crate::memory_write::set_subscription_routing(
+        &subscriber,
+        &["node-a".to_string()],
+        Some("https://relay.example"),
+    )
+    .unwrap();
+
+    assert_eq!(
+        crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap().len(),
+        1,
+        "the subscribed owner's pull sees its route",
+    );
+    assert!(
+        crate::memory_write::subscription_routing(&subscriber, &"cd".repeat(32))
+            .unwrap()
+            .is_empty(),
+        "another account's pull never sees this repository's routes",
     );
 }

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -1163,9 +1163,12 @@ fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
         Some("https://relay.example"),
     )
     .unwrap();
-    let (peers, relay) = crate::memory_write::subscription_routing(&subscriber).unwrap();
-    assert_eq!(peers, ["node-a", "node-b"], "the pull paths read these when nothing is configured");
-    assert_eq!(relay.as_deref(), Some("https://relay.example"));
+    let relay = Some("https://relay.example".to_string());
+    assert_eq!(
+        crate::memory_write::subscription_routing(&subscriber).unwrap(),
+        [("node-a".to_string(), relay.clone()), ("node-b".to_string(), relay)],
+        "each recorded peer carries the relay its locator named — the pull paths dial it there",
+    );
 }
 
 /// An operator-named subscribe supplies no routing, and must not inherit the previous owner's host:
@@ -1181,7 +1184,75 @@ fn re_subscribing_without_routing_clears_the_previous_owners_host() {
     .unwrap();
 
     crate::memory_write::set_subscription_routing(&subscriber, &[], None).unwrap();
-    let (peers, relay) = crate::memory_write::subscription_routing(&subscriber).unwrap();
-    assert!(peers.is_empty(), "stale routing is cleared, not carried onto the new owner");
-    assert_eq!(relay, None);
+    assert!(
+        crate::memory_write::subscription_routing(&subscriber).unwrap().is_empty(),
+        "stale routing is cleared, not carried onto the new owner",
+    );
+}
+
+/// A store upgraded from a release without the pin holds a live subscription and no pin. Reading
+/// that as first use would let a changed locator silently replace the owner an operator chose.
+#[test]
+fn an_upgraded_store_treats_its_existing_subscription_as_the_pin() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    subscriber.execute("DELETE FROM repo_meta WHERE key = 'memory_stream_pin'", []).unwrap();
+
+    let err = crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Locator,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains(&format!("pinned to {owner_hex}")),
+        "the existing subscription is the trust root: {err}",
+    );
+}
+
+/// The upgrade case again, with `sync unsubscribe` as the first thing run after it. Clearing the
+/// subscription must carry its owner into the pin, or the next locator subscribe reads as first
+/// use.
+#[test]
+fn unsubscribing_an_upgraded_store_first_still_keeps_its_trust_root() {
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    subscriber.execute("DELETE FROM repo_meta WHERE key = 'memory_stream_pin'", []).unwrap();
+
+    assert!(crate::memory_write::clear_subscription_owner(&subscriber).unwrap());
+    let err = crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &"ab".repeat(32),
+        NOW,
+        crate::memory_write::SubscribeTrust::Locator,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains(&format!("pinned to {owner_hex}")), "the pin was seeded: {err}");
+}
+
+/// Routing describes how to reach the owner a repo mirrors. Once it mirrors nobody, its host must
+/// drop out of every pull — an obsolete host stalls each pass behind a failing dial.
+#[test]
+fn routing_for_a_repo_that_no_longer_subscribes_is_never_dialed() {
+    let (_owner, subscriber, _owner_account) = subscription_pair();
+    crate::memory_write::set_subscription_routing(&subscriber, &["node-a".to_string()], None)
+        .unwrap();
+    assert!(crate::memory_write::clear_subscription_owner(&subscriber).unwrap());
+    assert!(
+        crate::memory_write::subscription_routing(&subscriber).unwrap().is_empty(),
+        "unsubscribe takes the routing out of every pull",
+    );
+
+    // And the reader holds the line on its own: routing rows that outlived their subscription by
+    // any other path are not pooled either.
+    let (_owner, stale, _owner_account) = subscription_pair();
+    crate::memory_write::set_subscription_routing(&stale, &["node-b".to_string()], None).unwrap();
+    stale.execute("DELETE FROM repo_meta WHERE key = 'memory_subscription_owner'", []).unwrap();
+    assert!(
+        crate::memory_write::subscription_routing(&stale).unwrap().is_empty(),
+        "routing without a live subscription is ignored",
+    );
 }

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -807,6 +807,7 @@ fn subscription_pair() -> (Connection, Connection, rag_rat_oplog::AccountId) {
         &owner_hex,
         NOW,
         crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .unwrap();
     (owner, subscriber, owner_account)
@@ -904,6 +905,7 @@ fn an_unsynced_or_mistyped_subscription_owner_never_becomes_removal_authority() 
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .unwrap();
     crate::drain_synced_memory(&subscriber).unwrap();
@@ -925,6 +927,7 @@ fn subscription_and_contribution_refuse_to_coexist() {
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .unwrap_err()
     .to_string();
@@ -977,6 +980,7 @@ fn subscribed_store_that_held_sibling_device_memories() -> Connection {
         &owner_hex,
         NOW,
         crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .unwrap();
     crate::drain_synced_memory(&subscriber).unwrap();
@@ -1051,6 +1055,7 @@ fn subscribing_to_your_own_account_is_refused() {
         &own_hex,
         NOW,
         crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .unwrap_err()
     .to_string();
@@ -1078,6 +1083,7 @@ fn a_locator_may_establish_a_pin_but_never_move_it() {
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Locator,
+        Default::default(),
     )
     .unwrap_err()
     .to_string();
@@ -1098,6 +1104,7 @@ fn a_locator_may_establish_a_pin_but_never_move_it() {
         &owner_hex,
         NOW,
         crate::memory_write::SubscribeTrust::Locator,
+        Default::default(),
     )
     .expect("a locator that agrees with the pin is the ordinary case");
 }
@@ -1114,6 +1121,7 @@ fn an_operator_named_account_moves_the_pin() {
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .expect("an operator may re-point");
     assert_eq!(
@@ -1144,6 +1152,7 @@ fn unsubscribing_does_not_reset_the_pin() {
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Locator,
+        Default::default(),
     )
     .unwrap_err()
     .to_string();
@@ -1157,13 +1166,12 @@ fn unsubscribing_does_not_reset_the_pin() {
 fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
     let (_owner, subscriber, owner_account) = subscription_pair();
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-
-    crate::memory_write::set_subscription_routing(
+    subscribe_via_locator(
         &subscriber,
+        &owner_hex,
         &["node-a".to_string(), "node-b".to_string()],
         Some("https://relay.example"),
-    )
-    .unwrap();
+    );
     let relay = Some("https://relay.example".to_string());
     assert_eq!(
         crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap(),
@@ -1178,17 +1186,19 @@ fn subscribing_from_a_locator_records_the_routing_that_reaches_the_owner() {
 fn re_subscribing_without_routing_clears_the_previous_owners_host() {
     let (_owner, subscriber, owner_account) = subscription_pair();
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-    crate::memory_write::set_subscription_routing(
+    subscribe_via_locator(&subscriber, &owner_hex, &["node-a".to_string()], Some("https://r"));
+
+    crate::memory_write::set_subscription_owner(
         &subscriber,
-        &["node-a".to_string()],
-        Some("https://relay.example"),
+        &owner_hex,
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
     )
     .unwrap();
-
-    crate::memory_write::set_subscription_routing(&subscriber, &[], None).unwrap();
     assert!(
         crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap().is_empty(),
-        "stale routing is cleared, not carried onto the new owner",
+        "stale routing is cleared, not carried onto the new subscription",
     );
 }
 
@@ -1205,6 +1215,7 @@ fn an_upgraded_store_treats_its_existing_subscription_as_the_pin() {
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Locator,
+        Default::default(),
     )
     .unwrap_err()
     .to_string();
@@ -1229,6 +1240,7 @@ fn unsubscribing_an_upgraded_store_first_still_keeps_its_trust_root() {
         &"ab".repeat(32),
         NOW,
         crate::memory_write::SubscribeTrust::Locator,
+        Default::default(),
     )
     .unwrap_err()
     .to_string();
@@ -1241,23 +1253,11 @@ fn unsubscribing_an_upgraded_store_first_still_keeps_its_trust_root() {
 fn routing_for_a_repo_that_no_longer_subscribes_is_never_dialed() {
     let (_owner, subscriber, owner_account) = subscription_pair();
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-    crate::memory_write::set_subscription_routing(&subscriber, &["node-a".to_string()], None)
-        .unwrap();
+    subscribe_via_locator(&subscriber, &owner_hex, &["node-a".to_string()], None);
     assert!(crate::memory_write::clear_subscription_owner(&subscriber).unwrap());
     assert!(
         crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap().is_empty(),
         "unsubscribe takes the routing out of every pull",
-    );
-
-    // And the reader holds the line on its own: routing rows that outlived their subscription by
-    // any other path are not pooled either.
-    let (_owner, stale, owner_account) = subscription_pair();
-    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-    crate::memory_write::set_subscription_routing(&stale, &["node-b".to_string()], None).unwrap();
-    stale.execute("DELETE FROM repo_meta WHERE key = 'memory_subscription_owner'", []).unwrap();
-    assert!(
-        crate::memory_write::subscription_routing(&stale, &owner_hex).unwrap().is_empty(),
-        "routing without a live subscription is ignored",
     );
 }
 
@@ -1268,12 +1268,7 @@ fn routing_for_a_repo_that_no_longer_subscribes_is_never_dialed() {
 fn routing_reaches_only_the_owner_its_locator_describes() {
     let (_owner, subscriber, owner_account) = subscription_pair();
     let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
-    crate::memory_write::set_subscription_routing(
-        &subscriber,
-        &["node-a".to_string()],
-        Some("https://relay.example"),
-    )
-    .unwrap();
+    subscribe_via_locator(&subscriber, &owner_hex, &["node-a".to_string()], Some("https://r"));
 
     assert_eq!(
         crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap().len(),
@@ -1286,4 +1281,85 @@ fn routing_reaches_only_the_owner_its_locator_describes() {
             .is_empty(),
         "another account's pull never sees this repository's routes",
     );
+}
+
+/// Owner, pin and routing change together or not at all. A re-subscribe whose routing write fails
+/// must leave the previous subscription whole: were the owner and pin committed first, the previous
+/// owner's routes would survive beside the new owner and be dialed on its behalf.
+#[test]
+fn a_resubscribe_that_cannot_record_its_routing_changes_nothing() {
+    use rusqlite::OptionalExtension;
+
+    let (_owner, subscriber, owner_account) = subscription_pair();
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    subscribe_via_locator(&subscriber, &owner_hex, &["node-a".to_string()], Some("https://r"));
+    let meta = |key: &str| -> Option<String> {
+        subscriber
+            .query_row("SELECT value FROM repo_meta WHERE key = ?1", [key], |row| row.get(0))
+            .optional()
+            .unwrap()
+    };
+
+    // Every write that would replace or clear the recorded routing now fails.
+    subscriber
+        .execute_batch(
+            "CREATE TEMP TRIGGER fail_routing_insert BEFORE INSERT ON repo_meta
+                 WHEN NEW.key = 'memory_subscription_peers'
+                 BEGIN SELECT RAISE(ABORT, 'injected routing failure'); END;
+             CREATE TEMP TRIGGER fail_routing_update BEFORE UPDATE ON repo_meta
+                 WHEN OLD.key = 'memory_subscription_peers'
+                 BEGIN SELECT RAISE(ABORT, 'injected routing failure'); END;
+             CREATE TEMP TRIGGER fail_routing_delete BEFORE DELETE ON repo_meta
+                 WHEN OLD.key = 'memory_subscription_peers'
+                 BEGIN SELECT RAISE(ABORT, 'injected routing failure'); END;",
+        )
+        .unwrap();
+
+    let other = "ab".repeat(32);
+    let err = crate::memory_write::set_subscription_owner(
+        &subscriber,
+        &other,
+        NOW,
+        crate::memory_write::SubscribeTrust::Operator,
+        Default::default(),
+    )
+    .unwrap_err();
+    assert!(
+        format!("{err:#}").contains("injected routing failure"),
+        "the injected fault is what failed: {err:#}",
+    );
+
+    assert_eq!(
+        meta("memory_subscription_owner"),
+        Some(owner_hex.clone()),
+        "the owner did not move"
+    );
+    assert_eq!(meta("memory_stream_pin"), Some(owner_hex.clone()), "the pin did not move");
+    assert_eq!(
+        meta("memory_subscription_peers").as_deref(),
+        Some("node-a"),
+        "routing kept its owner"
+    );
+    assert!(
+        crate::memory_write::subscription_routing(&subscriber, &other).unwrap().is_empty(),
+        "the new owner was never handed the previous owner's routes",
+    );
+}
+
+/// Re-subscribe `conn` to `owner_hex` from a locator carrying this routing — the only path that
+/// records routing, so tests set it up the way production does.
+fn subscribe_via_locator(
+    conn: &rusqlite::Connection,
+    owner_hex: &str,
+    peers: &[String],
+    relay: Option<&str>,
+) {
+    crate::memory_write::set_subscription_owner(
+        conn,
+        owner_hex,
+        NOW,
+        crate::memory_write::SubscribeTrust::Locator,
+        crate::memory_write::SubscriptionRouting { peers, relay },
+    )
+    .unwrap();
 }

--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -23,7 +23,11 @@ const NOW: i64 = 1_700_000_000_000;
 const REPO: &str = "repo-a";
 
 fn scoped_conn() -> Connection {
-    let conn = Connection::open_in_memory().unwrap();
+    scope(Connection::open_in_memory().unwrap())
+}
+
+/// Apply the schema, register the test repo and scope the connection to it.
+fn scope(conn: Connection) -> Connection {
     conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
     rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     conn.execute(
@@ -785,12 +789,19 @@ fn clearing_a_foreign_owner_propagates_a_resolution_failure_that_is_not_a_parse(
 /// guards observable (an account that owns nothing is vacuously fully-public and holds no rival
 /// stream at all). Returns `(owner, subscriber, owner_account)`.
 fn subscription_pair() -> (Connection, Connection, rag_rat_oplog::AccountId) {
+    subscription_pair_with(scoped_conn())
+}
+
+/// [`subscription_pair`] with the subscriber's connection supplied — file-backed when a test needs
+/// a second connection to the same store.
+fn subscription_pair_with(
+    subscriber: Connection,
+) -> (Connection, Connection, rag_rat_oplog::AccountId) {
     let owner = scoped_conn();
     let owner_account = local_account(&owner, NOW).unwrap();
     assert!(enable_public_authoring(&owner, NOW).unwrap());
     create_memory(&owner, concept("owner-note")).unwrap();
 
-    let subscriber = scoped_conn();
     let subscriber_account = local_account(&subscriber, NOW).unwrap();
     assert_ne!(owner_account, subscriber_account, "separate identities");
     create_memory(&subscriber, concept("subscriber-note")).unwrap();
@@ -1362,4 +1373,152 @@ fn subscribe_via_locator(
         crate::memory_write::SubscriptionRouting { peers, relay },
     )
     .unwrap();
+}
+
+/// A connection to a file-backed store with the pragmas production relies on for concurrency: WAL,
+/// so a reader keeps its snapshot while another connection commits, and a busy timeout.
+fn file_conn(path: &std::path::Path) -> Connection {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch("PRAGMA journal_mode = WAL;").unwrap();
+    conn.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
+    conn
+}
+
+/// Set once the locator's connection is waiting on the write lock — the causal signal the pin race
+/// commits on, rather than a sleep.
+static LOCATOR_WAITING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+fn locator_is_waiting(_attempts: i32) -> bool {
+    LOCATOR_WAITING.store(true, std::sync::atomic::Ordering::SeqCst);
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    true
+}
+
+/// A locator subscribe decides against the pin it commits under. An operator re-subscribe holds the
+/// write lock with a new pin not yet committed; the locator, naming the OLD owner that matched the
+/// pin a moment earlier, waits on that lock, and only then does the operator commit. Checked before
+/// taking the lock, the locator would pass against the stale pin and restore the old owner over the
+/// one just committed; checked under it, the locator sees the new pin and refuses.
+#[test]
+fn a_locator_subscribe_decides_against_the_pin_it_commits_under() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store.sqlite");
+    let (_owner, subscriber, owner_account) = subscription_pair_with(scope(file_conn(&path)));
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    let other = "ab".repeat(32);
+
+    let operator = file_conn(&path);
+    operator.execute_batch("BEGIN IMMEDIATE").unwrap();
+    operator
+        .execute(
+            "UPDATE repo_meta SET value = ?1 WHERE repo_id = ?2
+               AND key IN ('memory_subscription_owner', 'memory_stream_pin')",
+            params![other, REPO],
+        )
+        .unwrap();
+
+    LOCATOR_WAITING.store(false, std::sync::atomic::Ordering::SeqCst);
+    subscriber.busy_handler(Some(locator_is_waiting)).unwrap();
+    let locator = std::thread::spawn(move || {
+        crate::memory_write::set_subscription_owner(
+            &subscriber,
+            &owner_hex,
+            NOW,
+            crate::memory_write::SubscribeTrust::Locator,
+            Default::default(),
+        )
+        .map_err(|err| format!("{err:#}"))
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while !LOCATOR_WAITING.load(std::sync::atomic::Ordering::SeqCst) {
+        assert!(std::time::Instant::now() < deadline, "the locator never reached the write lock");
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    operator.execute_batch("COMMIT").unwrap();
+
+    let outcome = locator.join().unwrap();
+    let pin: String = operator
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'memory_stream_pin'",
+            [REPO],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(pin, other, "the pin committed ahead of the locator survives");
+    let refusal = outcome.expect_err("the locator must see that pin and refuse");
+    assert!(
+        refusal.contains(&format!("pinned to {other}")),
+        "it refuses against the new pin: {refusal}"
+    );
+}
+
+/// A routing lookup reads one subscription state. The reader's `repo_meta` is shadowed by a view
+/// that, the first time it is read, commits a re-subscribe to another owner from a second
+/// connection. Read in one statement, the lookup keeps its snapshot and returns this owner's own
+/// routes; read key by key, it would find this owner and then the NEXT owner's peers and relay.
+#[test]
+fn a_routing_lookup_reads_one_subscription_state() {
+    use rusqlite::functions::FunctionFlags;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store.sqlite");
+    let (_owner, subscriber, owner_account) = subscription_pair_with(scope(file_conn(&path)));
+    let owner_hex = rag_rat_base::hash::hex_lower(&owner_account.to_bytes());
+    subscribe_via_locator(
+        &subscriber,
+        &owner_hex,
+        &["node-a".to_string()],
+        Some("https://relay-a"),
+    );
+
+    let other = "ab".repeat(32);
+    let resubscribe = format!(
+        "BEGIN IMMEDIATE;
+         UPDATE repo_meta SET value = CASE key
+             WHEN 'memory_subscription_owner' \
+         THEN '{other}'
+             WHEN 'memory_subscription_peers' THEN 'node-b'
+             WHEN \
+         'memory_subscription_relay' THEN 'https://relay-b'
+             ELSE value END
+         WHERE repo_id = '{REPO}';
+         COMMIT;"
+    );
+    let writer = std::sync::Mutex::new(Some(file_conn(&path)));
+    subscriber
+        .create_scalar_function(
+            "resubscribe_concurrently",
+            0,
+            FunctionFlags::SQLITE_UTF8,
+            move |_| {
+                if let Some(writer) = writer.lock().unwrap().take() {
+                    writer
+                        .execute_batch(&resubscribe)
+                        .map_err(|err| rusqlite::Error::UserFunctionError(err.into()))?;
+                }
+                Ok(1)
+            },
+        )
+        .unwrap();
+    subscriber
+        .execute_batch(
+            "CREATE TEMP VIEW repo_meta AS
+                 SELECT repo_id, key, value FROM main.repo_meta WHERE resubscribe_concurrently()",
+        )
+        .unwrap();
+
+    assert_eq!(
+        crate::memory_write::subscription_routing(&subscriber, &owner_hex).unwrap(),
+        [("node-a".to_string(), Some("https://relay-a".to_string()))],
+        "one snapshot: this owner's own routes, never the next owner's",
+    );
+    let owner_now: String = file_conn(&path)
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'memory_subscription_owner'",
+            [REPO],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(owner_now, other, "the concurrent re-subscribe really committed mid-lookup");
 }

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -85,9 +85,10 @@ use crate::index::{self, IndexDatabase, schema};
 ///        source's EFFECTIVE pin crosses — its recorded pin, else the owner it is subscribed to,
 ///        which a store from before the pin existed records its trust decision as (that
 ///        subscription itself never crosses — see (b)). Until the rename lands the legacy index is
-///        the live store, so a retry replaces a pin an earlier run of this consolidation wrote
-///        (recorded in `memory_stream_pin_imported`); a conflicting pin the target decided itself
-///        REFUSES the run, since carrying either would silently override the other trust root.
+///        the live store, so a retry of the SAME legacy source replaces the pin its earlier,
+///        unfinished run wrote (recorded, with that source, in `memory_stream_pin_imported`, and
+///        retired once the rename lands); any other conflicting pin REFUSES the run, since carrying
+///        either would silently override the other trust root.
 ///
 ///  (b) DB-LOCAL STATE — never copied; each entry states why:
 ///      * freshness/progress cursors that would make a fresh 0-row index falsely report itself
@@ -109,9 +110,9 @@ use crate::index::{self, IndexDatabase, schema};
 ///      * `memory_subscription_peers` / `memory_subscription_relay` — how to reach the subscribed
 ///        owner's host. They describe a subscription, and the subscription never crosses; carried
 ///        alone they would route toward an owner this repo no longer mirrors.
-///      * `memory_stream_pin_imported` — the pin value an earlier run of this consolidation wrote,
-///        which is how a retry tells its own copy from a trust decision the target made; any `sync
-///        subscribe` there clears it.
+///      * `memory_stream_pin_imported` — the pin an UNFINISHED consolidation wrote and the legacy
+///        source it came from, which is how a retry of that source tells its own stale copy from a
+///        trust decision; it is retired once the rename lands, and any `sync subscribe` clears it.
 const CARRIED_META_KEYS: &[&str] = &[
     "active_embedding_model",
     "embedding_active_model_version",
@@ -414,6 +415,17 @@ fn run_inner(config: &Config, config_path: Option<&Path>) -> anyhow::Result<Cons
     fs::rename(&source, &imported)
         .with_context(|| format!("renaming {} to {}", source.display(), imported.display()))?;
     rename_wal_sidecars(&source, &imported);
+    // The legacy index is archived, so no retry of THIS consolidation can follow: the pin it wrote
+    // stops being a replaceable copy and becomes the global store's own trust decision. A failure
+    // here is left as a warning — the source identity in the marker already keeps any other source
+    // from claiming it, and failing an import that has completed would help nothing.
+    if let Err(error) = retire_pin_import(target_conn, &repo_id) {
+        tracing::warn!(
+            repo_id = %repo_id,
+            %error,
+            "consolidation completed but could not retire its stream pin import marker"
+        );
+    }
 
     Ok(ConsolidateOutcome::Imported(ImportSummary {
         repo_id,
@@ -1559,12 +1571,15 @@ fn merge_stream_pin(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
     let replaceable = match &target_pin {
         None => true,
         Some(pin) if *pin == source_pin => return Ok(0),
-        // The pin an earlier run of THIS consolidation wrote, untouched since: a subscribe in the
-        // target clears the marker. Until the rename lands the legacy index is the live store, so
-        // a repin made there in the crash-retry window must replace the copy the last run left —
-        // keeping it would restore a trust root the operator has since moved away from.
+        // The pin an earlier, unfinished run wrote FROM THIS SAME legacy source, untouched since —
+        // a subscribe in the target clears the marker, and a completed consolidation retires it.
+        // Until the rename lands the legacy index is the live store, so a repin made there in the
+        // crash-retry window must replace the copy the last run left. Another source's pin is not
+        // a stale copy of this one: two clones of a repository share its repo id, and letting the
+        // second overwrite the first would silently move the trust root.
         Some(pin) =>
-            target_meta(MEMORY_STREAM_PIN_IMPORTED_META_KEY)?.as_deref() == Some(pin.as_str()),
+            target_meta(MEMORY_STREAM_PIN_IMPORTED_META_KEY)?.as_deref()
+                == Some(pin_import_marker(source, pin).as_str()),
     };
     if !replaceable {
         anyhow::bail!(
@@ -1576,15 +1591,34 @@ fn merge_stream_pin(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
             target_pin.unwrap_or_default(),
         );
     }
+    let marker = pin_import_marker(source, &source_pin);
     let mut written = 0;
-    for key in [MEMORY_STREAM_PIN_META_KEY, MEMORY_STREAM_PIN_IMPORTED_META_KEY] {
+    for (key, value) in [
+        (MEMORY_STREAM_PIN_META_KEY, source_pin.as_str()),
+        (MEMORY_STREAM_PIN_IMPORTED_META_KEY, marker.as_str()),
+    ] {
         written += tx.execute(
             "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)
              ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value",
-            params![repo_id, key, source_pin],
+            params![repo_id, key, value],
         )?;
     }
     Ok(written as u64)
+}
+
+/// What `memory_stream_pin_imported` holds: the pin an import wrote AND the legacy source it came
+/// from, so only a retry of that same source can claim it. A legacy index is always a file, so its
+/// path identifies it for as long as the consolidation stays unfinished.
+fn pin_import_marker(source: &Connection, pin: &str) -> String {
+    serde_json::json!({ "source": source.path().unwrap_or_default(), "pin": pin }).to_string()
+}
+
+/// Retire the import marker once a consolidation has completed — see `merge_stream_pin`.
+fn retire_pin_import(conn: &Connection, repo_id: &str) -> rusqlite::Result<usize> {
+    conn.execute("DELETE FROM repo_meta WHERE repo_id = ?1 AND key = ?2", params![
+        repo_id,
+        MEMORY_STREAM_PIN_IMPORTED_META_KEY
+    ])
 }
 
 fn merge_stream_seal_policy(
@@ -3060,6 +3094,38 @@ mod tests {
         assert!(err.to_string().contains("consolidation refused"), "got: {err}");
         assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
         assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memories"), 0, "nothing imported");
+    }
+
+    /// Two clones of one repository hold separate legacy indexes. The pin the first one's import
+    /// wrote is not the second one's to replace — only a retry of the SAME source may — so a second
+    /// source carrying a conflicting pin refuses.
+    #[test]
+    fn a_second_source_cannot_replace_the_pin_another_source_imported() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_source = |name: &str, pin: &str| -> Connection {
+            let seed = seeded_source();
+            seed.execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', \
+                 'memory_stream_pin', ?1)",
+                [pin],
+            )
+            .unwrap();
+            let path = dir.path().join(name);
+            seed.execute("VACUUM INTO ?1", [path.to_str().unwrap()]).unwrap();
+            Connection::open(&path).unwrap()
+        };
+        let first = file_source("first.sqlite", "owner-a");
+        let second = file_source("second.sqlite", "owner-b");
+        let target = fresh_target();
+        import_from_source(&first, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
+
+        let err =
+            import_from_source(&second, &target, "global-repo", ImportMode::ConsolidateLegacy)
+                .err()
+                .expect("another source's conflicting pin is not a retry of the first");
+        assert!(err.to_string().contains("consolidation refused"), "got: {err}");
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
     }
 
     /// Until the rename lands the legacy index is the live store. A repin made there after an

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -79,6 +79,13 @@ use crate::index::{self, IndexDatabase, schema};
 ///      * `memory_stream_seal_policy` — the one-way privacy intent for the repo's owner stream.
 ///        Unlike model-state keys it is MERGED monotonically: `sealed` on either side wins, absence
 ///        never clears it, and unknown values abort consolidation before reconciliation.
+///      * `memory_stream_pin` — the owner this repo has trusted (see `sync subscribe`). MERGED, not
+///        copied verbatim: it is the one subscription field built to outlive the subscription, so
+///        dropping it on the move would let a changed `.rag-rat-stream` read as first use. The
+///        source's EFFECTIVE pin crosses — its recorded pin, else the owner it is subscribed to,
+///        which a store from before the pin existed records its trust decision as (that
+///        subscription itself never crosses — see (b)). A target already pinned keeps its own: it
+///        is the trust decision the target has acted on, and a pin survives either way.
 ///
 ///  (b) DB-LOCAL STATE — never copied; each entry states why:
 ///      * freshness/progress cursors that would make a fresh 0-row index falsely report itself
@@ -97,6 +104,9 @@ use crate::index::{self, IndexDatabase, schema};
 ///        either key, and a legacy source that carries one has nowhere to put it (the target's own
 ///        key must stay authoritative — it is what the target's drain already acted on). A repo
 ///        consolidates only while it owns its own stream.
+///      * `memory_subscription_peers` / `memory_subscription_relay` — how to reach the subscribed
+///        owner's host. They describe a subscription, and the subscription never crosses; carried
+///        alone they would route toward an owner this repo no longer mirrors.
 const CARRIED_META_KEYS: &[&str] = &[
     "active_embedding_model",
     "embedding_active_model_version",
@@ -108,6 +118,8 @@ const CARRIED_META_KEYS: &[&str] = &[
 
 const MEMORY_STREAM_SEAL_POLICY_META_KEY: &str = "memory_stream_seal_policy";
 const MEMORY_STREAM_ACCESS_MODE_META_KEY: &str = "memory_stream_access_mode";
+const MEMORY_STREAM_PIN_META_KEY: &str = "memory_stream_pin";
+const MEMORY_SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
 
 /// How long consolidate waits for the repo's per-repo write locks (global-side and legacy-side)
 /// before refusing — an in-flight index/maintenance pass finishes well within it, and an explicit
@@ -1498,6 +1510,7 @@ fn copy_model_state(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
     }
     count += merge_stream_seal_policy(source, tx, repo_id)?;
     count += merge_stream_access_mode(source, tx, repo_id)?;
+    count += merge_stream_pin(source, tx, repo_id)?;
     if let Some(model_id) = active_model {
         carry_active_model_readiness(source, tx, &model_id)?;
     }
@@ -1508,6 +1521,52 @@ fn copy_model_state(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
 /// understands is `sealed`; absence means no explicit intent. A sealed source must seal the target,
 /// while a target already sealed remains sealed across retries even if the legacy source is absent.
 /// Unknown values on either side fail closed before consolidation's reconciliation authoring.
+/// Carry the source's trust pin onto the target — see the `memory_stream_pin` entry in the
+/// classification on [`CARRIED_META_KEYS`]. Returns the rows written.
+fn merge_stream_pin(source: &Connection, tx: &Connection, repo_id: &str) -> anyhow::Result<u64> {
+    let source_meta = |key: &str| -> anyhow::Result<Option<String>> {
+        Ok(source
+            .query_row("SELECT value FROM repo_meta WHERE key = ?1 LIMIT 1", [key], |row| {
+                row.get::<_, Option<String>>(0)
+            })
+            .optional()?
+            .flatten())
+    };
+    // The EFFECTIVE pin: a store from before the pin existed, or one still subscribed, records its
+    // trust decision only as the subscription owner.
+    let Some(source_pin) = source_meta(MEMORY_STREAM_PIN_META_KEY)?
+        .or(source_meta(MEMORY_SUBSCRIPTION_OWNER_META_KEY)?)
+    else {
+        return Ok(0);
+    };
+    let target_pin: Option<String> = tx
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = ?2",
+            params![repo_id, MEMORY_STREAM_PIN_META_KEY],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    match target_pin {
+        None => Ok(tx.execute(
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)",
+            params![repo_id, MEMORY_STREAM_PIN_META_KEY, source_pin],
+        )? as u64),
+        Some(target_pin) => {
+            if target_pin != source_pin {
+                tracing::warn!(
+                    repo_id,
+                    target_pin = %target_pin,
+                    source_pin = %source_pin,
+                    "consolidation keeps the target's stream pin over a different one in the \
+                     legacy source"
+                );
+            }
+            Ok(0)
+        },
+    }
+}
+
 fn merge_stream_seal_policy(
     source: &Connection,
     tx: &Connection,
@@ -2900,6 +2959,81 @@ mod tests {
         assert!(err.to_string().contains("unknown memory stream seal policy"));
         assert_eq!(policy(), "sealed", "the conflicting import cannot downgrade the target");
         assert_eq!(count(&target, "SELECT COUNT(*) FROM content_entries"), 0);
+    }
+
+    fn target_meta(target: &Connection, key: &str) -> Option<String> {
+        target
+            .query_row(
+                "SELECT value FROM repo_meta WHERE repo_id = 'global-repo' AND key = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap()
+    }
+
+    /// The pin is the one subscription field built to outlive the subscription. Dropped on the
+    /// move, a changed `.rag-rat-stream` would read as first use afterward.
+    #[test]
+    fn consolidation_carries_the_trust_pin() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', \
+                 'memory_stream_pin', 'owner-a')",
+                [],
+            )
+            .unwrap();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
+    }
+
+    /// A store from before the pin existed, or one still subscribed, records its trust decision
+    /// only as the subscription owner. The pin carries that owner; the subscription itself
+    /// never crosses.
+    #[test]
+    fn consolidation_carries_a_subscription_owner_as_the_pin() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', \
+                 'memory_subscription_owner', 'owner-a')",
+                [],
+            )
+            .unwrap();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
+        assert_eq!(
+            target_meta(&target, "memory_subscription_owner"),
+            None,
+            "the subscription itself stays behind",
+        );
+    }
+
+    /// A target already pinned keeps its own pin: it is the trust decision the target acted on, and
+    /// a pin survives either way, so nothing reads as first use.
+    #[test]
+    fn an_existing_target_pin_stays_authoritative() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', \
+                 'memory_stream_pin', 'owner-b')",
+                [],
+            )
+            .unwrap();
+        let target = fresh_target();
+        target
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('global-repo', \
+                 'memory_stream_pin', 'owner-a')",
+                [],
+            )
+            .unwrap();
+        import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
     }
 
     /// The `repo_meta` classification (see [`CARRIED_META_KEYS`]): repo-PORTABLE configuration is

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -84,8 +84,10 @@ use crate::index::{self, IndexDatabase, schema};
 ///        dropping it on the move would let a changed `.rag-rat-stream` read as first use. The
 ///        source's EFFECTIVE pin crosses — its recorded pin, else the owner it is subscribed to,
 ///        which a store from before the pin existed records its trust decision as (that
-///        subscription itself never crosses — see (b)). A target already pinned keeps its own: it
-///        is the trust decision the target has acted on, and a pin survives either way.
+///        subscription itself never crosses — see (b)). Until the rename lands the legacy index is
+///        the live store, so a retry replaces a pin an earlier run of this consolidation wrote
+///        (recorded in `memory_stream_pin_imported`); a conflicting pin the target decided itself
+///        REFUSES the run, since carrying either would silently override the other trust root.
 ///
 ///  (b) DB-LOCAL STATE — never copied; each entry states why:
 ///      * freshness/progress cursors that would make a fresh 0-row index falsely report itself
@@ -107,6 +109,9 @@ use crate::index::{self, IndexDatabase, schema};
 ///      * `memory_subscription_peers` / `memory_subscription_relay` — how to reach the subscribed
 ///        owner's host. They describe a subscription, and the subscription never crosses; carried
 ///        alone they would route toward an owner this repo no longer mirrors.
+///      * `memory_stream_pin_imported` — the pin value an earlier run of this consolidation wrote,
+///        which is how a retry tells its own copy from a trust decision the target made; any `sync
+///        subscribe` there clears it.
 const CARRIED_META_KEYS: &[&str] = &[
     "active_embedding_model",
     "embedding_active_model_version",
@@ -119,6 +124,7 @@ const CARRIED_META_KEYS: &[&str] = &[
 const MEMORY_STREAM_SEAL_POLICY_META_KEY: &str = "memory_stream_seal_policy";
 const MEMORY_STREAM_ACCESS_MODE_META_KEY: &str = "memory_stream_access_mode";
 const MEMORY_STREAM_PIN_META_KEY: &str = "memory_stream_pin";
+const MEMORY_STREAM_PIN_IMPORTED_META_KEY: &str = "memory_stream_pin_imported";
 const MEMORY_SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
 
 /// How long consolidate waits for the repo's per-repo write locks (global-side and legacy-side)
@@ -1532,6 +1538,16 @@ fn merge_stream_pin(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
             .optional()?
             .flatten())
     };
+    let target_meta = |key: &str| -> anyhow::Result<Option<String>> {
+        Ok(tx
+            .query_row(
+                "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = ?2",
+                params![repo_id, key],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten())
+    };
     // The EFFECTIVE pin: a store from before the pin existed, or one still subscribed, records its
     // trust decision only as the subscription owner.
     let Some(source_pin) = source_meta(MEMORY_STREAM_PIN_META_KEY)?
@@ -1539,32 +1555,36 @@ fn merge_stream_pin(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
     else {
         return Ok(0);
     };
-    let target_pin: Option<String> = tx
-        .query_row(
-            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = ?2",
-            params![repo_id, MEMORY_STREAM_PIN_META_KEY],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .optional()?
-        .flatten();
-    match target_pin {
-        None => Ok(tx.execute(
-            "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)",
-            params![repo_id, MEMORY_STREAM_PIN_META_KEY, source_pin],
-        )? as u64),
-        Some(target_pin) => {
-            if target_pin != source_pin {
-                tracing::warn!(
-                    repo_id,
-                    target_pin = %target_pin,
-                    source_pin = %source_pin,
-                    "consolidation keeps the target's stream pin over a different one in the \
-                     legacy source"
-                );
-            }
-            Ok(0)
-        },
+    let target_pin = target_meta(MEMORY_STREAM_PIN_META_KEY)?;
+    let replaceable = match &target_pin {
+        None => true,
+        Some(pin) if *pin == source_pin => return Ok(0),
+        // The pin an earlier run of THIS consolidation wrote, untouched since: a subscribe in the
+        // target clears the marker. Until the rename lands the legacy index is the live store, so
+        // a repin made there in the crash-retry window must replace the copy the last run left —
+        // keeping it would restore a trust root the operator has since moved away from.
+        Some(pin) =>
+            target_meta(MEMORY_STREAM_PIN_IMPORTED_META_KEY)?.as_deref() == Some(pin.as_str()),
+    };
+    if !replaceable {
+        anyhow::bail!(
+            "consolidation refused: the legacy index for `{repo_id}` trusts stream owner \
+             {source_pin}, but the global store already pins {} from a decision made there, not \
+             from an earlier consolidation. Carrying either would silently override the other \
+             trust root. Confirm which owner this repository should trust, record it in the \
+             legacy index with `rag-rat sync subscribe <owner>`, and retry",
+            target_pin.unwrap_or_default(),
+        );
     }
+    let mut written = 0;
+    for key in [MEMORY_STREAM_PIN_META_KEY, MEMORY_STREAM_PIN_IMPORTED_META_KEY] {
+        written += tx.execute(
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)
+             ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value",
+            params![repo_id, key, source_pin],
+        )?;
+    }
+    Ok(written as u64)
 }
 
 fn merge_stream_seal_policy(
@@ -3012,10 +3032,10 @@ mod tests {
         );
     }
 
-    /// A target already pinned keeps its own pin: it is the trust decision the target acted on, and
-    /// a pin survives either way, so nothing reads as first use.
+    /// A conflicting pin the target decided itself is a separate trust decision. Carrying either
+    /// would silently override the other, so the run refuses — before anything is imported.
     #[test]
-    fn an_existing_target_pin_stays_authoritative() {
+    fn a_conflicting_target_pin_refuses_the_import() {
         let source = seeded_source();
         source
             .execute(
@@ -3032,8 +3052,76 @@ mod tests {
                 [],
             )
             .unwrap();
+
+        let err =
+            import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy)
+                .err()
+                .expect("two trust roots for one repository must not be reconciled silently");
+        assert!(err.to_string().contains("consolidation refused"), "got: {err}");
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memories"), 0, "nothing imported");
+    }
+
+    /// Until the rename lands the legacy index is the live store. A repin made there after an
+    /// import committed but the rename failed must replace the pin that import wrote; keeping it
+    /// would restore the owner the operator has just moved away from.
+    #[test]
+    fn a_retry_carries_a_repin_made_in_the_legacy_index() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', \
+                 'memory_stream_pin', 'owner-a')",
+                [],
+            )
+            .unwrap();
+        let target = fresh_target();
         import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
         assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-a"));
+
+        source
+            .execute("UPDATE repo_meta SET value = 'owner-b' WHERE key = 'memory_stream_pin'", [])
+            .unwrap();
+        import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
+        assert_eq!(
+            target_meta(&target, "memory_stream_pin").as_deref(),
+            Some("owner-b"),
+            "the retry carries the legacy-side repin forward",
+        );
+    }
+
+    /// A pin re-decided in the target after an import is the target's own decision again, not a
+    /// copy this consolidation left, so a retry carrying a different one refuses rather than
+    /// overwriting it.
+    #[test]
+    fn a_pin_re_decided_in_the_target_after_an_import_is_not_overwritten() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', \
+                 'memory_stream_pin', 'owner-a')",
+                [],
+            )
+            .unwrap();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy).unwrap();
+        target
+            .execute(
+                "UPDATE repo_meta SET value = 'owner-c' WHERE repo_id = 'global-repo' AND key = \
+                 'memory_stream_pin'",
+                [],
+            )
+            .unwrap();
+        source
+            .execute("UPDATE repo_meta SET value = 'owner-b' WHERE key = 'memory_stream_pin'", [])
+            .unwrap();
+
+        let err =
+            import_from_source(&source, &target, "global-repo", ImportMode::ConsolidateLegacy)
+                .err()
+                .expect("a pin the target re-decided is not this consolidation's to replace");
+        assert!(err.to_string().contains("consolidation refused"), "got: {err}");
+        assert_eq!(target_meta(&target, "memory_stream_pin").as_deref(), Some("owner-c"));
     }
 
     /// The `repo_meta` classification (see [`CARRIED_META_KEYS`]): repo-PORTABLE configuration is

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -180,6 +180,21 @@ impl IndexDatabase {
         )
     }
 
+    /// Record how to reach the subscribed owner's host, as a locator supplied it. Empty peers
+    /// clear the record — an operator-named subscribe must not inherit the previous owner's host.
+    pub fn set_subscription_routing(
+        &self,
+        peers: &[String],
+        relay: Option<&str>,
+    ) -> anyhow::Result<()> {
+        crate::memory_write::set_subscription_routing(self.storage.connection(), peers, relay)
+    }
+
+    /// Peers and relay recorded for a subscribed owner, pooled across this store's repos.
+    pub fn subscription_routing(&self) -> anyhow::Result<(Vec<String>, Option<String>)> {
+        crate::memory_write::subscription_routing(self.storage.connection())
+    }
+
     /// The owner this repo has pinned, if any — reported by `sync whoami` so an operator can see
     /// the trust root without reading repo_meta.
     pub fn stream_pin(&self) -> anyhow::Result<Option<String>> {

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -157,12 +157,33 @@ impl IndexDatabase {
     /// No Writer grant is involved — a subscriber authors nothing onto the owner's stream — but the
     /// owner's log must reach this store (automatic sync pulls it once the owner's host is in
     /// `[sync] server_peers`, or `sync pull <owner>`) before anything materializes.
+    /// Subscribe to an owner an OPERATOR named. Re-pins this repo's trust root: a human who
+    /// obtained the id out of band is entitled to move it.
     pub fn sync_subscribe(&self, owner_account_hex: &str) -> anyhow::Result<()> {
         crate::memory_write::set_subscription_owner(
             self.storage.connection(),
             owner_account_hex,
             rag_rat_base::time::now_ms(),
+            crate::memory_write::SubscribeTrust::Operator,
         )
+    }
+
+    /// Subscribe to the owner a checked-in `.rag-rat-stream` names. Refuses when this repo is
+    /// already pinned to a different owner — an editable in-repo file may establish a trust root,
+    /// never move one.
+    pub fn sync_subscribe_from_locator(&self, owner_account_hex: &str) -> anyhow::Result<()> {
+        crate::memory_write::set_subscription_owner(
+            self.storage.connection(),
+            owner_account_hex,
+            rag_rat_base::time::now_ms(),
+            crate::memory_write::SubscribeTrust::Locator,
+        )
+    }
+
+    /// The owner this repo has pinned, if any — reported by `sync whoami` so an operator can see
+    /// the trust root without reading repo_meta.
+    pub fn stream_pin(&self) -> anyhow::Result<Option<String>> {
+        crate::memory_write::stream_pin(self.storage.connection(), &self.active_repo_id)
     }
 
     /// Stop mirroring a subscribed owner (`sync unsubscribe`): the active repo's memories

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -190,8 +190,8 @@ impl IndexDatabase {
         crate::memory_write::set_subscription_routing(self.storage.connection(), peers, relay)
     }
 
-    /// Peers and relay recorded for a subscribed owner, pooled across this store's repos.
-    pub fn subscription_routing(&self) -> anyhow::Result<(Vec<String>, Option<String>)> {
+    /// Peers recorded for subscribed owners, each with the relay its locator named.
+    pub fn subscription_routing(&self) -> anyhow::Result<Vec<(String, Option<String>)>> {
         crate::memory_write::subscription_routing(self.storage.connection())
     }
 

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -191,8 +191,11 @@ impl IndexDatabase {
     }
 
     /// Peers recorded for subscribed owners, each with the relay its locator named.
-    pub fn subscription_routing(&self) -> anyhow::Result<Vec<(String, Option<String>)>> {
-        crate::memory_write::subscription_routing(self.storage.connection())
+    pub fn subscription_routing(
+        &self,
+        owner_hex: &str,
+    ) -> anyhow::Result<Vec<(String, Option<String>)>> {
+        crate::memory_write::subscription_routing(self.storage.connection(), owner_hex)
     }
 
     /// The owner this repo has pinned, if any — reported by `sync whoami` so an operator can see

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -165,29 +165,28 @@ impl IndexDatabase {
             owner_account_hex,
             rag_rat_base::time::now_ms(),
             crate::memory_write::SubscribeTrust::Operator,
+            crate::memory_write::SubscriptionRouting::default(),
         )
     }
 
     /// Subscribe to the owner a checked-in `.rag-rat-stream` names. Refuses when this repo is
     /// already pinned to a different owner — an editable in-repo file may establish a trust root,
     /// never move one.
-    pub fn sync_subscribe_from_locator(&self, owner_account_hex: &str) -> anyhow::Result<()> {
+    ///
+    /// The locator's routing commits in the same transaction as the owner and pin.
+    pub fn sync_subscribe_from_locator(
+        &self,
+        owner_account_hex: &str,
+        peers: &[String],
+        relay: Option<&str>,
+    ) -> anyhow::Result<()> {
         crate::memory_write::set_subscription_owner(
             self.storage.connection(),
             owner_account_hex,
             rag_rat_base::time::now_ms(),
             crate::memory_write::SubscribeTrust::Locator,
+            crate::memory_write::SubscriptionRouting { peers, relay },
         )
-    }
-
-    /// Record how to reach the subscribed owner's host, as a locator supplied it. Empty peers
-    /// clear the record — an operator-named subscribe must not inherit the previous owner's host.
-    pub fn set_subscription_routing(
-        &self,
-        peers: &[String],
-        relay: Option<&str>,
-    ) -> anyhow::Result<()> {
-        crate::memory_write::set_subscription_routing(self.storage.connection(), peers, relay)
     }
 
     /// Peers recorded for subscribed owners, each with the relay its locator named.

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -254,6 +254,20 @@ const SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
 /// behind by unsubscribe, and re-written ONLY when an operator names an account id themselves.
 const STREAM_PIN_META_KEY: &str = "memory_stream_pin";
 
+/// Routing to reach the subscribed owner's host, as the locator supplied it.
+///
+/// Persisted rather than merely echoed because the point of the locator is a clone that has NO
+/// `[sync] server_peers`: a subscriber cannot discover a foreign account's host — that account's
+/// discovery tag derives from its own secret — so without somewhere to keep these, the repo records
+/// a subscription it can never fetch. Both the manual pull and the automatic cross-account pass
+/// read them.
+///
+/// They carry NO authority and are safe to persist from an untrusted file: every entry pulled is
+/// verified against the pinned account's signature chain, so a hostile entry here can waste a dial,
+/// never forge content. One node id per line; the relay is a single URL.
+const SUBSCRIPTION_PEERS_META_KEY: &str = "memory_subscription_peers";
+const SUBSCRIPTION_RELAY_META_KEY: &str = "memory_subscription_relay";
+
 /// Who chose the account being subscribed to — the whole basis of the pin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SubscribeTrust {
@@ -660,6 +674,55 @@ pub(crate) fn set_subscription_owner(
 /// The owner this repo has pinned, if any. Survives `sync unsubscribe`.
 pub(crate) fn stream_pin(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<String>> {
     Ok(rag_rat_db::meta::repo_meta(conn, repo_id, STREAM_PIN_META_KEY)?)
+}
+
+/// Record how to reach the subscribed owner's host. Empty peers CLEAR the record rather than
+/// leaving a previous owner's routing behind to be dialed for a different account.
+pub(crate) fn set_subscription_routing(
+    conn: &Connection,
+    peers: &[String],
+    relay: Option<&str>,
+) -> anyhow::Result<()> {
+    let repo_id =
+        memory_repo_scope(conn)?.context("recording subscription routing requires a repo scope")?;
+    let joined = peers.join("\n");
+    if joined.is_empty() {
+        rag_rat_db::meta::delete_repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY)?;
+    } else {
+        rag_rat_db::meta::set_repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY, &joined)?;
+    }
+    match relay {
+        Some(relay) if !relay.trim().is_empty() =>
+            rag_rat_db::meta::set_repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY, relay)?,
+        _ => rag_rat_db::meta::delete_repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY)?,
+    };
+    Ok(())
+}
+
+/// Peers and relay recorded for the subscribed owner, across every repo in this store.
+///
+/// Store-wide rather than repo-scoped because the cross-account pull pass is store-wide: it pulls
+/// each foreign account once, not once per repo, so it needs every repo's routing pooled.
+pub(crate) fn subscription_routing(
+    conn: &Connection,
+) -> anyhow::Result<(Vec<String>, Option<String>)> {
+    let mut peers = Vec::new();
+    let mut relay = None;
+    for repo_id in rag_rat_db::schema::real_repo_ids(conn)? {
+        if let Some(recorded) =
+            rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY)?
+        {
+            peers.extend(
+                recorded.lines().map(str::trim).filter(|p| !p.is_empty()).map(String::from),
+            );
+        }
+        if relay.is_none() {
+            relay = rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY)?;
+        }
+    }
+    peers.sort_unstable();
+    peers.dedup();
+    Ok((peers, relay))
 }
 
 /// Stop mirroring another account (`sync unsubscribe` / `sync uncontribute`): drop the configured

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -244,6 +244,27 @@ pub(super) fn contribution_owner_account(
 /// re-points.
 const SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
 
+/// The owner this repo has ever been told to trust, kept SEPARATELY from the live subscription so
+/// it outlives `sync unsubscribe`.
+///
+/// Trust-on-first-use only works if the "first use" cannot be replayed. Were the pin the live
+/// subscription key, the refusal below would be defeated by the very sequence its message would
+/// otherwise suggest — unsubscribe, subscribe — and that sequence is what an agent handed a
+/// fail-closed error will try. So the pin is written on the first locator-driven subscribe, left
+/// behind by unsubscribe, and re-written ONLY when an operator names an account id themselves.
+const STREAM_PIN_META_KEY: &str = "memory_stream_pin";
+
+/// Who chose the account being subscribed to — the whole basis of the pin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubscribeTrust {
+    /// An operator passed the id on the command line, having obtained it out of band. A human
+    /// asserting a trust root: it re-pins.
+    Operator,
+    /// A checked-in `.rag-rat-stream` supplied it. Untrusted input — anyone who can land a commit
+    /// can change it — so it may establish a pin but never move one.
+    Locator,
+}
+
 pub(super) fn subscription_owner_account(
     conn: &Connection,
     repo_id: &str,
@@ -578,6 +599,7 @@ pub(crate) fn set_subscription_owner(
     conn: &Connection,
     owner_account_hex: &str,
     now_ms: i64,
+    trust: SubscribeTrust,
 ) -> anyhow::Result<()> {
     let repo_id =
         memory_repo_scope(conn)?.context("sync subscribe requires an active repo scope")?;
@@ -597,6 +619,26 @@ pub(crate) fn set_subscription_owner(
 
     let canonical = rag_rat_base::hash::hex_lower(&owner.to_bytes());
 
+    // A locator may establish this repo's trust root, never move it. Moving it is how an edited
+    // checked-in file would silently re-point a subscriber onto another account's stream — and a
+    // re-point is destructive, not merely redirecting: the drain removes the previous owner's
+    // mirrored rows, and the local binding work on them (a `memory rebind`, any local edge) does
+    // not come back on unsubscribe. The remedy names a human step rather than a command, because
+    // the point of the override is that the operator obtains the id from the owner, not from the
+    // file that just changed.
+    if trust == SubscribeTrust::Locator
+        && let Some(pinned) = rag_rat_db::meta::repo_meta(conn, &repo_id, STREAM_PIN_META_KEY)?
+        && pinned != canonical
+    {
+        anyhow::bail!(
+            "`{}` names owner {canonical}, but this repo is pinned to {pinned}.\n\nA checked-in \
+             locator cannot re-point a subscription. Confirm the new id with the stream's owner \
+             out of band, then subscribe to it explicitly:\n\n    rag-rat sync subscribe \
+             {canonical}",
+            rag_rat_base::stream_locator::STREAM_LOCATOR_FILE,
+        );
+    }
+
     let _durability = AuthoredDurability::begin(conn)?;
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     anyhow::ensure!(
@@ -608,8 +650,16 @@ pub(crate) fn set_subscription_owner(
         rag_rat_db::meta::set_repo_meta(tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)
             .map_err(Into::into)
     })?;
+    // Written under the same transaction as the subscription it authorizes, so a torn write cannot
+    // leave a repo subscribed to an owner it never pinned.
+    rag_rat_db::meta::set_repo_meta(&tx, &repo_id, STREAM_PIN_META_KEY, &canonical)?;
     tx.commit()?;
     Ok(())
+}
+
+/// The owner this repo has pinned, if any. Survives `sync unsubscribe`.
+pub(crate) fn stream_pin(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<String>> {
+    Ok(rag_rat_db::meta::repo_meta(conn, repo_id, STREAM_PIN_META_KEY)?)
 }
 
 /// Stop mirroring another account (`sync unsubscribe` / `sync uncontribute`): drop the configured

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -254,10 +254,10 @@ const SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
 /// behind by unsubscribe, and re-written ONLY when an operator names an account id themselves.
 const STREAM_PIN_META_KEY: &str = "memory_stream_pin";
 
-/// The pin value an earlier run of `rag-rat consolidate` wrote into this store. It is how a retried
-/// consolidation tells its own stale copy — replaceable, because the legacy index stays the live
-/// store until the rename lands — from a pin decided here, which it must not override. A subscribe
-/// decides the pin here, so it clears this.
+/// The pin an UNFINISHED `rag-rat consolidate` run wrote into this store, and the legacy source it
+/// came from. It is how a retry of that same source tells its own stale copy — replaceable, because
+/// the legacy index stays the live store until the rename lands — from a pin decided here, which it
+/// must not override. A subscribe decides the pin here, so it clears this.
 const STREAM_PIN_IMPORTED_META_KEY: &str = "memory_stream_pin_imported";
 
 /// Routing to reach the subscribed owner's host, as the locator supplied it.

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -710,22 +710,25 @@ pub(crate) fn set_subscription_routing(
     Ok(())
 }
 
-/// Every peer recorded for a subscribed owner, each paired with the relay its locator named.
+/// Every peer recorded by a subscription to `owner_hex`, each paired with the relay its locator
+/// named.
 ///
-/// Store-wide rather than repo-scoped because the cross-account pull pass is store-wide: it pulls
-/// each foreign account once, not once per repo, so it needs every repo's routing pooled. Pairing
-/// each peer with its OWN relay is what lets a locator's relay reach the host it names without
-/// retargeting the pass for accounts that never named it.
+/// Attributed to the owner because a locator describes how to reach ONE owner's host. Pooled across
+/// owners, one repository's locator could name another owner's peer through a dead relay and put
+/// that route in front of a live one; scoped, a pull for an account only ever sees routes toward
+/// that account. Pooled across the repositories subscribing to the same owner, since the pull pass
+/// pulls each account once, not once per repository.
 ///
-/// Only repos with a live subscription contribute. Routing describes how to reach the owner a repo
-/// mirrors; once it mirrors nobody, dialing that host is a wasted connection at best, and an
-/// obsolete one stalls every pull behind a failing attempt.
+/// Only live subscriptions contribute. Once a repository mirrors nobody, its host drops out of
+/// every pull — an obsolete host stalls each pass behind a failing dial.
 pub(crate) fn subscription_routing(
     conn: &Connection,
+    owner_hex: &str,
 ) -> anyhow::Result<Vec<(String, Option<String>)>> {
     let mut routes = Vec::new();
     for repo_id in rag_rat_db::schema::real_repo_ids(conn)? {
-        if rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_OWNER_META_KEY)?.is_none() {
+        let owner = rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_OWNER_META_KEY)?;
+        if owner.as_deref() != Some(owner_hex) {
             continue;
         }
         let Some(recorded) =

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -643,6 +643,17 @@ pub(crate) fn set_subscription_owner(
 
     let canonical = rag_rat_base::hash::hex_lower(&owner.to_bytes());
 
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    anyhow::ensure!(
+        memory_repo_scope(&tx)?.as_deref() == Some(repo_id.as_str()),
+        "active repo scope changed while starting sync subscribe; retry"
+    );
+    ensure_no_contribution_configured(&tx, &repo_id)?;
+    // Decided UNDER the write lock. A check made before `BEGIN IMMEDIATE` can pass against a pin
+    // another connection replaces before this transaction starts, and this write would then restore
+    // the owner that pin had just moved away from.
+    //
     // A locator may establish this repo's trust root, never move it. Moving it is how an edited
     // checked-in file would silently re-point a subscriber onto another account's stream — and a
     // re-point is destructive, not merely redirecting: the drain removes the previous owner's
@@ -651,7 +662,7 @@ pub(crate) fn set_subscription_owner(
     // the point of the override is that the operator obtains the id from the owner, not from the
     // file that just changed.
     if trust == SubscribeTrust::Locator
-        && let Some(pinned) = effective_stream_pin(conn, &repo_id)?
+        && let Some(pinned) = effective_stream_pin(&tx, &repo_id)?
         && pinned != canonical
     {
         anyhow::bail!(
@@ -662,14 +673,6 @@ pub(crate) fn set_subscription_owner(
             rag_rat_base::stream_locator::STREAM_LOCATOR_FILE,
         );
     }
-
-    let _durability = AuthoredDurability::begin(conn)?;
-    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    anyhow::ensure!(
-        memory_repo_scope(&tx)?.as_deref() == Some(repo_id.as_str()),
-        "active repo scope changed while starting sync subscribe; retry"
-    );
-    ensure_no_contribution_configured(&tx, &repo_id)?;
     repoint_authoritative_content_stream(&tx, &repo_id, StreamResolution::Strict, |tx| {
         rag_rat_db::meta::set_repo_meta(tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)
             .map_err(Into::into)
@@ -733,22 +736,37 @@ fn write_subscription_routing(
 ///
 /// Only live subscriptions contribute. Once a repository mirrors nobody, its host drops out of
 /// every pull — an obsolete host stalls each pass behind a failing dial.
+///
+/// ONE statement, so ownership, peers and relay come from one snapshot. Separate reads can straddle
+/// a concurrent re-subscribe — find this owner, then read the NEXT owner's peers — and hand one
+/// account the routes recorded for another. The write side commits all four fields together; that
+/// only protects a reader that also reads them together.
 pub(crate) fn subscription_routing(
     conn: &Connection,
     owner_hex: &str,
 ) -> anyhow::Result<Vec<(String, Option<String>)>> {
+    let mut stmt = conn.prepare(
+        "SELECT peers.value, relay.value
+         FROM repos
+         JOIN repo_meta AS owner ON owner.repo_id = repos.repo_id AND owner.key = ?2
+         JOIN repo_meta AS peers ON peers.repo_id = repos.repo_id AND peers.key = ?3
+         LEFT JOIN repo_meta AS relay ON relay.repo_id = repos.repo_id AND relay.key = ?4
+         WHERE owner.value = ?1 AND repos.repo_id != ?5
+         ORDER BY repos.repo_id",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            owner_hex,
+            SUBSCRIPTION_OWNER_META_KEY,
+            SUBSCRIPTION_PEERS_META_KEY,
+            SUBSCRIPTION_RELAY_META_KEY,
+            rag_rat_base::repo_identity::LEGACY_REPO_ID,
+        ],
+        |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+    )?;
     let mut routes = Vec::new();
-    for repo_id in rag_rat_db::schema::real_repo_ids(conn)? {
-        let owner = rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_OWNER_META_KEY)?;
-        if owner.as_deref() != Some(owner_hex) {
-            continue;
-        }
-        let Some(recorded) =
-            rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY)?
-        else {
-            continue;
-        };
-        let relay = rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY)?;
+    for row in rows {
+        let (Some(recorded), relay) = row? else { continue };
         routes.extend(
             recorded
                 .lines()

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -254,6 +254,12 @@ const SUBSCRIPTION_OWNER_META_KEY: &str = "memory_subscription_owner";
 /// behind by unsubscribe, and re-written ONLY when an operator names an account id themselves.
 const STREAM_PIN_META_KEY: &str = "memory_stream_pin";
 
+/// The pin value an earlier run of `rag-rat consolidate` wrote into this store. It is how a retried
+/// consolidation tells its own stale copy — replaceable, because the legacy index stays the live
+/// store until the rename lands — from a pin decided here, which it must not override. A subscribe
+/// decides the pin here, so it clears this.
+const STREAM_PIN_IMPORTED_META_KEY: &str = "memory_stream_pin_imported";
+
 /// Routing to reach the subscribed owner's host, as the locator supplied it.
 ///
 /// Persisted rather than merely echoed because the point of the locator is a clone that has NO
@@ -683,6 +689,9 @@ pub(crate) fn set_subscription_owner(
     // then attribute to the new account and dial on its behalf.
     rag_rat_db::meta::set_repo_meta(&tx, &repo_id, STREAM_PIN_META_KEY, &canonical)?;
     write_subscription_routing(&tx, &repo_id, &routing)?;
+    // The pin is now a decision made in THIS store, no longer a copy an earlier consolidation left:
+    // a retried consolidation may replace an imported pin, never this one.
+    rag_rat_db::meta::delete_repo_meta(&tx, &repo_id, STREAM_PIN_IMPORTED_META_KEY)?;
     tx.commit()?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -279,6 +279,15 @@ pub(crate) enum SubscribeTrust {
     Locator,
 }
 
+/// How to reach the owner being subscribed to, as a checked-in locator supplied it. Empty for an
+/// operator-named subscribe, which therefore CLEARS whatever routing a previous subscription
+/// recorded rather than dialing that owner's host for a different account.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SubscriptionRouting<'a> {
+    pub(crate) peers: &'a [String],
+    pub(crate) relay: Option<&'a str>,
+}
+
 pub(super) fn subscription_owner_account(
     conn: &Connection,
     repo_id: &str,
@@ -614,6 +623,7 @@ pub(crate) fn set_subscription_owner(
     owner_account_hex: &str,
     now_ms: i64,
     trust: SubscribeTrust,
+    routing: SubscriptionRouting<'_>,
 ) -> anyhow::Result<()> {
     let repo_id =
         memory_repo_scope(conn)?.context("sync subscribe requires an active repo scope")?;
@@ -664,9 +674,12 @@ pub(crate) fn set_subscription_owner(
         rag_rat_db::meta::set_repo_meta(tx, &repo_id, SUBSCRIPTION_OWNER_META_KEY, &canonical)
             .map_err(Into::into)
     })?;
-    // Written under the same transaction as the subscription it authorizes, so a torn write cannot
-    // leave a repo subscribed to an owner it never pinned.
+    // Owner, pin and routing commit together: this function is the single writer of all four
+    // subscription fields. A torn write could otherwise leave a repo subscribed to an owner it
+    // never pinned, or holding the previous owner's routes — which `subscription_routing` would
+    // then attribute to the new account and dial on its behalf.
     rag_rat_db::meta::set_repo_meta(&tx, &repo_id, STREAM_PIN_META_KEY, &canonical)?;
+    write_subscription_routing(&tx, &repo_id, &routing)?;
     tx.commit()?;
     Ok(())
 }
@@ -687,25 +700,24 @@ fn effective_stream_pin(conn: &Connection, repo_id: &str) -> anyhow::Result<Opti
     })
 }
 
-/// Record how to reach the subscribed owner's host. Empty peers CLEAR the record rather than
-/// leaving a previous owner's routing behind to be dialed for a different account.
-pub(crate) fn set_subscription_routing(
+/// Record how to reach the subscribed owner's host, or clear it when the routing is empty. Private
+/// and called only inside `set_subscription_owner`'s transaction, so there is no path that updates
+/// routing apart from the owner it belongs to.
+fn write_subscription_routing(
     conn: &Connection,
-    peers: &[String],
-    relay: Option<&str>,
+    repo_id: &str,
+    routing: &SubscriptionRouting<'_>,
 ) -> anyhow::Result<()> {
-    let repo_id =
-        memory_repo_scope(conn)?.context("recording subscription routing requires a repo scope")?;
-    let joined = peers.join("\n");
+    let joined = routing.peers.join("\n");
     if joined.is_empty() {
-        rag_rat_db::meta::delete_repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY)?;
+        rag_rat_db::meta::delete_repo_meta(conn, repo_id, SUBSCRIPTION_PEERS_META_KEY)?;
     } else {
-        rag_rat_db::meta::set_repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY, &joined)?;
+        rag_rat_db::meta::set_repo_meta(conn, repo_id, SUBSCRIPTION_PEERS_META_KEY, &joined)?;
     }
-    match relay {
+    match routing.relay {
         Some(relay) if !relay.trim().is_empty() =>
-            rag_rat_db::meta::set_repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY, relay)?,
-        _ => rag_rat_db::meta::delete_repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY)?,
+            rag_rat_db::meta::set_repo_meta(conn, repo_id, SUBSCRIPTION_RELAY_META_KEY, relay)?,
+        _ => rag_rat_db::meta::delete_repo_meta(conn, repo_id, SUBSCRIPTION_RELAY_META_KEY)?,
     };
     Ok(())
 }

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -641,7 +641,7 @@ pub(crate) fn set_subscription_owner(
     // the point of the override is that the operator obtains the id from the owner, not from the
     // file that just changed.
     if trust == SubscribeTrust::Locator
-        && let Some(pinned) = rag_rat_db::meta::repo_meta(conn, &repo_id, STREAM_PIN_META_KEY)?
+        && let Some(pinned) = effective_stream_pin(conn, &repo_id)?
         && pinned != canonical
     {
         anyhow::bail!(
@@ -673,7 +673,18 @@ pub(crate) fn set_subscription_owner(
 
 /// The owner this repo has pinned, if any. Survives `sync unsubscribe`.
 pub(crate) fn stream_pin(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<String>> {
-    Ok(rag_rat_db::meta::repo_meta(conn, repo_id, STREAM_PIN_META_KEY)?)
+    effective_stream_pin(conn, repo_id)
+}
+
+/// The recorded pin, or — when none was ever recorded — the owner this repo is already subscribed
+/// to. A store upgraded from a release without the pin holds a live subscription and no pin, and
+/// reading that as "never trusted anyone" would let a changed locator silently replace an owner an
+/// operator chose. An existing subscription IS an existing trust decision.
+fn effective_stream_pin(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<String>> {
+    Ok(match rag_rat_db::meta::repo_meta(conn, repo_id, STREAM_PIN_META_KEY)? {
+        Some(pinned) => Some(pinned),
+        None => rag_rat_db::meta::repo_meta(conn, repo_id, SUBSCRIPTION_OWNER_META_KEY)?,
+    })
 }
 
 /// Record how to reach the subscribed owner's host. Empty peers CLEAR the record rather than
@@ -699,30 +710,39 @@ pub(crate) fn set_subscription_routing(
     Ok(())
 }
 
-/// Peers and relay recorded for the subscribed owner, across every repo in this store.
+/// Every peer recorded for a subscribed owner, each paired with the relay its locator named.
 ///
 /// Store-wide rather than repo-scoped because the cross-account pull pass is store-wide: it pulls
-/// each foreign account once, not once per repo, so it needs every repo's routing pooled.
+/// each foreign account once, not once per repo, so it needs every repo's routing pooled. Pairing
+/// each peer with its OWN relay is what lets a locator's relay reach the host it names without
+/// retargeting the pass for accounts that never named it.
+///
+/// Only repos with a live subscription contribute. Routing describes how to reach the owner a repo
+/// mirrors; once it mirrors nobody, dialing that host is a wasted connection at best, and an
+/// obsolete one stalls every pull behind a failing attempt.
 pub(crate) fn subscription_routing(
     conn: &Connection,
-) -> anyhow::Result<(Vec<String>, Option<String>)> {
-    let mut peers = Vec::new();
-    let mut relay = None;
+) -> anyhow::Result<Vec<(String, Option<String>)>> {
+    let mut routes = Vec::new();
     for repo_id in rag_rat_db::schema::real_repo_ids(conn)? {
-        if let Some(recorded) =
+        if rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_OWNER_META_KEY)?.is_none() {
+            continue;
+        }
+        let Some(recorded) =
             rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_PEERS_META_KEY)?
-        {
-            peers.extend(
-                recorded.lines().map(str::trim).filter(|p| !p.is_empty()).map(String::from),
-            );
-        }
-        if relay.is_none() {
-            relay = rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY)?;
-        }
+        else {
+            continue;
+        };
+        let relay = rag_rat_db::meta::repo_meta(conn, &repo_id, SUBSCRIPTION_RELAY_META_KEY)?;
+        routes.extend(
+            recorded
+                .lines()
+                .map(str::trim)
+                .filter(|peer| !peer.is_empty())
+                .map(|peer| (peer.to_string(), relay.clone())),
+        );
     }
-    peers.sort_unstable();
-    peers.dedup();
-    Ok((peers, relay))
+    Ok(routes)
 }
 
 /// Stop mirroring another account (`sync unsubscribe` / `sync uncontribute`): drop the configured
@@ -741,7 +761,12 @@ pub(crate) fn subscription_routing(
 /// Stream resolution here is BEST-EFFORT, unlike the setters': an owner key that will not parse is
 /// exactly what this command removes, and a side that cannot resolve had no stream to drain — a
 /// strict resolution would make the recovery command unusable in the state that most needs it.
-fn clear_foreign_owner(conn: &Connection, meta_key: &str, command: &str) -> anyhow::Result<bool> {
+fn clear_foreign_owner(
+    conn: &Connection,
+    meta_key: &str,
+    command: &str,
+    before_clear: impl FnOnce(&Connection, &str) -> anyhow::Result<()>,
+) -> anyhow::Result<bool> {
     let repo_id = memory_repo_scope(conn)?
         .with_context(|| format!("{command} requires an active repo scope"))?;
 
@@ -754,6 +779,7 @@ fn clear_foreign_owner(conn: &Connection, meta_key: &str, command: &str) -> anyh
     if rag_rat_db::meta::repo_meta(&tx, &repo_id, meta_key)?.is_none() {
         return Ok(false);
     }
+    before_clear(&tx, &repo_id)?;
     repoint_authoritative_content_stream(&tx, &repo_id, StreamResolution::BestEffort, |tx| {
         rag_rat_db::meta::delete_repo_meta(tx, &repo_id, meta_key).map_err(Into::into)
     })?;
@@ -763,14 +789,25 @@ fn clear_foreign_owner(conn: &Connection, meta_key: &str, command: &str) -> anyh
 
 /// Stop mirroring a subscribed owner (`sync unsubscribe`).
 pub(crate) fn clear_subscription_owner(conn: &Connection) -> anyhow::Result<bool> {
-    clear_foreign_owner(conn, SUBSCRIPTION_OWNER_META_KEY, "sync unsubscribe")
+    clear_foreign_owner(conn, SUBSCRIPTION_OWNER_META_KEY, "sync unsubscribe", |tx, repo_id| {
+        // Only the trust root outlives the subscription. If the pin was never recorded — a store
+        // upgraded from before it existed, unsubscribing first — record the owner being cleared
+        // now, or the next locator subscribe would read as first use and pin whatever it names.
+        if rag_rat_db::meta::repo_meta(tx, repo_id, STREAM_PIN_META_KEY)?.is_none()
+            && let Some(owner) =
+                rag_rat_db::meta::repo_meta(tx, repo_id, SUBSCRIPTION_OWNER_META_KEY)?
+        {
+            rag_rat_db::meta::set_repo_meta(tx, repo_id, STREAM_PIN_META_KEY, &owner)?;
+        }
+        Ok(())
+    })
 }
 
 /// Stop contributing to a configured owner (`sync uncontribute`). The owner's Writer grant is
 /// untouched — only this store's routing changes — and the contributions already authored onto the
 /// owner's stream stay there; this store keeps its own `origin='local'` copies of them.
 pub(crate) fn clear_contribution_owner(conn: &Connection) -> anyhow::Result<bool> {
-    clear_foreign_owner(conn, CONTRIBUTION_OWNER_META_KEY, "sync uncontribute")
+    clear_foreign_owner(conn, CONTRIBUTION_OWNER_META_KEY, "sync uncontribute", |_, _| Ok(()))
 }
 
 fn explicit_stream_seal_policy(

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -24,10 +24,11 @@ pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory}
 // #583) can name it across the private module.
 pub(crate) use authoring::heal_memory_oplog_ghosts;
 pub(crate) use authoring::{
-    RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, catch_up_enrolled_device_keys,
-    clear_contribution_owner, clear_subscription_owner, enable_public_authoring,
-    enable_sealed_authoring, grant_repo_writer, list_repo_grants, published_grant_target,
-    repo_owner_config, revoke_repo_writer, set_contribution_owner, set_subscription_owner,
+    RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, SubscribeTrust,
+    catch_up_enrolled_device_keys, clear_contribution_owner, clear_subscription_owner,
+    enable_public_authoring, enable_sealed_authoring, grant_repo_writer, list_repo_grants,
+    published_grant_target, repo_owner_config, revoke_repo_writer, set_contribution_owner,
+    set_subscription_owner, stream_pin,
 };
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use authoring::{
     catch_up_enrolled_device_keys, clear_contribution_owner, clear_subscription_owner,
     enable_public_authoring, enable_sealed_authoring, grant_repo_writer, list_repo_grants,
     published_grant_target, repo_owner_config, revoke_repo_writer, set_contribution_owner,
-    set_subscription_owner, stream_pin,
+    set_subscription_owner, set_subscription_routing, stream_pin, subscription_routing,
 };
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -24,11 +24,11 @@ pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory}
 // #583) can name it across the private module.
 pub(crate) use authoring::heal_memory_oplog_ghosts;
 pub(crate) use authoring::{
-    RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, SubscribeTrust,
+    RepoGrantListing, RepoOwnerConfig, RepoRevokeReport, SubscribeTrust, SubscriptionRouting,
     catch_up_enrolled_device_keys, clear_contribution_owner, clear_subscription_owner,
     enable_public_authoring, enable_sealed_authoring, grant_repo_writer, list_repo_grants,
     published_grant_target, repo_owner_config, revoke_repo_writer, set_contribution_owner,
-    set_subscription_owner, set_subscription_routing, stream_pin, subscription_routing,
+    set_subscription_owner, stream_pin, subscription_routing,
 };
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -1026,16 +1026,33 @@ async fn pull_foreign_accounts(
     if targets.is_empty() {
         return Ok(());
     }
-    let peers = &config.sync.server_peers;
+    // Configured peers PLUS whatever a `.rag-rat-stream` recorded for a subscribed owner. A clone
+    // that subscribed from a locator has no `[sync] server_peers` by design — that is the routing
+    // the locator exists to carry — and discovery cannot stand in for it, since a foreign account's
+    // discovery tag derives from that account's own secret. Without the union this pass would skip
+    // exactly the repos the locator was meant to serve.
+    let (subscribed_peers, subscribed_relay) = crate::memory_write::subscription_routing(conn)?;
+    let mut peers = config.sync.server_peers.clone();
+    peers.extend(subscribed_peers);
+    peers.sort_unstable();
+    peers.dedup();
     if peers.is_empty() {
-        // Discovery cannot stand in: a foreign account's discovery tag derives from that
-        // account's own secret, which only its own devices hold.
         tracing::warn!(
-            "cross-account sync has accounts to pull but no [sync] server_peers to pull from"
+            "cross-account sync has accounts to pull but no peer to pull from: set [sync] \
+             server_peers, or subscribe from a `.rag-rat-stream` that names the owner's host"
         );
         return Ok(());
     }
-    let relay = relay_url(config);
+    let peers = &peers;
+    // The locator's relay fills a GAP only. This pass pulls every foreign account, not just the
+    // subscribed owner, so letting one repo's locator retarget the relay would move traffic for
+    // accounts that never named it; the configured relay (and its env override) stays
+    // authoritative wherever one is set.
+    let configured = relay_url(config);
+    let relay = match subscribed_relay {
+        Some(from_locator) if configured.trim().is_empty() => from_locator,
+        _ => configured,
+    };
     for target in targets {
         let account_hex = hash::hex_lower(&target.to_bytes());
         let memo_key = format!("{PULL_PEER_MEMO_PREFIX}{account_hex}");

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -968,52 +968,79 @@ fn foreign_pull_targets(
     Ok(targets)
 }
 
-/// The peers to try for a foreign account, each paired with the relay that reaches it.
+/// The routes to try for ONE foreign account, each a node paired with the relay that reaches it.
 ///
-/// Configured peers come first and dial through the configured relay. A peer a subscription's
-/// locator recorded dials through the relay THAT locator named: a locator relay must reach the host
-/// it describes, yet this pass pulls every foreign account, so no single locator may choose the
-/// relay for the pass. Treating the configured relay as an override would never let a locator's
-/// relay win, since the shipped default is always present. A locator peer that duplicates a
-/// configured one — under any spelling, compared as raw node-id bytes — keeps the configured route.
+/// `subscribed` must be that account's own routes (`subscription_routing(conn, account)`).
+/// Configured peers come first, through the configured relay; each locator route dials through the
+/// relay its locator named — the shipped default relay is always present, so it can never act as an
+/// override without silencing every locator relay.
+///
+/// Only an EXACT duplicate collapses: the same node, under any spelling (compared as raw node-id
+/// bytes), through the same relay. A route never suppresses another that reaches the same node a
+/// different way, so a dead or hostile relay recorded for a node cannot shadow the one that works.
 pub fn foreign_pull_peers(
     configured_peers: &[String],
     configured_relay: &str,
     subscribed: &[(String, Option<String>)],
 ) -> Vec<(String, String)> {
-    let mut routes: Vec<(String, String)> =
-        configured_peers.iter().map(|peer| (peer.clone(), configured_relay.to_string())).collect();
-    for (peer, relay) in subscribed {
-        if routes.iter().any(|(known, _)| peer_identity(known) == peer_identity(peer)) {
-            continue;
-        }
+    let configured = configured_peers.iter().map(|peer| (peer.as_str(), configured_relay));
+    let from_locators = subscribed.iter().map(|(peer, relay)| {
         let relay = relay.as_deref().filter(|relay| !relay.trim().is_empty());
-        routes.push((peer.clone(), relay.unwrap_or(configured_relay).to_string()));
+        (peer.as_str(), relay.unwrap_or(configured_relay))
+    });
+    let mut routes: Vec<(String, String)> = Vec::new();
+    for (peer, relay) in configured.chain(from_locators) {
+        let duplicate = routes.iter().any(|(known, known_relay)| {
+            peer_identity(known) == peer_identity(peer) && known_relay.trim() == relay.trim()
+        });
+        if !duplicate {
+            routes.push((peer.to_string(), relay.to_string()));
+        }
     }
     routes
 }
 
-/// Resolve peers, in dial order, to addresses — each through the relay its route names.
+/// Each node the routes name, once, in first-seen order. The peer memo ranks NODES, and a node
+/// reachable through several relays is still one node.
+pub fn distinct_peers(routes: &[(String, String)]) -> Vec<String> {
+    let mut peers: Vec<String> = Vec::new();
+    for (peer, _) in routes {
+        if !peers.iter().any(|known| peer_identity(known) == peer_identity(peer)) {
+            peers.push(peer.clone());
+        }
+    }
+    peers
+}
+
+/// Resolve nodes, in dial order, to addresses — one per route that names the node.
 ///
-/// Both pull paths dial through here, so a relay a locator recorded cannot be dropped at one call
-/// site while the other keeps it. `order` may spell a node id differently from `routes` — the peer
-/// memo stores whichever spelling answered — so a route is found by node identity; a peer with no
-/// route dials through `fallback_relay`.
+/// A node named by several routes through different relays is dialed through each in turn, so a
+/// relay that does not reach it costs one failed attempt rather than the node. Both pull paths dial
+/// through here, so a relay a locator recorded cannot be dropped at one call site while the other
+/// keeps it. `order` may spell a node id differently from `routes` — the peer memo keeps whichever
+/// spelling answered — so routes are matched by node identity; a node with no route dials through
+/// `fallback_relay`.
 pub fn route_addrs(
     order: &[String],
     routes: &[(String, String)],
     fallback_relay: &str,
 ) -> Vec<(String, Result<rag_rat_sync::EndpointAddr, String>)> {
-    order
-        .iter()
-        .map(|peer| {
-            let relay = routes
-                .iter()
-                .find(|(route, _)| peer_identity(route) == peer_identity(peer))
-                .map_or(fallback_relay, |(_, relay)| relay.as_str());
-            (peer.clone(), rag_rat_sync::peer_addr(peer, relay).map_err(|e| e.to_string()))
-        })
-        .collect()
+    let mut resolved = Vec::new();
+    for peer in order {
+        let mut relays: Vec<&str> = routes
+            .iter()
+            .filter(|(route, _)| peer_identity(route) == peer_identity(peer))
+            .map(|(_, relay)| relay.as_str())
+            .collect();
+        if relays.is_empty() {
+            relays.push(fallback_relay);
+        }
+        for relay in relays {
+            let addr = rag_rat_sync::peer_addr(peer, relay).map_err(|e| e.to_string());
+            resolved.push((peer.clone(), addr));
+        }
+    }
+    resolved
 }
 
 /// Which peer answered for which foreign account, so quiet cycles dial ONE peer instead of
@@ -1075,25 +1102,28 @@ async fn pull_foreign_accounts(
         return Ok(());
     }
     let configured_relay = relay_url(config);
-    let routes = foreign_pull_peers(
-        &config.sync.server_peers,
-        &configured_relay,
-        &crate::memory_write::subscription_routing(conn)?,
-    );
-    if routes.is_empty() {
-        // Discovery cannot stand in: a foreign account's discovery tag derives from that
-        // account's own secret, which only its own devices hold.
-        tracing::warn!(
-            "cross-account sync has accounts to pull but no peer to pull from: set [sync] \
-             server_peers, or subscribe from a `.rag-rat-stream` that names the owner's host"
-        );
-        return Ok(());
-    }
-    let peers: Vec<String> = routes.iter().map(|(peer, _)| peer.clone()).collect();
     for target in targets {
         let account_hex = hash::hex_lower(&target.to_bytes());
+        // The TARGET account's own routes only: a locator describes how to reach the owner its
+        // repository subscribes to, so another subscription's routes are never tried for this
+        // account, and never allowed to displace a route toward it.
+        let routes = foreign_pull_peers(
+            &config.sync.server_peers,
+            &configured_relay,
+            &crate::memory_write::subscription_routing(conn, &account_hex)?,
+        );
+        if routes.is_empty() {
+            // Discovery cannot stand in: a foreign account's discovery tag derives from that
+            // account's own secret, which only its own devices hold.
+            tracing::warn!(
+                account = %account_hex,
+                "cross-account sync has an account to pull but no peer to pull it from: set \
+                 [sync] server_peers, or subscribe from a `.rag-rat-stream` that names its host"
+            );
+            continue;
+        }
         let memo_key = format!("{PULL_PEER_MEMO_PREFIX}{account_hex}");
-        let order = ordered_pull_peers(conn, &memo_key, &peers)?;
+        let order = ordered_pull_peers(conn, &memo_key, &distinct_peers(&routes))?;
         let ordered: Vec<(String, rag_rat_sync::EndpointAddr)> = route_addrs(
             &order,
             &routes,
@@ -1951,19 +1981,44 @@ mod tests {
         assert_eq!(routes, [(NODE_A.to_string(), LOCATOR_RELAY.to_string())]);
     }
 
-    /// Configured peers keep the configured relay; a locator peer naming no relay falls back to it;
-    /// and a locator peer that duplicates a configured one under another spelling is the same node,
-    /// so it keeps the configured route rather than being dialed twice.
+    /// Only an exact duplicate — the same node, under any spelling, through the same relay —
+    /// collapses. A locator route reaching a configured node through ANOTHER relay is an extra way
+    /// in, not a conflict, and configured routes still come first.
     #[test]
-    fn configured_routes_win_and_duplicates_are_found_by_node_identity() {
+    fn only_an_exact_duplicate_route_collapses() {
         let routes = super::foreign_pull_peers(&[NODE_A.to_string()], CONFIGURED_RELAY, &[
-            (format!("  {NODE_A}  "), Some(LOCATOR_RELAY.to_string())),
+            (format!("  {NODE_A}  "), None),
+            (NODE_A.to_string(), Some(LOCATOR_RELAY.to_string())),
             (NODE_B.to_string(), None),
         ]);
         assert_eq!(routes, [
             (NODE_A.to_string(), CONFIGURED_RELAY.to_string()),
+            (NODE_A.to_string(), LOCATOR_RELAY.to_string()),
             (NODE_B.to_string(), CONFIGURED_RELAY.to_string()),
         ]);
+    }
+
+    /// Two routes naming one node through different relays are both dialed, in order. Keeping only
+    /// the first would let a dead or hostile relay recorded for a node shadow the relay that
+    /// reaches it — and the first is whichever repository happened to sort first.
+    #[test]
+    fn a_dead_relay_for_a_node_cannot_shadow_a_live_one() {
+        const DEAD_RELAY: &str = "https://relay.dead";
+        let routes = super::foreign_pull_peers(&[], CONFIGURED_RELAY, &[
+            (NODE_A.to_string(), Some(DEAD_RELAY.to_string())),
+            (NODE_A.to_string(), Some(LOCATOR_RELAY.to_string())),
+        ]);
+        let resolved =
+            super::route_addrs(&super::distinct_peers(&routes), &routes, CONFIGURED_RELAY);
+        let addrs: Vec<_> = resolved.into_iter().map(|(_, addr)| addr.unwrap()).collect();
+        assert_eq!(
+            addrs,
+            [
+                rag_rat_sync::peer_addr(NODE_A, DEAD_RELAY).unwrap(),
+                rag_rat_sync::peer_addr(NODE_A, LOCATOR_RELAY).unwrap(),
+            ],
+            "the live relay is still tried after the dead one",
+        );
     }
 
     /// The memo keeps whichever spelling of a node id answered, which need not match the spelling

--- a/crates/rag-rat-core/src/sync_driver.rs
+++ b/crates/rag-rat-core/src/sync_driver.rs
@@ -968,6 +968,54 @@ fn foreign_pull_targets(
     Ok(targets)
 }
 
+/// The peers to try for a foreign account, each paired with the relay that reaches it.
+///
+/// Configured peers come first and dial through the configured relay. A peer a subscription's
+/// locator recorded dials through the relay THAT locator named: a locator relay must reach the host
+/// it describes, yet this pass pulls every foreign account, so no single locator may choose the
+/// relay for the pass. Treating the configured relay as an override would never let a locator's
+/// relay win, since the shipped default is always present. A locator peer that duplicates a
+/// configured one — under any spelling, compared as raw node-id bytes — keeps the configured route.
+pub fn foreign_pull_peers(
+    configured_peers: &[String],
+    configured_relay: &str,
+    subscribed: &[(String, Option<String>)],
+) -> Vec<(String, String)> {
+    let mut routes: Vec<(String, String)> =
+        configured_peers.iter().map(|peer| (peer.clone(), configured_relay.to_string())).collect();
+    for (peer, relay) in subscribed {
+        if routes.iter().any(|(known, _)| peer_identity(known) == peer_identity(peer)) {
+            continue;
+        }
+        let relay = relay.as_deref().filter(|relay| !relay.trim().is_empty());
+        routes.push((peer.clone(), relay.unwrap_or(configured_relay).to_string()));
+    }
+    routes
+}
+
+/// Resolve peers, in dial order, to addresses — each through the relay its route names.
+///
+/// Both pull paths dial through here, so a relay a locator recorded cannot be dropped at one call
+/// site while the other keeps it. `order` may spell a node id differently from `routes` — the peer
+/// memo stores whichever spelling answered — so a route is found by node identity; a peer with no
+/// route dials through `fallback_relay`.
+pub fn route_addrs(
+    order: &[String],
+    routes: &[(String, String)],
+    fallback_relay: &str,
+) -> Vec<(String, Result<rag_rat_sync::EndpointAddr, String>)> {
+    order
+        .iter()
+        .map(|peer| {
+            let relay = routes
+                .iter()
+                .find(|(route, _)| peer_identity(route) == peer_identity(peer))
+                .map_or(fallback_relay, |(_, relay)| relay.as_str());
+            (peer.clone(), rag_rat_sync::peer_addr(peer, relay).map_err(|e| e.to_string()))
+        })
+        .collect()
+}
+
 /// Which peer answered for which foreign account, so quiet cycles dial ONE peer instead of
 /// re-probing (and re-warning about) every configured peer that does not hold the account.
 const PULL_PEER_MEMO_PREFIX: &str = "sync_pull_peer:";
@@ -1026,41 +1074,33 @@ async fn pull_foreign_accounts(
     if targets.is_empty() {
         return Ok(());
     }
-    // Configured peers PLUS whatever a `.rag-rat-stream` recorded for a subscribed owner. A clone
-    // that subscribed from a locator has no `[sync] server_peers` by design — that is the routing
-    // the locator exists to carry — and discovery cannot stand in for it, since a foreign account's
-    // discovery tag derives from that account's own secret. Without the union this pass would skip
-    // exactly the repos the locator was meant to serve.
-    let (subscribed_peers, subscribed_relay) = crate::memory_write::subscription_routing(conn)?;
-    let mut peers = config.sync.server_peers.clone();
-    peers.extend(subscribed_peers);
-    peers.sort_unstable();
-    peers.dedup();
-    if peers.is_empty() {
+    let configured_relay = relay_url(config);
+    let routes = foreign_pull_peers(
+        &config.sync.server_peers,
+        &configured_relay,
+        &crate::memory_write::subscription_routing(conn)?,
+    );
+    if routes.is_empty() {
+        // Discovery cannot stand in: a foreign account's discovery tag derives from that
+        // account's own secret, which only its own devices hold.
         tracing::warn!(
             "cross-account sync has accounts to pull but no peer to pull from: set [sync] \
              server_peers, or subscribe from a `.rag-rat-stream` that names the owner's host"
         );
         return Ok(());
     }
-    let peers = &peers;
-    // The locator's relay fills a GAP only. This pass pulls every foreign account, not just the
-    // subscribed owner, so letting one repo's locator retarget the relay would move traffic for
-    // accounts that never named it; the configured relay (and its env override) stays
-    // authoritative wherever one is set.
-    let configured = relay_url(config);
-    let relay = match subscribed_relay {
-        Some(from_locator) if configured.trim().is_empty() => from_locator,
-        _ => configured,
-    };
+    let peers: Vec<String> = routes.iter().map(|(peer, _)| peer.clone()).collect();
     for target in targets {
         let account_hex = hash::hex_lower(&target.to_bytes());
         let memo_key = format!("{PULL_PEER_MEMO_PREFIX}{account_hex}");
-        let ordered: Vec<(String, rag_rat_sync::EndpointAddr)> = ordered_pull_peers(
-            conn, &memo_key, peers,
-        )?
+        let order = ordered_pull_peers(conn, &memo_key, &peers)?;
+        let ordered: Vec<(String, rag_rat_sync::EndpointAddr)> = route_addrs(
+            &order,
+            &routes,
+            &configured_relay,
+        )
         .into_iter()
-        .filter_map(|peer| match rag_rat_sync::peer_addr(&peer, &relay) {
+        .filter_map(|(peer, addr)| match addr {
             Ok(addr) => Some((peer, addr)),
             Err(error) => {
                 tracing::warn!(peer, %error, "skipping cross-account peer: invalid node id");
@@ -1891,6 +1931,61 @@ mod tests {
         assert!(
             limiter.try_acquire(PEER_A, 1).is_some(),
             "the slot was released on the panic unwind, not leaked",
+        );
+    }
+
+    /// Real node ids, so the spelling comparison below exercises the byte path, not the fallback.
+    const NODE_A: &str = "3f73ab97d1b322be91b77890f1ac48f142f6e91daad428dd5fc73490a44b5b78";
+    const NODE_B: &str = "4fe0090702f76cfa4b74beb42e4c880d385dcc5699d909f4fd0a2b1190be3c08";
+    const CONFIGURED_RELAY: &str = "https://relay.configured";
+    const LOCATOR_RELAY: &str = "https://relay.locator";
+
+    /// A relay is ALWAYS configured — the shipped default is never empty — so a locator's relay
+    /// that only filled a gap would never reach the host it names.
+    #[test]
+    fn a_locator_relay_reaches_its_own_peer_though_a_relay_is_always_configured() {
+        let routes = super::foreign_pull_peers(&[], CONFIGURED_RELAY, &[(
+            NODE_A.to_string(),
+            Some(LOCATOR_RELAY.to_string()),
+        )]);
+        assert_eq!(routes, [(NODE_A.to_string(), LOCATOR_RELAY.to_string())]);
+    }
+
+    /// Configured peers keep the configured relay; a locator peer naming no relay falls back to it;
+    /// and a locator peer that duplicates a configured one under another spelling is the same node,
+    /// so it keeps the configured route rather than being dialed twice.
+    #[test]
+    fn configured_routes_win_and_duplicates_are_found_by_node_identity() {
+        let routes = super::foreign_pull_peers(&[NODE_A.to_string()], CONFIGURED_RELAY, &[
+            (format!("  {NODE_A}  "), Some(LOCATOR_RELAY.to_string())),
+            (NODE_B.to_string(), None),
+        ]);
+        assert_eq!(routes, [
+            (NODE_A.to_string(), CONFIGURED_RELAY.to_string()),
+            (NODE_B.to_string(), CONFIGURED_RELAY.to_string()),
+        ]);
+    }
+
+    /// The memo keeps whichever spelling of a node id answered, which need not match the spelling
+    /// the route recorded — so the relay is found by node identity, or a locator peer would
+    /// silently fall back to the configured relay and never reach a host homed elsewhere.
+    #[test]
+    fn a_peer_dials_through_its_routes_relay_whichever_spelling_names_it() {
+        let routes = [(NODE_A.to_string(), LOCATOR_RELAY.to_string())];
+        let resolved = super::route_addrs(
+            &[format!("  {NODE_A}  "), NODE_B.to_string()],
+            &routes,
+            CONFIGURED_RELAY,
+        );
+        assert_eq!(
+            resolved[0].1.as_ref().unwrap(),
+            &rag_rat_sync::peer_addr(NODE_A, LOCATOR_RELAY).unwrap(),
+            "a routed peer dials through its route's relay",
+        );
+        assert_eq!(
+            resolved[1].1.as_ref().unwrap(),
+            &rag_rat_sync::peer_addr(NODE_B, CONFIGURED_RELAY).unwrap(),
+            "an unrouted peer dials through the fallback",
         );
     }
 


### PR DESCRIPTION
Refs #407 (phase E discovery), #1156.

## Problem

Subscribing to a public knowledge base meant hand-carrying three artifacts out of band: the owner's 64-hex account id, a node id to reach their host, and a relay. A clone can now run `rag-rat sync subscribe` with no arguments.

Routing is not optional decoration. A subscriber **cannot** discover a foreign account's host — the discovery tag derives from that account's own secret, which only its own devices hold. A locator carrying an account id alone would name a stream nobody can reach, so the format carries `peers` and `relay` from the start.

## The file

`.rag-rat-stream` at the repo root, checked in:

```toml
owner = "4ddbda7c…"          # 64-hex account id — the trust root
peers = ["4fe00907…"]        # node ids for the owner's host
relay = "https://relay.example"
name  = "demo"               # display only
```

Unknown keys parse rather than fail: this file lives in other people's repos and is read by whatever version they happen to run.

It is read from the git root of the active checkout, but only when the cwd belongs to the configured repository — two checkouts are one repository exactly when they share a git common directory, which covers linked worktrees and sibling worktrees of a bare repository alike. `--config` naming another repository never lets the cwd's locator choose that repository's trust root.

## Trust

The file is untrusted input — anyone who can land a commit can edit it. **Exactly one field carries authority.** The first subscribe pins `owner`; a locator later naming a different one is refused:

```
Error: `.rag-rat-stream` names owner abab…, but this repo is pinned to 4ddb….

A checked-in locator cannot re-point a subscription. Confirm the new id with the
stream's owner out of band, then subscribe to it explicitly:

    rag-rat sync subscribe abab…
```

- **The remedy names a human step, not a command.** Passing an id explicitly still re-points, because an operator who obtained it from the owner is making a trust decision.
- **The pin outlives `sync unsubscribe`.** Were it the live subscription, the refusal would be undone by the exact sequence a reader of that error tries next.
- **An existing subscription counts as the pin.** A store from before the pin existed holds a live subscription and no pin record; the effective pin falls back to that subscription, and unsubscribe records the owner it clears. Neither path lets a changed locator read as first use.
- **The pin survives consolidation.** Moving a legacy index carries the source's effective pin, so storage migration cannot reset the trust decision. Until the final rename lands the legacy index stays the live store, so a retry of the same legacy source replaces the pin its earlier, unfinished run wrote — a repin made in the legacy index between attempts wins. The import marker records that source and is retired once the rename lands, so another clone of the same repository cannot pass for a retry. Any other conflicting pin is a separate trust decision, and consolidation refuses rather than silently choosing either.
- **The pin is checked under the write lock**, so a locator decides against the pin it commits under — never against one a concurrent re-subscribe is about to replace.

An account id commits to the founding device key, so pinning the id pins the trust root.

## Routing

The locator's peers and relay are persisted with the subscription and used by both the manual `sync pull` and the automatic cross-account pass, so a clone needs no `[sync] server_peers`.

- **Owner, pin and routing commit in one transaction**, and a lookup reads owner, peers and relay in **one statement**. A subscribe that fails partway changes nothing, and a lookup straddling a re-subscribe sees one subscription or the other, never a mix.
- **Routes belong to the owner their subscription names.** A pull for an account only sees routes toward that account, so one repository's locator cannot put a route in front of another owner's.
- **Each route dials through the relay its locator named**, and configured peers keep the configured relay.
- **Only an exact duplicate collapses** — the same node, under any spelling, through the same relay. Routes reaching one node through different relays are dialed in turn, so a dead or hostile relay recorded for a node costs one failed attempt instead of shadowing the relay that works.
- **Routing counts only while the repository subscribes**, and it stays behind on consolidation with the subscription it describes.
- **None of it carries authority**: every entry pulled verifies against the pinned account's signature chain, so a hostile peer can stall or withhold but never forge an entry or redirect the mirror.

## Verification

End to end against live stores:

| Scenario | Result |
|---|---|
| publish → serve → anonymous pull, no grant | `pulled`, converged |
| fresh clone, no `server_peers`: subscribe, then `sync pull <owner>` | `pulled`, converged — and deleting the recorded peers makes the same command fail |
| owner homed only on a relay the subscriber is not configured for; locator names that relay | manual pull converges; the automatic pass (post-commit hook) completes the pull |
| same, locator names no relay | manual pull times out; the automatic pass completes nothing |
| two subscriptions in one store; the one sorting first names the owner's node through a dead relay | manual pull converges; the automatic pass completes the pull toward the owner |
| operator re-subscribe to another id after a locator subscribe | owner and pin move, and the previous routing is gone in the same step |
| edited locator naming another owner | refused, exit 1 |
| `unsubscribe`, then subscribe from the locator | still refused |

The two concurrency guarantees are tested deterministically rather than by timing. A locator subscribe racing an operator's uncommitted re-subscribe waits on the lock — signalled by a busy handler — before the operator commits, and must then refuse against the new pin. A routing lookup whose `repo_meta` reads trigger a concurrent re-subscribe from a second connection must still return the original owner's own routes.

Each guard fails a test when removed, including: both races above, a consolidated store losing its pin (by a recorded pin or a subscription owner), a retried consolidation keeping the pin its earlier run wrote, a second source replacing a pin another source imported, a completed consolidation leaving its import marker behind (end to end, with two clones pinned to different owners), a conflicting target pin being overwritten or kept silently, a subscribe leaving an imported pin replaceable, a re-subscribe whose routing write fails (injected), a store upgraded without a pin record, unsubscribe run first on such a store, routing left behind by an unsubscribed repository, routes attributed to the wrong owner, a route shadowed by another through a different relay, a relay dropped for its own peer, a cwd outside the configured repository, and sibling worktrees of a bare repository.

Workspace **5311 passed, 7 skipped** under nextest, and green under `cargo test` including doctests; `clippy -D warnings` green in all four CI configurations; nightly `rustfmt --check` clean.

## Follow-up, not in scope

Subscribed memories carry no foreign-account attribution in the read path (#1156 item 7). That matters more once locators make subscribing easy, and deserves its own change.

