### PR TITLE
fix(sync): clear the drain watermarks when a repository is purged

### DIFF
--- a/crates/rag-rat-core/src/contributor_authoring_tests.rs
+++ b/crates/rag-rat-core/src/contributor_authoring_tests.rs
@@ -227,6 +227,41 @@ fn a_contributors_rebind_reaches_the_owners_creating_device() {
     assert_eq!(paths, vec!["src/new.rs".to_string()]);
 }
 
+/// Removing a repository and initializing it again brings its synced memories back: they are
+/// materialized from the stream's projection, which the removal leaves in place.
+#[test]
+fn a_repository_removed_and_initialized_again_gets_its_synced_memories_back() {
+    let conn = scoped_conn();
+    local_account(&conn, NOW).unwrap();
+    create_memory(&conn, concept("own-note")).unwrap();
+    let own_stream = rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap();
+    plant_projected_node(&conn, own_stream, "sibling", "sibling-note");
+    crate::drain_synced_memory(&conn).unwrap();
+    assert!(synced_memory_titles(&conn).contains(&"sibling-note".to_string()));
+
+    // `rag-rat rm`: purge and tombstone in one transaction.
+    let tx = conn.unchecked_transaction().unwrap();
+    rag_rat_db::schema::purge_repo_rows(&tx, REPO).unwrap();
+    rag_rat_db::schema::mark_repo_removed(&tx, REPO, NOW).unwrap();
+    tx.commit().unwrap();
+    assert!(memory_titles(&conn).is_empty());
+
+    // `rag-rat init`: clear the tombstone and register the repository again.
+    rag_rat_db::schema::clear_repo_removed(&conn, REPO).unwrap();
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+        [REPO],
+    )
+    .unwrap();
+    crate::drain_synced_memory(&conn).unwrap();
+
+    assert!(
+        synced_memory_titles(&conn).contains(&"sibling-note".to_string()),
+        "{:?}",
+        memory_titles(&conn),
+    );
+}
+
 /// EXACTLY ONE stream materializes a repo. A contributor's own owned stream is NOT it — nothing is
 /// ever authored there, so its projection is a rival authority whose removal anti-join reads every
 /// row the owner's stream materialized as condemned. Draining both would delete the owner's

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -413,6 +413,17 @@ pub fn purge_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
         conn.execute(&format!("DELETE FROM \"{table}\" WHERE repo_id = ?1"), params![repo_id])?;
     }
 
+    // A synced memory is materialized from its content stream's projection, which is store-global
+    // and survives this purge, and the memory drain walks a stream only when its projection moved
+    // past the drain's watermark. Left alone, a repository registered again would never get its
+    // synced memories back until their author published something new. The watermarks only let
+    // the drain skip unchanged streams, so dropping them costs each stream one full pass.
+    // ponytail: clears every stream's watermark, not just this repo's (purge cannot name a repo's
+    // content streams from this crate); scope it if purges ever become frequent.
+    if crate::schema::table_exists(conn, "oplog_meta")? {
+        conn.execute("DELETE FROM oplog_meta WHERE key LIKE 'content:drain-wm:%'", [])?;
+    }
+
     // commit_fts is external-content on git_commits, now desynced by the git-commit delete above.
     // 'rebuild' re-derives it from the remaining commits (all repos) — the desync-safe fixup.
     rebuild_commit_fts(conn)?;


### PR DESCRIPTION
Fixes #1283.

## Problem

A synced memory is materialized from its content stream's projection (`content_projected_nodes`), which is store-global and survives `rag-rat rm`. The memory drain walks a stream only when `content_drain_needed` reports that its projection moved past the drain's watermark (`content:drain-wm:<stream>` in `oplog_meta`). `purge_repo_rows` deleted the repository's memory rows but left the watermarks, and nothing cleared them when the repository was registered again — so after `rm` and a fresh `init` the synced memories stayed missing until their author happened to publish something new on that stream.

## Fix

`purge_repo_rows` clears the content drain watermarks. They exist only to let the drain skip unchanged streams, so dropping them costs each stream one full drain pass and nothing else. It clears every stream's watermark rather than just this repository's: the purge lives in the schema crate and cannot name a repository's content streams, and purges are rare. The removal tombstone is untouched, so a drain racing the purge still refuses to resurrect the purged rows.

## Verification

- `a_repository_removed_and_initialized_again_gets_its_synced_memories_back`: a sibling device's memory drained from the owner stream, then the real purge plus tombstone (`rag-rat rm`), then clearing the tombstone and registering again (`init`) — the synced memory comes back on the next drain. Without the watermark clear it stays missing.
- `cargo nextest run --workspace --no-default-features`, `cargo test --workspace --no-default-features` (including doctests), clippy with `--no-default-features` / `--all-features` / `--features eval` (with and without default features) at `-D warnings`, and nightly `fmt --check`.