### PR TITLE
test(base): hold the data-dir env lock in the config tests that read the global store path

### DIFF
--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -350,6 +350,7 @@ fn git_commit_all(dir: &Path) {
 /// so this never touches a developer's real global store.
 #[test]
 fn config_load_without_a_database_key_resolves_to_the_global_database() {
+    let _env = crate::data_dir::env_guard();
     let tmp = scratch("globaldb");
     std::fs::create_dir_all(tmp.join("src")).unwrap();
     std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
@@ -746,6 +747,7 @@ fn config_load_governs_from_main_even_when_a_branch_only_root_defeats_anchoring(
 /// environment (no env mutation ⇒ parallel-safe); `load` only resolves, never writes there.
 #[test]
 fn config_load_refuses_an_identity_less_pin_at_the_global_store() {
+    let _env = crate::data_dir::env_guard();
     let Some(global) = crate::data_dir::global_database_path() else {
         return; // no resolvable data dir on this platform — the gate cannot trigger
     };
@@ -859,6 +861,7 @@ fn config_load_anchors_the_database_key_to_the_main_worktree() {
 /// imports and renames it, after which resolution falls through to the global store.
 #[test]
 fn config_load_without_a_database_key_prefers_an_existing_legacy_index() {
+    let _env = crate::data_dir::env_guard();
     let tmp = scratch("legacydb");
     std::fs::create_dir_all(tmp.join("src")).unwrap();
     std::fs::create_dir_all(tmp.join(".rag-rat")).unwrap();
@@ -908,6 +911,7 @@ fn config_load_without_a_database_key_prefers_an_existing_legacy_index() {
 /// commit mints a real id. Two identity-less roots therefore NEVER share a database.
 #[test]
 fn config_load_without_a_database_key_stays_per_root_for_identity_less_roots() {
+    let _env = crate::data_dir::env_guard();
     let keyless_config = |tag: &str| {
         let tmp = scratch(&format!("noident-{tag}"));
         std::fs::create_dir_all(tmp.join("src")).unwrap();

--- a/crates/rag-rat-base/src/data_dir.rs
+++ b/crates/rag-rat-base/src/data_dir.rs
@@ -47,25 +47,29 @@ pub fn global_database_path() -> Option<PathBuf> {
     data_dir().map(|dir| dir.join("rag-rat.sqlite"))
 }
 
+/// Serializes every test that reads or writes the data-dir cascade variables. `set_var` /
+/// `remove_var` mutate PROCESS-global state, so under a thread-based runner (`cargo test`) a test
+/// that reads [`data_dir`] while another rewrites the variables flakes; nextest's
+/// process-per-test isolation hides it, and the lock keeps both runners honest. Hold the guard for
+/// the whole test.
+#[cfg(test)]
+pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, PoisonError};
-
     use super::*;
-
-    /// Serializes the env-mutating tests. `set_var`/`remove_var` mutate PROCESS-global state, so
-    /// under a thread-based runner (`cargo test`) two of these racing would flake; nextest's
-    /// process-per-test isolation makes it moot there, but the mutex keeps both runners honest.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// Run `body` with the four cascade vars forced to `values` (`None` = removed), restoring the
     /// prior environment afterward so tests never leak state into each other.
     fn with_env(values: &[(&str, Option<&str>)], body: impl FnOnce()) {
         const KEYS: [&str; 4] = ["RAG_RAT_DATA_DIR", "XDG_DATA_HOME", "HOME", "APPDATA"];
-        let _guard = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        let _guard = env_guard();
         let saved: Vec<(&str, Option<String>)> =
             KEYS.iter().map(|&key| (key, std::env::var(key).ok())).collect();
-        // SAFETY: env access is serialized by ENV_LOCK for the duration of this call.
+        // SAFETY: env access is serialized by `env_guard` for the duration of this call.
         unsafe {
             for &key in &KEYS {
                 std::env::remove_var(key);


### PR DESCRIPTION
## Problem

`config_load_without_a_database_key_resolves_to_the_global_database` (`crates/rag-rat-base/src/config/tests.rs`) failed intermittently under plain `cargo test`. The data-dir tests (`crates/rag-rat-base/src/data_dir.rs`) rewrite `RAG_RAT_DATA_DIR`, `XDG_DATA_HOME` and `HOME` under a lock private to their test module, while four config tests resolve `global_database_path()` from those same variables without taking it. With a thread-based runner, a data-dir test could rewrite them between a config load and the expected path. Nextest's process-per-test isolation hid the race, which is why CI stayed green.

## Fix

The lock becomes a crate-level test helper, `data_dir::env_guard()`, used by the data-dir tests' `with_env` and held for the whole body of every config test that reads the cascade. Test-only; no production change.

## Verification

- `cargo test -p rag-rat-base --no-default-features` three times in a row, and `cargo nextest run -p rag-rat-base`: all 231 pass.
- clippy `--all-targets --all-features -D warnings` on `rag-rat-base`, nightly `fmt --check`.