### PR TITLE
fix(test): release points instead of sleeps in the mcp blocking tests

### DIFF
--- a/crates/rag-rat-mcp/src/http/tests.rs
+++ b/crates/rag-rat-mcp/src/http/tests.rs
@@ -656,16 +656,37 @@ async fn dropping_a_request_cancels_its_database_work() {
     };
     let cancelled_observed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let task_observed = std::sync::Arc::clone(&cancelled_observed);
+    let (work_started, has_started) = tokio::sync::oneshot::channel();
     let mut request = Box::pin(run_db(state.clone(), move |_, _, cancelled| {
-        while !cancelled.load(Ordering::Acquire) {
+        let _ = work_started.send(());
+        // Bounded: waiting on a flag that a REGRESSION would never set is how this test wedges
+        // rather than fails. Tokio's shutdown waits for blocking tasks, so an unbounded loop here
+        // means the runtime can never drop and the run hangs with no failure to read. Only a loop
+        // that actually observed cancellation records it, so the assertion still fails.
+        let give_up_at = std::time::Instant::now() + Duration::from_secs(10);
+        while !cancelled.load(Ordering::Acquire) && std::time::Instant::now() < give_up_at {
             std::thread::sleep(Duration::from_millis(1));
         }
-        task_observed.store(true, Ordering::Release);
+        if cancelled.load(Ordering::Acquire) {
+            task_observed.store(true, Ordering::Release);
+        }
         Ok(())
     }));
-    // Poll far enough for the blocking work to start, then drop the future the way axum drops a
+    // Wait for the blocking work to actually START, then drop the future the way axum drops a
     // request whose client disconnected — the editor aborts a file lane on every index change.
-    assert!(tokio::time::timeout(Duration::from_millis(250), &mut request).await.is_err());
+    // Polling for a fixed 250ms instead assumed the work had begun by then; under load it may not
+    // have, and dropping a request with nothing in flight cancels nothing while still looking
+    // like it passed the setup.
+    // Bounded for the same reason: the runner loops until cancelled, so if it never starts,
+    // neither branch of the select can ever complete and the test would hang instead of fail.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::select! {
+            _ = &mut request => panic!("the request loops until cancelled, so it cannot end here"),
+            started = has_started => started.expect("the blocking work must reach its runner"),
+        }
+    })
+    .await
+    .expect("the blocking work must start within the deadlock guard");
     drop(request);
 
     tokio::time::timeout(Duration::from_secs(10), async {

--- a/crates/rag-rat-mcp/src/server/tests.rs
+++ b/crates/rag-rat-mcp/src/server/tests.rs
@@ -171,17 +171,29 @@ async fn blocking_tool_work_returns_timeout_error() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn blocking_tool_work_applies_worker_limit() {
     let workers = test_tool_workers(1);
+    // The runner only runs once the permit is held, so signalling from inside it is the fact the
+    // queued call needs: sleeping instead assumed 10ms was long enough to acquire a semaphore, and
+    // under load it is not. Holding until the test releases it removes the other half of the same
+    // bet — that 100ms of held worker outlasts a 20ms timeout that may itself be scheduled late.
+    let (holds_worker, worker_held) = tokio::sync::oneshot::channel();
+    let (release, wait_for_release) = tokio::sync::oneshot::channel::<()>();
     let slow = tokio::spawn(blocking::run_blocking_tool(
         "slow_test_tool".to_string(),
         Duration::from_secs(1),
         ToolTimeoutPolicy::ReturnTimeout,
         Arc::clone(&workers),
-        || {
-            std::thread::sleep(Duration::from_millis(100));
+        move || {
+            let _ = holds_worker.send(());
+            let _ = wait_for_release.blocking_recv();
             Ok(ok_result())
         },
     ));
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    // Bounded, so a runner that never starts FAILS instead of hanging: the wait has no other way
+    // to end, and an unbounded one leaves the suite stuck rather than red.
+    tokio::time::timeout(Duration::from_secs(10), worker_held)
+        .await
+        .expect("the slow tool must reach its runner within the deadlock guard")
+        .expect("reaching the runner means it holds the worker");
 
     let err = blocking::run_blocking_tool(
         "queued_test_tool".to_string(),
@@ -197,6 +209,7 @@ async fn blocking_tool_work_applies_worker_limit() {
         "queued timeout error should be actionable, got: {}",
         err.message
     );
+    let _ = release.send(());
     slow.await.unwrap().unwrap();
 }
 


### PR DESCRIPTION
Two of the three tests #1242 names are fixed (the `rag-rat-llm` one in #1248/#1258). This is the `rag-rat-mcp` one, plus a sibling in the same crate with the same shape.

## Sleeps replaced with release points

| test | was | now |
|---|---|---|
| `blocking_tool_work_applies_worker_limit` | `sleep(10ms)` to let the slow tool acquire the semaphore, then 100ms of held worker expected to outlast a 20ms timeout | the runner signals from inside — it only runs once the permit is held — and holds the worker until the test releases it |
| `dropping_a_request_cancels_its_database_work` | `timeout(250ms, &mut request)` to "poll far enough for the blocking work to start" | waits for the runner to signal that it started |

The second one had a real bet in it. If the work had not begun within 250ms, the test dropped a request with **nothing in flight** — cancelling nothing, while still looking like the setup succeeded.

Both are also faster: 0.028s and 0.047s, against ~110ms and ~250ms of unconditional waiting.

## The waits are bounded, and so is the runner's loop

A wait with no other way to end turns a regression into a **hang** rather than a failure.

The runner's cancellation loop already had that shape: it spins on a flag that a broken drop-guard never sets, and tokio's shutdown waits for blocking tasks — so the runtime can never drop. Disarming `CancelOnDrop` in `http.rs` made the run hang indefinitely with no failure to read.

It now gives up on a deadline and records the observation **only if cancellation actually happened**, so the assertion still fails on a regression. Measured against the same mutation:

| | disarmed `CancelOnDrop` |
|---|---|
| before | hangs indefinitely — runtime cannot shut down |
| after | **fails in 10.0s** with its own message |

The two new waits carry the same guard for the same reason: if the runner never starts, neither has any other way to complete.

## Verification

```
cargo nextest run --workspace                                                         → 5258 passed
cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings  → 0
cargo +nightly fmt --check                                                            → 0
```

Mutations run and reverted: worker limit raised to 2 (fails), `CancelOnDrop` disarmed (fails in 10s, previously hung).

## Not covered

#1242's third case, `a_realistically_large_compilation_database_is_validated_in_one_pass`, is a 30s wall-clock throughput budget that only holds on an idle box. Moving it to the criterion harness that already tracks baselines — and keeping the fixture here while asserting on work completed — is a judgement call for the owner rather than a mechanical edit, so this leaves it open.

Advances #1242.
