### PR TITLE
feat(cli): expose tool catalog as native subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ rag-rat query "where is config reload handled?"
 rag-rat important-symbols --limit 20
 rag-rat brief --mode spine
 rag-rat clusters --limit 10
+rag-rat tools impact-surface --symbol parse_config
 ```
 
 ## The agent loop
@@ -304,8 +305,11 @@ Prefer reusing the existing function(s) over duplicating — impact_surface / sy
 
 ## The tools
 
-rag-rat's **MCP tools** — the full catalog with JSON schemas lives in
-[`docs/mcp-tools.md`](docs/mcp-tools.md). The ones you'll reach for most:
+rag-rat's **tool catalog** is exposed through both MCP and native CLI commands. The full catalog
+and JSON schemas are documented in [`docs/mcp-tools.md`](docs/mcp-tools.md). Run
+`rag-rat tools --help` to browse every tool or `rag-rat tools <name> --help` to inspect arguments
+from the canonical schema. Existing curated commands such as `query`, `brief`, `memory`, and `dream`
+stay unchanged. The ones you'll reach for most:
 
 - **`impact_surface`** — the coding preflight from the loop above: callers, callees, tests, git
   history, GitHub papertrail, and the repo memories crossing a symbol, in one call. Memories default
@@ -532,6 +536,7 @@ rag-rat hooks install              # git maintenance hooks
 rag-rat gc                         # prune rows for dead git contexts
 rag-rat eval [--json|--update-baseline]   # CI search-quality gate; requires a `--features eval` build (absent from the released binary)
 rag-rat serve                      # authenticated editor Lens HTTP API
+rag-rat tools <name>               # invoke any tool directly; see `tools --help`
 rag-rat mcp                        # start the STDIO server
 ```
 

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -22,7 +22,7 @@ rag-rat-dream.workspace = true
 rag-rat-llm = { workspace = true, default-features = false }
 rag-rat-papertrail.workspace = true
 anyhow.workspace = true
-clap = { version = "4.6", features = ["derive"] }
+clap = { version = "4.6", features = ["derive", "string"] }
 dialoguer = "0.12"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 tui-tree-widget = "0.24"

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -82,6 +82,9 @@ pub(crate) enum Command {
     /// Run the stdio MCP server.
     Mcp,
 
+    /// Invoke repository intelligence tools directly, without requiring an MCP client or server.
+    Tools(ToolsArgs),
+
     /// Serve the authenticated editor Lens HTTP API.
     Serve(ServeArgs),
 
@@ -188,6 +191,14 @@ pub(crate) enum AgentHookHarnessArg {
     Auto,
     Cursor,
     Vscode,
+}
+
+#[derive(Debug, Args)]
+#[command(disable_help_flag = true, trailing_var_arg = true)]
+pub(crate) struct ToolsArgs {
+    /// Tool command and arguments. Run `rag-rat tools --help` to inspect the generated catalog.
+    #[arg(value_name = "TOOL_ARGS", num_args = 0.., allow_hyphen_values = true)]
+    pub args: Vec<String>,
 }
 
 #[derive(Debug, Args)]
@@ -1121,6 +1132,25 @@ mod tests {
 
         let flagged = Cli::try_parse_from(["rag-rat", "query", "foo", "--json"]).expect("parse");
         assert!(flagged.json, "--json must be accepted globally, after the subcommand");
+    }
+
+    #[test]
+    fn tools_namespace_captures_dynamic_subcommand_arguments() {
+        let cli = Cli::try_parse_from([
+            "rag-rat",
+            "tools",
+            "find-callers",
+            "--symbol",
+            "parse_config",
+            "--limit",
+            "20",
+        ])
+        .expect("parse tools namespace");
+        match cli.command {
+            Command::Tools(ToolsArgs { args }) =>
+                assert_eq!(args, ["find-callers", "--symbol", "parse_config", "--limit", "20"]),
+            other => panic!("expected tools namespace, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ mod runtime_env;
 mod search;
 mod status;
 mod sync;
+mod tools;
 
 pub(crate) use clones::{clones, clones_for};
 pub(crate) use config_info::{dump_config, version_check};
@@ -41,3 +42,4 @@ pub(crate) use runtime_env::apply_embedding_runtime_env;
 pub(crate) use search::{brief, clusters, important_symbols, query};
 pub(crate) use status::status;
 pub(crate) use sync::sync;
+pub(crate) use tools::run_tools;

--- a/crates/rag-rat-cli/src/commands/tools.rs
+++ b/crates/rag-rat-cli/src/commands/tools.rs
@@ -1,0 +1,627 @@
+//! Native CLI projection of the repository intelligence tool catalog from the canonical schema.
+//!
+//! MCP remains one transport for these tools, not their implementation boundary. The canonical
+//! names, descriptions, JSON schemas, defaults, worktree scoping, read/write classification, and
+//! handlers stay owned by `rag-rat-mcp`. This module derives a conventional Clap surface from that
+//! catalog, converts supplied flags back into the canonical JSON argument object, and dispatches it
+//! through `call_tool_for_config` in the same process. No MCP server or client is started.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use clap::builder::PossibleValuesParser;
+use clap::error::ErrorKind;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::{Map, Value, json};
+
+use crate::commands::{apply_embedding_runtime_env, set_output_format};
+use crate::load_config_or_hint;
+use crate::render::print_output;
+
+const ARGUMENTS_JSON: &str = "arguments-json";
+const CONFIG: &str = "config";
+const JSON_OUTPUT: &str = "json";
+const SCHEMA: &str = "schema";
+
+/// Run the `rag-rat tools` namespace. Catalog, help, and schema paths do not need a config. A tool
+/// invocation enters the same config/runtime/logging setup as the rest of the CLI before calling
+/// the canonical dispatcher by name.
+pub(crate) fn run_tools(
+    outer_config: Option<&str>,
+    outer_json: bool,
+    argv: &[String],
+) -> anyhow::Result<()> {
+    let command = tools_command();
+    let mut args = Vec::with_capacity(argv.len() + 1);
+    args.push("rag-rat tools".to_string());
+    args.extend(argv.iter().cloned());
+
+    let matches = match command.try_get_matches_from(args) {
+        Ok(matches) => matches,
+        Err(err) if matches!(err.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) => {
+            err.print()?;
+            return Ok(());
+        },
+        Err(err) => err.exit(),
+    };
+
+    let json_output = outer_json || matches.get_flag(JSON_OUTPUT);
+    set_output_format(if json_output {
+        rag_rat_core::OutputFormat::Json
+    } else {
+        rag_rat_core::OutputFormat::Toon
+    });
+
+    let Some((cli_tool_name, tool_matches)) = matches.subcommand() else {
+        debug_assert!(matches.get_flag(SCHEMA));
+        return print_output(&rag_rat_mcp::tools::list_tools());
+    };
+    let tool_name = canonical_tool_name(cli_tool_name)
+        .ok_or_else(|| anyhow::anyhow!("unknown repository intelligence tool `{cli_tool_name}`"))?;
+
+    if matches.get_flag(SCHEMA) || tool_matches.get_flag(SCHEMA) {
+        return print_output(&tool_metadata(tool_name));
+    }
+
+    let arguments = if let Some(raw) = tool_matches.get_one::<String>(ARGUMENTS_JSON) {
+        parse_json_object(ARGUMENTS_JSON, raw)?
+    } else {
+        arguments_from_matches(tool_name, tool_matches)?
+    };
+
+    let explicit_config = matches.get_one::<String>(CONFIG).map(String::as_str).or(outer_config);
+    let config = load_config_or_hint(explicit_config)?;
+    apply_embedding_runtime_env(&config.llm.embedding.runtime);
+    let _log = rag_rat_base::logging::init_logging(
+        &config,
+        rag_rat_base::logging::Role::Cli(format!("tools_{}", cli_name(tool_name))),
+    );
+
+    let result =
+        rag_rat_mcp::tools::call_tool_for_config(&config, tool_name, Value::Object(arguments))?;
+    print_output(&result)
+}
+
+/// Build the complete native command tree from the same catalog MCP advertises through
+/// `tools/list`. The visible CLI spelling uses kebab case. The canonical snake_case name is
+/// retained only for dispatch so the wire/API contract never changes.
+fn tools_command() -> Command {
+    let mut command = Command::new("tools")
+        .bin_name("rag-rat tools")
+        .about("Invoke repository intelligence tools directly, without requiring MCP")
+        .version(env!("RAG_RAT_VERSION"))
+        .propagate_version(true)
+        .long_about(
+            "Invoke the same repository intelligence tool catalog exposed over MCP directly from \
+             the CLI. Tool commands, descriptions, arguments, required fields, and enum values \
+             are derived from the canonical MCP schemas; execution uses the same process \
+             dispatcher and does not start an MCP server or client.",
+        )
+        .arg_required_else_help(true)
+        .subcommand_required(false)
+        .arg(
+            Arg::new(CONFIG)
+                .long(CONFIG)
+                .value_name("PATH")
+                .global(true)
+                .help("Path to rag-rat.toml; otherwise use normal config discovery"),
+        )
+        .arg(
+            Arg::new(JSON_OUTPUT)
+                .long(JSON_OUTPUT)
+                .global(true)
+                .action(ArgAction::SetTrue)
+                .help("Emit JSON instead of the default TOON output"),
+        )
+        .arg(
+            Arg::new(SCHEMA)
+                .long(SCHEMA)
+                .global(true)
+                .action(ArgAction::SetTrue)
+                .help("Print the canonical tool catalog/schema instead of invoking a tool"),
+        );
+
+    for &tool_name in rag_rat_mcp::tools::TOOL_NAMES {
+        command = command.subcommand(tool_command(tool_name));
+    }
+    command
+}
+
+fn tool_command(tool_name: &'static str) -> Command {
+    let schema = rag_rat_mcp::tools::schema(tool_name);
+    let required: BTreeSet<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect();
+
+    let cli_tool_name = cli_name(tool_name);
+    let description = rag_rat_mcp::tools::description(tool_name);
+    let mut command = Command::new(cli_tool_name.clone())
+        .about(short_description(description))
+        .long_about(description);
+    if cli_tool_name != tool_name {
+        // Keep the canonical MCP spelling as a hidden compatibility alias for automation while
+        // showing idiomatic kebab case in CLI help.
+        command = command.alias(tool_name);
+    }
+    let properties = schema.get("properties").and_then(Value::as_object);
+    let mut property_names = Vec::new();
+    if let Some(properties) = properties {
+        // serde_json's map order is not a public CLI contract. Sort flags so generated help is
+        // deterministic across feature/build changes while required/default semantics remain in
+        // the schema itself.
+        let sorted: BTreeMap<&str, &Value> =
+            properties.iter().map(|(name, value)| (name.as_str(), value)).collect();
+        for (name, property) in sorted {
+            property_names.push(name.to_string());
+            command = command.arg(property_arg(&schema, name, property, required.contains(name)));
+        }
+    }
+
+    command.arg(
+        Arg::new(ARGUMENTS_JSON)
+            .long(ARGUMENTS_JSON)
+            .value_name("JSON")
+            .conflicts_with_all(property_names)
+            .help(
+                "Pass the complete canonical JSON argument object directly; escape hatch for \
+                 nested or otherwise awkward shell values",
+            ),
+    )
+}
+
+fn property_arg(root_schema: &Value, name: &str, property: &Value, required: bool) -> Arg {
+    let spec = resolve_property(root_schema, property);
+    let mut arg = Arg::new(name.to_string()).long(cli_name(name)).value_name(value_name(&spec));
+    if let Some(help) = property_description(property, &spec) {
+        arg = arg.help(help);
+    }
+
+    if required {
+        arg = arg.required_unless_present_any([ARGUMENTS_JSON, SCHEMA]);
+    }
+
+    match spec.kind {
+        PropertyKind::Boolean { default } =>
+            if default {
+                arg.action(ArgAction::Set)
+                    .num_args(1)
+                    .value_parser(clap::value_parser!(bool))
+                    .value_name("BOOL")
+                    .help_heading("Tool arguments")
+            } else {
+                arg.action(ArgAction::SetTrue)
+            },
+        PropertyKind::Array { values } => {
+            let mut arg = arg
+                .action(ArgAction::Append)
+                .num_args(0..)
+                .value_delimiter(',')
+                .help_heading("Tool arguments");
+            if !values.is_empty() {
+                arg = arg.value_parser(PossibleValuesParser::new(values));
+            }
+            arg
+        },
+        PropertyKind::String { values } => {
+            let mut arg = arg.action(ArgAction::Set).num_args(1).help_heading("Tool arguments");
+            if !values.is_empty() {
+                arg = arg.value_parser(PossibleValuesParser::new(values));
+            }
+            arg
+        },
+        PropertyKind::Integer { .. } | PropertyKind::Number | PropertyKind::Json =>
+            arg.action(ArgAction::Set).num_args(1).help_heading("Tool arguments"),
+    }
+}
+
+#[derive(Debug)]
+struct PropertySpec {
+    kind: PropertyKind,
+    description: Option<String>,
+}
+
+#[derive(Debug)]
+enum PropertyKind {
+    String { values: Vec<String> },
+    Integer { unsigned: bool },
+    Number,
+    Boolean { default: bool },
+    Array { values: Vec<String> },
+    Json,
+}
+
+fn resolve_property(root_schema: &Value, property: &Value) -> PropertySpec {
+    let description = property.get("description").and_then(Value::as_str).map(str::to_string);
+
+    if let Some(reference) = property.get("$ref").and_then(Value::as_str)
+        && let Some(target) = resolve_ref(root_schema, reference)
+    {
+        return property_spec_from_fragment(
+            root_schema,
+            target,
+            description
+                .or_else(|| target.get("description").and_then(Value::as_str).map(str::to_string)),
+        );
+    }
+
+    if let Some(any_of) = property.get("anyOf").and_then(Value::as_array)
+        && let Some(non_null) = any_of.iter().find(|item| !is_null_schema(item))
+    {
+        if let Some(reference) = non_null.get("$ref").and_then(Value::as_str)
+            && let Some(target) = resolve_ref(root_schema, reference)
+        {
+            return property_spec_from_fragment(
+                root_schema,
+                target,
+                description.or_else(|| {
+                    target.get("description").and_then(Value::as_str).map(str::to_string)
+                }),
+            );
+        }
+        return property_spec_from_fragment(root_schema, non_null, description);
+    }
+
+    property_spec_from_fragment(root_schema, property, description)
+}
+
+fn property_spec_from_fragment(
+    root_schema: &Value,
+    fragment: &Value,
+    description: Option<String>,
+) -> PropertySpec {
+    let types: Vec<&str> = match fragment.get("type") {
+        Some(Value::String(kind)) => vec![kind],
+        Some(Value::Array(kinds)) => kinds.iter().filter_map(Value::as_str).collect(),
+        _ => Vec::new(),
+    };
+    let enum_values = enum_values(fragment);
+    let kind = if types.contains(&"boolean") {
+        PropertyKind::Boolean {
+            default: fragment.get("default").and_then(Value::as_bool).unwrap_or(false),
+        }
+    } else if types.contains(&"integer") {
+        let unsigned = fragment
+            .get("format")
+            .and_then(Value::as_str)
+            .is_some_and(|format| format.starts_with("uint"))
+            || fragment.get("minimum").and_then(Value::as_i64).is_some_and(|minimum| minimum >= 0);
+        PropertyKind::Integer { unsigned }
+    } else if types.contains(&"number") {
+        PropertyKind::Number
+    } else if types.contains(&"array") {
+        match string_array_values(root_schema, fragment) {
+            Some(values) => PropertyKind::Array { values },
+            None => PropertyKind::Json,
+        }
+    } else if types.contains(&"string") || !enum_values.is_empty() {
+        PropertyKind::String { values: enum_values }
+    } else {
+        // Nested objects (`memory_* bind`) and intentionally polymorphic payloads remain lossless
+        // JSON values rather than growing a second nested CLI schema that must be maintained
+        // separately.
+        PropertyKind::Json
+    };
+    PropertySpec { kind, description }
+}
+
+fn string_array_values(root_schema: &Value, fragment: &Value) -> Option<Vec<String>> {
+    let items = fragment.get("items")?;
+    let items = items
+        .get("$ref")
+        .and_then(Value::as_str)
+        .and_then(|reference| resolve_ref(root_schema, reference))
+        .unwrap_or(items);
+    let values = enum_values(items);
+    let string_items =
+        items.get("type").and_then(Value::as_str) == Some("string") || !values.is_empty();
+    string_items.then_some(values)
+}
+
+fn enum_values(fragment: &Value) -> Vec<String> {
+    if let Some(values) = fragment.get("enum").and_then(Value::as_array) {
+        return values.iter().filter_map(Value::as_str).map(str::to_string).collect();
+    }
+    fragment
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("const").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+fn resolve_ref<'a>(root_schema: &'a Value, reference: &str) -> Option<&'a Value> {
+    let name = reference.strip_prefix("#/$defs/")?;
+    root_schema.get("$defs")?.get(name)
+}
+
+fn is_null_schema(value: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("null")
+}
+
+fn property_description(property: &Value, spec: &PropertySpec) -> Option<String> {
+    let mut description = spec.description.clone().unwrap_or_default();
+    if let Some(default) = property.get("default").filter(|value| !value.is_object()) {
+        if !description.is_empty() {
+            description.push(' ');
+        }
+        description.push_str("[default: ");
+        description.push_str(&compact_json(default));
+        description.push(']');
+    }
+    (!description.is_empty()).then_some(description)
+}
+
+fn value_name(spec: &PropertySpec) -> &'static str {
+    match spec.kind {
+        PropertyKind::String { .. } => "VALUE",
+        PropertyKind::Integer { .. } => "INTEGER",
+        PropertyKind::Number => "NUMBER",
+        PropertyKind::Boolean { .. } => "BOOL",
+        PropertyKind::Array { .. } => "VALUE",
+        PropertyKind::Json => "JSON",
+    }
+}
+
+fn arguments_from_matches(
+    tool_name: &str,
+    matches: &ArgMatches,
+) -> anyhow::Result<Map<String, Value>> {
+    let schema = rag_rat_mcp::tools::schema(tool_name);
+    let mut arguments = Map::new();
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return Ok(arguments);
+    };
+
+    for (name, property) in properties {
+        // Do not materialize schema defaults into the request: omission is meaningful for fields
+        // such as `include`, and the canonical request structs own their defaults. Only explicit
+        // command line input crosses the dispatcher boundary.
+        if !matches.contains_id(name)
+            || matches.value_source(name) != Some(clap::parser::ValueSource::CommandLine)
+        {
+            continue;
+        }
+        let spec = resolve_property(&schema, property);
+        let value = match spec.kind {
+            PropertyKind::Boolean { default } => {
+                let value = if default {
+                    *matches
+                        .get_one::<bool>(name)
+                        .ok_or_else(|| anyhow::anyhow!("missing value for --{}", cli_name(name)))?
+                } else {
+                    matches.get_flag(name)
+                };
+                Value::Bool(value)
+            },
+            PropertyKind::Array { .. } => {
+                let values = matches
+                    .get_many::<String>(name)
+                    .map(|items| items.map(|item| Value::String(item.clone())).collect())
+                    .unwrap_or_default();
+                Value::Array(values)
+            },
+            PropertyKind::String { .. } => Value::String(required_string(matches, name)?),
+            PropertyKind::Integer { unsigned } => {
+                let raw = required_string(matches, name)?;
+                if unsigned {
+                    Value::Number(raw.parse::<u64>()?.into())
+                } else {
+                    Value::Number(raw.parse::<i64>()?.into())
+                }
+            },
+            PropertyKind::Number => {
+                let raw = required_string(matches, name)?;
+                let parsed: f64 = raw.parse()?;
+                let number = serde_json::Number::from_f64(parsed).ok_or_else(|| {
+                    anyhow::anyhow!("--{} must be a finite JSON number", cli_name(name))
+                })?;
+                Value::Number(number)
+            },
+            PropertyKind::Json => {
+                let raw = required_string(matches, name)?;
+                serde_json::from_str(&raw).map_err(|err| {
+                    anyhow::anyhow!("invalid JSON for --{}: {err}", cli_name(name))
+                })?
+            },
+        };
+        arguments.insert(name.clone(), value);
+    }
+    Ok(arguments)
+}
+
+fn required_string(matches: &ArgMatches, name: &str) -> anyhow::Result<String> {
+    matches
+        .get_one::<String>(name)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing value for --{}", cli_name(name)))
+}
+
+fn parse_json_object(flag: &str, raw: &str) -> anyhow::Result<Map<String, Value>> {
+    let value: Value = serde_json::from_str(raw)
+        .map_err(|err| anyhow::anyhow!("invalid JSON for --{flag}: {err}"))?;
+    value.as_object().cloned().ok_or_else(|| anyhow::anyhow!("--{flag} must be a JSON object"))
+}
+
+fn tool_metadata(tool_name: &str) -> Value {
+    json!({
+        "name": tool_name,
+        "description": rag_rat_mcp::tools::description(tool_name),
+        "inputSchema": rag_rat_mcp::tools::schema(tool_name),
+    })
+}
+
+fn short_description(description: &str) -> String {
+    const LIMIT: usize = 160;
+    let compact = description.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= LIMIT {
+        return compact;
+    }
+
+    let mut summary = String::new();
+    for word in compact.split_whitespace() {
+        let next_len =
+            summary.chars().count() + usize::from(!summary.is_empty()) + word.chars().count();
+        if next_len > LIMIT.saturating_sub(1) {
+            break;
+        }
+        if !summary.is_empty() {
+            summary.push(' ');
+        }
+        summary.push_str(word);
+    }
+    summary.push('…');
+    summary
+}
+
+fn canonical_tool_name(cli_spelling: &str) -> Option<&'static str> {
+    rag_rat_mcp::tools::TOOL_NAMES
+        .iter()
+        .copied()
+        .find(|name| cli_name(name) == cli_spelling || *name == cli_spelling)
+}
+
+fn cli_name(name: &str) -> String {
+    name.replace('_', "-")
+}
+
+fn compact_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> ArgMatches {
+        let mut argv = vec!["rag-rat tools"];
+        argv.extend_from_slice(args);
+        tools_command().try_get_matches_from(argv).expect("parse generated tools command")
+    }
+
+    #[test]
+    fn arguments_json_can_be_combined_with_global_output_and_config_flags() {
+        let matches = parse(&[
+            "--json",
+            "--config",
+            "/tmp/rag-rat.toml",
+            "symbol-lookup",
+            "--arguments-json",
+            r#"{"symbol":"Foo"}"#,
+        ]);
+        assert!(matches.get_flag(JSON_OUTPUT));
+        assert_eq!(
+            matches.get_one::<String>(CONFIG).map(String::as_str),
+            Some("/tmp/rag-rat.toml")
+        );
+        let (_, tool_matches) = matches.subcommand().expect("tool subcommand");
+        assert_eq!(
+            tool_matches.get_one::<String>(ARGUMENTS_JSON).map(String::as_str),
+            Some(r#"{"symbol":"Foo"}"#)
+        );
+    }
+
+    #[test]
+    fn compact_help_does_not_treat_abbreviations_as_sentence_boundaries() {
+        let description = "List edges, e.g. dependencies, and continue with more useful context \
+                           after the abbreviation.";
+        let summary = short_description(description);
+        assert!(summary.contains("dependencies"));
+        assert!(summary.contains("continue"));
+    }
+
+    #[test]
+    fn generated_command_tree_satisfies_clap_invariants() {
+        tools_command().debug_assert();
+    }
+
+    #[test]
+    fn generated_catalog_has_every_canonical_tool_as_kebab_case() {
+        let command = tools_command();
+        let names: BTreeSet<_> = command
+            .get_subcommands()
+            .filter(|cmd| cmd.get_name() != "help")
+            .map(|cmd| cmd.get_name().to_string())
+            .collect();
+        let expected: BTreeSet<_> =
+            rag_rat_mcp::tools::TOOL_NAMES.iter().map(|name| cli_name(name)).collect();
+        assert_eq!(names, expected);
+    }
+
+    #[test]
+    fn primitive_enum_array_and_boolean_flags_round_trip_to_canonical_json() {
+        let matches = parse(&[
+            "semantic-search",
+            "--query",
+            "config reload",
+            "--limit",
+            "7",
+            "--include",
+            "git,papertrail",
+            "--explain",
+        ]);
+        let (_, tool) = matches.subcommand().unwrap();
+        let arguments = arguments_from_matches("semantic_search", tool).unwrap();
+        assert_eq!(
+            Value::Object(arguments),
+            json!({
+                "query": "config reload",
+                "limit": 7,
+                "include": ["git", "papertrail"],
+                "explain": true,
+            })
+        );
+    }
+
+    #[test]
+    fn bare_array_flag_represents_an_explicit_empty_array() {
+        let matches = parse(&["symbol-lookup", "--symbol", "Thing", "--include"]);
+        let (_, tool) = matches.subcommand().unwrap();
+        let arguments = arguments_from_matches("symbol_lookup", tool).unwrap();
+        assert_eq!(arguments.get("include"), Some(&json!([])));
+    }
+
+    #[test]
+    fn non_string_arrays_fail_closed_to_json_valued_flags() {
+        let root = json!({});
+        let property = json!({"type":"array","items":{"type":"integer"}});
+        let spec = resolve_property(&root, &property);
+        assert!(matches!(spec.kind, PropertyKind::Json));
+    }
+
+    #[test]
+    fn nested_json_arguments_remain_lossless_without_a_second_nested_schema() {
+        let matches = parse(&[
+            "memory-rebind",
+            "--memory-id",
+            "mem_123",
+            "--bind",
+            r#"{"path":"src/lib.rs","start_line":4,"end_line":8}"#,
+        ]);
+        let (_, tool) = matches.subcommand().unwrap();
+        let arguments = arguments_from_matches("memory_rebind", tool).unwrap();
+        assert_eq!(
+            arguments.get("bind"),
+            Some(&json!({"path":"src/lib.rs","start_line":4,"end_line":8}))
+        );
+    }
+
+    #[test]
+    fn arguments_json_is_a_lossless_escape_hatch() {
+        let matches = parse(&[
+            "find-callers",
+            "--arguments-json",
+            r#"{"symbol":"parse_config","include":[]}"#,
+        ]);
+        let (_, tool) = matches.subcommand().unwrap();
+        let raw = tool.get_one::<String>(ARGUMENTS_JSON).unwrap();
+        assert_eq!(
+            Value::Object(parse_json_object(ARGUMENTS_JSON, raw).unwrap()),
+            json!({"symbol":"parse_config","include":[]})
+        );
+    }
+}

--- a/crates/rag-rat-cli/src/commands/tools.rs
+++ b/crates/rag-rat-cli/src/commands/tools.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use clap::builder::PossibleValuesParser;
+use clap::builder::{PossibleValuesParser, Resettable};
 use clap::error::ErrorKind;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use serde_json::{Map, Value, json};
@@ -30,12 +30,11 @@ pub(crate) fn run_tools(
     outer_json: bool,
     argv: &[String],
 ) -> anyhow::Result<()> {
-    let command = tools_command();
     let mut args = Vec::with_capacity(argv.len() + 1);
     args.push("rag-rat tools".to_string());
     args.extend(argv.iter().cloned());
 
-    let matches = match command.try_get_matches_from(args) {
+    let matches = match parse_tools(&args) {
         Ok(matches) => matches,
         Err(err) if matches!(err.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) => {
             err.print()?;
@@ -79,6 +78,23 @@ pub(crate) fn run_tools(
     let result =
         rag_rat_mcp::tools::call_tool_for_config(&config, tool_name, Value::Object(arguments))?;
     print_output(&result)
+}
+
+fn parse_tools(args: &[String]) -> Result<ArgMatches, clap::Error> {
+    let command = tools_command();
+    // Clap propagates global values after subcommand validation, so a parent-level --schema
+    // cannot waive a child's required_unless check. Defer only those checks until the schema
+    // flag is resolved; discovery still validates flag names, values, and conflicts.
+    let matches = command
+        .clone()
+        .mut_subcommands(|subcommand| {
+            subcommand.mut_args(|arg| arg.required_unless_present(Resettable::Reset))
+        })
+        .try_get_matches_from(args)?;
+    if matches.get_flag(SCHEMA) {
+        return Ok(matches);
+    }
+    command.try_get_matches_from(args)
 }
 
 /// Build the complete native command tree from the same catalog MCP advertises through
@@ -180,7 +196,7 @@ fn property_arg(root_schema: &Value, name: &str, property: &Value, required: boo
     }
 
     if required {
-        arg = arg.required_unless_present_any([ARGUMENTS_JSON, SCHEMA]);
+        arg = arg.required_unless_present(ARGUMENTS_JSON);
     }
 
     match spec.kind {
@@ -500,7 +516,8 @@ mod tests {
     fn parse(args: &[&str]) -> ArgMatches {
         let mut argv = vec!["rag-rat tools"];
         argv.extend_from_slice(args);
-        tools_command().try_get_matches_from(argv).expect("parse generated tools command")
+        let argv: Vec<String> = argv.into_iter().map(str::to_string).collect();
+        parse_tools(&argv).expect("parse generated tools command")
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -72,14 +72,18 @@ fn main() -> anyhow::Result<()> {
     configure_jemalloc();
     let cli = Cli::parse();
 
-    // Pin the process-wide output format from the global flag before any command runs, so
+    // Pin the process wide output format from the global flag before normal commands run, so
     // `print_output` renders TOON by default and JSON under `--json` without threading the format
-    // through every command signature.
-    set_output_format(if cli.json {
-        rag_rat_core::OutputFormat::Json
-    } else {
-        rag_rat_core::OutputFormat::Toon
-    });
+    // through every command signature. `tools` owns a second stage dynamic parser so flags after
+    // `tools` (including its inherited `--json`) are intentionally resolved there before the
+    // OnceLock is set.
+    if !matches!(&cli.command, Cmd::Tools(_)) {
+        set_output_format(if cli.json {
+            rag_rat_core::OutputFormat::Json
+        } else {
+            rag_rat_core::OutputFormat::Toon
+        });
+    }
 
     // These commands must tolerate the ABSENCE of a config: `init` creates one; `agent-hook`
     // reads its event from stdin; `mcp` serves a dormant server so a globally-registered MCP stays
@@ -95,6 +99,7 @@ fn main() -> anyhow::Result<()> {
         // agent-hook.
         Cmd::EditReindex(args) => return agent_hook::edit_reindex::run(&args.cwd, &args.paths),
         Cmd::Mcp => return run_mcp(cli.config.as_deref(), cli.json),
+        Cmd::Tools(args) => return run_tools(cli.config.as_deref(), cli.json, &args.args),
         Cmd::Doctor(args) => return run_doctor(args, cli.config.as_deref()),
         // `status` is a cross-repo view of the consolidated global store, so — like `doctor` — it
         // tolerates config absence: outside a rag-rat repo it still reports the machine-global
@@ -123,7 +128,8 @@ fn main() -> anyhow::Result<()> {
         | Cmd::Mcp
         | Cmd::Doctor(_)
         | Cmd::Status
-        | Cmd::Rm(_) => unreachable!("handled before the config load above"),
+        | Cmd::Rm(_)
+        | Cmd::Tools(_) => unreachable!("handled before the config load above"),
         Cmd::Index(args) => index(&config, &args)?,
         Cmd::Query(args) => query(&config, &args)?,
         Cmd::Brief(args) => brief(&config, &args)?,

--- a/crates/rag-rat-cli/tests/tools_dispatch.rs
+++ b/crates/rag-rat-cli/tests/tools_dispatch.rs
@@ -96,18 +96,52 @@ fn schema_discovery_is_configless_and_uses_the_canonical_catalog() {
     let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(actual, rag_rat_mcp::tools::list_tools());
 
-    let output = run(&["--json", "tools", "find-callers", "--schema"], &root);
-    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
-    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(actual["name"], "find_callers");
-    assert_eq!(actual["inputSchema"], rag_rat_mcp::tools::schema("find_callers"));
+    // Every tool, including those with required fields, supports either global flag position.
+    for &tool in rag_rat_mcp::tools::TOOL_NAMES {
+        let cli_name = tool.replace('_', "-");
+        for args in [["--json", "tools", "--schema", cli_name.as_str()], [
+            "--json",
+            "tools",
+            cli_name.as_str(),
+            "--schema",
+        ]] {
+            let output = run(&args, &root);
+            assert!(
+                output.status.success(),
+                "{args:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(
+                actual,
+                json!({
+                    "name": tool,
+                    "description": rag_rat_mcp::tools::description(tool),
+                    "inputSchema": rag_rat_mcp::tools::schema(tool),
+                }),
+                "{args:?}"
+            );
+        }
+    }
+}
 
-    // Schema discovery must bypass the generated required argument gate as well.
-    let output = run(&["--json", "tools", "semantic-search", "--schema"], &root);
-    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
-    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(actual["name"], "semantic_search");
-    assert_eq!(actual["inputSchema"], rag_rat_mcp::tools::schema("semantic_search"));
+#[test]
+fn schema_discovery_still_rejects_invalid_arguments() {
+    let root = unique_dir("cli_tools_schema_invalid");
+    fs::create_dir_all(&root).unwrap();
+
+    for args in [
+        vec!["tools", "--schema", "unknown-tool"],
+        vec!["tools", "--schema", "semantic-search", "--unknown-flag"],
+        vec!["tools", "semantic-search", "--schema", "--unknown-flag"],
+        vec!["tools", "--schema", "semantic-search", "--include", "invalid"],
+        vec!["tools", "--schema", "semantic-search", "--query"],
+        vec!["tools", "--schema", "semantic-search", "--query", "text", "--arguments-json", "{}"],
+    ] {
+        let output = run(&args, &root);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+    }
 }
 
 #[test]
@@ -153,8 +187,14 @@ fn required_schema_fields_are_required_by_the_generated_cli() {
     let root = unique_dir("cli_tools_required");
     fs::create_dir_all(&root).unwrap();
 
-    let output = run(&["tools", "semantic-search"], &root);
-    assert!(!output.status.success());
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("--query"), "unexpected stderr: {stderr}");
+    for args in [
+        vec!["tools", "semantic-search"],
+        vec!["tools", "--config=--schema", "semantic-search"],
+        vec!["tools", "semantic-search", "--config=--schema"],
+    ] {
+        let output = run(&args, &root);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains("--query"), "{args:?}: {stderr}");
+    }
 }

--- a/crates/rag-rat-cli/tests/tools_dispatch.rs
+++ b/crates/rag-rat-cli/tests/tools_dispatch.rs
@@ -1,0 +1,160 @@
+//! End to end coverage for the native CLI projection of the MCP tool catalog.
+//!
+//! The public surface is `rag-rat tools <tool> ...`; command names and flags are generated
+//! from the canonical catalog and schema, while execution still uses the same dispatcher by name
+//! as MCP. Help and schema discovery must work without a configured repository.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use rag_rat_base::config::Config;
+use serde_json::{Value, json};
+
+mod common;
+
+use common::{ScratchRoot, unique_dir};
+
+fn build_index() -> (ScratchRoot, Config, PathBuf) {
+    let root = unique_dir("cli_tools_dispatch");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\npub fn close_database() {}\n")
+        .unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let config_path = root.join("rag-rat.toml");
+    let config = Config::load(&config_path).unwrap();
+    rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+    (root, config, config_path)
+}
+
+fn run(args: &[&str], cwd: &std::path::Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rag-rat")).args(args).current_dir(cwd).output().unwrap()
+}
+
+#[test]
+fn tools_help_is_configless_and_lists_the_complete_generated_catalog() {
+    let root = unique_dir("cli_tools_help");
+    fs::create_dir_all(&root).unwrap();
+
+    let output = run(&["tools", "--help"], &root);
+    assert!(
+        output.status.success(),
+        "tools --help failed outside a configured repo: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for tool in rag_rat_mcp::tools::TOOL_NAMES {
+        let cli_name = tool.replace('_', "-");
+        assert!(stdout.contains(&cli_name), "missing generated command {cli_name}:\n{stdout}");
+    }
+    assert!(stdout.contains("does not start an MCP server or client"));
+}
+
+#[test]
+fn tools_namespace_preserves_global_version_behavior() {
+    let root = unique_dir("cli_tools_version");
+    fs::create_dir_all(&root).unwrap();
+
+    let output = run(&["tools", "--version"], &root);
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")), "unexpected stdout: {stdout}");
+}
+
+#[test]
+fn per_tool_help_is_generated_from_the_canonical_schema() {
+    let root = unique_dir("cli_tools_subcommand_help");
+    fs::create_dir_all(&root).unwrap();
+
+    let output = run(&["tools", "find-callers", "--help"], &root);
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for flag in ["--symbol", "--resolution", "--limit", "--include", "--edge-kinds", "--worktree"] {
+        assert!(stdout.contains(flag), "missing generated flag {flag}:\n{stdout}");
+    }
+    assert!(stdout.contains("reverse call graph"));
+
+    let output = run(&["tools", "help", "find-callers"], &root);
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Usage: rag-rat tools find-callers"));
+    assert!(stdout.contains("--edge-kinds"));
+}
+
+#[test]
+fn schema_discovery_is_configless_and_uses_the_canonical_catalog() {
+    let root = unique_dir("cli_tools_schema");
+    fs::create_dir_all(&root).unwrap();
+
+    let output = run(&["--json", "tools", "--schema"], &root);
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(actual, rag_rat_mcp::tools::list_tools());
+
+    let output = run(&["--json", "tools", "find-callers", "--schema"], &root);
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(actual["name"], "find_callers");
+    assert_eq!(actual["inputSchema"], rag_rat_mcp::tools::schema("find_callers"));
+
+    // Schema discovery must bypass the generated required argument gate as well.
+    let output = run(&["--json", "tools", "semantic-search", "--schema"], &root);
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(actual["name"], "semantic_search");
+    assert_eq!(actual["inputSchema"], rag_rat_mcp::tools::schema("semantic_search"));
+}
+
+#[test]
+fn native_tool_invocation_matches_the_canonical_dispatcher() {
+    let (_root, config, config_path) = build_index();
+    let arguments = json!({"symbol": "open_database", "limit": 5});
+    let expected =
+        rag_rat_mcp::tools::call_tool_for_config(&config, "symbol_lookup", arguments).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--json", "tools", "symbol-lookup", "--symbol", "open_database", "--limit", "5"])
+        .arg("--config")
+        .arg(&config_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn arguments_json_preserves_the_full_wire_shape() {
+    let (_root, config, config_path) = build_index();
+    let arguments = json!({"symbol":"open_database","include":[],"limit":5});
+    let expected =
+        rag_rat_mcp::tools::call_tool_for_config(&config, "symbol_lookup", arguments.clone())
+            .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .arg("--config")
+        .arg(&config_path)
+        .args(["--json", "tools", "symbol-lookup", "--arguments-json"])
+        .arg(arguments.to_string())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn required_schema_fields_are_required_by_the_generated_cli() {
+    let root = unique_dir("cli_tools_required");
+    fs::create_dir_all(&root).unwrap();
+
+    let output = run(&["tools", "semantic-search"], &root);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("--query"), "unexpected stderr: {stderr}");
+}

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -52,12 +52,51 @@ specific profile, and `rag-rat mcp --json` switches tool results from TOON to JS
 To run from a checkout without installing, use a project-scoped server whose command is
 `cargo run --manifest-path /path/to/rag-rat/Cargo.toml --bin rag-rat -- mcp`.
 
+## Native CLI
+
+MCP is one way to expose the catalog, but it is not required to use it. The same tools are also
+available as ordinary CLI subcommands for shells, CI, agents, and subprocess automation:
+
+```bash
+rag-rat tools semantic-search --query "config reload" --limit 5
+rag-rat tools find-callers --symbol parse_config --limit 20
+rag-rat --json tools impact-surface --symbol parse_config
+```
+
+The native surface is generated from the same canonical catalog and JSON schemas served by MCP
+`tools/list`. Execution calls the same `call_tool_for_config` path used by MCP `tools/call`, directly
+in the current process. No MCP server or client is started, and there is no second set of handlers or
+argument definitions. Existing curated top level commands such as `query`, `brief`, `memory`, and
+`dream` remain unchanged. `tools` exposes every catalog entry.
+
+Tool names and argument names use normal CLI kebab case (`find_callers` becomes `find-callers`,
+`full_memories` becomes `--full-memories`). Discovery follows the normal CLI help model:
+
+```bash
+rag-rat tools --help
+rag-rat tools find-callers --help
+```
+
+Machine readable discovery is available without a repository config:
+
+```bash
+rag-rat --json tools --schema
+rag-rat --json tools find-callers --schema
+```
+
+Actual invocations use normal `rag-rat.toml` discovery or the global `--config`. Primitive, enum,
+boolean, and string or enum array fields become native flags. String and enum arrays accept repeated
+or comma separated values. A bare array flag represents an explicit empty list. Nested, polymorphic,
+or otherwise complex values stay as JSON arguments. Callers that need the exact canonical object can
+use `--arguments-json '<object>'`.
+
 ## Tools
 
-The MCP surface is **47 tools** in nine groups. The signatures are below; the prose sections that
-follow describe response shapes and per-tool behavior. Every read tool additionally accepts an
-optional `"worktree": string` — an absolute path to a linked git worktree, served as a branch
-overlay over the indexed checkout — omitted from the signatures below for brevity. The write tools
+The catalog is **47 tools** in nine groups. The signatures below use canonical MCP snake_case.
+The native CLI exposes the same names in kebab case under `rag-rat tools` and derives its flags from
+the same schemas. Every read tool also accepts an optional `"worktree": string`, an absolute path to
+a linked git worktree served as a branch overlay over the indexed checkout. It is omitted from the
+signatures below for brevity. The write tools
 and `compare_graph_to_text` do not: they stay scoped to the indexed checkout, so they neither
 declare the parameter nor honor one.
 
@@ -168,14 +207,12 @@ used by the handlers. Existing tool names and response fields are kept stable fo
 
 ### Response encoding (TOON)
 
-Tool **results** are returned as **TOON** (Token-Oriented Object Notation), not JSON. TOON is a
-token-efficient text encoding that renders uniform result rows (caller lists, symbol candidates,
-clusters) as a dense `[N]{cols}:` table — measured ~30% smaller than compact JSON on those payloads,
-and never larger in practice (it ties compact JSON on nested shapes). Because MCP results are text
-content consumed by an LLM, the denser encoding is both valid and cheaper. There is no per-call flag;
-MCP output is always TOON. The JSON snippets below describe the **logical shape** of each response —
-the same fields, just shown in JSON for readability. (The `rag-rat` CLI mirrors this: it defaults to
-TOON and takes a global `--json` flag for JSON output.)
+Tool **results** default to **TOON**, not JSON. TOON renders
+uniform result rows such as callers, symbol candidates, and clusters as dense `[N]{cols}:` tables.
+On those payloads it measured about 30% smaller than compact JSON and was never larger in practice.
+MCP has no per call format flag, so launch `rag-rat mcp --json` when the client requires JSON. Native
+`rag-rat tools <name>` follows the CLI format setting: TOON by default and JSON with `--json`. The
+snippets below show the logical response shapes in JSON for readability.
 
 `symbol_lookup` is the candidate-selection step for symbol-shaped tools. It returns:
 


### PR DESCRIPTION
## Summary

This PR exposes the full rag-rat tool catalog under `rag-rat tools`.

```bash
rag-rat tools semantic-search --query "config reload" --limit 5
rag-rat tools find-callers --symbol parse_config
rag-rat tools impact-surface --symbol parse_config
```

The CLI is generated from the same canonical tool catalog and JSON schemas used by MCP. It reuses the existing `call_tool_for_config(...)` dispatcher. No MCP client, MCP server, daemon, or duplicate handler layer is added.

Tool and argument names are projected to kebab case. Primitive fields become normal CLI flags. Arrays support repeated or comma separated values. Complex values stay JSON. `--arguments-json` is available for passing the exact canonical argument object.

This makes the full tool surface usable from shells, CI, subprocess based agents, and other environments that do not use or want MCP.

```bash
rag-rat tools --help
rag-rat tools find-callers --help
rag-rat --json tools --schema
rag-rat --json tools find-callers --schema
```

Existing curated commands such as `query`, `brief`, `memory`, and `dream` are unchanged.

Validation: `cargo build`, 5275 workspace tests passed with 7 skipped, `cargo clippy --all-targets -- -D warnings`, and nightly `cargo fmt --all -- --check`.
