### PR TITLE
chore(oracle): shim a bare python for corpora that spell it that way

### DIFF
--- a/tools/oracle-run.sh
+++ b/tools/oracle-run.sh
@@ -69,8 +69,24 @@ cleanup_checkout() {
     if [ "${KEEP_CHECKOUT:-0}" != "1" ]; then
         rm -rf "$CHECKOUT" "$DB" "$DB"-wal "$DB"-shm
     fi
+    rm -rf "${PYTHON_SHIM:-}"
 }
 trap cleanup_checkout EXIT
+
+# A python corpus's prepare step spells `python`, which Debian and Ubuntu leave absent unless
+# `python-is-python3` is installed — so it works in CI, whose setup action provides a bare `python`,
+# and fails on a stock dev box with `python: command not found`.
+#
+# The environment is adjusted rather than the command, and that is the whole point: the prepare
+# string is hashed into `corpus_profile_hash`, which is what lets a run be declared comparable with
+# the recorded ones. Rewriting it to `python3` would silently make every future run incomparable
+# with every prior one, to fix a portability nit.
+if ! command -v python >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    PYTHON_SHIM="$(mktemp -d)"
+    ln -s "$(command -v python3)" "$PYTHON_SHIM/python"
+    export PATH="$PYTHON_SHIM:$PATH"
+    echo "oracle-run: no bare 'python' on PATH; shimmed to $(command -v python3)" >&2
+fi
 
 echo "oracle-run: corpus=$CORPUS tool=$TOOL repo=$REPO rev=$REV (budget ${TIMEOUT_MINUTES}m)" >&2
 


### PR DESCRIPTION
The `py-rich` and `py-django` prepare steps run `python -m venv .venv`. Debian and Ubuntu ship `python3` and leave `python` absent unless `python-is-python3` is installed, so the run dies at the first prepare step on a stock dev box:

```
oracle-run: prepare> python -m venv .venv
bash: line 1: python: command not found
```

CI is unaffected — its Python setup action provides a bare `python`.

## Why the environment moves and not the command

The prepare string is hashed into `corpus_profile_hash`, which is what lets a run be declared comparable with the recorded ones. Rewriting it to `python3` would silently make every future run incomparable with every prior one, to fix a portability nit — so `tools/oracle-corpora.toml` is untouched and the runner shims `python` onto `python3` when, and only when, a bare `python` is missing and `python3` is present. The existing exit trap removes the shim.

This is option 1 of the three the issue lays out, and for the reason it gives.

## Verified against a stripped PATH

Rather than run a whole corpus, a probe built a PATH holding `python3` but no bare `python` — what a stock Debian box gives you — and ran the prepare command through it:

| | result |
|---|---|
| control: bare `python` on the stripped PATH | absent |
| control: `python3` on the stripped PATH | present |
| the prepare command as written, before the shim | `bash: line 1: python: command not found` |
| after the shim block | `python now resolves: …/python` |
| after the trap's cleanup | shim directory gone |

The first of those is the reported failure reproduced exactly.

`bash -n` passes. `rm -rf ""` exits 0 under `-f`, so the cleanup is safe under `set -euo pipefail` when no shim was ever created.

Fixes #1233.
