### PR TITLE
fix(oplog): never compact away an entry that still carries a row

### DIFF
--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -815,8 +815,8 @@ pub(crate) fn stale_row_disposition(
         return Ok(StaleRow::Unknown);
     };
     let Some(op) = super::store::winning_entry_op(tx, stream, &device_hex, lamport)? else {
-        // The entry is gone. Nothing prunes today; when retention lands it must refresh a row
-        // before dropping that row's winner, or this arm becomes a permanent stale state.
+        // The entry is gone. Retention never drops a live winner (the pin rule, #1277), so only a
+        // store compacted before that rule reaches this arm — and re-authoring repairs it.
         return Ok(StaleRow::Unknown);
     };
     // The entry is located by `(stream, device, lamport)`, which identifies it uniquely WITHIN a

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -216,56 +216,35 @@ pub(crate) fn process_readoption_work_for_stream(
         else {
             continue;
         };
-        let op = match readoption_repair_op(tx, ctx, spec, stream, &candidate.row_pk, &removed_hex)?
-        {
-            ReadoptionRepair::Skip => continue,
-            ReadoptionRepair::Unrepairable => {
-                unrepairable += 1;
-                continue;
-            },
-            ReadoptionRepair::Repair(op) => op,
+        let op =
+            match row_repair_op(tx, ctx.repo_id, spec, stream, &candidate.row_pk, &removed_hex)? {
+                RowRepair::Skip => continue,
+                RowRepair::Unrepairable => {
+                    unrepairable += 1;
+                    continue;
+                },
+                RowRepair::Repair(op) => op,
+            };
+        let Some(adopted_entry_hash) = author_repair(tx, ctx, spec, stream, &op, "re-adoption")?
+        else {
+            unrepairable += 1;
+            continue;
         };
-        let signed = store::author_row_entry(tx, stream, ctx.device.secret(), &op, ctx.now_ms)?;
-        let meta =
-            OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
-        match apply::apply_row_op_on_stream(tx, spec, ctx.repo_id, stream, &op, meta)? {
-            ApplyOutcome::Applied => {
-                store::record_readoption_audit(tx, store::ReadoptionAudit {
-                    account_id: ctx.account_id,
-                    removed,
-                    adopter: ctx.device.fingerprint(),
-                    stream,
-                    repo_id: context.repo_id.clone(),
-                    scope_id: context.scope_id.clone(),
-                    table_name: spec.name.to_string(),
-                    row_pk: candidate.row_pk.clone(),
-                    original_lamport: candidate.original_lamport,
-                    original_entry_hash: candidate.entry_hash,
-                    adopted_entry_hash: signed.entry.entry_hash,
-                    adopted_at_ms: ctx.now_ms,
-                })?;
-                authored += 1;
-            },
-            ApplyOutcome::Superseded => {
-                // Same diagnosis as the produce path: a locally-authored op takes the stream's
-                // MAX(lamport)+1, so losing its own self-apply means the row's clock carries a
-                // lamport from ANOTHER stream — the shape a scope or account move leaves behind.
-                // Swallowing it would mark the removal complete with the orphan unrepaired and no
-                // retry left. Fail the pass instead: the work item stays pending and the rollback
-                // drops the just-inserted entry.
-                anyhow::bail!(
-                    "table-sync: a re-adoption op lost its own self-apply on `{}` — the row's \
-                     write clock carries a lamport from another stream",
-                    spec.name
-                );
-            },
-            outcome @ (ApplyOutcome::Quarantined(_) | ApplyOutcome::Unprojectable(_)) => {
-                anyhow::bail!(
-                    "table-sync: a re-adoption op did not self-apply on `{}`: {outcome:?}",
-                    spec.name
-                );
-            },
-        }
+        store::record_readoption_audit(tx, store::ReadoptionAudit {
+            account_id: ctx.account_id,
+            removed,
+            adopter: ctx.device.fingerprint(),
+            stream,
+            repo_id: context.repo_id.clone(),
+            scope_id: context.scope_id.clone(),
+            table_name: spec.name.to_string(),
+            row_pk: candidate.row_pk.clone(),
+            original_lamport: candidate.original_lamport,
+            original_entry_hash: candidate.entry_hash,
+            adopted_entry_hash,
+            adopted_at_ms: ctx.now_ms,
+        })?;
+        authored += 1;
     }
     if unrepairable > 0 {
         // A row the pass cannot carry today is NOT written off: completing here would abandon it
@@ -285,63 +264,145 @@ pub(crate) fn process_readoption_work_for_stream(
     Ok(Some(authored))
 }
 
-/// What the drain can do with one candidate row.
-enum ReadoptionRepair {
-    /// Re-author this op under the local key.
-    Repair(RowOp),
-    /// Nothing owed: the row is settled under another writer, or physically consistent with its
-    /// merge state (an absent row under a live clock is the producer's `Remove` to author, not
-    /// this pass's).
-    Skip,
-    /// The physical row exists but a synced column cannot be read as its declared type. NOT
-    /// abandoned: the work item stays pending so a pass after the cell is repaired still
-    /// converges the fresh replica.
-    Unrepairable,
+/// Re-author the oldest `pins` of this device's own chain at its tail, in order, so compaction can
+/// drop the entries that carried them (#1277). Stops at the first pin that cannot be carried today
+/// and returns how many leading pins moved; the rest still pin. A pin cannot be carried while its
+/// physical row disagrees with its merge state (the producer owes that row), a synced column is
+/// unreadable, an accepted entry this binary cannot apply yet sits above it, or its re-signed
+/// entry would not fit the transport limit.
+///
+/// A re-authored pin is a NEW write of the row's current cells. It competes under LWW with any
+/// concurrent edit to the same row this device has not received yet, and can win it — the same
+/// cost re-adoption accepts when it re-authors a removed writer's rows.
+pub(crate) fn reauthor_chain_pins(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+    scope_id: &str,
+    stream: crate::stream::StreamId,
+    pins: &[super::retention::Pin],
+) -> anyhow::Result<usize> {
+    if pins.is_empty() {
+        return Ok(0);
+    }
+    // Never author into a store a NEWER projector folded (the producer's gate).
+    refold::assert_projector_not_newer(tx)?;
+    let device_hex = ctx.device.fingerprint().to_string();
+    for (moved, pin) in pins.iter().enumerate() {
+        let Some(spec) = ctx
+            .registry
+            .iter()
+            .find(|spec| spec.scope_id == scope_id && spec.name == pin.table_name)
+        else {
+            return Ok(moved);
+        };
+        let RowRepair::Repair(op) =
+            row_repair_op(tx, ctx.repo_id, spec, stream, &pin.row_pk, &device_hex)?
+        else {
+            return Ok(moved);
+        };
+        if author_repair(tx, ctx, spec, stream, &op, "compaction")?.is_none() {
+            return Ok(moved);
+        }
+    }
+    Ok(pins.len())
 }
 
-/// The physical-table repair for one still-orphaned candidate row.
-fn readoption_repair_op(
+/// Sign `op` under the local key and self-apply it, returning the new entry's hash — `None`, with
+/// nothing stored, when the re-signed entry would not fit the transport limit (the row stays
+/// where it is). A repair that does not self-apply cleanly is a failure, never a settlement: the
+/// caller rolls back and the just-inserted entry goes with it.
+fn author_repair(
     tx: &Transaction<'_>,
     ctx: &SyncCtx<'_>,
     spec: &TableSpec,
     stream: crate::stream::StreamId,
+    op: &RowOp,
+    what: &str,
+) -> anyhow::Result<Option<[u8; 32]>> {
+    let Some(signed) =
+        store::author_row_entry_if_it_fits(tx, stream, ctx.device.secret(), op, ctx.now_ms)?
+    else {
+        return Ok(None);
+    };
+    let meta = OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
+    match apply::apply_row_op_on_stream(tx, spec, ctx.repo_id, stream, op, meta)? {
+        ApplyOutcome::Applied => Ok(Some(signed.entry.entry_hash)),
+        // Same diagnosis as the produce path: a locally-authored op takes the stream's
+        // MAX(lamport)+1, so losing its own self-apply means the row's clock carries a lamport
+        // from ANOTHER stream — the shape a scope or account move leaves behind. Swallowing it
+        // would record the repair done with the row unrepaired and no retry left.
+        ApplyOutcome::Superseded => anyhow::bail!(
+            "table-sync: a {what} op lost its own self-apply on `{}` — the row's write clock \
+             carries a lamport from another stream",
+            spec.name
+        ),
+        outcome @ (ApplyOutcome::Quarantined(_) | ApplyOutcome::Unprojectable(_)) => {
+            anyhow::bail!(
+                "table-sync: a {what} op did not self-apply on `{}`: {outcome:?}",
+                spec.name
+            )
+        },
+    }
+}
+
+/// What a repair pass can do with one row it wants to carry under the local key.
+enum RowRepair {
+    /// Re-author this op under the local key.
+    Repair(RowOp),
+    /// Nothing to carry: the row is settled under another writer, or physically inconsistent with
+    /// its merge state (an absent row under a live clock is the producer's `Remove` to author).
+    Skip,
+    /// The row cannot be carried today: a synced column cannot be read as its declared type, or an
+    /// accepted entry this binary cannot apply yet sits above the winner. Retried later, never
+    /// written off.
+    Unrepairable,
+}
+
+/// The physical-table repair for one row while `winner_hex` still owns its merge state.
+fn row_repair_op(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    spec: &TableSpec,
+    stream: crate::stream::StreamId,
     row_pk: &str,
-    removed_hex: &str,
-) -> anyhow::Result<ReadoptionRepair> {
-    let clock = apply::row_clock_winner_on_stream(tx, stream, ctx.repo_id, spec.name, row_pk)?;
-    let tombstone = apply::tombstone_winner_on_stream(tx, stream, ctx.repo_id, spec.name, row_pk)?;
-    Ok(match (clock, tombstone) {
-        // A live clock and a tombstone can only coexist with the clock newer: a remove raises the
-        // tombstone at its own lamport, and a remove that BEATS the clock clears the clock. So a
-        // live clock always owns the row; re-adopt it while the removed writer is that winner.
-        // What the PHYSICAL row allows decides the repair: carried (re-author), absent (the
-        // producer's Remove owns it), or unreadable (stay pending until repaired).
-        (Some((_, winner)), _) if winner == removed_hex => {
-            let pk = row_op::row_pk_values(row_pk)?;
-            match apply::read_synced_cells(tx, spec, &pk)? {
-                apply::SyncedRow::Cells(cells) => ReadoptionRepair::Repair(RowOp::Upsert {
-                    table: spec.name.to_string(),
-                    spec_version: spec.spec_version,
-                    pk,
-                    cells,
-                }),
-                apply::SyncedRow::Absent => ReadoptionRepair::Skip,
-                apply::SyncedRow::Unreadable(_) => ReadoptionRepair::Unrepairable,
-            }
-        },
-        // A tombstone with no live clock owns the deletion. Re-adopt it only while no physical
-        // row exists; otherwise a live local row would be destroyed by a stale repair.
-        (None, Some((_, winner))) if winner == removed_hex => {
-            let pk = row_op::row_pk_values(row_pk)?;
-            match apply::read_synced_cells(tx, spec, &pk)? {
-                apply::SyncedRow::Absent =>
-                    ReadoptionRepair::Repair(apply::readopt_remove(spec, row_pk)?),
-                apply::SyncedRow::Cells(_) => ReadoptionRepair::Skip,
-                apply::SyncedRow::Unreadable(_) => ReadoptionRepair::Unrepairable,
-            }
-        },
-        _ => ReadoptionRepair::Skip,
-    })
+    winner_hex: &str,
+) -> anyhow::Result<RowRepair> {
+    let clock = apply::row_clock_winner_on_stream(tx, stream, repo_id, spec.name, row_pk)?;
+    let tombstone = apply::tombstone_winner_on_stream(tx, stream, repo_id, spec.name, row_pk)?;
+    // A live clock and a tombstone can only coexist with the clock newer: a remove raises the
+    // tombstone at its own lamport, and a remove that BEATS the clock clears the clock. So a live
+    // clock always owns the row, and a tombstone owns the deletion only without one.
+    let (winner_lamport, live) = match (clock, tombstone) {
+        (Some((lamport, winner)), _) if winner == winner_hex => (lamport, true),
+        (None, Some((lamport, winner))) if winner == winner_hex => (lamport, false),
+        _ => return Ok(RowRepair::Skip),
+    };
+    // What the PHYSICAL row allows decides the repair. A live winner is carried while its row is
+    // (an absent one is the producer's Remove to author); a deletion is carried only while no row
+    // exists, or a live local row would be destroyed by a stale repair.
+    let pk = row_op::row_pk_values(row_pk)?;
+    let repair = match (live, apply::read_synced_cells(tx, spec, &pk)?) {
+        (true, apply::SyncedRow::Cells(cells)) => RowRepair::Repair(RowOp::Upsert {
+            table: spec.name.to_string(),
+            spec_version: spec.spec_version,
+            pk,
+            cells,
+        }),
+        (false, apply::SyncedRow::Absent) =>
+            RowRepair::Repair(apply::readopt_remove(spec, row_pk)?),
+        (_, apply::SyncedRow::Unreadable(_)) => RowRepair::Unrepairable,
+        _ => RowRepair::Skip,
+    };
+    // A repair is signed at the stream tail, above every accepted entry. One retained for replay
+    // above the winner (a newer spec version during a rolling upgrade) may be a newer write to
+    // this very row: peers that understand it have applied it, and the repair would beat it there
+    // with the stale cells. Hold the repair until that entry replays.
+    if matches!(repair, RowRepair::Repair(_))
+        && store::pending_entry_at_or_above(tx, stream, winner_lamport)?
+    {
+        return Ok(RowRepair::Unrepairable);
+    }
+    Ok(repair)
 }
 
 /// **The caller MUST roll back on `Err`.** Everything here runs in the caller's transaction and
@@ -864,6 +925,79 @@ mod tests {
         enroll_writer(&d.conn, AccountId::from_bytes([42; 32]), c.local.fingerprint());
         assert_eq!(d.ingest_all(&reauthored, &c.pubkey()), vec![IngestOutcome::Applied]);
         assert_eq!(d.title().as_deref(), Some("distilled"));
+    }
+
+    /// A re-adoption is signed at the stream tail. An accepted entry this binary cannot apply yet,
+    /// above the removed writer's winner, may be a newer write to that row — re-adopting over it
+    /// would overwrite it on up-to-date peers — so the work waits until the entry replays.
+    #[test]
+    fn readoption_waits_while_a_parked_newer_write_sits_above_the_winner() {
+        let mut a = Device::new();
+        let mut c = Device::new();
+        let account = AccountId::from_bytes([42; 32]);
+        let stream = scope_stream_id("repo", account, [0x44; 32], "demo/1");
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'distilled')", []).unwrap();
+        let entry = a.produce();
+        enroll_writer(&c.conn, account, a.pubkey().fingerprint());
+        enroll_writer(&c.conn, account, c.local.fingerprint());
+        assert_eq!(c.ingest_all(&entry, &a.pubkey()), vec![IngestOutcome::Applied]);
+        remove_writer(&c.conn, account, a.pubkey().fingerprint());
+        c.conn
+            .execute(
+                "INSERT INTO table_sync_entries(
+                     entry_hash, stream_id, device_fingerprint, lamport, signed_bytes,
+                     received_at_ms, pending_reason
+                 ) VALUES (x'77', ?1, ?2, 3, x'00', 0, 'newer_spec_version')",
+                rusqlite::params![stream.to_bytes().as_slice(), [2u8; 32].as_slice()],
+            )
+            .unwrap();
+        {
+            let tx = c.conn.transaction().unwrap();
+            store::enqueue_readoption_work(
+                &tx,
+                account,
+                a.pubkey().fingerprint(),
+                stream,
+                [7; 32],
+                9,
+                10,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        let drain = |c: &mut Device| {
+            let tx = c.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                incarnation_ref: [0x44; 32],
+                device: &c.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            let processed = process_readoption_work_for_stream(&tx, &ctx, stream).unwrap();
+            tx.commit().unwrap();
+            processed
+        };
+
+        assert_eq!(drain(&mut c), None, "the removal cannot drain past the parked write");
+        let own: i64 = c
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM table_sync_entries WHERE device_fingerprint = ?1",
+                [c.local.fingerprint().to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(own, 0, "nothing was re-authored over it");
+
+        c.conn
+            .execute(
+                "UPDATE table_sync_entries SET pending_reason = NULL WHERE entry_hash = x'77'",
+                [],
+            )
+            .unwrap();
+        assert_eq!(drain(&mut c), Some(1), "once it replays, the row is re-adopted");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/table_sync/retention.rs
+++ b/crates/rag-rat-oplog/src/table_sync/retention.rs
@@ -2,10 +2,17 @@
 //! a recorded floor (#1127).
 //!
 //! Anchors/1 launches fully retained; the first high-churn scope cannot. Compaction here drops
-//! accepted entries with `lamport < floor` for ONE device chain, after refreshing every row whose
-//! LWW winner is one of those entries — the hard constraint from #1020: without the refresh,
-//! every such row's next producer pass takes the stale-version winner lookup, finds the entry
-//! gone, reads `StaleRow::Unknown`, and the whole table re-authors at once.
+//! accepted entries with `lamport < floor` for ONE device chain — and only SUPERSEDED ones. The
+//! invariant (#1277): every entry that still carries a row's merge state stays retained. Those
+//! are the chain's *pins* ([`chain_pins`]): a live whole-row winner, and a tombstone whose pk has
+//! no live row. A fresh peer folds only the retained suffix, so a dropped live winner is a row it
+//! never receives; a re-rooting peer (below) never sees the region between its old tip and the
+//! floor, so a dropped orphan tombstone is a deleted row it keeps. A tombstone whose pk is live
+//! again is not a pin: anything it would suppress also loses to the live clock.
+//! [`compact_chain_prefix`] refuses a floor above a pin; the driver
+//! (`table_sync_compact_overdue`) clamps its floor at the oldest pin, and on this device's own
+//! chain first re-authors the oldest pins at the tail when that frees at least twice what it
+//! authors.
 //!
 //! The floor is recorded durably (`table_sync_retained_floors`) and advertised on the wire: a
 //! FRESH peer (no local chain) accepts the floor entry as its local root on exact
@@ -13,10 +20,9 @@
 //! is bounded by the chain-tip witness: a purged chain's retained tip is chain state, and a floor
 //! at or below a different witness entry classifies as the equivocation it is. A re-offered entry
 //! below the floor is idempotently ignored instead of classifying as a fork against the retained
-//! tail. The driver (`table_sync_compact_overdue`) counts and floors only reclaimable entries,
-//! clamps at the lowest pending lamport so forward-compat payloads stay offerable, treats a
-//! non-advancing floor as the steady-state no-op, and stays inert for anchors/1 — its production
-//! caller arrives with the first scope whose retention policy bounds it (overlay).
+//! tail. The driver counts and floors only reclaimable entries, clamps at the lowest pending
+//! lamport so forward-compat payloads stay offerable, treats a non-advancing floor as the
+//! steady-state no-op, and stays inert for anchors/1.
 //!
 //! A peer whose accepted TIP fell below the sender's floor (offline while the scope churned
 //! past it) recovers by re-rooting: the session plans the offer AT the floor instead of a suffix
@@ -26,17 +32,16 @@
 //! classification, same as at any other tip. Re-rooting also discards fork evidence in a receiver's
 //! divergent below-floor prefix, even when that receiver had not compacted it.
 //!
-//! Two accepted horizons, named rather than hidden:
+//! Accepted horizons, named rather than hidden:
 //!
-//! - **Spec bumps un-invisibilize refreshed rows.** The refresh restamps the published record but
-//!   the row clock keeps pointing at the dropped winner, so the next table spec-version bump takes
-//!   every refreshed row stale → the winner lookup finds the entry gone → `Unknown` → the producer
-//!   re-authors it: one entry per refreshed row per spec bump. A clock can only point at a live
-//!   entry, so this churn is the accepted cost of reclaiming the prefix — bounded, and far cheaper
-//!   than the table-wide storm the refresh prevents on the uncompacted path. In the window between
-//!   a spec bump and the next producer pass, the refold reads the same `Unknown` as a possible
-//!   unsent edit and defers replay over those rows — the safe direction, and worth knowing when
-//!   diagnosing a deferred entry after an upgrade.
+//! - **Pins are the retention floor.** A chain holds at least its pins, whatever the budget: live
+//!   rows past the budget, or orphan tombstones (nothing collects them yet), keep the chain over
+//!   budget honestly instead of dropping what a peer needs. A foreign chain is never re-authored —
+//!   only its writer can carry its rows forward — so it reclaims only the superseded prefix below
+//!   its oldest pin.
+//! - **A re-authored pin is a new write.** It carries the row's current cells at the tail, so it
+//!   competes under LWW with a concurrent edit to that row this device has not received yet, and
+//!   can win it — the cost re-adoption already accepts.
 //! - **Below-floor equivocations are undetectable after a floor is recorded.** The accept path
 //!   answers `AlreadyPresent` for any entry below the floor, so the peer discards fork evidence a
 //!   peer without that floor would still classify. Accepted: `Fork` is non-storing and a
@@ -45,17 +50,12 @@
 
 use rusqlite::{OptionalExtension, Transaction, params};
 
-use super::apply::{self, SyncedRow};
-use super::registry::TableSpec;
-use super::{row_op, store};
 use crate::op::DeviceFingerprint;
 use crate::stream::StreamId;
 
 /// What one prefix compaction did.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CompactionReport {
-    /// Rows whose published record was restamped to the current spec before their winner dropped.
-    pub refreshed_rows: usize,
     /// Accepted entries dropped from the chain prefix.
     pub dropped_entries: usize,
     /// Gapped entries swept below the floor — they can never promote once their predecessor is
@@ -125,21 +125,80 @@ pub(crate) fn record_adopted_floor(
     Ok(())
 }
 
+/// A row whose current merge state is carried by one entry on a device chain: a live whole-row
+/// winner, or a tombstone whose pk has no live row. Compaction never drops the entry at `lamport`
+/// while the pin stands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Pin {
+    pub table_name: String,
+    pub row_pk: String,
+    pub lamport: u64,
+}
+
+/// The pins on `device`'s chain in `stream` with `from <= lamport < below`, oldest first, at most
+/// `limit` of them.
+pub(crate) fn chain_pins(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+    from: u64,
+    below: u64,
+    limit: usize,
+) -> anyhow::Result<Vec<Pin>> {
+    // The merge tables store the winner's fingerprint as the lowercase hex the applier wrote. A
+    // live clock owns its row whatever tombstone sits beside it; a tombstone pins only without one.
+    let mut stmt = tx.prepare(
+        "SELECT table_name, row_pk, lamport FROM sync_row_clocks
+         WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport >= ?3 AND lamport < ?4
+         UNION ALL
+         SELECT t.table_name, t.row_pk, t.lamport FROM sync_row_tombstones t
+         WHERE t.stream_id = ?1 AND t.device_fingerprint = ?2 AND t.lamport >= ?3
+           AND t.lamport < ?4
+           AND NOT EXISTS (
+               SELECT 1 FROM sync_row_clocks c
+               WHERE c.stream_id = t.stream_id AND c.table_name = t.table_name
+                 AND c.row_pk = t.row_pk
+           )
+         ORDER BY lamport, table_name, row_pk
+         LIMIT ?5",
+    )?;
+    let pins = stmt
+        .query_map(
+            params![
+                stream.to_bytes().as_slice(),
+                device.to_string(),
+                i64::try_from(from)?,
+                i64::try_from(below)?,
+                i64::try_from(limit).unwrap_or(i64::MAX),
+            ],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?)),
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    pins.into_iter()
+        .map(|(table_name, row_pk, lamport)| {
+            Ok(Pin { table_name, row_pk, lamport: u64::try_from(lamport)? })
+        })
+        .collect()
+}
+
 /// Drop every accepted entry on `device`'s chain in `stream` with `lamport < floor_lamport`.
 ///
 /// The floor entry itself is RETAINED and must exist on the chain — an arbitrary lamport cannot
 /// invent a floor that no peer could ever be pointed at. Entries retained for replay
 /// (`pending_reason IS NOT NULL`) are never compacted: their payloads are owed to a later binary,
-/// and dropping them would silently lose the forward-compat contract.
+/// and dropping them would silently lose the forward-compat contract. A floor above a pin is
+/// refused (#1277): only superseded entries are reclaimable. The check covers the window this
+/// compaction reclaims — a store compacted before the pin rule may already hold pins below its
+/// recorded floor, whose entries are gone; the driver re-authors those on the local chain.
 pub(crate) fn compact_chain_prefix(
     tx: &Transaction<'_>,
     stream: StreamId,
     device: DeviceFingerprint,
     floor_lamport: u64,
-    registry: &[TableSpec],
     now_ms: i64,
 ) -> anyhow::Result<CompactionReport> {
-    if let Some(current) = retained_floor(tx, stream, device)?
+    let current = retained_floor(tx, stream, device)?;
+    if let Some(current) = current
         && floor_lamport <= current
     {
         anyhow::bail!(
@@ -165,12 +224,17 @@ pub(crate) fn compact_chain_prefix(
              must be a retained entry a peer can be pointed at"
         );
     };
-
-    let Some(context) = store::stream_context(tx, stream)? else {
-        anyhow::bail!("table-sync compaction needs the stream's apply context");
-    };
-    let refreshed_rows =
-        refresh_winners_below(tx, stream, &context.repo_id, registry, device, floor_lamport)?;
+    if let Some(pin) =
+        chain_pins(tx, stream, device, current.unwrap_or(0), floor_lamport, 1)?.first()
+    {
+        anyhow::bail!(
+            "table-sync compaction floor {floor_lamport} would drop the entry at lamport {} that \
+             still carries `{}` row {} — only superseded entries are reclaimable",
+            pin.lamport,
+            pin.table_name,
+            pin.row_pk
+        );
+    }
     let dropped_entries = tx.execute(
         "DELETE FROM table_sync_entries
          WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport < ?3
@@ -210,86 +274,15 @@ pub(crate) fn compact_chain_prefix(
             now_ms,
         ],
     )?;
-    Ok(CompactionReport { refreshed_rows, dropped_entries, swept_gapped })
-}
-
-/// Restamp the published record of every UNTOUCHED row whose whole-row LWW winner is one of the
-/// entries about to drop. After the refresh such a row compares hashes at the CURRENT spec
-/// version and never consults the winner lookup, so the dropped entry is invisible to it.
-///
-/// The `registry` MUST be the full production registry, not the scope's subset: a row whose table
-/// is missing here keeps its stale published record while its winner drops anyway — the
-/// conservative direction (a later pass re-authors it), but a silent one.
-///
-/// The refresh is deliberately verdict-gated on [`apply::StaleRow::Unchanged`]: a raw local write
-/// does not advance the row clock, so restamping to the CURRENT row contents would record an
-/// unsent edit as published — the producer would then see no delta and never author it (the
-/// `StaleRow::Unknown` path it would otherwise take authors, the safe direction), and the replay
-/// guard that keys off the published record would let a remote upsert clobber the edit. A
-/// `LocallyChanged` or `Unknown` row is left alone: the producer authors it at a retained
-/// lamport, exactly as it would without compaction. An unreadable row is skipped for the same
-/// reason it always was — no comparable hash exists to restamp.
-fn refresh_winners_below(
-    tx: &Transaction<'_>,
-    stream: StreamId,
-    repo_id: &str,
-    registry: &[TableSpec],
-    device: DeviceFingerprint,
-    floor_lamport: u64,
-) -> anyhow::Result<usize> {
-    let device_hex = device.to_string();
-    let mut stmt = tx.prepare(
-        "SELECT table_name, row_pk FROM sync_row_clocks
-         WHERE stream_id = ?1 AND repo_id = ?2 AND device_fingerprint = ?3 AND lamport < ?4",
-    )?;
-    let rows = stmt
-        .query_map(
-            params![
-                stream.to_bytes().as_slice(),
-                repo_id,
-                device_hex,
-                i64::try_from(floor_lamport)?
-            ],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-        )?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    let mut refreshed = 0;
-    for (table_name, row_pk) in rows {
-        let Some(spec) = registry.iter().find(|spec| spec.name == table_name) else {
-            continue;
-        };
-        let pk = row_op::row_pk_values(&row_pk)?;
-        let SyncedRow::Cells(cells) = apply::read_synced_cells(tx, spec, &pk)? else {
-            continue;
-        };
-        // The winner still exists at this point (the refresh runs before the drop), so the
-        // disposition is settled against the entry itself — not against the published record,
-        // which is exactly what may be lying about the row being sent.
-        if apply::stale_row_disposition(tx, spec, repo_id, stream, &pk, &cells)?
-            != apply::StaleRow::Unchanged
-        {
-            continue;
-        }
-        apply::record_published(
-            tx,
-            stream,
-            repo_id,
-            spec.name,
-            &row_pk,
-            &row_op::cells_hash(&cells),
-            spec.spec_version,
-        )?;
-        refreshed += 1;
-    }
-    Ok(refreshed)
+    Ok(CompactionReport { dropped_entries, swept_gapped })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::table_sync::registry::{ColumnSpec, ValueType};
-    use crate::table_sync::store::record_stream_context;
-    use crate::table_sync::{Cell, RowOp, TypedValue};
+    use crate::table_sync::registry::{ColumnSpec, TableSpec, ValueType};
+    use crate::table_sync::store::{self, record_stream_context};
+    use crate::table_sync::{Cell, RowOp, TypedValue, apply};
     use crate::{AccountId, LocalDevice};
 
     const SPEC: TableSpec = TableSpec {
@@ -301,7 +294,6 @@ mod tests {
         local_columns: &[],
         repo_column: None,
     };
-    const REGISTRY: &[TableSpec] = &[SPEC];
 
     fn conn() -> rusqlite::Connection {
         let c = rusqlite::Connection::open_in_memory().unwrap();
@@ -344,21 +336,40 @@ mod tests {
         }
     }
 
-    /// Author `n` entries on the device chain (r{i} = v{i}), recording the stream context.
-    fn author_chain(conn: &mut rusqlite::Connection, device: &LocalDevice, n: u64) {
+    fn remove(id: &str) -> RowOp {
+        RowOp::Remove {
+            spec_version: 1,
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text(id.to_string())],
+        }
+    }
+
+    /// Author and self-apply `ops` on the device chain in order, recording the stream context.
+    fn author(conn: &mut rusqlite::Connection, device: &LocalDevice, ops: &[RowOp]) {
         enroll(conn, device);
         let tx = conn.transaction().unwrap();
         record_stream_context(&tx, stream(), "repo", account(), [0x44; 32], "demo/1").unwrap();
-        for i in 0..n {
-            let op = upsert(&format!("r{i}"), &format!("v{i}"));
-            let signed = store::author_row_entry(&tx, stream(), device.secret(), &op, 0).unwrap();
+        for op in ops {
+            let signed = store::author_row_entry(&tx, stream(), device.secret(), op, 0).unwrap();
             let meta = crate::op::OpMeta {
                 lamport: signed.entry.lamport,
                 device: signed.entry.device_fingerprint,
             };
-            apply::apply_row_op_on_stream(&tx, &SPEC, "repo", stream(), &op, meta).unwrap();
+            apply::apply_row_op_on_stream(&tx, &SPEC, "repo", stream(), op, meta).unwrap();
         }
         tx.commit().unwrap();
+    }
+
+    /// Author `n` entries on distinct rows (r{i} = v{i}): every entry carries a live row.
+    fn author_chain(conn: &mut rusqlite::Connection, device: &LocalDevice, n: u64) {
+        let ops: Vec<_> = (0..n).map(|i| upsert(&format!("r{i}"), &format!("v{i}"))).collect();
+        author(conn, device, &ops);
+    }
+
+    /// Author `n` successive writes to ONE row: every entry but the last is superseded.
+    fn author_rewrites(conn: &mut rusqlite::Connection, device: &LocalDevice, n: u64) {
+        let ops: Vec<_> = (0..n).map(|i| upsert("hot", &format!("v{i}"))).collect();
+        author(conn, device, &ops);
     }
 
     fn entry_lamports(conn: &rusqlite::Connection, device: &LocalDevice) -> Vec<i64> {
@@ -378,89 +389,66 @@ mod tests {
     }
 
     #[test]
-    fn compaction_drops_the_prefix_and_keeps_the_rows_authorable() {
+    fn compaction_drops_only_superseded_entries() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
-        author_chain(&mut c, &device, 6);
-        // A second write to r1: its winner is lamport 6 (retained), r0's winner is lamport 0
-        // (about to drop below the floor).
-        {
-            let tx = c.transaction().unwrap();
-            let op = upsert("r1", "v1b");
-            let signed = store::author_row_entry(&tx, stream(), device.secret(), &op, 0).unwrap();
-            let meta = crate::op::OpMeta {
-                lamport: signed.entry.lamport,
-                device: signed.entry.device_fingerprint,
-            };
-            apply::apply_row_op_on_stream(&tx, &SPEC, "repo", stream(), &op, meta).unwrap();
-            tx.commit().unwrap();
-        }
-        // Age the published record so the producer would consult the winner lookup without the
-        // refresh: a differing spec version is exactly the stale path compaction must close.
-        c.execute("UPDATE sync_published_rows SET spec_version = 99", []).unwrap();
+        // 0: r0 (superseded by 3), 1: r1 (superseded by 2), 2: r1, 3: r0, 4: r2.
+        author(&mut c, &device, &[
+            upsert("r0", "v0"),
+            upsert("r1", "v1"),
+            upsert("r1", "v1b"),
+            upsert("r0", "v0b"),
+            upsert("r2", "v2"),
+        ]);
 
         let report = {
             let tx = c.transaction().unwrap();
-            let report =
-                compact_chain_prefix(&tx, stream(), device.fingerprint(), 4, REGISTRY, 0).unwrap();
+            let report = compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, 0).unwrap();
             tx.commit().unwrap();
             report
         };
-        assert_eq!(report.dropped_entries, 4, "entries 0..4 are reclaimed");
-        assert_eq!(
-            report.refreshed_rows, 3,
-            "r0/r2/r3's winners dropped; r1 rewrote at 6 and r4/r5 are retained"
-        );
-        assert_eq!(entry_lamports(&c, &device), vec![4, 5, 6]);
-
+        assert_eq!(report.dropped_entries, 2, "the two superseded entries are reclaimed");
+        {
+            let tx = c.transaction().unwrap();
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, 0).unwrap_err();
+            assert!(err.to_string().contains("would drop"), "r1's winner at 2 pins: {err}");
+        }
+        assert_eq!(entry_lamports(&c, &device), vec![2, 3, 4]);
         let floor = {
             let tx = c.transaction().unwrap();
             retained_floor(&tx, stream(), device.fingerprint()).unwrap()
         };
-        assert_eq!(floor, Some(4));
+        assert_eq!(floor, Some(2));
 
-        // The producer sees no delta: refreshed rows compare at the current spec version, so the
-        // dropped winners never surface as a table-wide re-authoring storm.
+        // Every live row still has its winning entry, so a spec bump after compaction resolves each
+        // stale row against it: the producer re-authors nothing.
+        c.execute("UPDATE sync_published_rows SET spec_version = 99", []).unwrap();
         let tx = c.transaction().unwrap();
         let ops = super::super::produce::produce_row_ops(&tx, &SPEC, "repo", stream()).unwrap();
-        assert!(ops.is_empty(), "refresh-before-drop leaves nothing to re-author");
-        tx.commit().unwrap();
-
-        // Authoring continues on the retained tail.
-        author_chain(&mut c, &device, 0);
-        let tx = c.transaction().unwrap();
-        let op = upsert("r9", "v9");
-        let signed = store::author_row_entry(&tx, stream(), device.secret(), &op, 0).unwrap();
-        assert_eq!(signed.entry.lamport, 7, "the stream clock is based on the retained tail");
+        assert!(ops.is_empty(), "no compacted winner reads as Unknown: {ops:?}");
+        let signed =
+            store::author_row_entry(&tx, stream(), device.secret(), &upsert("r9", "v9"), 0)
+                .unwrap();
+        assert_eq!(signed.entry.lamport, 5, "the stream clock is based on the retained tail");
         tx.commit().unwrap();
     }
 
-    /// A raw local edit on a row whose winner drops below the floor must NOT be restamped as
-    /// published: that would disown the edit (the producer would see no delta) and disarm the
-    /// replay guard that keys off the published record.
+    /// A live winner is a pin: a floor above it is refused, so a raw local edit on that row keeps
+    /// its published record and the producer still authors it.
     #[test]
-    fn an_unsent_local_edit_survives_compaction_and_is_authored() {
+    fn a_live_winner_pins_its_entry_and_an_unsent_edit_is_still_authored() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
         author_chain(&mut c, &device, 4);
-        // Raw local write: no entry, no clock advance, published record still says v0.
         c.execute("UPDATE t_demo SET title = 'local-edit' WHERE id = 'r0'", []).unwrap();
 
-        let report = {
+        {
             let tx = c.transaction().unwrap();
-            let report =
-                compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
-            tx.commit().unwrap();
-            report
-        };
-        assert_eq!(report.dropped_entries, 2);
-        assert_eq!(
-            report.refreshed_rows, 1,
-            "only the untouched r1 is restamped; r0 is left for the producer"
-        );
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 1, 0).unwrap_err();
+            assert!(err.to_string().contains("would drop"), "r0's winner pins lamport 0: {err}");
+        }
+        assert_eq!(entry_lamports(&c, &device), vec![0, 1, 2, 3], "the refusal drops nothing");
 
-        // The edit is authored: the published record still names v0, so the producer sees the
-        // delta it must carry — the safe direction the refresh must never close.
         let tx = c.transaction().unwrap();
         let ops = super::super::produce::produce_row_ops(&tx, &SPEC, "repo", stream()).unwrap();
         assert_eq!(ops.len(), 1, "the unsent edit is produced, not disowned");
@@ -471,11 +459,39 @@ mod tests {
         tx.commit().unwrap();
     }
 
+    /// A tombstone whose pk has no live row is a pin — a peer that re-roots past it would keep the
+    /// deleted row — until a later write makes the row live again.
+    #[test]
+    fn an_orphan_tombstone_pins_until_its_row_is_live_again() {
+        let mut c = conn();
+        let device = crate::local_device(&c, 0).unwrap();
+        // 0: r0, 1: remove r0 (orphan tombstone), 2: hot (superseded by 3), 3: hot.
+        author(&mut c, &device, &[
+            upsert("r0", "v0"),
+            remove("r0"),
+            upsert("hot", "v0"),
+            upsert("hot", "v1"),
+        ]);
+        {
+            let tx = c.transaction().unwrap();
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, 0).unwrap_err();
+            assert!(err.to_string().contains("would drop"), "the tombstone at 1 pins: {err}");
+        }
+
+        // r0 is live again at 4: anything the tombstone would suppress loses to that clock.
+        author(&mut c, &device, &[upsert("r0", "v0b")]);
+        let tx = c.transaction().unwrap();
+        let report = compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, 0).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(report.dropped_entries, 3);
+        assert_eq!(entry_lamports(&c, &device), vec![3, 4]);
+    }
+
     #[test]
     fn compaction_never_drops_a_pending_entry_or_invents_a_floor() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
-        author_chain(&mut c, &device, 3);
+        author_rewrites(&mut c, &device, 3);
         c.execute(
             "UPDATE table_sync_entries SET pending_reason = 'unknown_column' WHERE lamport = 1",
             [],
@@ -484,16 +500,14 @@ mod tests {
 
         {
             let tx = c.transaction().unwrap();
-            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 9, REGISTRY, 0)
-                .unwrap_err();
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 9, 0).unwrap_err();
             assert!(err.to_string().contains("names no entry"), "a floor must be a retained entry");
             tx.commit().unwrap();
         }
 
         let report = {
             let tx = c.transaction().unwrap();
-            let report =
-                compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            let report = compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, 0).unwrap();
             tx.commit().unwrap();
             report
         };
@@ -505,17 +519,16 @@ mod tests {
     fn a_second_compaction_advances_the_floor_and_a_retreat_is_refused() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
-        author_chain(&mut c, &device, 6);
+        author_rewrites(&mut c, &device, 6);
 
         {
             let tx = c.transaction().unwrap();
-            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, 0).unwrap();
             tx.commit().unwrap();
         }
         {
             let tx = c.transaction().unwrap();
-            let report =
-                compact_chain_prefix(&tx, stream(), device.fingerprint(), 4, REGISTRY, 0).unwrap();
+            let report = compact_chain_prefix(&tx, stream(), device.fingerprint(), 4, 0).unwrap();
             tx.commit().unwrap();
             assert_eq!(report.dropped_entries, 2, "entries 2 and 3 drop in the second pass");
         }
@@ -528,8 +541,7 @@ mod tests {
 
         {
             let tx = c.transaction().unwrap();
-            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, REGISTRY, 0)
-                .unwrap_err();
+            let err = compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, 0).unwrap_err();
             assert!(
                 err.to_string().contains("does not advance"),
                 "a retreating floor is a caller bug, not a silent re-compaction: {err}",
@@ -545,7 +557,7 @@ mod tests {
     fn an_equivocation_at_the_floor_lamport_is_still_a_fork() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
-        author_chain(&mut c, &device, 4);
+        author_rewrites(&mut c, &device, 4);
         let tail_hash: Vec<u8> = c
             .query_row("SELECT entry_hash FROM table_sync_entries WHERE lamport = 1", [], |row| {
                 row.get(0)
@@ -553,7 +565,7 @@ mod tests {
             .unwrap();
         {
             let tx = c.transaction().unwrap();
-            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, 0).unwrap();
             tx.commit().unwrap();
         }
 
@@ -585,23 +597,18 @@ mod tests {
         tx.commit().unwrap();
     }
 
-    /// The re-adoption candidate set derives from the merge state, which survives compaction:
-    /// compact a writer's prefix, THEN remove the writer, and the drain still repairs the row —
-    /// with the audit naming the slot by lamport alone (the winning entry is gone).
+    /// A store compacted before the pin rule dropped entries that still carried live rows. The
+    /// re-adoption candidate set derives from the merge state, which survived: remove the writer
+    /// and the drain still repairs every row — the audit naming the slot by lamport alone.
     #[test]
-    fn compaction_before_a_removal_does_not_shrink_the_repair_set() {
+    fn a_winner_whose_entry_is_gone_is_still_a_repair_candidate() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
         author_chain(&mut c, &device, 4);
-        {
-            let tx = c.transaction().unwrap();
-            compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, REGISTRY, 0).unwrap();
-            tx.commit().unwrap();
-        }
+        c.execute("DELETE FROM table_sync_entries WHERE lamport < 3", []).unwrap();
         let removed_fp = device.fingerprint();
 
-        // The writer is removed after its prefix was compacted: entries 0..3 named the winners of
-        // r0..r2, and those winners are GONE from the entry log now.
+        // Entries 0..3 named the winners of r0..r2, and those winners are GONE from the entry log.
         let work = {
             let tx = c.transaction().unwrap();
             store::enqueue_readoption_work(&tx, account(), removed_fp, stream(), [9; 32], 9, 10)
@@ -634,7 +641,7 @@ mod tests {
     fn compaction_sweeps_gapped_entries_below_the_floor() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
-        author_chain(&mut c, &device, 4);
+        author_rewrites(&mut c, &device, 4);
         c.execute(
             "INSERT INTO table_sync_gapped_entries(
                  entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
@@ -647,8 +654,7 @@ mod tests {
 
         let report = {
             let tx = c.transaction().unwrap();
-            let report =
-                compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, REGISTRY, 0).unwrap();
+            let report = compact_chain_prefix(&tx, stream(), device.fingerprint(), 3, 0).unwrap();
             tx.commit().unwrap();
             report
         };
@@ -985,7 +991,7 @@ mod tests {
     fn a_reoffered_entry_below_the_floor_is_idempotent_not_a_fork() {
         let mut c = conn();
         let device = crate::local_device(&c, 0).unwrap();
-        author_chain(&mut c, &device, 3);
+        author_rewrites(&mut c, &device, 3);
         let dropped: Vec<u8> = c
             .query_row("SELECT signed_bytes FROM table_sync_entries WHERE lamport = 0", [], |row| {
                 row.get(0)
@@ -993,7 +999,7 @@ mod tests {
             .unwrap();
         {
             let tx = c.transaction().unwrap();
-            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, REGISTRY, 0).unwrap();
+            compact_chain_prefix(&tx, stream(), device.fingerprint(), 2, 0).unwrap();
             tx.commit().unwrap();
         }
 

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -241,6 +241,45 @@ pub(crate) fn author_row_entry(
     op: &RowOp,
     now_ms: i64,
 ) -> anyhow::Result<SignedEntry> {
+    let signed = sign_next_row_entry(tx, stream, secret, op)?;
+    anyhow::ensure!(
+        signed.signed_bytes.len() <= super::TABLE_SYNC_ENTRY_MAX_BYTES,
+        "table-sync signed entry is {} bytes, over the {}-byte transport limit",
+        signed.signed_bytes.len(),
+        super::TABLE_SYNC_ENTRY_MAX_BYTES,
+    );
+    // A locally-authored op is projected by construction: the producer builds it from THIS
+    // registry, so it can never carry a column or op-kind this binary does not understand.
+    insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms, None)?;
+    Ok(signed)
+}
+
+/// [`author_row_entry`] for a repair that re-signs a row already carried: `None`, storing nothing,
+/// when the entry would exceed the transport limit. A retained entry at the limit grows when
+/// re-signed under a predecessor hash, and a repair that cannot fit must leave the row where it is
+/// rather than fail the pass.
+pub(crate) fn author_row_entry_if_it_fits(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    secret: &DeviceSecret,
+    op: &RowOp,
+    now_ms: i64,
+) -> anyhow::Result<Option<SignedEntry>> {
+    let signed = sign_next_row_entry(tx, stream, secret, op)?;
+    if signed.signed_bytes.len() > super::TABLE_SYNC_ENTRY_MAX_BYTES {
+        return Ok(None);
+    }
+    insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms, None)?;
+    Ok(Some(signed))
+}
+
+/// Sign `op` as the next entry on this device's chain in `stream`, without storing it.
+fn sign_next_row_entry(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    secret: &DeviceSecret,
+    op: &RowOp,
+) -> anyhow::Result<SignedEntry> {
     let device = secret.public().fingerprint();
     let stored_tail = chain_tail(tx, stream, device)?;
     if let Some(witness) = chain_witness(tx, stream, device)?
@@ -253,18 +292,24 @@ pub(crate) fn author_row_entry(
     }
     let lamport = next_stream_lamport(tx, stream)?;
     let prev_hash = stored_tail.map(|(_, entry_hash)| entry_hash);
-    let signed =
-        entry::sign_entry_from_op_bytes(secret, stream, prev_hash, lamport, row_op::encode(op));
-    anyhow::ensure!(
-        signed.signed_bytes.len() <= super::TABLE_SYNC_ENTRY_MAX_BYTES,
-        "table-sync signed entry is {} bytes, over the {}-byte transport limit",
-        signed.signed_bytes.len(),
-        super::TABLE_SYNC_ENTRY_MAX_BYTES,
-    );
-    // A locally-authored op is projected by construction: the producer builds it from THIS
-    // registry, so it can never carry a column or op-kind this binary does not understand.
-    insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms, None)?;
-    Ok(signed)
+    Ok(entry::sign_entry_from_op_bytes(secret, stream, prev_hash, lamport, row_op::encode(op)))
+}
+
+/// Whether `stream` holds an accepted entry retained for replay (`pending_reason IS NOT NULL`) at
+/// or above `lamport`, on any device chain — a write this binary accepted but cannot apply yet.
+pub(crate) fn pending_entry_at_or_above(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    lamport: u64,
+) -> anyhow::Result<bool> {
+    Ok(tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM table_sync_entries
+             WHERE stream_id = ?1 AND pending_reason IS NOT NULL AND lamport >= ?2
+         )",
+        params![stream.to_bytes().as_slice(), i64::try_from(lamport)?],
+        |row| row.get(0),
+    )?)
 }
 
 /// One past the highest lamport on `stream` across all devices — the next Lamport-clock tick. `0`

--- a/crates/rag-rat-oplog/src/table_sync/transport.rs
+++ b/crates/rag-rat-oplog/src/table_sync/transport.rs
@@ -214,8 +214,9 @@ pub const OVERLAY_ACCEPTED_RETENTION: u64 = 256;
 
 /// `distill/1` is higher-churn than overlay: one record regeneration authors a burst of entries
 /// across the cluster, so the budget must clear several full-cluster regenerations before the
-/// retained floor advances. A large initial backfill exceeds this immediately and converges through
-/// the retained-floor/compaction path — by design, not loss.
+/// retained floor advances. A large initial backfill is all live rows, which pin their chain over
+/// budget until later regenerations supersede them — retention never drops a row a peer still
+/// needs (#1277).
 pub const DISTILL_ACCEPTED_RETENTION: u64 = 512;
 
 pub fn scope_retention_budget(scope_id: &str) -> Option<u64> {
@@ -226,16 +227,24 @@ pub fn scope_retention_budget(scope_id: &str) -> Option<u64> {
     }
 }
 
+/// The most pins one compaction pass re-authors on a chain: bounds the pass's signing and transfer
+/// cost. A longer paying run moves over later passes.
+const COMPACTION_REAUTHOR_MAX: usize = 64;
+
 /// Compact accepted chain prefixes for scopes whose retention policy bounds them (#1127).
 ///
 /// `retain` answers the per-chain accepted-entry budget for a scope, `None` for full retention
-/// (anchors/1 stays unbounded). A chain with more RECLAIMABLE entries than its budget compacts to
-/// keep its newest; chains within budget are untouched. Entries retained for forward-compat
-/// replay (`pending_reason IS NOT NULL`) are neither counted nor dropped — a chain pinned above
-/// budget by pending entries makes the computed floor not advance, which is a steady-state no-op,
-/// never an error, so the driver is safely re-runnable on any cadence. Each stream compacts in
-/// its own IMMEDIATE transaction, and the caller's authoring pass already ran, so a winner
-/// restamp never disowns an unsent local edit (see the retention module docs).
+/// (anchors/1 stays unbounded). A chain with more RECLAIMABLE entries than its budget compacts
+/// toward keeping its newest; chains within budget are untouched. Entries retained for
+/// forward-compat replay (`pending_reason IS NOT NULL`) are neither counted nor dropped.
+///
+/// Only superseded entries drop (#1277, see the retention module docs): the floor clamps at the
+/// chain's oldest pin. On this device's own chain the driver first re-authors the oldest pins at
+/// the tail — the longest run whose move frees at least twice the entries it authors, at most
+/// [`COMPACTION_REAUTHOR_MAX`] per pass — and re-authors any row a store compacted before the pin
+/// rule left below its floor. A foreign chain is never re-authored. A floor that does not advance
+/// is a steady-state no-op, never an error, so the driver is safely re-runnable on any cadence.
+/// Each stream compacts in its own IMMEDIATE transaction.
 ///
 /// Returns the number of accepted entries reclaimed.
 pub fn table_sync_compact_overdue(
@@ -244,15 +253,48 @@ pub fn table_sync_compact_overdue(
     now_ms: i64,
     retain: &dyn Fn(&str) -> Option<u64>,
 ) -> anyhow::Result<usize> {
-    let streams = supported_streams_against(conn, account_id, SYNCABLE_TABLES)?;
-    let registry = repo_registry(SYNCABLE_TABLES);
+    compact_overdue_against(conn, account_id, now_ms, retain, SYNCABLE_TABLES)
+}
+
+fn compact_overdue_against(
+    conn: &Connection,
+    account_id: AccountId,
+    now_ms: i64,
+    retain: &dyn Fn(&str) -> Option<u64>,
+    registry: &[TableSpec],
+) -> anyhow::Result<usize> {
+    let streams = supported_streams_against(conn, account_id, registry)?;
+    let device = crate::local_device(conn, now_ms)?;
+    let local = device.fingerprint();
+    let writer = account::device_is_effective_writer(conn, account_id, local)?;
+    let _durability = writer.then(|| crate::AuthoredDurability::begin(conn)).transpose()?;
     let mut compacted = 0;
     for stream in streams {
         let Some(keep) = retain(&stream.scope_id) else {
             continue;
         };
         anyhow::ensure!(keep >= 1, "a retention budget of zero keeps no chain tail to build on");
+        let stream_id = StreamId::from_bytes(stream.stream_id);
         let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+        let ctx = writer.then(|| SyncCtx {
+            repo_id: &stream.repo_id,
+            account_id,
+            incarnation_ref: stream.incarnation_ref,
+            device: &device,
+            registry,
+            now_ms,
+        });
+        // A store compacted before the pin rule may have dropped the entries carrying live rows
+        // below its floor: peers that folded only the retained suffix never received those rows.
+        // Carrying them to the tail repairs that once; afterwards nothing pins below the floor.
+        // Each moves on its own, so a row that cannot be carried today holds back no other.
+        if let Some(ctx) = &ctx
+            && let Some(floor) = retention::retained_floor(&tx, stream_id, local)?
+        {
+            for pin in retention::chain_pins(&tx, stream_id, local, 0, floor, usize::MAX)? {
+                engine::reauthor_chain_pins(&tx, ctx, &stream.scope_id, stream_id, &[pin])?;
+            }
+        }
         let chains = {
             let mut stmt = tx.prepare(
                 "SELECT device_fingerprint, COUNT(*) FROM table_sync_entries
@@ -269,21 +311,21 @@ pub fn table_sync_compact_overdue(
             if count <= keep {
                 continue;
             }
-            // The floor is the oldest RECLAIMABLE entry to retain: the one at offset
+            let chain = crate::op::DeviceFingerprint::from_bytes(fixed32(device_bytes)?);
+            // The budget floor is the oldest RECLAIMABLE entry to retain: the one at offset
             // (count - keep) in lamport order. compact_chain_prefix drops strictly below it.
-            let floor_lamport: i64 = tx.query_row(
+            let target: i64 = tx.query_row(
                 "SELECT lamport FROM table_sync_entries
                  WHERE stream_id = ?1 AND device_fingerprint = ?2 AND pending_reason IS NULL
                  ORDER BY lamport LIMIT 1 OFFSET ?3",
                 params![
                     stream.stream_id.as_slice(),
-                    device_bytes.as_slice(),
+                    chain.to_bytes().as_slice(),
                     i64::try_from(count - keep)?
                 ],
                 |row| row.get(0),
             )?;
-            let floor_lamport = u64::try_from(floor_lamport)?;
-            let device = crate::op::DeviceFingerprint::from_bytes(fixed32(device_bytes)?);
+            let target = u64::try_from(target)?;
             // A pending entry below the computed floor would survive locally yet become
             // unreachable to floor-adopting peers (served early it parks and is swept; served
             // late it reads as already-present) — silent loss of the forward-compat payload it
@@ -294,36 +336,91 @@ pub fn table_sync_compact_overdue(
                     "SELECT MIN(lamport) FROM table_sync_entries
                      WHERE stream_id = ?1 AND device_fingerprint = ?2
                        AND pending_reason IS NOT NULL",
-                    params![stream.stream_id.as_slice(), device.to_bytes().as_slice()],
+                    params![stream.stream_id.as_slice(), chain.to_bytes().as_slice()],
                     |row| row.get(0),
                 )
                 .optional()?
                 .flatten();
-            let floor_lamport = match lowest_pending {
-                Some(pending) if (pending as u64) < floor_lamport => pending as u64,
-                _ => floor_lamport,
+            let target = match lowest_pending {
+                Some(pending) if (pending as u64) < target => pending as u64,
+                _ => target,
             };
-            // A chain pinned by pending entries (or simply already compacted past this point)
-            // computes a floor that does not advance: steady state, not the caller bug
-            // compact_chain_prefix's refusal exists to catch.
-            if retention::retained_floor(&tx, StreamId::from_bytes(stream.stream_id), device)?
-                .is_some_and(|current| floor_lamport <= current)
-            {
+            let from = retention::retained_floor(&tx, stream_id, chain)?.unwrap_or(0);
+            if target <= from {
                 continue;
             }
-            let report = retention::compact_chain_prefix(
-                &tx,
-                StreamId::from_bytes(stream.stream_id),
-                device,
-                floor_lamport,
-                &registry,
-                now_ms,
-            )?;
-            compacted += report.dropped_entries;
+            // The writer's own chain weighs its whole run of pins; any other needs only the oldest.
+            let reauthor = ctx.as_ref().filter(|_| chain == local);
+            let limit = if reauthor.is_some() { usize::MAX } else { 1 };
+            let pins = retention::chain_pins(&tx, stream_id, chain, from, target, limit)?;
+            let floor = match (reauthor, pins.first()) {
+                (_, None) => target,
+                (Some(ctx), Some(_)) => {
+                    let worth = pins_worth_reauthoring(&tx, stream_id, chain, &pins, target)?;
+                    let moved = engine::reauthor_chain_pins(
+                        &tx,
+                        ctx,
+                        &stream.scope_id,
+                        stream_id,
+                        &pins[..worth.min(COMPACTION_REAUTHOR_MAX)],
+                    )?;
+                    pins.get(moved).map_or(target, |pin| pin.lamport)
+                },
+                (None, Some(oldest)) => oldest.lamport,
+            };
+            // A chain pinned at its bottom (or already compacted past this point) computes a
+            // floor that does not advance: steady state, not the caller bug compact_chain_prefix's
+            // refusal exists to catch.
+            if floor <= from {
+                continue;
+            }
+            compacted += retention::compact_chain_prefix(&tx, stream_id, chain, floor, now_ms)?
+                .dropped_entries;
         }
         tx.commit()?;
     }
     Ok(compacted)
+}
+
+/// How many of the chain's oldest `pins` are worth re-authoring: the largest `k` whose move frees
+/// at least `2k` entries, so every entry authored reclaims at least one more. Zero when no prefix
+/// pays for itself — a chain that is all pins authors nothing, however far over budget.
+///
+/// Weighed over the whole run, not the per-pass cap: a paying move longer than the cap proceeds
+/// over several passes, each one freeing at least the entries it authors. Weighing only the capped
+/// prefix would stall for good behind more cold pins than the cap.
+fn pins_worth_reauthoring(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    chain: crate::op::DeviceFingerprint,
+    pins: &[retention::Pin],
+    target: u64,
+) -> anyhow::Result<usize> {
+    // Everything below `target` is reclaimable (the target clamps at the lowest pending entry).
+    let lamports = tx
+        .prepare(
+            "SELECT lamport FROM table_sync_entries
+             WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport < ?3
+             ORDER BY lamport",
+        )?
+        .query_map(
+            params![
+                stream.to_bytes().as_slice(),
+                chain.to_bytes().as_slice(),
+                i64::try_from(target)?
+            ],
+            |row| row.get::<_, i64>(0),
+        )?
+        .map(|lamport| Ok(u64::try_from(lamport?)?))
+        .collect::<anyhow::Result<Vec<u64>>>()?;
+    let mut worth = 0;
+    for k in 1..=pins.len() {
+        let bound = pins.get(k).map_or(target, |pin| pin.lamport);
+        if lamports.partition_point(|&lamport| lamport < bound) >= 2 * k {
+            worth = k;
+        }
+    }
+    Ok(worth)
 }
 
 /// Recompute an advertised route from local current-incarnation authority and the production
@@ -785,6 +882,7 @@ mod tests {
 
     use super::*;
     use crate::table_sync::registry::{ColumnSpec, ValueType};
+    use crate::table_sync::{Cell, RowOp, TypedValue};
 
     const INCARNATION: [u8; 32] = [0x24; 32];
 
@@ -1537,25 +1635,6 @@ mod tests {
 
     #[test]
     fn accepted_transfer_is_idempotent_and_obeys_the_current_roster_write_gate() {
-        fn add_repo_state(conn: &Connection, account: AccountId) {
-            conn.execute_batch(
-                "CREATE TABLE t_transport(
-                     repo_id TEXT NOT NULL,
-                     id TEXT NOT NULL,
-                     title TEXT NOT NULL,
-                     PRIMARY KEY(repo_id, id)
-                 ) STRICT;",
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO account_repo_incarnation_current(
-                     account_id, repository_id, incarnation_ref
-                 ) VALUES (?1, 'repo-a', ?2)",
-                params![account.to_bytes().as_slice(), INCARNATION.as_slice()],
-            )
-            .unwrap();
-        }
-
         let mut source = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&source, &crate::test_hooks()).unwrap();
         let account = crate::local_account(&source, 0).unwrap();
@@ -1641,5 +1720,484 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM table_sync_entries", [], |row| row.get(0))
             .unwrap();
         assert_eq!(accepted, 0, "a removed writer reaches no accepted table history");
+    }
+
+    /// The synthetic repo table plus a current incarnation for `repo-a`.
+    fn add_repo_state(conn: &Connection, account: AccountId) {
+        conn.execute_batch(
+            "CREATE TABLE t_transport(
+                 repo_id TEXT NOT NULL,
+                 id TEXT NOT NULL,
+                 title TEXT NOT NULL,
+                 PRIMARY KEY(repo_id, id)
+             ) STRICT;",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO account_repo_incarnation_current(
+                 account_id, repository_id, incarnation_ref
+             ) VALUES (?1, 'repo-a', ?2)",
+            params![account.to_bytes().as_slice(), INCARNATION.as_slice()],
+        )
+        .unwrap();
+    }
+
+    /// A store whose local device owns a real account, so it is a roster-effective writer and a
+    /// peer can verify its entries.
+    fn writer_store() -> (Connection, AccountId) {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        let account = crate::local_account(&conn, 0).unwrap();
+        add_repo_state(&conn, account);
+        (conn, account)
+    }
+
+    /// A fresh device that has folded `source`'s account log but holds no table history, and is
+    /// not a writer of that account.
+    fn peer_of(source: &Connection, account: AccountId) -> Connection {
+        let peer = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&peer, &crate::test_hooks()).unwrap();
+        crate::local_device(&peer, 0).unwrap();
+        for entry in crate::account_entries_for_sync(source, account).unwrap() {
+            crate::account_ingest(&peer, &entry.signed_bytes, 0).unwrap();
+        }
+        add_repo_state(&peer, account);
+        peer
+    }
+
+    fn write(conn: &Connection, id: &str, title: &str) {
+        conn.execute(
+            "INSERT OR REPLACE INTO t_transport(repo_id, id, title) VALUES ('repo-a', ?1, ?2)",
+            params![id, title],
+        )
+        .unwrap();
+    }
+
+    fn author(conn: &Connection, account: AccountId) {
+        let local = crate::load_local_device(conn).unwrap().unwrap();
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let ctx = SyncCtx {
+            repo_id: "repo-a",
+            account_id: account,
+            incarnation_ref: INCARNATION,
+            device: &local,
+            registry: &[REPO_SPEC],
+            now_ms: 0,
+        };
+        engine::produce_and_author(&tx, &ctx).unwrap();
+        tx.commit().unwrap();
+    }
+
+    /// `write` then `author`, once per title: successive writes to one row.
+    fn rewrite(conn: &Connection, account: AccountId, id: &str, times: usize) {
+        for i in 0..times {
+            write(conn, id, &format!("v{i}"));
+            author(conn, account);
+        }
+    }
+
+    fn compact(conn: &Connection, account: AccountId, keep: u64) -> usize {
+        compact_overdue_against(conn, account, 9, &|_| Some(keep), &[REPO_SPEC]).unwrap()
+    }
+
+    fn chain_lamports(conn: &Connection) -> Vec<i64> {
+        conn.prepare("SELECT lamport FROM table_sync_entries ORDER BY lamport")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    }
+
+    fn live_rows(conn: &Connection) -> Vec<(String, String)> {
+        conn.prepare("SELECT id, title FROM t_transport ORDER BY id")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    }
+
+    /// Live rows and orphan tombstones whose carrying entry is gone: what a peer folding only the
+    /// retained log can never learn.
+    fn stranded_rows(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT stream_id, device_fingerprint, lamport FROM sync_row_clocks
+                 UNION ALL
+                 SELECT t.stream_id, t.device_fingerprint, t.lamport FROM sync_row_tombstones t
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM sync_row_clocks c
+                     WHERE c.stream_id = t.stream_id AND c.table_name = t.table_name
+                       AND c.row_pk = t.row_pk
+                 )
+             ) p
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM table_sync_entries e
+                 WHERE e.stream_id = p.stream_id AND e.lamport = p.lamport
+                   AND lower(hex(e.device_fingerprint)) = p.device_fingerprint
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// Offer every chain of `source` to `peer` as a session planning a fresh or below-floor peer
+    /// does: from the recorded floor (advertised on the floor entry), else from the beginning.
+    /// Re-offers of entries the peer holds read idempotent.
+    fn sync_chains(source: &Connection, peer: &Connection, account: AccountId) {
+        let route = supported_streams_against(source, account, &[REPO_SPEC]).unwrap().remove(0);
+        for head in accepted_chain_page(source, route.stream_id, None, 16).unwrap() {
+            let start =
+                head.floor.map_or(TableSyncEntryStart::Beginning, |(lamport, entry_hash)| {
+                    TableSyncEntryStart::At { lamport, entry_hash }
+                });
+            for entry in accepted_chain_entries(
+                source,
+                route.stream_id,
+                head.device_fingerprint,
+                start,
+                1024,
+            )
+            .unwrap()
+            {
+                let floor = head.floor.filter(|(lamport, _)| *lamport == entry.lamport);
+                ingest_against(
+                    peer,
+                    account,
+                    &route,
+                    head.device_fingerprint,
+                    &entry.signed_bytes,
+                    1,
+                    floor,
+                    &[REPO_SPEC],
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    /// The #1277 probe: more live rows than the budget. Every entry carries a row, so nothing is
+    /// reclaimable and nothing is worth re-authoring — the chain stays honestly over budget.
+    #[test]
+    fn live_rows_past_the_budget_are_kept_and_nothing_is_reauthored() {
+        let (a, account) = writer_store();
+        for i in 0..5 {
+            write(&a, &format!("r{i}"), "v");
+        }
+        author(&a, account);
+        assert_eq!(compact(&a, account, 4), 0);
+        assert_eq!(compact(&a, account, 4), 0, "a second pass authors nothing either");
+        assert_eq!(chain_lamports(&a), vec![0, 1, 2, 3, 4]);
+        let floors: i64 = a
+            .query_row("SELECT COUNT(*) FROM table_sync_retained_floors", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(floors, 0, "no floor is recorded for a chain that cannot shrink");
+
+        let peer = peer_of(&a, account);
+        sync_chains(&a, &peer, account);
+        assert_eq!(live_rows(&peer), live_rows(&a));
+    }
+
+    /// The writer's own chain moves its oldest pins to the tail when that pays — here two entries
+    /// authored free eight — and settles once the chain is only its pins.
+    #[test]
+    fn the_writer_reauthors_its_oldest_pins_when_that_frees_twice_as_much() {
+        let (a, account) = writer_store();
+        write(&a, "a", "a");
+        write(&a, "b", "b");
+        author(&a, account); // a@0, b@1
+        rewrite(&a, account, "c", 8); // c@2..9, only c@9 live
+
+        assert_eq!(compact(&a, account, 2), 8, "moving a and b clears the way to the budget floor");
+        assert_eq!(chain_lamports(&a), vec![8, 9, 10, 11]);
+        assert_eq!(stranded_rows(&a), 0);
+
+        assert_eq!(compact(&a, account, 2), 2, "moving c frees c@8 and c@9");
+        assert_eq!(compact(&a, account, 2), 0, "moving a to free one entry does not pay");
+        assert_eq!(chain_lamports(&a), vec![10, 11, 12], "three live rows, three entries");
+        assert_eq!(stranded_rows(&a), 0);
+
+        let peer = peer_of(&a, account);
+        sync_chains(&a, &peer, account);
+        assert_eq!(live_rows(&peer), live_rows(&a), "a fresh peer folds every live row");
+    }
+
+    /// Moving pins is worth it only when every entry authored reclaims at least one more: two
+    /// moved to free three is refused, and the floor clamps at the oldest pin instead.
+    #[test]
+    fn moving_pins_that_free_less_than_twice_their_cost_does_not_pay() {
+        let (a, account) = writer_store();
+        write(&a, "a", "a");
+        write(&a, "b", "b");
+        author(&a, account); // a@0, b@1
+        rewrite(&a, account, "c", 2); // c@2, c@3
+
+        assert_eq!(compact(&a, account, 1), 0);
+        assert_eq!(chain_lamports(&a), vec![0, 1, 2, 3], "nothing authored or dropped");
+    }
+
+    /// A peer compacted before the pin rule may hold a foreign chain whose pins sit below its
+    /// floor, with their entries gone. Nothing can carry those forward, and they must not wedge
+    /// compaction of the region above the floor.
+    #[test]
+    fn a_foreign_chain_stranded_below_an_earlier_floor_still_compacts() {
+        let (a, account) = writer_store();
+        write(&a, "a", "a");
+        author(&a, account); // a@0
+        rewrite(&a, account, "c", 8); // c@1..8, only c@8 live
+        let peer = peer_of(&a, account);
+        sync_chains(&a, &peer, account);
+        let route = supported_streams_against(&peer, account, &[REPO_SPEC]).unwrap().remove(0);
+        let writer = crate::load_local_device(&a).unwrap().unwrap().fingerprint();
+        {
+            let tx = Transaction::new_unchecked(&peer, TransactionBehavior::Immediate).unwrap();
+            let floor_hash: Vec<u8> = tx
+                .query_row(
+                    "SELECT entry_hash FROM table_sync_entries WHERE lamport = 4",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            tx.execute("DELETE FROM table_sync_entries WHERE lamport < 4", []).unwrap();
+            retention::record_adopted_floor(
+                &tx,
+                StreamId::from_bytes(route.stream_id),
+                writer,
+                4,
+                fixed32(floor_hash).unwrap(),
+                0,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(stranded_rows(&peer), 1, "a@0 is gone below the floor");
+
+        assert_eq!(compact(&peer, account, 2), 3, "entries 4, 5 and 6 above the floor drop");
+        assert_eq!(chain_lamports(&peer), vec![7, 8]);
+    }
+
+    /// More cold pins than one pass may carry, under a churning row: the paying move spans several
+    /// passes instead of stalling behind the cap, and the chain reaches its budget.
+    #[test]
+    fn a_run_of_pins_longer_than_the_pass_cap_still_reaches_the_budget() {
+        let (a, account) = writer_store();
+        for i in 0..=COMPACTION_REAUTHOR_MAX {
+            write(&a, &format!("cold{i:03}"), "v");
+        }
+        author(&a, account); // 65 cold rows at 0..=64
+        rewrite(&a, account, "hot", 200); // 65..=264, only the last live
+
+        let mut passes = Vec::new();
+        loop {
+            let reclaimed = compact(&a, account, 100);
+            if reclaimed == 0 {
+                break;
+            }
+            passes.push(reclaimed);
+            assert!(passes.len() < 8, "compaction settles: {passes:?}");
+        }
+        assert_eq!(passes, vec![64, 165, 1], "carry 64, then the last cold pin, then the budget");
+        assert_eq!(chain_lamports(&a).len(), 100, "the chain is at its budget");
+        assert_eq!(stranded_rows(&a), 0);
+
+        let peer = peer_of(&a, account);
+        sync_chains(&a, &peer, account);
+        assert_eq!(live_rows(&peer), live_rows(&a));
+    }
+
+    /// An accepted entry this binary cannot apply yet may be a newer write to a pinned row, on any
+    /// chain. Re-authoring the pin above it would overwrite that write on up-to-date peers, so the
+    /// pin stays until the entry replays.
+    #[test]
+    fn a_parked_newer_write_holds_the_pins_below_it() {
+        let (a, account) = writer_store();
+        write(&a, "a", "a");
+        write(&a, "b", "b");
+        author(&a, account); // a@0, b@1
+        rewrite(&a, account, "c", 8); // c@2..9
+        let route = supported_streams_against(&a, account, &[REPO_SPEC]).unwrap().remove(0);
+        a.execute(
+            "INSERT INTO table_sync_entries(
+                 entry_hash, stream_id, device_fingerprint, lamport, signed_bytes, received_at_ms,
+                 pending_reason
+             ) VALUES (x'77', ?1, ?2, 5, x'00', 0, 'newer_spec_version')",
+            params![route.stream_id.as_slice(), [2u8; 32].as_slice()],
+        )
+        .unwrap();
+
+        assert_eq!(compact(&a, account, 2), 0, "a and b stay below the parked write");
+        assert_eq!(chain_lamports(&a).len(), 11, "ten local entries and the parked one");
+
+        a.execute(
+            "UPDATE table_sync_entries SET pending_reason = NULL WHERE entry_hash = x'77'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(compact(&a, account, 2), 8, "once it replays, the pins move");
+    }
+
+    /// A retained entry at the transport limit grows when re-signed under a predecessor hash. The
+    /// pin it carries cannot move, and must clamp the floor rather than fail every session.
+    #[test]
+    fn a_pin_too_large_to_resign_stays_pinned() {
+        let (a, account) = writer_store();
+        let route = supported_streams_against(&a, account, &[REPO_SPEC]).unwrap().remove(0);
+        let local = crate::load_local_device(&a).unwrap().unwrap();
+        let genesis_len = |title: &str| {
+            let op = RowOp::Upsert {
+                table: "t_transport".to_string(),
+                spec_version: 1,
+                pk: vec![
+                    TypedValue::Text("repo-a".to_string()),
+                    TypedValue::Text("big".to_string()),
+                ],
+                cells: vec![Cell {
+                    column: "title".to_string(),
+                    value: TypedValue::Text(title.to_string()),
+                }],
+            };
+            crate::entry::sign_entry_from_op_bytes(
+                local.secret(),
+                StreamId::from_bytes(route.stream_id),
+                None,
+                0,
+                super::super::row_op::encode(&op),
+            )
+            .signed_bytes
+            .len()
+        };
+        let probe = super::super::TABLE_SYNC_ENTRY_MAX_BYTES - 256;
+        let title = "x".repeat(
+            probe + super::super::TABLE_SYNC_ENTRY_MAX_BYTES - genesis_len(&"x".repeat(probe)),
+        );
+        write(&a, "big", &title);
+        author(&a, account); // big@0, exactly at the limit
+        let stored: i64 = a
+            .query_row(
+                "SELECT length(signed_bytes) FROM table_sync_entries WHERE lamport = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, super::super::TABLE_SYNC_ENTRY_MAX_BYTES as i64);
+        rewrite(&a, account, "c", 8); // c@1..8
+
+        assert_eq!(compact(&a, account, 2), 0, "big cannot move, so it clamps the floor");
+        assert_eq!(chain_lamports(&a), (0..9).collect::<Vec<_>>(), "nothing authored or dropped");
+    }
+
+    /// Only a chain's writer can carry its rows forward: a peer compacting a foreign chain drops
+    /// the superseded prefix below the oldest pin and authors nothing.
+    #[test]
+    fn a_foreign_chain_clamps_at_its_oldest_pin_and_is_never_reauthored() {
+        let (a, account) = writer_store();
+        rewrite(&a, account, "c", 8); // c@0..7, only c@7 live
+        write(&a, "a", "a");
+        write(&a, "b", "b");
+        author(&a, account); // a@8, b@9
+        let peer = peer_of(&a, account);
+        sync_chains(&a, &peer, account);
+
+        assert_eq!(compact(&peer, account, 2), 7, "the prefix below c's winner drops");
+        assert_eq!(chain_lamports(&peer), vec![7, 8, 9], "and the peer authored nothing");
+        assert_eq!(stranded_rows(&peer), 0);
+
+        assert_eq!(compact(&a, account, 2), 8, "the writer moves c instead and reaches the budget");
+        assert_eq!(chain_lamports(&a), vec![8, 9, 10]);
+    }
+
+    /// A pin whose physical row disagrees with its merge state is the producer's to settle, not
+    /// compaction's: re-authoring stops there and the floor clamps at it.
+    #[test]
+    fn a_pin_that_cannot_be_carried_halts_reauthoring_and_clamps_there() {
+        let (a, account) = writer_store();
+        write(&a, "a", "a");
+        write(&a, "b", "b");
+        author(&a, account);
+        rewrite(&a, account, "c", 8);
+        // Deleted but not yet authored: a's clock still names this chain, the row is gone.
+        a.execute("DELETE FROM t_transport WHERE id = 'a'", []).unwrap();
+
+        assert_eq!(compact(&a, account, 2), 0);
+        assert_eq!(chain_lamports(&a), (0..10).collect::<Vec<_>>(), "nothing authored or dropped");
+    }
+
+    /// The re-root case the tombstone pin exists for: a peer offline since before a delete
+    /// rejoins below the writer's floor, and the delete still reaches it.
+    #[test]
+    fn a_peer_rejoining_below_the_floor_still_receives_a_delete() {
+        let (a, account) = writer_store();
+        for id in ["r0", "r1", "r2"] {
+            write(&a, id, id);
+        }
+        author(&a, account); // r0@0, r1@1, r2@2
+        let rejoining = peer_of(&a, account);
+        sync_chains(&a, &rejoining, account);
+
+        a.execute("DELETE FROM t_transport WHERE id = 'r0'", []).unwrap();
+        author(&a, account); // remove r0 @3
+        rewrite(&a, account, "h", 8); // h@4..11, only h@11 live
+        assert_eq!(compact(&a, account, 2), 10);
+        assert_eq!(chain_lamports(&a), vec![10, 11, 12, 13, 14], "r1, r2 and the delete moved");
+        assert_eq!(stranded_rows(&a), 0);
+
+        sync_chains(&a, &rejoining, account);
+        assert_eq!(live_rows(&rejoining), live_rows(&a), "the rejoining peer dropped r0");
+        let fresh = peer_of(&a, account);
+        sync_chains(&a, &fresh, account);
+        assert_eq!(live_rows(&fresh), live_rows(&a));
+    }
+
+    /// A store compacted before the pin rule dropped entries that still carried live rows; the
+    /// driver re-authors those once, whatever the budget, so fresh peers receive them again.
+    #[test]
+    fn rows_stranded_below_an_earlier_floor_are_reauthored_once() {
+        let (a, account) = writer_store();
+        write(&a, "a", "a");
+        write(&a, "b", "b");
+        author(&a, account);
+        rewrite(&a, account, "c", 8);
+        let route = supported_streams_against(&a, account, &[REPO_SPEC]).unwrap().remove(0);
+        let local = crate::load_local_device(&a).unwrap().unwrap().fingerprint();
+        {
+            // What the earlier compaction to floor 8 left behind.
+            let tx = Transaction::new_unchecked(&a, TransactionBehavior::Immediate).unwrap();
+            let floor_hash: Vec<u8> = tx
+                .query_row(
+                    "SELECT entry_hash FROM table_sync_entries WHERE lamport = 8",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            tx.execute("DELETE FROM table_sync_entries WHERE lamport < 8", []).unwrap();
+            retention::record_adopted_floor(
+                &tx,
+                StreamId::from_bytes(route.stream_id),
+                local,
+                8,
+                fixed32(floor_hash).unwrap(),
+                0,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(stranded_rows(&a), 2, "a and b are unreachable from the retained log");
+        // Deleted but not yet authored: a cannot be carried until the producer settles it, and
+        // must not hold b back.
+        a.execute("DELETE FROM t_transport WHERE id = 'a'", []).unwrap();
+
+        assert_eq!(compact(&a, account, 100), 0, "the chain is within budget");
+        assert_eq!(stranded_rows(&a), 1, "b moved to the tail; a waits for its delete");
+        author(&a, account);
+        assert_eq!(stranded_rows(&a), 0, "the producer's delete carries a");
+        assert_eq!(chain_lamports(&a), vec![8, 9, 10, 11]);
+        assert_eq!(compact(&a, account, 100), 0);
+        assert_eq!(chain_lamports(&a), vec![8, 9, 10, 11], "the repair runs once");
+
+        let peer = peer_of(&a, account);
+        sync_chains(&a, &peer, account);
+        assert_eq!(live_rows(&peer), live_rows(&a));
     }
 }

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -390,11 +390,12 @@ impl<F: Fn() -> i64> TableSyncStore for OplogTableSyncStore<'_, F> {
     }
 
     fn prepare(&mut self) -> anyhow::Result<()> {
-        // Author local edits FIRST, then compact: the retention docs require the authoring pass to
-        // have run so a winner restamp never disowns an unsent local edit. `prepare` runs only when
-        // the local device can push, so a read-only peer never compacts. Compaction is a
-        // re-runnable steady-state no-op — bounded scopes (overlay/1) trim to their budget,
-        // fully-retained scopes (anchors/1) are inert.
+        // Author local edits FIRST, then compact: a row whose physical state disagrees with its
+        // merge state halts compaction's re-authoring until the producer has settled it, so
+        // authoring first lets compaction reach its budget in the same pass. `prepare` runs only
+        // when the local device can push, so a read-only peer never compacts. Compaction is
+        // a re-runnable steady-state no-op — bounded scopes (overlay/1) trim to their
+        // budget, fully-retained scopes (anchors/1) are inert.
         let now_ms = (self.now_fn)();
         rag_rat_oplog::table_sync_author_pending(self.conn, self.account_id, now_ms)?;
         rag_rat_oplog::table_sync_compact_overdue(

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -1557,7 +1557,7 @@ async fn a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_flo
         )
         .unwrap();
     rag_rat_oplog::ensure_repo_incarnation(&owner, "repo-a", NOW + 1).unwrap().unwrap();
-    for (memory, path) in [("memory-a", "src/a.rs"), ("memory-b", "src/b.rs")] {
+    let bind = |memory: &str, path: &str| {
         owner
             .execute(
                 "INSERT INTO repo_memory_bindings(
@@ -1568,14 +1568,22 @@ async fn a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_flo
             )
             .unwrap();
         rag_rat_oplog::table_sync_author_pending(&owner, account, NOW + 2).unwrap();
-    }
-    // Compact the owner's chain below all but its last entry: the first binding's winning entry
-    // drops, and only the floor advertisement lets a fresh peer converge.
+    };
+    // 0: memory-a, 1: memory-a moved (supersedes 0), 2: memory-b.
+    bind("memory-a", "src/a.rs");
+    owner
+        .execute("UPDATE repo_memory_bindings SET start_line = 6 WHERE memory_id = 'memory-a'", [])
+        .unwrap();
+    rag_rat_oplog::table_sync_author_pending(&owner, account, NOW + 2).unwrap();
+    bind("memory-b", "src/b.rs");
+    // Compact the owner's chain to a budget of one: memory-a's live entry moves to the tail, and
+    // everything below memory-b's entry drops. Only the floor advertisement lets a fresh peer
+    // converge.
     let compacted = rag_rat_oplog::table_sync_compact_overdue(&owner, account, NOW + 3, &|scope| {
         (scope == "anchors/1").then_some(1)
     })
     .unwrap();
-    assert_eq!(compacted, 1, "the first binding's entry is reclaimed");
+    assert_eq!(compacted, 2, "memory-a's two entries are reclaimed");
     for entry in account_entries_for_sync(&owner, account).unwrap() {
         rag_rat_oplog::account_ingest(&joiner, &entry.signed_bytes, NOW + 2).unwrap();
     }
@@ -1601,34 +1609,29 @@ async fn a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_flo
     let client_report = client.unwrap();
     assert_eq!(alpn, TABLE_SYNC_ALPN);
     assert_eq!(
-        client_report.entries_newly_stored, 1,
+        client_report.entries_newly_stored, 2,
         "only the retained suffix transfers — the floor entry roots the fresh chain",
     );
 
-    let surviving: bool = joiner
-        .query_row(
-            "SELECT EXISTS(
-                 SELECT 1 FROM repo_memory_bindings
-                 WHERE repo_id = 'repo-a' AND memory_id = 'memory-b')",
-            [],
-            |row| row.get(0),
+    let bindings: Vec<(String, i64)> = joiner
+        .prepare(
+            "SELECT memory_id, start_line FROM repo_memory_bindings
+             WHERE repo_id = 'repo-a' ORDER BY memory_id",
         )
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
         .unwrap();
-    assert!(surviving, "the row whose entry is at/above the floor converges");
-    let compacted_row: bool = joiner
-        .query_row(
-            "SELECT EXISTS(
-                 SELECT 1 FROM repo_memory_bindings
-                 WHERE repo_id = 'repo-a' AND memory_id = 'memory-a')",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap();
-    assert!(!compacted_row, "the reclaimed prefix honestly does not arrive");
+    assert_eq!(
+        bindings,
+        vec![("memory-a".to_string(), 6), ("memory-b".to_string(), 4)],
+        "every live row converges, memory-a at its latest state",
+    );
     let floor: Option<i64> = joiner
         .query_row("SELECT lamport FROM table_sync_retained_floors", [], |row| row.get(0))
         .ok();
-    assert_eq!(floor, Some(1), "the adopted floor is recorded, so re-offers propagate it");
+    assert_eq!(floor, Some(2), "the adopted floor is recorded, so re-offers propagate it");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Table-sync compaction dropped every accepted entry below the floor, including entries that were still the LWW winner of a live row or the tombstone of a deleted one. It then restamped the published record so the producer would not re-author those rows. That hid the loss rather than preventing it:

- A fresh peer folds only the retained suffix, so it never received a row whose winner had been dropped.
- A peer re-rooting past a dropped delete kept the deleted row.

## The pin rule

A chain's *pins* are its live winners and the tombstones whose pk has no live row. Only superseded entries are reclaimable.

- `compact_chain_prefix` refuses a floor above a pin. The check covers only the window being reclaimed (`[current floor, new floor)`), so rows already stranded by the earlier rule never wedge it.
- The driver clamps its floor at the oldest pin. A foreign chain is never re-authored; only its writer can carry its rows forward.
- On the local device's own chain, the driver first re-authors its oldest pins at the tail. It picks the longest run whose move frees at least twice the entries it authors, weighed over the whole run and carried at most 64 per pass. Long-lived rows therefore do not pin a churning chain forever, total re-authoring stays bounded by genuine writes, and a chain that is all pins authors nothing.
- A store compacted by the earlier rule may hold rows whose carrying entry is already gone. The driver re-authors those on the local chain once, each row on its own.

`refresh_winners_below` and `CompactionReport.refreshed_rows` are gone. The spec-bump horizon they caused (a restamped row taking `StaleRow::Unknown` after a spec bump) is gone with them.

## Shared repair seam

The re-adoption drain and compaction now share `row_repair_op` and the author-and-self-apply step. Both hold a repair when:

- **An accepted entry this binary cannot apply yet sits above the row's winner**, for example a newer spec version during a rolling upgrade. That entry may be a newer write to the row which up-to-date peers have applied, and a repair signed at the stream tail would overwrite it there.
- **The re-signed entry would exceed the transport limit.** A retained entry at the limit grows under a predecessor hash. The row stays pinned instead of failing every session's `prepare`.

## Accepted horizons (module docs)

- A chain holds at least its pins, whatever its budget. Orphan tombstones stay pinned until tombstone collection exists.
- A re-authored pin is a new write. It competes under LWW with a concurrent edit to that row which this device has not received yet, which is the same cost re-adoption already accepts.

## Tests

- `retention.rs`:
  - `compaction_drops_only_superseded_entries`, which includes a spec bump after compaction (the producer authors nothing).
  - `a_live_winner_pins_its_entry_and_an_unsent_edit_is_still_authored`
  - `an_orphan_tombstone_pins_until_its_row_is_live_again`
  - The existing tests now compact superseded prefixes. The repair-candidate test simulates a store compacted by the earlier rule.
- `transport.rs` driver:
  - `live_rows_past_the_budget_are_kept_and_nothing_is_reauthored`
  - `the_writer_reauthors_its_oldest_pins_when_that_frees_twice_as_much`
  - `moving_pins_that_free_less_than_twice_their_cost_does_not_pay`
  - `a_run_of_pins_longer_than_the_pass_cap_still_reaches_the_budget`
  - `a_foreign_chain_clamps_at_its_oldest_pin_and_is_never_reauthored`
  - `a_foreign_chain_stranded_below_an_earlier_floor_still_compacts`
  - `a_pin_that_cannot_be_carried_halts_reauthoring_and_clamps_there`
  - `a_parked_newer_write_holds_the_pins_below_it`
  - `a_pin_too_large_to_resign_stays_pinned`
  - `a_peer_rejoining_below_the_floor_still_receives_a_delete`: a peer offline since before a delete re-roots onto the floor and drops the row, and a fresh peer matches.
  - `rows_stranded_below_an_earlier_floor_are_reauthored_once`
- `engine.rs`: `readoption_waits_while_a_parked_newer_write_sits_above_the_winner`.
- `rag-rat-sync/tests/oplog_sync.rs`: `a_fresh_peer_converges_through_a_compacted_chain_via_the_advertised_floor` previously asserted that the compacted row does not arrive. It now asserts that every live row converges over a real session.

Each rule was checked by breaking it in turn: the missing guard, no tombstone pins, a live-again tombstone still pinning, the guard window starting at 0, the capped search, the `> k` threshold, the smallest `k`, no per-pass cap, ignoring a halted re-author, no stranded repair, the repair not being per row, no pending guard, and a size error. Each makes at least one test fail.

`cargo nextest run --workspace` (5377 passed), plain `cargo test` including doctests, clippy under all four CI configurations at `-D warnings`, and `cargo +nightly fmt --check` all pass.

Fixes #1277
