### PR TITLE
fix(watch): stop re-registering paths notify already watches

### DIFF
--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -21,7 +21,8 @@ use super::pass::{
 use super::placement::{
     LinkedWorktreeWatches, WatchPlacementCounters, event_requests_maintenance,
     event_targets_binary, is_gitignore_path, kind_is_mutation, place_initial_watch_state,
-    recompile_ignore_and_place_watches, sync_linked_worktrees_after_pass,
+    rebuild_watch_state_after_rescan, recompile_ignore_and_place_watches,
+    sync_linked_worktrees_after_pass,
 };
 use crate::fleet;
 use crate::index::ignore_rules::IgnoreMatcher;
@@ -247,7 +248,7 @@ fn watcher_main(
         counters: &watch_counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
-        worktree_registry: worktree_registry.as_deref(),
+        worktree_registry,
         rx,
         pass_tx: &pass_tx,
         scheduler: &mut scheduler,
@@ -342,7 +343,7 @@ pub(crate) struct EventLoop<'a, W: notify::Watcher> {
     pub(crate) counters: &'a WatchPlacementCounters,
     pub(crate) ignore: &'a mut IgnoreMatcher,
     pub(crate) linked_worktrees: &'a mut LinkedWorktreeWatches,
-    pub(crate) worktree_registry: Option<&'a Path>,
+    pub(crate) worktree_registry: Option<PathBuf>,
     pub(crate) rx: Receiver<LoopMsg>,
     pub(crate) pass_tx: &'a Sender<PassRequest>,
     pub(crate) scheduler: &'a mut PassScheduler,
@@ -357,7 +358,7 @@ pub(crate) struct EventLoop<'a, W: notify::Watcher> {
 impl<W: notify::Watcher> EventLoop<'_, W> {
     /// Run until `stop`; returns whether a final shutdown refresh is owed (the debounce is still
     /// armed — events arrived after the last dispatched pass).
-    pub(crate) fn run(self) -> bool {
+    pub(crate) fn run(mut self) -> bool {
         let mut debounce = Debounce::new(
             Duration::from_millis(self.config.watch.debounce_ms),
             Duration::from_millis(self.config.watch.max_latency_ms),
@@ -434,6 +435,21 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
             match self.rx.recv_timeout(wait) {
                 Ok(LoopMsg::Fs(Ok(event))) => {
                     let now = Instant::now();
+                    // A rescan means the backend dropped events, so anything could have vanished
+                    // unseen — including a watched directory that was deleted and recreated.
+                    // Rebuild the whole watch state before classifying, or a record left over
+                    // from before the gap suppresses the placement that recovers it (#1269).
+                    if event.need_rescan() {
+                        self.worktree_registry = rebuild_watch_state_after_rescan(
+                            self.notify_watcher,
+                            self.counters,
+                            self.config,
+                            self.target_dirs,
+                            self.ignore,
+                            self.linked_worktrees,
+                            self.fleet_bin,
+                        );
+                    }
                     // Place watches on newly-appeared, non-ignored directories REGARDLESS of
                     // relevance (#332). Target dirs are watched NON-recursively (#331), so notify
                     // won't auto-descend into a new subdir — and a bare `mkdir src/foo` is NOT
@@ -457,7 +473,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                         self.target_dirs,
                         self.ignore,
                         self.linked_worktrees,
-                        self.worktree_registry,
+                        self.worktree_registry.as_deref(),
                     ) {
                         debounce.on_event(now);
                         pending_overlay_scope = Some(match pending_overlay_scope.take() {

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -54,7 +54,8 @@ pub(crate) use placement::{
     created_dir_placement, event_is_relevant, event_requests_maintenance, event_touches_worktree,
     gitignore_rule_watch_dirs, gitignore_watch_dirs, is_gitignore_path, kind_is_mutation,
     missing_config_root_bootstrap_dirs, place_initial_watch_state,
-    recompile_ignore_and_place_watches, sync_linked_worktrees_after_pass, watch_created_dirs,
+    rebuild_watch_state_after_rescan, recompile_ignore_and_place_watches,
+    sync_linked_worktrees_after_pass, watch_configured_trees, watch_created_dirs,
     watch_linked_worktrees, watch_tree_pruned, worktree_watch_targets,
 };
 

--- a/crates/rag-rat-core/src/watch/placement.rs
+++ b/crates/rag-rat-core/src/watch/placement.rs
@@ -1,6 +1,7 @@
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use notify::event::{AccessKind, AccessMode, EventKind, ModifyKind, RemoveKind, RenameMode};
@@ -24,6 +25,9 @@ use crate::index::target_for_path;
 /// in [`watch_tree_pruned`], its whole unwalked subtree) then silently falls back to the periodic
 /// sweep. These counters make that fallback *observable*. Interior atomics so the shared `&self`
 /// can be read on the pass thread while the event-loop thread records placements concurrently.
+///
+/// It also carries the set of watches this watcher has live, which is what keeps a re-placement
+/// pass from registering an already-watched path a second time (#1269).
 #[derive(Debug, Default)]
 pub(crate) struct WatchPlacementCounters {
     attempts: AtomicU64,
@@ -32,6 +36,17 @@ pub(crate) struct WatchPlacementCounters {
     /// (instance-local), NOT on the persisted high-water mark — a restarted watcher whose fresh
     /// count is below a prior high-water still has real new failures to log.
     last_warned: AtomicU64,
+    /// Live placements, so a path already watched at the SAME recursive mode is never registered
+    /// twice. `notify::Watcher::watch` is idempotent on inotify and FSEvents, but the Windows
+    /// `ReadDirectoryChangesW` backend stores a fresh watch state over the old one without
+    /// releasing it — every duplicate strands a directory handle, a semaphore, and the pending
+    /// 16 KiB read request (#1269). Re-placement is routine here, not exceptional: the
+    /// linked-worktree trees are re-placed after every pass and the base tree on every
+    /// `.gitignore` edit, so unguarded duplicates grow handles and memory without bound for as
+    /// long as the watcher runs. A record that stops being trustworthy is retired — unwatched,
+    /// then dropped — by [`retire_placements`], so the path is watched again on a live handle
+    /// instead of trusting the dead one.
+    placed: Mutex<BTreeMap<PathBuf, RecursiveMode>>,
 }
 
 impl WatchPlacementCounters {
@@ -62,21 +77,124 @@ impl WatchPlacementCounters {
         let prior = self.last_warned.fetch_max(current, Ordering::Relaxed);
         (current > prior).then_some(current)
     }
+
+    /// The recursive mode `path` is currently watched at, if any. A poisoned lock answers `None`,
+    /// so the worst case is the unguarded re-registration this repo had before.
+    fn placed_mode(&self, path: &Path) -> Option<RecursiveMode> {
+        self.placed.lock().ok().and_then(|placed| placed.get(path).copied())
+    }
+
+    fn record_placed(&self, path: &Path, mode: RecursiveMode) {
+        if let Ok(mut placed) = self.placed.lock() {
+            placed.insert(path.to_path_buf(), mode);
+        }
+    }
+
+    /// Drop every record at or below `prefix` — or ALL of them when `prefix` is `None` — and hand
+    /// the paths back so the caller can unwatch them. Taking them out under the lock and
+    /// unwatching outside it keeps the notify call off this mutex.
+    fn take_placed_under(&self, prefix: Option<&Path>) -> Vec<PathBuf> {
+        let Ok(mut placed) = self.placed.lock() else {
+            return Vec::new();
+        };
+        let taken: Vec<PathBuf> = placed
+            .keys()
+            .filter(|watched| prefix.is_none_or(|prefix| watched.starts_with(prefix)))
+            .cloned()
+            .collect();
+        for path in &taken {
+            placed.remove(path);
+        }
+        taken
+    }
 }
 
-/// Place one non-recursive watch, counting the outcome into `counters`; returns `true` on success.
-/// EVERY `.watch()` in this module goes through here so a swallowed failure is still counted.
-/// Behavior is unchanged — a failed watch still falls back to the sweep exactly as before; only its
-/// visibility changes.
+/// Hand every watch at or below `path` — or EVERY watch, when `path` is `None` — back to notify
+/// and drop its record, so the next placement registers afresh instead of trusting a record that
+/// may describe a dead watch.
+///
+/// Unwatching rather than merely forgetting is the point: notify still holds the old registration,
+/// and on Windows re-`watch()`ing over a live entry is what strands its handles (#1269). Retiring
+/// first is therefore both the correctness fix (the recreated path IS re-watched) and the leak fix
+/// (the dead watch is released instead of duplicated).
+///
+/// Called wherever a record stops being trustworthy: a directory that reappeared under a name we
+/// already watch, a directory that went away ([`retire_removed_dirs`]), a linked checkout that
+/// left the worktree set (`git worktree remove` may be followed by an `add` at the same path), a
+/// backend rescan (events were dropped, so any disappearance inside that window went unseen), and
+/// a mode change on an existing watch.
+///
+/// The record is taken out from under the lock BEFORE `unwatch`, so the notify call never runs
+/// while the mutex is held. A failed `unwatch` therefore leaves no record behind — which is the
+/// right outcome, because the only way it fails is that notify was not holding the watch, and
+/// re-registering a path the backend has already dropped strands nothing.
+fn retire_placements(
+    watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
+    path: Option<&Path>,
+) {
+    for retired in counters.take_placed_under(path) {
+        // The directory is usually already gone — that is why we are retiring it — and the backend
+        // may have dropped the watch itself. Either way there is nothing to recover from the error.
+        let _ = watcher.unwatch(&retired);
+    }
+}
+
+/// Retire the records for directories an event says are GONE, so the map does not grow one entry
+/// per created-and-deleted directory for the life of the watcher. Without this only a reappearance
+/// at the same path, a departed checkout or a rescan ever removes anything, and a repo that churns
+/// uniquely-named directories under a target would accumulate keys indefinitely.
+///
+/// Gated on the path actually being absent: a `Remove` names a path that is gone, but the same
+/// event can race a recreate, and retiring a live directory would drop a watch that only a later
+/// re-place would restore. A rename AWAY (`RenameMode::From`) is a removal from this watcher's
+/// point of view. `RenameMode::Both` is deliberately left alone — its second path is the
+/// destination, which [`watch_created_dirs`] retires and re-places.
+fn retire_removed_dirs(
+    watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
+    event: &Event,
+) {
+    let dir_left = matches!(event.kind, EventKind::Remove(_))
+        || matches!(event.kind, EventKind::Modify(ModifyKind::Name(RenameMode::From)));
+    if !dir_left {
+        return;
+    }
+    for path in &event.paths {
+        if path.try_exists().unwrap_or(true) {
+            continue;
+        }
+        retire_placements(watcher, counters, Some(path));
+    }
+}
+
+/// Place one non-recursive watch, counting the outcome into `counters`; returns `true` on success
+/// or when the watch is already live. EVERY `.watch()` in this module goes through here so a
+/// swallowed failure is still counted and no path is registered twice (#1269). A failed watch
+/// still falls back to the sweep exactly as before.
 fn place_watch(
     watcher: &mut impl notify::Watcher,
     counters: &WatchPlacementCounters,
     path: &Path,
     mode: RecursiveMode,
 ) -> bool {
+    match counters.placed_mode(path) {
+        Some(current) if current == mode => return true,
+        // A mode change REPLACES the watch: hand the old registration back first, or notify
+        // strands it exactly as a duplicate would. Only this entry — descendants hold their own
+        // watches, which this call does not re-place, so retiring them would leave them dark.
+        // `record_placed` below overwrites the record with the new mode.
+        Some(_) => {
+            let _ = watcher.unwatch(path);
+        },
+        None => {},
+    }
     counters.record_attempt();
     match watcher.watch(path, mode) {
-        Ok(()) => true,
+        Ok(()) => {
+            counters.record_placed(path, mode);
+            true
+        },
         Err(_) => {
             // Only a watch that failed on a directory that EXISTS is a silently-dropped watch (the
             // ENOSPC / inotify-exhaustion case this signal is for). A watch that failed because the
@@ -290,6 +408,21 @@ impl LinkedWorktreeWatches {
         base_config: &Config,
         checkout_roots: Vec<PathBuf>,
     ) {
+        // A checkout that leaves the set can come back at the SAME path — `git worktree remove`
+        // deletes the directory, a later `add` recreates it — and the watches did not survive the
+        // removal. Retire the departed roots so a re-add places watches instead of skipping them
+        // as already live (#1269).
+        let retained: BTreeSet<&Path> = checkout_roots.iter().map(PathBuf::as_path).collect();
+        let departed: Vec<PathBuf> = self
+            .states
+            .iter()
+            .map(|state| state.checkout_root.clone())
+            .filter(|root| !retained.contains(root.as_path()))
+            .collect();
+        for root in departed {
+            retire_placements(watcher, counters, Some(&root));
+        }
+
         let mut states = Vec::with_capacity(checkout_roots.len());
         for root in checkout_roots {
             let state = LinkedWorktreeWatch::new(base_config, root);
@@ -592,6 +725,10 @@ pub(crate) fn watch_created_dirs(
         if !is_real_dir {
             continue;
         }
+        // This directory is NEW — created, or moved in over a deleted one — so any watch recorded
+        // for it or below it is on a handle that no longer refers to this tree. Retire those or
+        // the placements below would be skipped as already live (#1269).
+        retire_placements(watcher, counters, Some(path));
         match created_dir_placement(config, target_dirs, path, bootstrap_root) {
             CreatedDirPlacement::OutsideTargets => continue,
             CreatedDirPlacement::TargetAncestor => {
@@ -621,6 +758,42 @@ pub(crate) fn watch_created_dirs(
         }
     }
     placed_target_watch
+}
+
+/// Rebuild every watch this watcher holds, after a backend rescan.
+///
+/// A rescan means events were DROPPED, so a watched directory may have been deleted and recreated
+/// without a create event ever arriving: every placement record is suspect, and a stale one would
+/// suppress the re-placement that recovers such a directory (a watcher with the periodic sweep
+/// disabled would then never see it again). Retiring hands the watches back to notify rather than
+/// merely forgetting them, so nothing is stranded (#1269).
+///
+/// The rebuild goes through [`place_initial_watch_state`] — the SAME placement the watcher boots
+/// with — because a retire that is not matched by an equally complete re-place silently drops a
+/// whole category of watch. The `.gitignore` rule directories, the fleet binary's parent and the
+/// worktree registry are placed nowhere else, so re-placing only the configured trees would leave
+/// them dark for the rest of the process's life.
+///
+/// Returns the rebuilt worktree registry, which the caller must ADOPT: the registry path is
+/// derived from the repo, and a root that was not a Git checkout when the watcher booted has one
+/// now. Classifying later events against the boot-time value would watch the registry the rebuild
+/// just placed while never attributing its events.
+#[must_use]
+pub(crate) fn rebuild_watch_state_after_rescan(
+    watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
+    config: &Config,
+    target_dirs: &[PathBuf],
+    ignore: &mut IgnoreMatcher,
+    linked_worktrees: &mut LinkedWorktreeWatches,
+    fleet_bin: Option<&Path>,
+) -> Option<PathBuf> {
+    retire_placements(watcher, counters, None);
+    *ignore = IgnoreMatcher::compile(&config.root, target_dirs);
+    let (rebuilt, registry) =
+        place_initial_watch_state(watcher, counters, config, target_dirs, ignore, fleet_bin);
+    *linked_worktrees = rebuilt;
+    registry
 }
 
 pub(crate) fn place_initial_watch_state(
@@ -666,6 +839,7 @@ pub(crate) fn event_requests_maintenance(
     linked_worktrees: &mut LinkedWorktreeWatches,
     worktree_registry: Option<&Path>,
 ) -> Option<OverlayScope> {
+    retire_removed_dirs(watcher, counters, event);
     let created_dir_watch_placed =
         watch_created_dirs(watcher, counters, event, config, target_dirs, ignore, None);
     let linked_created_dir_roots = linked_worktrees.watch_created_dirs(watcher, counters, event);

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -226,6 +226,7 @@ fn activate_ephemeral_model(config: &Config, repo_id: &str, query_endpoint: Opti
 #[derive(Debug, Default)]
 struct RecordingWatcher {
     watched: Vec<(PathBuf, RecursiveMode)>,
+    unwatched: Vec<PathBuf>,
 }
 
 impl notify::Watcher for RecordingWatcher {
@@ -244,7 +245,8 @@ impl notify::Watcher for RecordingWatcher {
         Ok(())
     }
 
-    fn unwatch(&mut self, _path: &Path) -> notify::Result<()> {
+    fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+        self.unwatched.push(path.to_path_buf());
         Ok(())
     }
 
@@ -275,6 +277,270 @@ impl notify::Watcher for FailingWatcher {
     fn kind() -> notify::WatcherKind {
         notify::WatcherKind::NullWatcher
     }
+}
+
+/// Re-placing a tree must not register a path notify already watches. The watcher re-places
+/// routinely — the linked-worktree trees after every pass, the base tree on every `.gitignore`
+/// edit — and Windows' `ReadDirectoryChangesW` backend does not release the previous watch when a
+/// path is registered again: each duplicate strands a directory handle, a semaphore and a 16 KiB
+/// read request, so an unguarded re-place grows handles and memory for as long as the watcher runs
+/// (#1269). A directory that REAPPEARS is the exception — its old watch is on a handle that no
+/// longer refers to it, so placement must run again.
+#[test]
+fn re_placing_a_tree_does_not_register_an_already_watched_path_twice() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let id = N.fetch_add(1, Ordering::Relaxed);
+    let scratch = scratch_root(format!("ragrat-watch-dedup-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(scratch.join("src/inner")).unwrap();
+    let scratch = scratch.canonicalize().unwrap();
+    let target_dirs = vec![PathBuf::from(".")];
+    let (config, root) = whole_root_config(&scratch, &target_dirs);
+    let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
+
+    let counters = placement_counters();
+    let mut watcher = RecordingWatcher::default();
+    watch_tree_pruned(&mut watcher, &counters, &root, &ignore);
+    let first = watcher.watched.clone();
+    assert!(first.len() >= 3, "the first placement walks the tree: {first:?}");
+
+    watch_tree_pruned(&mut watcher, &counters, &root, &ignore);
+    assert_eq!(
+        watcher.watched, first,
+        "re-placing an unchanged tree must not hand notify a single duplicate registration",
+    );
+    assert_eq!(
+        counters.counts().0,
+        first.len() as u64,
+        "a skipped duplicate is not a placement attempt either",
+    );
+
+    // The nested directory is deleted and recreated: the recorded watch is on a dead handle, so
+    // the create event has to re-place it rather than trust the record.
+    let recreated = root.join("src/inner");
+    std::fs::remove_dir_all(&recreated).unwrap();
+    std::fs::create_dir(&recreated).unwrap();
+    let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(recreated.clone());
+    assert!(
+        watch_created_dirs(
+            &mut watcher,
+            &counters,
+            &create,
+            &config,
+            &target_dirs,
+            &mut ignore,
+            None
+        ),
+        "a recreated directory below a target is a placement",
+    );
+    assert!(
+        watcher.watched[first.len()..].iter().any(|(path, _)| path == &recreated),
+        "the recreated directory is watched again: {:?}",
+        &watcher.watched[first.len()..],
+    );
+    assert!(
+        watcher.unwatched.contains(&recreated),
+        "the dead registration is handed back, not merely forgotten: {:?}",
+        watcher.unwatched,
+    );
+}
+
+/// A backend rescan means events were DROPPED, so a watched directory could have been deleted and
+/// recreated without a create event ever arriving — every placement record is suspect. The watcher
+/// must retire the records (handing the watches back to notify, not merely forgetting them, so the
+/// dead registrations are released rather than duplicated) and rebuild. The rebuild has to be as
+/// COMPLETE as the retire: the `.gitignore` rule directories, the fleet binary's parent and the
+/// worktree registry are placed nowhere but the initial placement, so re-placing only the
+/// configured trees would leave a whole category dark for the rest of the process's life (#1269).
+#[test]
+fn a_rescan_retires_every_placement_and_rebuilds_the_full_watch_state() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let id = N.fetch_add(1, Ordering::Relaxed);
+    let scratch = scratch_root(format!("ragrat-watch-rescan-{}-{id}", std::process::id()));
+    let linked = scratch_root(format!("ragrat-watch-rescan-linked-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(scratch.join("src")).unwrap();
+    rag_rat_base::test_git::run(&scratch, &["init", "-q"]);
+    rag_rat_base::test_git::run(&scratch, &["config", "user.email", "t@e"]);
+    rag_rat_base::test_git::run(&scratch, &["config", "user.name", "t"]);
+    std::fs::write(scratch.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    rag_rat_base::test_git::run(&scratch, &["add", "-A"]);
+    rag_rat_base::test_git::run(&scratch, &["commit", "-qm", "seed"]);
+    let linked_arg = linked.to_string_lossy().into_owned();
+    rag_rat_base::test_git::run(&scratch, &["worktree", "add", "-q", "-b", "feature", &linked_arg]);
+
+    let fleet_bin = scratch.join("bin/rag-rat");
+    std::fs::create_dir_all(fleet_bin.parent().unwrap()).unwrap();
+    let scratch = scratch.canonicalize().unwrap();
+    let target_dirs = vec![PathBuf::from("src")];
+    let (config, root) = whole_root_config(&scratch, &target_dirs);
+    let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
+    let counters = placement_counters();
+    let mut watcher = RecordingWatcher::default();
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+
+    let (_, registry) = place_initial_watch_state(
+        &mut watcher,
+        &counters,
+        &config,
+        &target_dirs,
+        &ignore,
+        Some(fleet_bin.as_path()),
+    );
+    let placed = watcher.watched.clone();
+    let registry = registry.expect("a git checkout has a worktree registry");
+    for expected in [root.join("src"), fleet_bin.parent().unwrap().to_path_buf(), registry.clone()]
+    {
+        assert!(
+            placed.iter().any(|(path, _)| path == &expected),
+            "{expected:?} is watched by the initial placement: {placed:?}",
+        );
+    }
+
+    let rebuilt_registry = rebuild_watch_state_after_rescan(
+        &mut watcher,
+        &counters,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        &mut linked_worktrees,
+        Some(fleet_bin.as_path()),
+    );
+    assert_eq!(
+        rebuilt_registry.as_ref(),
+        Some(&registry),
+        "the rebuild hands back the registry for the caller to classify against",
+    );
+
+    for (path, _) in &placed {
+        assert!(
+            watcher.unwatched.contains(path),
+            "a rescan hands {path:?} back to notify instead of stranding it: {:?}",
+            watcher.unwatched,
+        );
+    }
+    let rebuilt = &watcher.watched[placed.len()..];
+    for (path, mode) in &placed {
+        assert!(
+            rebuilt.contains(&(path.clone(), *mode)),
+            "a rescan re-places {path:?} — every category, not just the configured trees: \
+             {rebuilt:?}",
+        );
+    }
+}
+
+/// A directory that goes away must drop its placement record. Only a reappearance at the same
+/// path, a departed checkout or a backend rescan retires anything otherwise, so a repo that churns
+/// uniquely-named directories under a target would grow the map by one key per directory for the
+/// life of the watcher (#1269). The record is dropped only when the path is really gone — a remove
+/// event racing a recreate must not strip a live directory of its watch.
+#[test]
+fn a_removed_directory_drops_its_placement_record() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let id = N.fetch_add(1, Ordering::Relaxed);
+    let scratch = scratch_root(format!("ragrat-watch-removed-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(scratch.join("src/gone")).unwrap();
+    std::fs::create_dir_all(scratch.join("src/stays")).unwrap();
+    let scratch = scratch.canonicalize().unwrap();
+    let target_dirs = vec![PathBuf::from("src")];
+    let (config, root) = whole_root_config(&scratch, &target_dirs);
+    let ignore = IgnoreMatcher::compile(&root, &target_dirs);
+    let counters = placement_counters();
+    let mut watcher = RecordingWatcher::default();
+    let mut linked = LinkedWorktreeWatches::default();
+
+    watch_configured_trees(&mut watcher, &counters, &config, &target_dirs, &ignore);
+    let gone = root.join("src/gone");
+    let stays = root.join("src/stays");
+    assert!(watcher.watched.iter().any(|(path, _)| path == &gone), "{:?}", watcher.watched);
+
+    // Still present: a remove event that races a recreate must leave the live watch alone.
+    let mut ignore = ignore;
+    let racing = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(stays.clone());
+    event_requests_maintenance(
+        &mut watcher,
+        &counters,
+        &racing,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        &mut linked,
+        None,
+    );
+    assert!(
+        !watcher.unwatched.contains(&stays),
+        "a directory that still exists keeps its watch: {:?}",
+        watcher.unwatched,
+    );
+
+    // Actually gone: the record is retired, so a later directory at that path is watched afresh.
+    std::fs::remove_dir_all(&gone).unwrap();
+    let removed = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(gone.clone());
+    event_requests_maintenance(
+        &mut watcher,
+        &counters,
+        &removed,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        &mut linked,
+        None,
+    );
+    assert!(
+        watcher.unwatched.contains(&gone),
+        "the departed directory's watch is handed back: {:?}",
+        watcher.unwatched,
+    );
+
+    std::fs::create_dir(&gone).unwrap();
+    let before = watcher.watched.len();
+    watch_configured_trees(&mut watcher, &counters, &config, &target_dirs, &ignore);
+    assert!(
+        watcher.watched[before..].iter().any(|(path, _)| path == &gone),
+        "a re-place after the retire watches the path again: {:?}",
+        &watcher.watched[before..],
+    );
+}
+
+/// `git worktree remove` deletes the checkout directory, taking its watches with it; a later `add`
+/// can recreate the very same path. The placement records must not survive that round trip, or the
+/// restored checkout is skipped as already watched and never observed again (#1269).
+#[test]
+fn a_linked_checkout_removed_and_re_added_at_the_same_path_is_watched_again() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let id = N.fetch_add(1, Ordering::Relaxed);
+    let scratch = scratch_root(format!("ragrat-watch-readd-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(scratch.join("wt/src")).unwrap();
+    let scratch = scratch.canonicalize().unwrap();
+    let target_dirs = vec![PathBuf::from("src")];
+    let (config, root) = whole_root_config(&scratch, &target_dirs);
+    let checkout = root.join("wt");
+    let counters = placement_counters();
+    let mut watcher = RecordingWatcher::default();
+    let mut worktrees = LinkedWorktreeWatches::default();
+
+    worktrees.sync(&mut watcher, &counters, &config, vec![checkout.clone()]);
+    let placed = watcher.watched.clone();
+    assert!(placed.iter().any(|(path, _)| path.starts_with(&checkout)), "{placed:?}");
+
+    // Removed: the checkout leaves the set, and its watches die with the directory.
+    worktrees.sync(&mut watcher, &counters, &config, Vec::new());
+    assert!(
+        watcher.unwatched.iter().any(|path| path.starts_with(&checkout)),
+        "a departed checkout's watches are handed back: {:?}",
+        watcher.unwatched,
+    );
+
+    // Re-added at the same path.
+    let before = watcher.watched.len();
+    worktrees.sync(&mut watcher, &counters, &config, vec![checkout.clone()]);
+    assert!(
+        watcher.watched[before..].iter().any(|(path, _)| path.starts_with(&checkout)),
+        "the restored checkout is watched again: {:?}",
+        &watcher.watched[before..],
+    );
 }
 
 /// A failed watch placement is COUNTED (so `index_status` can surface silent degradation), and the


### PR DESCRIPTION
Fixes #1269.

## The leak

The watcher re-places whole trees routinely — `sync_linked_worktrees_after_pass` rebuilds every linked worktree's watches after *every* pass, and `recompile_ignore_and_place_watches` re-walks the base tree on *every* `.gitignore` edit. Each of those called `notify::Watcher::watch` on paths that were already watched. A comment in the event loop stated the assumption outright: "notify's `watch()` is idempotent for an already-watched path."

That holds on inotify and FSEvents. It does not hold on Windows. In `notify-8.2.0/src/windows.rs`, `add_watch` ends with a bare `self.watches.insert(path, ws)` — no `remove_watch` first, and `WatchState` has no `Drop` — so the previous entry's directory handle, semaphore and pending 16 KiB `ReadDirectoryChangesW` request are stranded. Reported effect: ~12 GB resident and ~760k handles.

## The fix

Track the live placements per watcher and skip a registration for a path already watched at the same recursive mode. All `.watch()` calls in the module already route through `place_watch`, so the guard goes in one place.

Where a record stops being trustworthy it is *retired* — dropped from the map and handed back to notify, rather than merely forgotten. Unwatching is what releases the dead registration instead of leaving notify holding it:

- **A directory that reappears** under a name already watched (deleted and recreated, or moved in over a deletion). Its old watch is on a handle that no longer refers to that tree.
- **A directory that goes away.** This is also what bounds the map: without it, only a reappearance at the same path, a departed checkout or a rescan removes anything, so a repo churning uniquely-named directories under a target would accumulate keys for the life of the watcher. Gated on the path actually being absent, so a remove event racing a recreate cannot strip a live directory of its watch.
- **A linked checkout that leaves the worktree set.** `git worktree remove` deletes the directory and its watches; a later `add` can recreate the same path.
- **A backend rescan.** Events were dropped, so any disappearance inside that window went unseen and every record is suspect. Recovery rebuilds through `place_initial_watch_state` — the same placement the watcher boots with — because a retire that is not matched by an equally complete re-place drops whole categories: the `.gitignore` rule directories, the fleet binary's parent and the worktree registry are placed nowhere else. The rebuild returns the registry for the event loop to adopt, so a root that was not a Git checkout at boot is classified against the registry that now exists.

A mode change on an existing watch also unwatches the exact path first, so that path can't strand its registration either. No production call site changes mode today; the guard keeps it from becoming a trap.

Records are taken out from under the mutex before `unwatch`, so the notify call never runs while the lock is held.

## Upstream

This is fixed in notify as of `9.0.0-rc.4` (notify-rs/notify#708, "replace an existing watch when `watch` is called again for the same path, avoiding duplicate FSEvent paths and leaked Windows watch handles"). That fix exists only on the 9.0 release-candidate line — the stable line is 8.2.0 and there is no 8.x backport — and notify 9 also changes event-path representation, so it is a migration rather than a bump. The guard stays worthwhile afterwards regardless: notify 9 *replaces* the watch, i.e. a stop/start per duplicate, which is still cheaper to skip. When we do migrate, `Watcher::watched_paths()` (added in 9.0.0-rc.3) can replace the map maintained here.

The same duplicate registration also produced duplicate FSEvents paths on macOS, so the guard is not Windows-only value.

## Verification

Four new tests, each verified to fail with its guard removed:

- `re_placing_a_tree_does_not_register_an_already_watched_path_twice` — a second `watch_tree_pruned` over an unchanged tree hands notify nothing, and a recreated directory is re-placed on a fresh handle.
- `a_rescan_retires_every_placement_and_rebuilds_the_full_watch_state` — over a real Git checkout with a linked worktree, so the registry and fleet-binary categories are exercised; fails if the rebuild only re-places the configured trees.
- `a_removed_directory_drops_its_placement_record` — covers both the retire and the live-directory guard.
- `a_linked_checkout_removed_and_re_added_at_the_same_path_is_watched_again`.

`cargo nextest run -p rag-rat-core`: 2095 passed. Both CI clippy legs (`--no-default-features` and `--all-features`, `-D warnings`) clean.

Note that `ci-cross-platform.yml` (the Windows and macOS legs) runs only on tags and `workflow_dispatch`, so a normal PR gets no coverage on the platform this bug lives on. Dispatched manually against this branch.

## Known gap, not addressed here

`fleet_bin.parent()` and the worktree registry are placed only by `place_initial_watch_state`. If either directory is deleted, its watch is dead and nothing outside a rescan re-places it — true before this change as well. Filed as #1271.