### PR TITLE
feat(sync): publish each symbol anchor's scope so a rebind between twin impls follows

### DIFF
--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -632,7 +632,7 @@ fn consolidate_rebuilds_stale_content_projection_before_reconcile() {
     // Pinned as a literal because the constant is oplog-internal and exporting it would make a
     // projector detail a public commitment for one assertion's sake. Move this with the next
     // CONTENT_PROJECTOR_VERSION bump.
-    assert_eq!(stamp, "6", "consolidate upgraded the store-global projector stamp");
+    assert_eq!(stamp, "7", "consolidate upgraded the store-global projector stamp");
 }
 
 /// Two clones of one repository share its repo id but hold separate legacy indexes, each pinned to

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
@@ -1928,6 +1928,7 @@ fn a_published_rebind_between_same_named_impls_follows_the_signature() {
                 &memory_id,
                 &rag_rat_oplog::PortableAnchor { binding_kind, binding_id, ..published },
                 None,
+                None,
             )
             .unwrap();
             tx.commit().unwrap();
@@ -2094,8 +2095,13 @@ fn an_edited_symbols_memory_is_not_taken_by_a_sibling_with_its_old_signature() {
                 .unwrap();
         // The drain compares against what the author published last — the recorded values — not
         // the row, which relocation refreshed to this checkout's `new(cap)`.
-        let previous = Some((recorded_kind.clone(), recorded_signature.clone()));
-        crate::memory_write::refresh_binding(&tx, &repo_id, &memory_id, &anchor, previous).unwrap();
+        let previous = Some(rag_rat_query::memory::AppliedTarget {
+            symbol_kind: recorded_kind.clone(),
+            signature_hash: recorded_signature.clone(),
+            scope_hash: None,
+        });
+        crate::memory_write::refresh_binding(&tx, &repo_id, &memory_id, &anchor, previous, None)
+            .unwrap();
         tx.commit().unwrap();
         db.memory_validate().unwrap();
         assert_eq!(
@@ -2214,6 +2220,7 @@ fn a_linked_checkout_without_the_authors_target_leaves_the_retarget_to_the_base(
                 moniker_tool: None,
                 moniker_tool_version: None,
             },
+            None,
             None,
         )
         .unwrap();
@@ -2369,6 +2376,396 @@ fn a_local_kind_change_is_not_taken_by_a_sibling_with_the_old_kind() {
 
     let _ = fs::remove_dir_all(&linked);
     let _ = fs::remove_dir_all(&main);
+}
+
+/// `(logical id, start line, signature hash, scope path)` of a symbol row.
+fn twin_facts(db: &IndexDatabase, symbol_id: i64) -> (i64, i64, Option<String>, String) {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT (SELECT m.logical_symbol_id FROM logical_symbol_members m
+                      WHERE m.symbol_id = s.id LIMIT 1),
+                    c.start_line, s.signature, s.scope_path
+               FROM symbols s JOIN chunks c ON c.symbol_id = s.id
+              WHERE s.id = ?1",
+            [symbol_id],
+            |r| {
+                let signature: Option<String> = r.get(2)?;
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    signature.map(|sig| rag_rat_base::hash::hex_sha256(sig.trim().as_bytes())),
+                    r.get(3)?,
+                ))
+            },
+        )
+        .unwrap()
+}
+
+/// Apply a foreign author's rebind of `memory_id` to the impl at `start_line` as the drain does:
+/// the row refreshed in place against the baseline the previous set recorded (`previous_scope`),
+/// and the new set's kind, signature and scope recorded as the memory's applied targets.
+fn apply_scoped_rebind(
+    db: &IndexDatabase,
+    memory_id: &str,
+    start_line: i64,
+    signature_hash: Option<String>,
+    previous_scope: Option<&str>,
+    published_scope: Option<&str>,
+) {
+    use rag_rat_query::memory::{AppliedTarget, encode_applied_targets};
+
+    let conn = db.storage.connection();
+    let (repo_id, binding_kind, binding_id): (String, String, String) = conn
+        .query_row(
+            "SELECT repo_id, binding_kind, binding_id FROM repo_memory_bindings
+              WHERE memory_id = ?1",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    let anchor = rag_rat_oplog::PortableAnchor {
+        binding_kind: binding_kind.clone(),
+        binding_id: binding_id.clone(),
+        path: Some("src/lib.rs".to_string()),
+        start_line: Some(start_line),
+        end_line: Some(start_line),
+        commit_hash: None,
+        tracker: None,
+        project: None,
+        item_key: None,
+        created_at_ms: 1,
+        symbol_kind: Some("impl".to_string()),
+        signature_hash: signature_hash.clone(),
+        moniker_tool: None,
+        moniker_tool_version: None,
+    };
+    let target = |scope: Option<&str>| AppliedTarget {
+        symbol_kind: Some("impl".to_string()),
+        signature_hash: signature_hash.clone(),
+        scope_hash: scope.map(str::to_string),
+    };
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)
+        .unwrap();
+    crate::memory_write::refresh_binding(
+        &tx,
+        &repo_id,
+        memory_id,
+        &anchor,
+        Some(target(previous_scope)),
+        published_scope,
+    )
+    .unwrap();
+    let targets = [((binding_kind, binding_id), target(published_scope))].into_iter().collect();
+    tx.execute(
+        "UPDATE repo_memories SET anchors_applied_targets = ?2, source_text_hash = NULL
+          WHERE id = ?1",
+        params![memory_id, encode_applied_targets(&targets).unwrap()],
+    )
+    .unwrap();
+    tx.commit().unwrap();
+}
+
+/// `(start line, relocation reason, verdict)` of a memory's one binding.
+fn landed_binding(db: &IndexDatabase, memory_id: &str) -> (Option<i64>, Option<String>, String) {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT start_line, relocation_reason, anchor_status FROM repo_memory_bindings
+              WHERE memory_id = ?1",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap()
+}
+
+/// A memory bound to the Alpha impl of [`TWO_TRAIT_IMPLS_FIXTURE`], by raw id or logical handle.
+fn memory_on_alpha(db: &IndexDatabase, alpha: i64, by_logical_handle: bool, title: &str) -> String {
+    let (alpha_group, ..) = twin_facts(db, alpha);
+    let bind = if by_logical_handle {
+        rag_rat_query::memory::RepoMemoryBindTarget {
+            logical_symbol_id: Some(alpha_group),
+            ..Default::default()
+        }
+    } else {
+        rag_rat_query::memory::RepoMemoryBindTarget { symbol_id: Some(alpha), ..Default::default() }
+    };
+    let memory_id = db
+        .memory_create(rag_rat_query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: format!("{title}, bound to the Alpha impl."),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind,
+        })
+        .unwrap()
+        .memory
+        .memory_id;
+    db.memory_validate().unwrap();
+    memory_id
+}
+
+/// Two impls of one type with the trait on a later line agree on the qualified name, the kind and
+/// the captured signature, so a published rebind between them changes nothing the anchor carries
+/// (#1276). The author publishes each symbol anchor's SCOPE beside the set; the drain marks the row
+/// when it changed, and the validator follows it to Beta over the handle that still names Alpha. A
+/// republish of the same scope is no retarget, and a scope nothing here has names nothing: the
+/// handle stands and the mark waits for a checkout that holds the author's target.
+#[test]
+fn a_published_rebind_between_identical_signature_twins_follows_the_scope() {
+    use rag_rat_base::hash::hex_sha256;
+    use rag_rat_query::memory::RETARGETED_REASON;
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let (alpha, beta) = trait_impl_twins(&db);
+    let (_, _, signature, alpha_scope) = twin_facts(&db, alpha);
+    let (_, beta_line, _, beta_scope) = twin_facts(&db, beta);
+    let (alpha_hash, beta_hash) =
+        (hex_sha256(alpha_scope.as_bytes()), hex_sha256(beta_scope.as_bytes()));
+
+    for (title, by_logical_handle) in [("raw symbol id", false), ("logical handle", true)] {
+        let memory_id = memory_on_alpha(&db, alpha, by_logical_handle, title);
+        let validated = |previous: &str, published: &str| {
+            apply_scoped_rebind(
+                &db,
+                &memory_id,
+                beta_line,
+                signature.clone(),
+                Some(previous),
+                Some(published),
+            );
+            db.memory_validate().unwrap();
+            db.memory_validate().unwrap();
+            landed_binding(&db, &memory_id)
+        };
+
+        let (line, reason, status) = validated(&alpha_hash, &beta_hash);
+        assert_eq!(line, Some(beta_line), "bound by {title}: the scope names Beta");
+        assert_eq!(reason, None, "bound by {title}: landing on it answers the mark");
+        assert_eq!(status, "current", "bound by {title}");
+
+        let (line, reason, _) = validated(&beta_hash, &beta_hash);
+        assert_eq!(line, Some(beta_line), "bound by {title}: the same scope is a republish");
+        assert_eq!(reason, None, "bound by {title}: and marks nothing");
+
+        let gamma_hash = hex_sha256(b"Twin as Gamma");
+        let (line, reason, status) = validated(&beta_hash, &gamma_hash);
+        assert_eq!(line, Some(beta_line), "bound by {title}: a scope nothing here has keeps it");
+        assert_eq!(reason.as_deref(), Some(RETARGETED_REASON), "bound by {title}: mark waits");
+        assert_ne!(status, "gone", "bound by {title}: the handle is validated live");
+    }
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// The retarget mark sits on a row every checkout of the repo shares. A linked worktree that does
+/// not hold the author's twin (it renamed Beta's trait, which changes the scope) must leave the
+/// mark and the handle for the base checkout, which then moves the memory to Beta and answers.
+#[test]
+fn a_linked_checkout_without_the_authors_twin_leaves_the_scope_retarget_to_the_base() {
+    use rag_rat_base::hash::hex_sha256;
+    use rag_rat_query::memory::RETARGETED_REASON;
+
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.to_path_buf(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let (alpha, beta) = trait_impl_twins(&db);
+    let (_, alpha_line, signature, alpha_scope) = twin_facts(&db, alpha);
+    let (_, beta_line, _, beta_scope) = twin_facts(&db, beta);
+    let memory_id = memory_on_alpha(&db, alpha, false, "Rebound from Alpha to Beta by its author");
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(
+        linked.join("src/lib.rs"),
+        TWO_TRAIT_IMPLS_FIXTURE.replace("Beta for Twin {", "Gamma for Twin {"),
+    )
+    .unwrap();
+    run_git(&linked, &["commit", "-q", "-am", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    apply_scoped_rebind(
+        &db,
+        &memory_id,
+        beta_line,
+        signature,
+        Some(&hex_sha256(alpha_scope.as_bytes())),
+        Some(&hex_sha256(beta_scope.as_bytes())),
+    );
+
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    for pass in 0..2 {
+        db.memory_validate().unwrap();
+        let (line, reason, _) = landed_binding(&db, &memory_id);
+        assert_eq!(line, Some(alpha_line), "linked pass {pass}: no Beta here, the handle stands");
+        assert_eq!(
+            reason.as_deref(),
+            Some(RETARGETED_REASON),
+            "linked pass {pass}: the mark is left for the base checkout",
+        );
+    }
+
+    db.use_worktree_scope(&main, None).unwrap();
+    db.memory_validate().unwrap();
+    let (line, reason, _) = landed_binding(&db, &memory_id);
+    assert_eq!(line, Some(beta_line), "the base checkout moves the memory to Beta");
+    assert_eq!(reason, None, "and answers the retarget");
+
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(&main);
+}
+
+/// A linked worktree that holds the author's twin (it edited only Beta's body, so Beta keeps its
+/// logical identity) answers the scope retarget itself, and the base checkout then lands on its own
+/// Beta through the shared logical handle rather than being pulled back to Alpha.
+#[test]
+fn a_linked_checkout_holding_the_authors_twin_answers_the_scope_retarget_for_both() {
+    use rag_rat_base::hash::hex_sha256;
+
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.to_path_buf(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let (alpha, beta) = trait_impl_twins(&db);
+    let (_, _, signature, alpha_scope) = twin_facts(&db, alpha);
+    let (_, beta_line, _, beta_scope) = twin_facts(&db, beta);
+    let memory_id = memory_on_alpha(&db, alpha, false, "Rebound to Beta, answered on a branch");
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(
+        linked.join("src/lib.rs"),
+        TWO_TRAIT_IMPLS_FIXTURE.replace(
+            "Beta for Twin { fn run(&self) {} }",
+            "Beta for Twin { fn run(&self) { let _ = 1; } }",
+        ),
+    )
+    .unwrap();
+    run_git(&linked, &["commit", "-q", "-am", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    apply_scoped_rebind(
+        &db,
+        &memory_id,
+        beta_line,
+        signature,
+        Some(&hex_sha256(alpha_scope.as_bytes())),
+        Some(&hex_sha256(beta_scope.as_bytes())),
+    );
+
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    db.memory_validate().unwrap();
+    let (line, reason, _) = landed_binding(&db, &memory_id);
+    assert_eq!(line, Some(beta_line), "the linked checkout holds Beta and follows the scope");
+    assert_eq!(reason, None, "and answers the retarget");
+
+    db.use_worktree_scope(&main, None).unwrap();
+    for pass in 0..2 {
+        db.memory_validate().unwrap();
+        let (line, reason, _) = landed_binding(&db, &memory_id);
+        assert_eq!(line, Some(beta_line), "base pass {pass}: lands on its own Beta, never Alpha");
+        assert_eq!(reason, None, "base pass {pass}");
+    }
+
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(&main);
+}
+
+/// The author publishes each symbol anchor's scope, hashed, beside the set — read through the
+/// row's own handle, raw or logical.
+#[test]
+fn the_author_publishes_each_symbol_anchor_s_scope_beside_the_set() {
+    use rag_rat_base::hash::hex_sha256;
+    use rag_rat_oplog::MemoryOp;
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let (_, beta) = trait_impl_twins(&db);
+    let (beta_group, _, _, beta_scope) = twin_facts(&db, beta);
+    let struct_twin: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM symbols WHERE name = 'Twin' AND kind = 'struct'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let bound_to = |title: &str, bind: rag_rat_query::memory::RepoMemoryBindTarget| {
+        db.memory_create(rag_rat_query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind,
+        })
+        .unwrap()
+        .memory
+        .memory_id
+    };
+    let published_scopes = |memory_id: &str| -> Vec<(String, String)> {
+        let ops = crate::memory_write::anchor_publication_ops(db.storage.connection(), memory_id)
+            .unwrap();
+        let [
+            MemoryOp::NodeSourceHash { .. },
+            MemoryOp::NodeAnchorScopes { scopes, .. },
+            MemoryOp::NodeAnchors { .. },
+        ] = ops.as_slice()
+        else {
+            panic!("hash, scopes, anchors expected: {ops:?}");
+        };
+        scopes.iter().map(|s| (s.binding_kind.clone(), s.scope_hash.clone())).collect()
+    };
+    let beta_hash = hex_sha256(beta_scope.as_bytes());
+
+    let by_raw = bound_to("By raw id", rag_rat_query::memory::RepoMemoryBindTarget {
+        symbol_id: Some(beta),
+        ..Default::default()
+    });
+    assert_eq!(published_scopes(&by_raw), vec![("symbol".to_string(), beta_hash.clone())]);
+
+    let by_logical = bound_to("By logical handle", rag_rat_query::memory::RepoMemoryBindTarget {
+        logical_symbol_id: Some(beta_group),
+        ..Default::default()
+    });
+    assert_eq!(published_scopes(&by_logical), vec![("logical_symbol".to_string(), beta_hash)]);
+
+    // A scope path always ends in the symbol's own segment, so even a top-level type carries one.
+    let top_level = bound_to("Top level", rag_rat_query::memory::RepoMemoryBindTarget {
+        symbol_id: Some(struct_twin),
+        ..Default::default()
+    });
+    assert_eq!(published_scopes(&top_level), vec![("symbol".to_string(), hex_sha256(b"Twin"))]);
+
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Each trait sits on the line AFTER `impl` so both impl symbols capture the same signature text,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/key_drift/refresh.rs
@@ -2570,6 +2570,9 @@ fn a_published_rebind_between_identical_signature_twins_follows_the_scope() {
 /// The retarget mark sits on a row every checkout of the repo shares. A linked worktree that does
 /// not hold the author's twin (it renamed Beta's trait, which changes the scope) must leave the
 /// mark and the handle for the base checkout, which then moves the memory to Beta and answers.
+/// That is the raw-id arm, whose candidates are the validating checkout's own. The logical arm's
+/// candidates are repo-wide, so the linked checkout answers there itself, moving the handle to
+/// Beta's logical group; the base checkout then validates it live on its Beta.
 #[test]
 fn a_linked_checkout_without_the_authors_twin_leaves_the_scope_retarget_to_the_base() {
     use rag_rat_base::hash::hex_sha256;
@@ -2586,8 +2589,9 @@ fn a_linked_checkout_without_the_authors_twin_leaves_the_scope_retarget_to_the_b
     let mut db = IndexDatabase::rebuild(&config).unwrap();
     let (alpha, beta) = trait_impl_twins(&db);
     let (_, alpha_line, signature, alpha_scope) = twin_facts(&db, alpha);
-    let (_, beta_line, _, beta_scope) = twin_facts(&db, beta);
-    let memory_id = memory_on_alpha(&db, alpha, false, "Rebound from Alpha to Beta by its author");
+    let (beta_group, beta_line, _, beta_scope) = twin_facts(&db, beta);
+    let by_raw = memory_on_alpha(&db, alpha, false, "Rebound to Beta, bound by raw id");
+    let by_logical = memory_on_alpha(&db, alpha, true, "Rebound to Beta, bound by logical handle");
 
     let linked = unique_temp_root();
     let _ = fs::remove_dir_all(&linked);
@@ -2600,32 +2604,50 @@ fn a_linked_checkout_without_the_authors_twin_leaves_the_scope_retarget_to_the_b
     run_git(&linked, &["commit", "-q", "-am", "branch"]);
     db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
 
-    apply_scoped_rebind(
-        &db,
-        &memory_id,
-        beta_line,
-        signature,
-        Some(&hex_sha256(alpha_scope.as_bytes())),
-        Some(&hex_sha256(beta_scope.as_bytes())),
-    );
+    for memory_id in [&by_raw, &by_logical] {
+        apply_scoped_rebind(
+            &db,
+            memory_id,
+            beta_line,
+            signature.clone(),
+            Some(&hex_sha256(alpha_scope.as_bytes())),
+            Some(&hex_sha256(beta_scope.as_bytes())),
+        );
+    }
+    let logical_handle = |db: &IndexDatabase, memory_id: &str| -> Option<i64> {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
 
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
     for pass in 0..2 {
         db.memory_validate().unwrap();
-        let (line, reason, _) = landed_binding(&db, &memory_id);
+        let (line, reason, _) = landed_binding(&db, &by_raw);
         assert_eq!(line, Some(alpha_line), "linked pass {pass}: no Beta here, the handle stands");
         assert_eq!(
             reason.as_deref(),
             Some(RETARGETED_REASON),
             "linked pass {pass}: the mark is left for the base checkout",
         );
+        let (_, reason, _) = landed_binding(&db, &by_logical);
+        assert_eq!(reason, None, "linked pass {pass}: the logical arm answers repo-wide");
+        assert_eq!(logical_handle(&db, &by_logical), Some(beta_group), "linked pass {pass}");
     }
 
     db.use_worktree_scope(&main, None).unwrap();
     db.memory_validate().unwrap();
-    let (line, reason, _) = landed_binding(&db, &memory_id);
+    let (line, reason, _) = landed_binding(&db, &by_raw);
     assert_eq!(line, Some(beta_line), "the base checkout moves the memory to Beta");
     assert_eq!(reason, None, "and answers the retarget");
+    let (line, reason, status) = landed_binding(&db, &by_logical);
+    assert_eq!(line, Some(beta_line), "the base checkout validates the handle live on Beta");
+    assert_eq!((reason, status.as_str()), (None, "current"));
 
     let _ = fs::remove_dir_all(&linked);
     let _ = fs::remove_dir_all(&main);
@@ -2704,6 +2726,10 @@ fn the_author_publishes_each_symbol_anchor_s_scope_beside_the_set() {
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), TWO_TRAIT_IMPLS_FIXTURE).unwrap();
+    // A git root, so the memory scope is stable and a create authors into the op-log.
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "base"]);
     let config = source_config(root.clone(), Language::Rust);
     let db = IndexDatabase::rebuild(&config).unwrap();
     let (_, beta) = trait_impl_twins(&db);
@@ -2745,18 +2771,41 @@ fn the_author_publishes_each_symbol_anchor_s_scope_beside_the_set() {
         scopes.iter().map(|s| (s.binding_kind.clone(), s.scope_hash.clone())).collect()
     };
     let beta_hash = hex_sha256(beta_scope.as_bytes());
+    // The scope a create actually published, read back from the PROJECTION: through the op, the
+    // fold's pairing and `anchors_json`, as a peer would see it.
+    let projected_scope = |memory_id: &str, binding_kind: &str| -> Option<String> {
+        let conn = db.storage.connection();
+        let repo_id: String = conn
+            .query_row("SELECT repo_id FROM repo_memories WHERE id = ?1", [memory_id], |r| r.get(0))
+            .unwrap();
+        let stream = rag_rat_oplog::owned_stream_v2_id(conn, &repo_id).unwrap().unwrap();
+        rag_rat_oplog::list_projected_content_nodes(conn, stream)
+            .unwrap()
+            .into_iter()
+            .find(|node| node.node_id == memory_id)
+            .expect("the memory projects as a node")
+            .anchor_scopes
+            .into_iter()
+            .find(|((kind, _), _)| kind == binding_kind)
+            .map(|(_, scope)| scope)
+    };
 
     let by_raw = bound_to("By raw id", rag_rat_query::memory::RepoMemoryBindTarget {
         symbol_id: Some(beta),
         ..Default::default()
     });
     assert_eq!(published_scopes(&by_raw), vec![("symbol".to_string(), beta_hash.clone())]);
+    assert_eq!(projected_scope(&by_raw, "symbol"), Some(beta_hash.clone()), "projected");
 
     let by_logical = bound_to("By logical handle", rag_rat_query::memory::RepoMemoryBindTarget {
         logical_symbol_id: Some(beta_group),
         ..Default::default()
     });
-    assert_eq!(published_scopes(&by_logical), vec![("logical_symbol".to_string(), beta_hash)]);
+    assert_eq!(published_scopes(&by_logical), vec![(
+        "logical_symbol".to_string(),
+        beta_hash.clone()
+    )]);
+    assert_eq!(projected_scope(&by_logical, "logical_symbol"), Some(beta_hash), "projected");
 
     // A scope path always ends in the symbol's own segment, so even a top-level type carries one.
     let top_level = bound_to("Top level", rag_rat_query::memory::RepoMemoryBindTarget {

--- a/crates/rag-rat-core/src/memory_write/api.rs
+++ b/crates/rag-rat-core/src/memory_write/api.rs
@@ -645,6 +645,7 @@ mod anchor_authoring_tests {
         assert!(
             matches!(ops.as_slice(), [
                 MemoryOp::NodeSourceHash { .. },
+                MemoryOp::NodeAnchorScopes { .. },
                 MemoryOp::NodeAnchors { .. }
             ]),
             "{ops:?}"
@@ -653,8 +654,11 @@ mod anchor_authoring_tests {
         assert!(
             matches!(
                 ops.as_slice(),
-                [MemoryOp::NodeSourceHash { source_text_hash, .. }, MemoryOp::NodeAnchors { .. }]
-                    if source_text_hash.is_empty()
+                [
+                    MemoryOp::NodeSourceHash { source_text_hash, .. },
+                    MemoryOp::NodeAnchorScopes { scopes, .. },
+                    MemoryOp::NodeAnchors { .. }
+                ] if source_text_hash.is_empty() && scopes.is_empty()
             ),
             "{ops:?}"
         );

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -1177,24 +1177,65 @@ fn read_anchor_backfill_ids(
     repo_id: &str,
     stream: StreamId,
 ) -> anyhow::Result<Vec<String>> {
-    let mut stmt = conn.prepare(
+    // The scope leg republishes this device's bindings as the memory's set, so it is confined to
+    // sets THIS account authored whose bindings still equal the projected set by target: a
+    // contributor's set on an owner-created memory, or a sibling device's newer rebind the local
+    // rows have yet to catch up with, must not be re-signed here as this device's own.
+    let local_account = rag_rat_oplog::read_local_account(conn)?.map(|account| account.to_bytes());
+    let mut stmt = conn.prepare(&format!(
         // `origin = 'local'` for the same load-bearing reason as the node anti-join above: a
         // synced row is a peer's to publish, never this device's to author.
+        //
+        // The second leg is the scope backfill (#1276): a set published before the scope op
+        // existed projects symbol anchors with no `scope_hash`. Where such an anchor's binding
+        // still resolves a scope, the memory is swept again, so an upgraded author republishes its
+        // unchanged set with scopes beside it and a receiver's baseline gains them before the next
+        // rebind. It converges: the republished scope lands in the projection, and an anchor whose
+        // handle resolves nothing is never selected. Only for a set this account authored whose
+        // bindings still equal the projected set by target (see `ANCHOR_MATCHES_BINDING_SQL`).
         "SELECT m.id
          FROM repo_memories m
          JOIN content_projected_nodes p ON p.stream_id = ?2 AND p.node_id = m.id
          WHERE m.repo_id = ?1
            AND m.origin = 'local'
-           AND p.anchors_json IS NULL
            AND EXISTS (
                  SELECT 1 FROM repo_memory_bindings b
                  WHERE b.memory_id = m.id AND b.repo_id = m.repo_id)
+           AND (p.anchors_json IS NULL
+                OR (p.anchors_author = ?4
+                    AND EXISTS (
+                         SELECT 1 FROM json_each(p.anchors_json) a
+                         JOIN repo_memory_bindings b
+                           ON b.memory_id = m.id AND b.repo_id = m.repo_id
+                          AND b.binding_kind = json_extract(a.value, '$.binding_kind')
+                          AND b.binding_id = json_extract(a.value, '$.binding_id')
+                         WHERE json_extract(a.value, '$.binding_kind')
+                                   IN ('symbol', 'logical_symbol')
+                           AND json_extract(a.value, '$.scope_hash') IS NULL
+                           AND COALESCE({BOUND_SCOPE_PATH_SQL}, '') != '')
+                    AND NOT EXISTS (
+                         SELECT 1 FROM repo_memory_bindings b
+                         WHERE b.memory_id = m.id AND b.repo_id = m.repo_id
+                           AND NOT EXISTS (
+                                 SELECT 1 FROM json_each(p.anchors_json) a
+                                 WHERE {ANCHOR_MATCHES_BINDING_SQL}))
+                    AND NOT EXISTS (
+                         SELECT 1 FROM json_each(p.anchors_json) a
+                         WHERE NOT EXISTS (
+                                 SELECT 1 FROM repo_memory_bindings b
+                                 WHERE b.memory_id = m.id AND b.repo_id = m.repo_id
+                                   AND {ANCHOR_MATCHES_BINDING_SQL}))))
          ORDER BY m.created_at_ms, m.id
-         LIMIT ?3",
-    )?;
+         LIMIT ?3"
+    ))?;
     let ids = stmt
         .query_map(
-            params![repo_id, stream.to_bytes().as_slice(), ANCHOR_BACKFILL_SCAN_PER_PASS],
+            params![
+                repo_id,
+                stream.to_bytes().as_slice(),
+                ANCHOR_BACKFILL_SCAN_PER_PASS,
+                local_account.as_ref().map(|bytes| bytes.as_slice()),
+            ],
             |row| row.get::<_, String>(0),
         )?
         .collect::<Result<Vec<_>, _>>()?;
@@ -2220,27 +2261,55 @@ pub(crate) fn anchor_publication_ops(
     Ok(vec![hash, scopes, anchors])
 }
 
+/// The scope path a symbol binding `b` resolves to through its own handle, as a SQL expression: the
+/// raw symbol row first, else the logical group's first member. Either is trusted only if it still
+/// answers to the binding's qualified name — a raw symbol id is a rowid reassigned on reindex and
+/// carries no foreign key, so a stale one can name an unrelated live symbol, whose scope would then
+/// be published as this target's. NULL, or empty, when the handle is dead or predates the column.
+const BOUND_SCOPE_PATH_SQL: &str = "COALESCE(
+    (SELECT s.scope_path FROM symbols s
+      WHERE s.id = b.symbol_id
+        AND s.qualified_name_id = (SELECT id FROM name_strings WHERE value = b.binding_id)),
+    (SELECT s.scope_path FROM logical_symbol_members m
+       JOIN symbols s ON s.id = m.symbol_id
+       JOIN logical_symbols ls ON ls.id = m.logical_symbol_id
+      WHERE m.logical_symbol_id = b.logical_symbol_id
+        AND ls.qualified_name_id = (SELECT id FROM name_strings WHERE value = b.binding_id)
+      ORDER BY m.start_line LIMIT 1))";
+
+/// Whether a projected anchor `a` (a `json_each` row over `anchors_json`) and a binding row `b`
+/// name the same row, the same target AND the same publication, as a SQL predicate. The target is
+/// compared as the drain's `same_target` compares it — on what identifies it, not where it sits,
+/// since the validate loop rewrites `path` and the line span for the same target. The publication
+/// is `created_at_ms`: each rebind restamps it and `anchors/1` carries it verbatim, so it tells a
+/// row a sibling device's newer rebind has yet to reach from the set that device published —
+/// which the target columns cannot, when the rebind was between twins agreeing on all of them.
+const ANCHOR_MATCHES_BINDING_SQL: &str = "json_extract(a.value, '$.binding_kind') = b.binding_kind
+    AND json_extract(a.value, '$.binding_id') = b.binding_id
+    AND json_extract(a.value, '$.created_at_ms') = b.created_at_ms
+    AND json_extract(a.value, '$.symbol_kind') IS b.symbol_kind
+    AND json_extract(a.value, '$.signature_hash') IS b.signature_hash
+    AND json_extract(a.value, '$.moniker_tool') IS b.moniker_tool
+    AND json_extract(a.value, '$.commit_hash') IS b.commit_hash
+    AND json_extract(a.value, '$.tracker') IS b.tracker
+    AND json_extract(a.value, '$.project') IS b.project
+    AND json_extract(a.value, '$.item_key') IS b.item_key";
+
 /// The `NodeAnchorScopes` op for a memory's symbol bindings: each one's live target's scope path,
 /// hashed — the identity component the anchor itself leaves out, and the only one that tells two
 /// impls of different traits for one type apart when their kind and captured signature agree
-/// (#1276). Read through the row's own handle, so a binding whose handle is dead, or whose target
-/// row predates the scope column, contributes nothing: a scope is published only where it is
-/// known, never guessed.
+/// (#1276). Read through the row's own handle ([`BOUND_SCOPE_PATH_SQL`]), so a binding whose
+/// handle is dead, or whose target row predates the scope column, contributes nothing: a scope is
+/// published only where it is known, never guessed.
 fn anchor_scopes_op(conn: &Connection, memory_id: &str) -> anyhow::Result<MemoryOp> {
-    let mut stmt = conn.prepare(
-        "SELECT b.binding_kind, b.binding_id,
-                COALESCE(
-                    (SELECT s.scope_path FROM symbols s WHERE s.id = b.symbol_id),
-                    (SELECT s.scope_path FROM logical_symbol_members m
-                       JOIN symbols s ON s.id = m.symbol_id
-                      WHERE m.logical_symbol_id = b.logical_symbol_id
-                      ORDER BY m.start_line LIMIT 1))
+    let mut stmt = conn.prepare(&format!(
+        "SELECT b.binding_kind, b.binding_id, {BOUND_SCOPE_PATH_SQL}
          FROM repo_memory_bindings b
          WHERE b.memory_id = ?1
            AND b.repo_id = (SELECT repo_id FROM repo_memories WHERE id = ?1)
            AND b.binding_kind IN ('symbol', 'logical_symbol')
-         ORDER BY b.binding_kind, b.binding_id",
-    )?;
+         ORDER BY b.binding_kind, b.binding_id"
+    ))?;
     let scopes = stmt
         .query_map(params![memory_id], |row| {
             Ok((
@@ -2642,6 +2711,112 @@ mod tests {
             "the publishable one is still authored: anchors, the hash describing them, scopes",
         );
         assert!(work.has_authorable_work(), "progress is available despite the quarantined head");
+    }
+
+    /// A memory whose projected set predates the scope op — a symbol anchor with no `scope_hash`
+    /// — is swept again once its binding can supply one, so an upgraded author republishes its
+    /// unchanged set with scopes beside it. A set that already carries the scope, or a binding
+    /// that no longer resolves one, is left alone, so the sweep converges; a set another account
+    /// authored, or one the local rows no longer match by target, is never re-signed as this
+    /// device's own.
+    #[test]
+    fn the_anchor_sweep_republishes_a_projected_set_whose_symbol_anchor_lacks_a_scope() {
+        let (conn, stream) = conn_with_stream();
+        let own = rag_rat_oplog::read_local_account(&conn).unwrap().unwrap().to_bytes();
+        conn.execute(
+            "INSERT INTO files(repo_id, path, language, kind, sha256, modified_at_ms, \
+             indexed_at_ms)
+             VALUES (?1, 'src/lib.rs', 'rust', 'code', 'sha', 1, 1)",
+            [REPO],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('src/lib.rs::Twin')", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, scope_path, kind,
+                    start_byte, end_byte, start_line, end_line)
+             VALUES (?1, 'rust', 'Twin', (SELECT id FROM name_strings WHERE value = \
+             'src/lib.rs::Twin'),
+                     'Twin as Beta', 'impl', 0, 1, 1, 1)",
+            [file_id],
+        )
+        .unwrap();
+        let symbol_id = conn.last_insert_rowid();
+        let seed = |id: &str, symbol_id: Option<i64>, scope_hash: Option<&str>| {
+            insert_memory(&conn, id, "active", 1);
+            conn.execute(
+                "INSERT INTO repo_memory_bindings(
+                     repo_id, memory_id, binding_kind, binding_id, symbol_id, symbol_kind,
+                     anchor_status, created_at_ms)
+                 VALUES (?1, ?2, 'symbol', 'src/lib.rs::Twin', ?3, 'impl', 'current', 1)",
+                params![REPO, id, symbol_id],
+            )
+            .unwrap();
+            let anchors = serde_json::json!([{
+                "binding_kind": "symbol", "binding_id": "src/lib.rs::Twin",
+                "path": "src/lib.rs", "start_line": 1, "end_line": 1,
+                "commit_hash": null, "tracker": null, "project": null, "item_key": null,
+                "created_at_ms": 1, "symbol_kind": "impl", "signature_hash": null,
+                "moniker_tool": null, "moniker_tool_version": null, "scope_hash": scope_hash,
+            }]);
+            conn.execute(
+                "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status, \
+                 anchors_json, anchors_author)
+                 VALUES (?1, ?2, '{}', 'active', ?3, ?4)",
+                params![stream.to_bytes().as_slice(), id, anchors.to_string(), own.as_slice()],
+            )
+            .unwrap();
+        };
+        seed("mem_unscoped", Some(symbol_id), None);
+        seed("mem_scoped", Some(symbol_id), Some("already"));
+        seed("mem_dead", None, None);
+        // A set another account authored on this memory — a contributor's rebind — is that
+        // account's to publish: re-signing it here would outlive the contributor's revocation.
+        seed("mem_foreign", Some(symbol_id), None);
+        conn.execute(
+            "UPDATE content_projected_nodes SET anchors_author = ?1 WHERE node_id = 'mem_foreign'",
+            [[9u8; 32].as_slice()],
+        )
+        .unwrap();
+        // A local row that no longer matches the projected set by target — a sibling device's
+        // newer rebind the rows have yet to catch up with — must not be republished over it.
+        seed("mem_behind", Some(symbol_id), None);
+        conn.execute(
+            "UPDATE repo_memory_bindings SET signature_hash = 'newer' WHERE memory_id = \
+             'mem_behind'",
+            [],
+        )
+        .unwrap();
+        // The same, when the sibling's rebind was between twins the target columns cannot tell
+        // apart: only the rebind stamp says the local row is not the published one.
+        seed("mem_sibling", Some(symbol_id), None);
+        conn.execute(
+            "UPDATE repo_memory_bindings SET created_at_ms = 2 WHERE memory_id = 'mem_sibling'",
+            [],
+        )
+        .unwrap();
+
+        let work = read_reconcile_work(&conn, REPO, stream, StreamSealPolicy::Plaintext).unwrap();
+        let swept: BTreeSet<String> = work
+            .anchor_backfill_ops
+            .iter()
+            .map(|op| match op {
+                MemoryOp::NodeAnchors { node_id, .. }
+                | MemoryOp::NodeSourceHash { node_id, .. }
+                | MemoryOp::NodeAnchorScopes { node_id, .. } => node_id.as_str().to_string(),
+                other => panic!("unexpected sweep op {other:?}"),
+            })
+            .collect();
+        assert_eq!(swept, BTreeSet::from(["mem_unscoped".to_string()]));
+        let scopes = work.anchor_backfill_ops.iter().find_map(|op| match op {
+            MemoryOp::NodeAnchorScopes { scopes, .. } => Some(scopes.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            scopes.map(|scopes| scopes.into_iter().map(|s| s.scope_hash).collect::<Vec<_>>()),
+            Some(vec![rag_rat_base::hash::hex_sha256(b"Twin as Beta")]),
+        );
     }
 
     /// The publish budget counts MEMORIES, not ops. Each swept memory owes up to two ops — its

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -2039,6 +2039,13 @@ fn reject_unauthorable_content_op(op: &MemoryOp, policy: StreamSealPolicy) -> an
                 anchors.len(),
                 rag_rat_oplog::MAX_ANCHORS_PER_OP
             ),
+            MemoryOp::NodeAnchorScopes { node_id, scopes } => anyhow::bail!(
+                "memory `{}` cannot store its {} anchor scopes: a scope set holds at most {} \
+                 entries and must not name one binding twice",
+                node_id.as_str(),
+                scopes.len(),
+                rag_rat_oplog::MAX_ANCHORS_PER_OP
+            ),
             // No other op kind has a structural limit today; this arm keeps the branch total.
             _ => anyhow::bail!("this memory operation has a shape the op log cannot encode"),
         }
@@ -2182,20 +2189,22 @@ pub(crate) fn author_anchors(
     author_in_owner_stream(tx, &ops, prepared, now_ms)
 }
 
-/// The ops that publish a memory's anchor set — its source hash, then the set — or none when the
-/// memory holds no binding. A memory with no hash publishes an EMPTY one: the register's only
-/// retraction, and the op that keeps the pair a pair.
+/// The ops that publish a memory's anchor set — its source hash, its anchor scopes, then the set —
+/// or none when the memory holds no binding. A memory with no hash publishes an EMPTY one, and one
+/// whose symbol anchors have no scope publishes an EMPTY scope set: each register's only
+/// retraction, and the ops that keep the triple a triple.
 ///
-/// Always BOTH, never one alone. The fold takes a winning set's hash from the device that wrote it
-/// — that device's latest hash — so a device's pair holds against any other writer, whichever order
-/// the other wrote its own in. A set published alone would pair with the device's PREVIOUS hash,
-/// the one describing the target it just left, for good, since nothing republishes afterwards.
+/// Always ALL THREE, never one alone. The fold takes a winning set's hash and scopes from the
+/// device that wrote it — that device's latest of each — so a device's triple holds against any
+/// other writer, whichever order the other wrote its own in. A set published alone would pair with
+/// the device's PREVIOUS hash and scopes, the ones describing the target it just left, for good,
+/// since nothing republishes afterwards.
 ///
-/// The hash goes FIRST. The two are separate entries on one chain, and a peer accepts a chain in
-/// order, so a pull that stops between them leaves a prefix. Hash-first makes that prefix a newer
-/// hash beside the older set, which the next entry resolves. Set-first would pair the new bindings
-/// with the previous target's hash, and a receiver relocating by hash could move a binding back to
-/// the target its author just left — where the late hash, arriving alone, no longer moves it.
+/// The set goes LAST. The three are separate entries on one chain, and a peer accepts a chain in
+/// order, so a pull that stops between them leaves a prefix. Set-last makes that prefix newer
+/// companions beside the older set, which the next entry resolves. Set-first would pair the new
+/// bindings with the previous target's hash and scopes, and a receiver could read the new set as
+/// a retarget away from the target its author just moved to.
 pub(crate) fn anchor_publication_ops(
     conn: &Connection,
     memory_id: &str,
@@ -2207,7 +2216,52 @@ pub(crate) fn anchor_publication_ops(
         node_id: NodeId::from(memory_id),
         source_text_hash: String::new(),
     });
-    Ok(vec![hash, anchors])
+    let scopes = anchor_scopes_op(conn, memory_id)?;
+    Ok(vec![hash, scopes, anchors])
+}
+
+/// The `NodeAnchorScopes` op for a memory's symbol bindings: each one's live target's scope path,
+/// hashed — the identity component the anchor itself leaves out, and the only one that tells two
+/// impls of different traits for one type apart when their kind and captured signature agree
+/// (#1276). Read through the row's own handle, so a binding whose handle is dead, or whose target
+/// row predates the scope column, contributes nothing: a scope is published only where it is
+/// known, never guessed.
+fn anchor_scopes_op(conn: &Connection, memory_id: &str) -> anyhow::Result<MemoryOp> {
+    let mut stmt = conn.prepare(
+        "SELECT b.binding_kind, b.binding_id,
+                COALESCE(
+                    (SELECT s.scope_path FROM symbols s WHERE s.id = b.symbol_id),
+                    (SELECT s.scope_path FROM logical_symbol_members m
+                       JOIN symbols s ON s.id = m.symbol_id
+                      WHERE m.logical_symbol_id = b.logical_symbol_id
+                      ORDER BY m.start_line LIMIT 1))
+         FROM repo_memory_bindings b
+         WHERE b.memory_id = ?1
+           AND b.repo_id = (SELECT repo_id FROM repo_memories WHERE id = ?1)
+           AND b.binding_kind IN ('symbol', 'logical_symbol')
+         ORDER BY b.binding_kind, b.binding_id",
+    )?;
+    let scopes = stmt
+        .query_map(params![memory_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .filter_map(|row| {
+            row.map(|(binding_kind, binding_id, scope_path)| {
+                let scope_path = scope_path.filter(|scope| !scope.is_empty())?;
+                Some(rag_rat_oplog::AnchorScope {
+                    binding_kind,
+                    binding_id,
+                    scope_hash: rag_rat_base::hash::hex_sha256(scope_path.as_bytes()),
+                })
+            })
+            .transpose()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(MemoryOp::NodeAnchorScopes { node_id: NodeId::from(memory_id), scopes })
 }
 
 /// The `NodeSourceHash` op for a memory's stamped source hash, or `None` when it has none — in
@@ -2584,8 +2638,8 @@ mod tests {
         assert_eq!(work.quarantined_anchor_ids, vec!["mem_fat".to_string()]);
         assert_eq!(
             work.anchor_backfill_ops.len(),
-            2,
-            "the publishable one is still authored, anchors and the hash describing them",
+            3,
+            "the publishable one is still authored: anchors, the hash describing them, scopes",
         );
         assert!(work.has_authorable_work(), "progress is available despite the quarantined head");
     }
@@ -2624,15 +2678,16 @@ mod tests {
             .iter()
             .map(|op| match op {
                 MemoryOp::NodeAnchors { node_id, .. }
-                | MemoryOp::NodeSourceHash { node_id, .. } => node_id.as_str().to_string(),
-                other => panic!("the sweep authors anchors and hashes only, got {other:?}"),
+                | MemoryOp::NodeSourceHash { node_id, .. }
+                | MemoryOp::NodeAnchorScopes { node_id, .. } => node_id.as_str().to_string(),
+                other => panic!("the sweep authors anchors, hashes and scopes only, got {other:?}"),
             })
             .collect();
         assert_eq!(swept.len(), ANCHOR_BACKFILL_PER_PASS, "a full budget of memories");
         assert_eq!(
             work.anchor_backfill_ops.len(),
-            ANCHOR_BACKFILL_PER_PASS * 2,
-            "each swept memory owes its anchors and the hash describing them",
+            ANCHOR_BACKFILL_PER_PASS * 3,
+            "each swept memory owes its anchors, the hash describing them and their scopes",
         );
         assert!(
             !swept.contains(&format!("mem_{ANCHOR_BACKFILL_PER_PASS:04}")),

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -757,45 +757,35 @@ fn apply_published_anchors(
         )?;
     } else if let Some(mut targets) = decode_applied_targets(applied.targets.as_deref()) {
         // The scopes paired with a set can move without the set's bytes changing: an upgrade
-        // re-folds the `node_anchor_scopes` ops an older binary retained opaque, an author
-        // upgrading republishes its unchanged set with scopes beside it, and a writer may publish
-        // new scopes ahead of an identical set. The paired scopes are therefore judged on their
-        // own: a scope the baseline lacks is filled in, so the author's next rebind between
-        // twins has a recorded scope to differ from, and a known scope that changed is the
-        // retarget itself, refreshed the way a set change would refresh the row.
+        // re-folds the `node_anchor_scopes` ops an older binary retained opaque, and an author
+        // upgrading republishes its unchanged set with scopes beside it (the sweep in
+        // `read_anchor_backfill_ids`). The baseline follows the paired scopes — a missing one is
+        // filled in, so the author's next rebind between twins has a recorded scope to differ
+        // from; a withdrawn one is cleared; a changed one replaces the old — and marks nothing: a
+        // rebind always changes the set's bytes, so a scope moving under identical ones is a
+        // change of derivation, not of target, and a mark would hold back every such row at once.
+        // Only for anchors a held row still matches by target, as the set-changed path records
+        // its baseline: a row relocated here since must not have a scope recorded on its behalf.
         let scopes = published_anchor_scopes(repo_id, node);
-        let converges = !own && (applied.digest.is_some() || applied.local);
+        let held_now = super::authoring::portable_anchors_of(tx, &node.node_id)?;
         let mut moved = false;
         for ((kind, id), target) in targets.iter_mut() {
-            let Some((_, _, scope)) = scopes.iter().find(|(k, i, _)| k == kind && i == id) else {
-                // A scope the publication no longer carries is withdrawn evidence: cleared without
-                // a mark, as a set change would record it.
-                if target.scope_hash.take().is_some() {
-                    moved = true;
-                }
-                continue;
-            };
-            if target.scope_hash.as_deref() == Some(scope.as_str()) {
+            let matched = anchors.iter().any(|anchor| {
+                anchor.binding_kind == *kind
+                    && anchor.binding_id == *id
+                    && held_now.iter().any(|row| same_target(row, anchor))
+            });
+            if !matched {
                 continue;
             }
-            if target.scope_hash.is_some()
-                && converges
-                && let Some(anchor) = anchors
-                    .iter()
-                    .find(|anchor| anchor.binding_kind == *kind && anchor.binding_id == *id)
-            {
-                refresh_binding(
-                    tx,
-                    repo_id,
-                    &node.node_id,
-                    anchor,
-                    Some(target.clone()),
-                    Some(scope),
-                )?;
-                changed = true;
+            let published = scopes
+                .iter()
+                .find(|(k, i, _)| k == kind && i == id)
+                .map(|(_, _, scope)| scope.clone());
+            if target.scope_hash != published {
+                target.scope_hash = published;
+                moved = true;
             }
-            target.scope_hash = Some(scope.clone());
-            moved = true;
         }
         if moved {
             tx.execute(
@@ -2278,7 +2268,8 @@ mod tests {
             "and the rebind that follows is a retarget",
         );
 
-        // A known scope that changes under an unchanged set is the retarget itself.
+        // A known scope that changes under an unchanged set replaces the recorded one without a
+        // mark: a rebind always changes the set's bytes, so this is a change of derivation.
         conn.execute(
             "UPDATE repo_memory_bindings SET relocation_reason = NULL WHERE memory_id = 'mem_peer'",
             [],
@@ -2287,8 +2278,28 @@ mod tests {
         let gamma = rag_rat_base::hash::hex_sha256(b"Twin as Gamma");
         set_projected_anchor_field(&conn, stream, "mem_peer", "scope_hash", &gamma);
         drain_worker(&conn, stream, 9_000);
-        assert_eq!(reason().as_deref(), Some(rag_rat_query::memory::RETARGETED_REASON));
-        assert_eq!(recorded_scope().as_deref(), Some(gamma.as_str()));
+        assert_eq!(reason(), None, "a scope moving under identical bytes marks nothing");
+        assert_eq!(recorded_scope().as_deref(), Some(gamma.as_str()), "but is recorded");
+
+        // A row relocated here since the set was applied is not the author's target any more, so
+        // no scope is recorded on its behalf under an unchanged set.
+        conn.execute(
+            "UPDATE repo_memory_bindings SET signature_hash = 'sig-local' WHERE memory_id = \
+             'mem_peer'",
+            [],
+        )
+        .unwrap();
+        let delta = rag_rat_base::hash::hex_sha256(b"Twin as Delta");
+        set_projected_anchor_field(&conn, stream, "mem_peer", "scope_hash", &delta);
+        drain_worker(&conn, stream, 9_500);
+        assert_eq!(recorded_scope().as_deref(), Some(gamma.as_str()), "a relocated row is skipped");
+        conn.execute(
+            "UPDATE repo_memory_bindings SET signature_hash = 'sig' WHERE memory_id = 'mem_peer'",
+            [],
+        )
+        .unwrap();
+        drain_worker(&conn, stream, 9_600);
+        assert_eq!(recorded_scope().as_deref(), Some(delta.as_str()), "matched again, recorded");
 
         // A scope withdrawn under an unchanged set is cleared without a mark, so the rebind that
         // follows compares against nothing.

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -56,7 +56,9 @@
 //! simply re-materializes on the next pass.
 
 use rag_rat_oplog::{self, ProjectedContentEdge, ProjectedContentNode, StreamId};
-use rag_rat_query::memory;
+use rag_rat_query::memory::{
+    self, AppliedTarget, AppliedTargets, decode_applied_targets, encode_applied_targets,
+};
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 /// The `repo_memories.memory_version` a synced row is stamped with — the author-side constant the
@@ -629,45 +631,9 @@ struct AppliedSnapshot {
     digest: Option<String>,
     /// The published hash last applied, as stored; NULL until one is, or when it was none.
     hash: Option<String>,
-    /// What that set named for each symbol anchor (see [`applied_targets_json`]); NULL until a set
-    /// is applied.
+    /// What that set named for each symbol anchor (see [`encode_applied_targets`]); NULL until a
+    /// set is applied.
     targets: Option<String>,
-}
-
-/// What an applied set named for each symbol anchor: identity `(binding_kind, binding_id)` to the
-/// `(symbol_kind, signature_hash)` its author recorded — the baseline a later set's anchors are
-/// compared against to tell a retarget from a republish of the same target.
-type AppliedTargets =
-    std::collections::BTreeMap<(String, String), (Option<String>, Option<String>)>;
-
-/// Serialize the [`AppliedTargets`] of `anchors` for `repo_memories.anchors_applied_targets`.
-fn applied_targets_json(anchors: &[rag_rat_oplog::PortableAnchor]) -> anyhow::Result<String> {
-    let targets: Vec<(&str, &str, Option<&str>, Option<&str>)> = anchors
-        .iter()
-        .filter(|anchor| matches!(anchor.binding_kind.as_str(), "symbol" | "logical_symbol"))
-        .map(|anchor| {
-            (
-                anchor.binding_kind.as_str(),
-                anchor.binding_id.as_str(),
-                anchor.symbol_kind.as_deref(),
-                anchor.signature_hash.as_deref(),
-            )
-        })
-        .collect();
-    Ok(serde_json::to_string(&targets)?)
-}
-
-/// Parse [`applied_targets_json`]'s output; `None` when nothing was recorded or it does not parse,
-/// which leaves the retarget decision to the row's own values.
-fn parse_applied_targets(json: Option<&str>) -> Option<AppliedTargets> {
-    let targets: Vec<(String, String, Option<String>, Option<String>)> =
-        serde_json::from_str(json?).ok()?;
-    Some(
-        targets
-            .into_iter()
-            .map(|(kind, id, symbol_kind, signature)| ((kind, id), (symbol_kind, signature)))
-            .collect(),
-    )
 }
 
 fn applied_snapshot(
@@ -751,16 +717,24 @@ fn apply_published_anchors(
     // set lost its rows some other way — a sibling device's quarantine or re-point removing them
     // through `anchors/1` — and seeding into that vacuum is what heals it.
     if held.is_empty() && !set_changed {
-        changed |= converge_bindings(tx, repo_id, &node.node_id, anchors, &held, None)?;
+        changed |= converge_bindings(tx, repo_id, &node.node_id, anchors, &held, None, &[])?;
     }
     if set_changed {
         // Bindings held with no digest recorded arrived some other way: the set is recorded
         // against them rather than replacing them. A local memory's held bindings are its creator's
         // own last set, which another account's set supersedes on first sight.
         if held.is_empty() || (!own && (applied.digest.is_some() || applied.local)) {
-            let previous = parse_applied_targets(applied.targets.as_deref());
-            changed |=
-                converge_bindings(tx, repo_id, &node.node_id, anchors, &held, previous.as_ref())?;
+            let previous = decode_applied_targets(applied.targets.as_deref());
+            let scopes = published_anchor_scopes(repo_id, node);
+            changed |= converge_bindings(
+                tx,
+                repo_id,
+                &node.node_id,
+                anchors,
+                &held,
+                previous.as_ref(),
+                &scopes,
+            )?;
         }
         // The baseline a later set is judged against holds only anchors a held row now matches by
         // target. A set recorded against rows that are not its own — a stale seed, a local rebind,
@@ -772,11 +746,64 @@ fn apply_published_anchors(
             .filter(|anchor| held_now.iter().any(|row| same_target(row, anchor)))
             .cloned()
             .collect();
+        let targets = encode_applied_targets(&applied_targets_of(
+            &matched,
+            &published_anchor_scopes(repo_id, node),
+        ))?;
         tx.execute(
             "UPDATE repo_memories SET anchors_applied_digest = ?3, anchors_applied_targets = ?4
              WHERE id = ?1 AND repo_id = ?2",
-            params![node.node_id, repo_id, digest, applied_targets_json(&matched)?],
+            params![node.node_id, repo_id, digest, targets],
         )?;
+    } else if let Some(mut targets) = decode_applied_targets(applied.targets.as_deref()) {
+        // The scopes paired with a set can move without the set's bytes changing: an upgrade
+        // re-folds the `node_anchor_scopes` ops an older binary retained opaque, an author
+        // upgrading republishes its unchanged set with scopes beside it, and a writer may publish
+        // new scopes ahead of an identical set. The paired scopes are therefore judged on their
+        // own: a scope the baseline lacks is filled in, so the author's next rebind between
+        // twins has a recorded scope to differ from, and a known scope that changed is the
+        // retarget itself, refreshed the way a set change would refresh the row.
+        let scopes = published_anchor_scopes(repo_id, node);
+        let converges = !own && (applied.digest.is_some() || applied.local);
+        let mut moved = false;
+        for ((kind, id), target) in targets.iter_mut() {
+            let Some((_, _, scope)) = scopes.iter().find(|(k, i, _)| k == kind && i == id) else {
+                // A scope the publication no longer carries is withdrawn evidence: cleared without
+                // a mark, as a set change would record it.
+                if target.scope_hash.take().is_some() {
+                    moved = true;
+                }
+                continue;
+            };
+            if target.scope_hash.as_deref() == Some(scope.as_str()) {
+                continue;
+            }
+            if target.scope_hash.is_some()
+                && converges
+                && let Some(anchor) = anchors
+                    .iter()
+                    .find(|anchor| anchor.binding_kind == *kind && anchor.binding_id == *id)
+            {
+                refresh_binding(
+                    tx,
+                    repo_id,
+                    &node.node_id,
+                    anchor,
+                    Some(target.clone()),
+                    Some(scope),
+                )?;
+                changed = true;
+            }
+            target.scope_hash = Some(scope.clone());
+            moved = true;
+        }
+        if moved {
+            tx.execute(
+                "UPDATE repo_memories SET anchors_applied_targets = ?3
+                 WHERE id = ?1 AND repo_id = ?2",
+                params![node.node_id, repo_id, encode_applied_targets(&targets)?],
+            )?;
+        }
     }
     let published = published_source_hash(repo_id, node);
     // Reconsidered when the SET changes, not only the hash: a new set can give an unchanged hash
@@ -853,6 +880,55 @@ fn anchor_snapshot_digest(node_id: &str, anchors: &[rag_rat_oplog::PortableAncho
     ))
 }
 
+/// What a published set names for each symbol anchor — the kind and signature the anchor carries,
+/// and the scope its `node_anchor_scopes` companion carries for it — as the baseline a later set is
+/// judged against.
+fn applied_targets_of(
+    anchors: &[rag_rat_oplog::PortableAnchor],
+    scopes: &[(String, String, String)],
+) -> AppliedTargets {
+    anchors
+        .iter()
+        .filter(|anchor| matches!(anchor.binding_kind.as_str(), "symbol" | "logical_symbol"))
+        .map(|anchor| {
+            let scope_hash = scopes
+                .iter()
+                .find(|(kind, id, _)| *kind == anchor.binding_kind && *id == anchor.binding_id)
+                .map(|(_, _, scope)| scope.clone());
+            ((anchor.binding_kind.clone(), anchor.binding_id.clone()), AppliedTarget {
+                symbol_kind: anchor.symbol_kind.clone(),
+                signature_hash: anchor.signature_hash.clone(),
+                scope_hash,
+            })
+        })
+        .collect()
+}
+
+/// The published anchor scopes this store will record: each a lowercase-hex sha256, as
+/// `(binding_kind, binding_id, scope_hash)` for [`encode_applied_targets`]. An off-shape value is a
+/// peer's this binary cannot read and is dropped here, where it would be stored — never in the
+/// content gate, for the same reason as the hash.
+fn published_anchor_scopes(
+    repo_id: &str,
+    node: &ProjectedContentNode,
+) -> Vec<(String, String, String)> {
+    node.anchor_scopes
+        .iter()
+        .filter_map(|((kind, id), scope_hash)| {
+            if is_hex_sha256(scope_hash) {
+                return Some((kind.clone(), id.clone(), scope_hash.clone()));
+            }
+            tracing::debug!(
+                repo_id,
+                node_id = %node.node_id,
+                binding_kind = %kind,
+                "not recording a published anchor scope outside the lowercase-hex-sha256 shape",
+            );
+            None
+        })
+        .collect()
+}
+
 /// The published hash as this store holds it: a lowercase-hex sha256, or `None`. An empty string is
 /// an author's explicit retraction. Any other off-shape value is a peer's this binary cannot read,
 /// so it is dropped — here, where it would be stored, and not in the content gate, where failing
@@ -892,6 +968,7 @@ fn converge_bindings(
     anchors: &[rag_rat_oplog::PortableAnchor],
     held: &[rag_rat_oplog::PortableAnchor],
     previous: Option<&AppliedTargets>,
+    scopes: &[(String, String, String)],
 ) -> anyhow::Result<bool> {
     let mut changed = false;
     for row in held.iter().filter(|row| SEEDABLE_BINDING_KINDS.contains(&row.binding_kind.as_str()))
@@ -903,7 +980,11 @@ fn converge_bindings(
                         targets.get(&(row.binding_kind.clone(), row.binding_id.clone()))
                     })
                     .cloned();
-                refresh_binding(tx, repo_id, memory_id, anchor, previous)?
+                let published_scope = scopes
+                    .iter()
+                    .find(|(kind, id, _)| *kind == row.binding_kind && *id == row.binding_id)
+                    .map(|(_, _, scope)| scope.as_str());
+                refresh_binding(tx, repo_id, memory_id, anchor, previous, published_scope)?
             },
             None => {
                 tx.execute(
@@ -948,12 +1029,20 @@ fn converge_bindings(
 /// The baseline is the author's last statement, not the row: relocation refreshes the row's kind
 /// and signature to this checkout's view, so after a local edit an unchanged republish would read
 /// as a retarget, and the validator would follow the old signature to a same-named sibling.
+///
+/// The target's published scope (`published_scope`, see `rag_rat_oplog::AnchorScope`) is judged the
+/// same way, against the scope the baseline recorded — and only where BOTH are known. Two impls of
+/// different traits for one type can agree on the kind and the captured signature, so the scope is
+/// what says a rebind between them moved (#1276). A scope missing on either side is no evidence:
+/// an older author publishes none, and marking on its absence would retarget every symbol row on
+/// the first publication after an upgrade.
 pub(crate) fn refresh_binding(
     tx: &Transaction<'_>,
     repo_id: &str,
     memory_id: &str,
     anchor: &rag_rat_oplog::PortableAnchor,
-    previous: Option<(Option<String>, Option<String>)>,
+    previous: Option<AppliedTarget>,
+    published_scope: Option<&str>,
 ) -> anyhow::Result<()> {
     let held: Option<(Option<String>, Option<String>, Option<String>)> = tx
         .query_row(
@@ -966,10 +1055,19 @@ pub(crate) fn refresh_binding(
     let retarget = rag_rat_query::memory::RETARGETED_REASON;
     let retargeted = matches!(anchor.binding_kind.as_str(), "symbol" | "logical_symbol")
         && held.is_some_and(|(kind, signature, reason)| {
-            let (kind, signature) = previous.unwrap_or((kind, signature));
+            let previous = previous.unwrap_or(AppliedTarget {
+                symbol_kind: kind,
+                signature_hash: signature,
+                scope_hash: None,
+            });
+            let scope_moved = match (previous.scope_hash.as_deref(), published_scope) {
+                (Some(recorded), Some(published)) => recorded != published,
+                _ => false,
+            };
             reason.as_deref() == Some(retarget)
-                || kind != anchor.symbol_kind
-                || signature != anchor.signature_hash
+                || previous.symbol_kind != anchor.symbol_kind
+                || previous.signature_hash != anchor.signature_hash
+                || scope_moved
         });
     tx.execute(
         "UPDATE repo_memory_bindings
@@ -2075,6 +2173,143 @@ mod tests {
             Some(rag_rat_query::memory::RETARGETED_REASON),
             "a changed signature is"
         );
+    }
+
+    /// Two impls of different traits for one type can agree on the kind and the captured
+    /// signature, so a rebind between them changes only the target's SCOPE, published beside the
+    /// set (#1276). A changed scope marks the row `retargeted`; the same scope does not; and a
+    /// scope missing on either side is no evidence, so an older author's set never marks on its
+    /// absence. The baseline records the scope beside the kind and signature.
+    #[test]
+    fn a_changed_published_scope_marks_a_retarget_and_a_missing_one_never_does() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x44; 32]);
+        let publish = |path: &str, scope: Option<&str>| {
+            seed_projected_node_with_anchors(
+                &conn,
+                stream,
+                "mem_peer",
+                Some(&[("symbol", "src/lib.rs::Twin")]),
+            );
+            set_projected_anchor_field(&conn, stream, "mem_peer", "path", path);
+            set_projected_anchor_field(&conn, stream, "mem_peer", "symbol_kind", "impl");
+            set_projected_anchor_field(&conn, stream, "mem_peer", "signature_hash", "sig");
+            if let Some(scope) = scope {
+                set_projected_anchor_field(&conn, stream, "mem_peer", "scope_hash", scope);
+            }
+        };
+        let reason = || -> Option<String> {
+            conn.query_row(
+                "SELECT relocation_reason FROM repo_memory_bindings WHERE memory_id = 'mem_peer'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        let recorded_scope = || -> Option<String> {
+            let json: Option<String> = conn
+                .query_row(
+                    "SELECT anchors_applied_targets FROM repo_memories WHERE id = 'mem_peer'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            decode_applied_targets(json.as_deref())
+                .and_then(|t| {
+                    t.get(&("symbol".to_string(), "src/lib.rs::Twin".to_string())).cloned()
+                })
+                .and_then(|target| target.scope_hash)
+        };
+        let alpha = rag_rat_base::hash::hex_sha256(b"Twin as Alpha");
+        let beta = rag_rat_base::hash::hex_sha256(b"Twin as Beta");
+
+        publish("src/lib.rs", Some(&alpha));
+        drain_worker(&conn, stream, 1_000);
+        assert_eq!(reason(), None, "a first sight marks nothing");
+        assert_eq!(recorded_scope().as_deref(), Some(alpha.as_str()), "the baseline records it");
+
+        publish("src/moved.rs", Some(&alpha));
+        drain_worker(&conn, stream, 2_000);
+        assert_eq!(reason(), None, "the same scope is a republish of the same target");
+
+        publish("src/twins.rs", Some(&beta));
+        drain_worker(&conn, stream, 3_000);
+        assert_eq!(
+            reason().as_deref(),
+            Some(rag_rat_query::memory::RETARGETED_REASON),
+            "a changed scope under an unchanged kind and signature is a retarget",
+        );
+        assert_eq!(recorded_scope().as_deref(), Some(beta.as_str()));
+
+        // Answered, then republished by an older author that publishes no scopes.
+        conn.execute(
+            "UPDATE repo_memory_bindings SET relocation_reason = NULL WHERE memory_id = 'mem_peer'",
+            [],
+        )
+        .unwrap();
+        publish("src/older.rs", None);
+        drain_worker(&conn, stream, 4_000);
+        assert_eq!(reason(), None, "a scope missing on the new side is no evidence");
+        assert_eq!(recorded_scope(), None);
+
+        publish("src/newer.rs", Some(&alpha));
+        drain_worker(&conn, stream, 5_000);
+        assert_eq!(reason(), None, "nor is one missing on the recorded side");
+
+        // A malformed scope from a peer is dropped where it would be stored, never quarantined.
+        publish("src/odd.rs", Some("not-a-hash"));
+        drain_worker(&conn, stream, 6_000);
+        assert_eq!(reason(), None);
+        assert_eq!(recorded_scope(), None, "an off-shape scope is not recorded");
+        assert_eq!(status_of(&conn, "mem_peer"), "active", "and the memory survives");
+
+        // Scopes exposed for the SAME set — an upgrade re-folding retained scope ops, or an author
+        // republishing an unchanged set with scopes — fill the baseline in, so the next twin rebind
+        // has a recorded scope to differ from.
+        set_projected_anchor_field(&conn, stream, "mem_peer", "scope_hash", &alpha);
+        drain_worker(&conn, stream, 7_000);
+        assert_eq!(reason(), None, "filling the baseline marks nothing");
+        assert_eq!(recorded_scope().as_deref(), Some(alpha.as_str()), "the baseline gains it");
+        publish("src/twins-again.rs", Some(&beta));
+        drain_worker(&conn, stream, 8_000);
+        assert_eq!(
+            reason().as_deref(),
+            Some(rag_rat_query::memory::RETARGETED_REASON),
+            "and the rebind that follows is a retarget",
+        );
+
+        // A known scope that changes under an unchanged set is the retarget itself.
+        conn.execute(
+            "UPDATE repo_memory_bindings SET relocation_reason = NULL WHERE memory_id = 'mem_peer'",
+            [],
+        )
+        .unwrap();
+        let gamma = rag_rat_base::hash::hex_sha256(b"Twin as Gamma");
+        set_projected_anchor_field(&conn, stream, "mem_peer", "scope_hash", &gamma);
+        drain_worker(&conn, stream, 9_000);
+        assert_eq!(reason().as_deref(), Some(rag_rat_query::memory::RETARGETED_REASON));
+        assert_eq!(recorded_scope().as_deref(), Some(gamma.as_str()));
+
+        // A scope withdrawn under an unchanged set is cleared without a mark, so the rebind that
+        // follows compares against nothing.
+        conn.execute(
+            "UPDATE repo_memory_bindings SET relocation_reason = NULL WHERE memory_id = 'mem_peer'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE content_projected_nodes
+             SET anchors_json = json_remove(anchors_json, '$[0].scope_hash')
+             WHERE stream_id = ?1 AND node_id = 'mem_peer'",
+            params![stream.to_bytes().as_slice()],
+        )
+        .unwrap();
+        drain_worker(&conn, stream, 10_000);
+        assert_eq!(reason(), None, "a withdrawal marks nothing");
+        assert_eq!(recorded_scope(), None, "and clears the baseline");
+        publish("src/after-withdrawal.rs", Some(&beta));
+        drain_worker(&conn, stream, 11_000);
+        assert_eq!(reason(), None, "the next scope compares against nothing");
     }
 
     /// A set first recorded against rows that are not its own — here a seed from before the

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -17,6 +17,10 @@ mod edges;
 mod oracle_relocation_tests;
 
 pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory};
+// The drain's in-place refresh of a held binding, driven against a real index by the
+// relocation tests.
+#[cfg(test)]
+pub(crate) use authoring::anchor_publication_ops;
 // The scope-READING reconcile entry (#541) as index MAINTENANCE runs it: reconciles the active
 // repo's owner stream, reading the repo id from the connection scope, no-oping under an
 // absent/unstable scope, and skipping the stream-establishment refusal that must not fail a
@@ -36,8 +40,6 @@ pub(crate) use authoring::{
     contribution_targets, ensure_not_mirroring_another_account, reconcile_owner_stream_for_repo,
     subscription_owners,
 };
-// The drain's in-place refresh of a held binding, driven against a real index by the
-// relocation tests.
 #[cfg(test)]
 pub(crate) use drain::refresh_binding;
 // The synced-content drain entries (#691 A1): the per-repo drain (consolidate) and the

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -33,8 +33,7 @@ use super::op::{
     self, DecodedOp, DeviceFingerprint, EdgeSpec, Entry, NodeContent, NodeStatus, OpMeta,
     PortableAnchor, ResolvedAnchor,
 };
-use super::project;
-use super::project::ProjectedState;
+use super::project::{self, AnchorScopes, ProjectedState};
 use super::store::{EdgeSpecRow, NodeContentRow, PortableAnchorRow, ResolvedAnchorRow};
 use super::stream::StreamId;
 
@@ -56,7 +55,10 @@ use super::stream::StreamId;
 // v6 (#1243): the node fold records which account authored the winning anchor set, so the drain
 // can leave a set the local account's `anchors/1` already carries to that carrier, and takes the
 // source hash from the device that wrote that set, so pairs written in opposite orders never split.
-pub(crate) const CONTENT_PROJECTOR_VERSION: i64 = 6;
+// v7 (#1276): the node fold gains the anchor-scopes register, paired with the winning set like the
+// hash, so `anchors_json` rows carry each symbol anchor's `scope_hash`. The bump re-folds every
+// stream, `node_anchor_scopes` ops an older binary kept opaque included.
+pub(crate) const CONTENT_PROJECTOR_VERSION: i64 = 7;
 
 /// The `oplog_meta` key holding the `/3` projector version the content projection was last folded
 /// by. DISTINCT from the `/1` `projector_version` (they evolve independently and share one meta
@@ -360,8 +362,15 @@ fn write_projection(
             .anchors
             .as_ref()
             .map(|anchors| {
-                let rows: Vec<PortableAnchorRow> =
-                    anchors.iter().map(PortableAnchorRow::from).collect();
+                let rows: Vec<PortableAnchorRow> = anchors
+                    .iter()
+                    .map(|anchor| {
+                        let mut row = PortableAnchorRow::from(anchor);
+                        let identity = (anchor.binding_kind.clone(), anchor.binding_id.clone());
+                        row.scope_hash = node.anchor_scopes.get(&identity).cloned();
+                        row
+                    })
+                    .collect();
                 serde_json::to_string(&rows)
             })
             .transpose()
@@ -559,6 +568,10 @@ pub struct ProjectedContentNode {
     /// local checkout; `None` surfaces UNMARKED, since an absent hash is not evidence of
     /// drift.
     pub source_text_hash: Option<String>,
+    /// The scope of each symbol anchor's target, keyed by anchor identity, from the device that
+    /// wrote the winning set; empty when it published none. The drain records it beside the kind
+    /// and signature it judges a retarget by (#1276).
+    pub anchor_scopes: AnchorScopes,
     /// The account that authored the winning anchor set, or `None` when none was folded. The drain
     /// leaves a set the local account authored to `anchors/1`, which already carries it, and
     /// converges only sets another account authored.
@@ -605,14 +618,19 @@ pub fn list_projected_content_nodes(
         let status = NodeStatus::from_db_str(&status).with_context(|| {
             format!("projected /3 node `{node_id}` carries unknown status `{status}`")
         })?;
-        let anchors = anchors_json
-            .map(|json| {
-                serde_json::from_str::<Vec<PortableAnchorRow>>(&json).map(|rows| {
-                    rows.into_iter().map(PortableAnchor::from).collect::<Vec<PortableAnchor>>()
-                })
-            })
+        let rows = anchors_json
+            .map(|json| serde_json::from_str::<Vec<PortableAnchorRow>>(&json))
             .transpose()
             .with_context(|| format!("decode projected /3 node anchors for `{node_id}`"))?;
+        let anchor_scopes: AnchorScopes = rows
+            .iter()
+            .flatten()
+            .filter_map(|row| {
+                let scope_hash = row.scope_hash.clone()?;
+                Some(((row.binding_kind.clone(), row.binding_id.clone()), scope_hash))
+            })
+            .collect();
+        let anchors = rows.map(|rows| rows.into_iter().map(PortableAnchor::from).collect());
         let anchors_author = anchors_author
             .map(|bytes| {
                 <[u8; 32]>::try_from(bytes.as_slice()).map(AccountId::from_bytes).map_err(|_| {
@@ -628,6 +646,7 @@ pub fn list_projected_content_nodes(
             status,
             anchors,
             source_text_hash,
+            anchor_scopes,
             anchors_author,
         });
     }

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -169,9 +169,11 @@ pub use identity::{LocalDevice, load_local_device, local_device};
 // payload: the memory drain digests an anchor set to record which one it applied.
 pub use op::encode as encode_op;
 pub use op::{
-    DeviceFingerprint, EdgeKey, EdgeSpec, MAX_ANCHORS_PER_OP, MemoryOp, NodeContent, NodeId,
-    NodeStatus, ParseDeviceFingerprintError, PortableAnchor, ResolvedAnchor, within_wire_limits,
+    AnchorScope, DeviceFingerprint, EdgeKey, EdgeSpec, MAX_ANCHORS_PER_OP, MemoryOp, NodeContent,
+    NodeId, NodeStatus, ParseDeviceFingerprintError, PortableAnchor, ResolvedAnchor,
+    within_wire_limits,
 };
+pub use project::AnchorScopes;
 // The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
 // standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only
 // scaffolding for the retained `/1` store. The live memory path now authors owner-bound `/3`

--- a/crates/rag-rat-oplog/src/op.rs
+++ b/crates/rag-rat-oplog/src/op.rs
@@ -294,6 +294,31 @@ impl PortableAnchor {
     }
 }
 
+/// The scope of one symbol anchor's target, hashed — the part of a symbol's identity the anchor
+/// leaves out. An anchor carries a symbol's path, qualified name, kind and signature; its
+/// enclosing scope is the fifth component of the index's logical key, and the only one that tells
+/// apart two symbols agreeing on the other four — in Rust, two impls of different traits for one
+/// type with the trait on a later line (`Twin as Alpha` / `Twin as Beta`), whose kind and captured
+/// signature are both `impl` (#1276).
+///
+/// Keyed by the row it describes, `(binding_kind, binding_id)`, so it rides beside a `node_anchors`
+/// set rather than inside it: `PortableAnchor` is a byte-canonical fixed-arity array, and widening
+/// it would cost every older binary the anchors themselves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchorScope {
+    pub binding_kind: String,
+    pub binding_id: String,
+    /// `hex_sha256` of the target's scope path, as the author's index derives it.
+    pub scope_hash: String,
+}
+
+impl AnchorScope {
+    /// The anchor this scope describes — the same identity a `node_anchors` set is keyed by.
+    pub(crate) fn identity(&self) -> (&str, &str) {
+        (self.binding_kind.as_str(), self.binding_id.as_str())
+    }
+}
+
 /// The most anchors one `node_anchors` op may carry. A memory holds a handful of bindings in
 /// practice (its own, plus an auto-moniker), so this is a generous structural bound rather than a
 /// budget.
@@ -343,6 +368,15 @@ pub fn within_wire_limits(op: &MemoryOp) -> bool {
             identities.sort_unstable();
             identities.windows(2).all(|pair| pair[0] != pair[1])
         },
+        MemoryOp::NodeAnchorScopes { scopes, .. } => {
+            if scopes.len() > MAX_ANCHORS_PER_OP {
+                return false;
+            }
+            let mut identities: Vec<(&str, &str)> =
+                scopes.iter().map(AnchorScope::identity).collect();
+            identities.sort_unstable();
+            identities.windows(2).all(|pair| pair[0] != pair[1])
+        },
         // Listed rather than wildcarded ON PURPOSE: this seam's contract is "reject exactly what
         // `decode` rejects", so the next op kind that grows a count cap or an ordering rule must
         // fail to compile here instead of silently answering `true` — the same under-approximation
@@ -384,6 +418,14 @@ pub enum MemoryOp {
     /// binary retains an unknown kind opaque, which under that shape would cost it the ANCHORS.
     /// Split, the same binary keeps its anchors and loses only the staleness marking.
     NodeSourceHash { node_id: NodeId, source_text_hash: String },
+    /// The scope of each symbol anchor's target in a node's anchor set (see [`AnchorScope`]) — a
+    /// FULL-SET statement, keyed by anchor identity; an empty set retracts.
+    ///
+    /// A sibling of `node_anchors` for the same reason `node_source_hash` is, and paired with it
+    /// the same way: the fold takes a node's scopes from the device that wrote the winning
+    /// anchor set, so an older binary that never publishes them contributes none, and an older
+    /// receiver retains this kind opaque and keeps the anchors it already understands.
+    NodeAnchorScopes { node_id: NodeId, scopes: Vec<AnchorScope> },
     /// A converged-state boundary marker; inert in the fold this increment (§5.4/C4).
     Snapshot,
 }
@@ -400,6 +442,7 @@ impl MemoryOp {
             Self::Rebind { .. } => "rebind",
             Self::NodeAnchors { .. } => "node_anchors",
             Self::NodeSourceHash { .. } => "node_source_hash",
+            Self::NodeAnchorScopes { .. } => "node_anchor_scopes",
             Self::Snapshot => "snapshot",
         }
     }
@@ -480,6 +523,11 @@ fn encode_payload(enc: &mut VecEncoder<'_>, op: &MemoryOp) {
             enc.str(node_id.as_str()).expect(INFALLIBLE);
             enc.str(source_text_hash).expect(INFALLIBLE);
         },
+        MemoryOp::NodeAnchorScopes { node_id, scopes } => {
+            enc.array(2).expect(INFALLIBLE);
+            enc.str(node_id.as_str()).expect(INFALLIBLE);
+            encode_anchor_scopes(enc, scopes);
+        },
         MemoryOp::Snapshot => {
             // Inert boundary marker: a strictly-null payload. A future snapshot that carries a
             // coverage manifest (§5.4/C4) is a NEW op kind — NOT a non-null payload under this kind
@@ -544,6 +592,20 @@ fn encode_anchors(enc: &mut VecEncoder<'_>, anchors: &[PortableAnchor]) {
     enc.array(ordered.len() as u64).expect(INFALLIBLE);
     for anchor in ordered {
         encode_anchor(enc, anchor);
+    }
+}
+
+/// Encode the scope SET in identity order, under the same rules as [`encode_anchors`]: the sort
+/// canonicalizes, and `decode`'s strictly-increasing check is what rejects a duplicated identity.
+fn encode_anchor_scopes(enc: &mut VecEncoder<'_>, scopes: &[AnchorScope]) {
+    let mut ordered: Vec<&AnchorScope> = scopes.iter().collect();
+    ordered.sort_by(|a, b| a.identity().cmp(&b.identity()));
+    enc.array(ordered.len() as u64).expect(INFALLIBLE);
+    for scope in ordered {
+        enc.array(3).expect(INFALLIBLE);
+        enc.str(&scope.binding_kind).expect(INFALLIBLE);
+        enc.str(&scope.binding_id).expect(INFALLIBLE);
+        enc.str(&scope.scope_hash).expect(INFALLIBLE);
     }
 }
 
@@ -626,6 +688,12 @@ fn decode_envelope(bytes: &[u8]) -> Result<DecodedOp, CborError> {
             cbor::expect_array(&mut d, 2)?;
             let node_id = NodeId::from(d.str()?);
             Some(MemoryOp::NodeSourceHash { node_id, source_text_hash: d.str()?.to_string() })
+        },
+        "node_anchor_scopes" => {
+            cbor::expect_array(&mut d, 2)?;
+            let node_id = NodeId::from(d.str()?);
+            let scopes = decode_anchor_scopes(&mut d)?;
+            Some(MemoryOp::NodeAnchorScopes { node_id, scopes })
         },
         "snapshot" => {
             d.null()?;
@@ -751,6 +819,35 @@ fn decode_anchors(d: &mut Decoder<'_>) -> Result<Vec<PortableAnchor>, CborError>
             ));
         }
         out.push(anchor);
+    }
+    Ok(out)
+}
+
+/// The scope-set twin of [`decode_anchors`]: the count is judged from the header, and the set must
+/// be strictly increasing by identity, which rejects both an unsorted payload and a duplicate.
+fn decode_anchor_scopes(d: &mut Decoder<'_>) -> Result<Vec<AnchorScope>, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    if len > MAX_ANCHORS_PER_OP as u64 {
+        return Err(CborError::message(format!(
+            "node_anchor_scopes carries {len} scopes, over the {MAX_ANCHORS_PER_OP} limit"
+        )));
+    }
+    let mut out: Vec<AnchorScope> = Vec::new();
+    for _ in 0..len {
+        cbor::expect_array(d, 3)?;
+        let scope = AnchorScope {
+            binding_kind: d.str()?.to_string(),
+            binding_id: d.str()?.to_string(),
+            scope_hash: d.str()?.to_string(),
+        };
+        if let Some(previous) = out.last()
+            && previous.identity() >= scope.identity()
+        {
+            return Err(CborError::message(
+                "node_anchor_scopes must be strictly increasing by (binding_kind, binding_id)",
+            ));
+        }
+        out.push(scope);
     }
     Ok(out)
 }
@@ -974,8 +1071,21 @@ mod tests {
                 source_text_hash:
                     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(),
             }),
+            ("node_anchor_scopes", MemoryOp::NodeAnchorScopes {
+                node_id: NodeId::from("mem_1"),
+                scopes: scopes(),
+            }),
             ("snapshot", MemoryOp::Snapshot),
         ]
+    }
+
+    /// One scope, for the symbol anchor in [`anchors`]. Already in identity order.
+    fn scopes() -> Vec<AnchorScope> {
+        vec![AnchorScope {
+            binding_kind: "symbol".to_string(),
+            binding_id: "crates/x/src/lib.rs::run".to_string(),
+            scope_hash: "5c0p3".to_string(),
+        }]
     }
 
     #[test]
@@ -1011,6 +1121,10 @@ mod tests {
             (
                 "node_source_hash",
                 "836c7261672d7261742f6f702f31706e6f64655f736f757263655f6861736882656d656d5f31784065336230633434323938666331633134396166626634633839393666623932343237616534316534363439623933346361343935393931623738353262383535",
+            ),
+            (
+                "node_anchor_scopes",
+                "836c7261672d7261742f6f702f31726e6f64655f616e63686f725f73636f70657382656d656d5f3181836673796d626f6c78186372617465732f782f7372632f6c69622e72733a3a72756e653563307033",
             ),
             ("snapshot", "836c7261672d7261742f6f702f3168736e617073686f74f6"),
         ];
@@ -1106,6 +1220,41 @@ mod tests {
             anchors: anchors(),
         }));
         assert!(every_variant().iter().all(|(_, op)| within_wire_limits(op)));
+    }
+
+    /// The scope set is bounded and keyed like the anchor set it describes: a duplicated identity
+    /// and an over-cap count are refused before signing, and `decode` refuses the same bytes.
+    #[test]
+    fn anchor_scopes_share_the_anchor_set_s_wire_limits() {
+        let scope = |index: usize| AnchorScope {
+            binding_id: format!("id_{index:03}"),
+            ..scopes()[0].clone()
+        };
+        let duplicated = vec![scope(1), scope(1)];
+        let op = MemoryOp::NodeAnchorScopes { node_id: NodeId::from("mem_1"), scopes: duplicated };
+        assert!(!within_wire_limits(&op));
+        let err = decode(&encode(&op)).unwrap_err().to_string();
+        assert!(err.contains("strictly increasing"), "{err}");
+
+        let over_cap: Vec<AnchorScope> = (0..=MAX_ANCHORS_PER_OP).map(scope).collect();
+        let op = MemoryOp::NodeAnchorScopes { node_id: NodeId::from("mem_1"), scopes: over_cap };
+        assert!(!within_wire_limits(&op));
+        let err = decode(&encode(&op)).unwrap_err().to_string();
+        assert!(err.contains(&format!("over the {MAX_ANCHORS_PER_OP} limit")), "{err}");
+
+        // A set is a SET: the wire bytes ignore the caller's order, and an empty set is a
+        // retraction that round-trips.
+        let sorted = MemoryOp::NodeAnchorScopes {
+            node_id: NodeId::from("mem_1"),
+            scopes: vec![scope(1), scope(2)],
+        };
+        let reversed = MemoryOp::NodeAnchorScopes {
+            node_id: NodeId::from("mem_1"),
+            scopes: vec![scope(2), scope(1)],
+        };
+        assert_eq!(encode(&sorted), encode(&reversed));
+        let empty = MemoryOp::NodeAnchorScopes { node_id: NodeId::from("mem_1"), scopes: vec![] };
+        assert_eq!(decode(&encode(&empty)).unwrap(), DecodedOp::Known(empty));
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/project.rs
+++ b/crates/rag-rat-oplog/src/project.rs
@@ -19,6 +19,13 @@
 //!   its latest set — whichever order its binary wrote the pair in — while two independent
 //!   registers split pairs written in opposite orders: `anchors A @10, hash A @11` from one device
 //!   and `hash B @10, anchors B @11` from another would settle on anchors B beside hash A.
+//! - node **anchor scopes** — the scope of each symbol anchor's target, paired with the anchor set
+//!   by device like the source hash, but positionally: the latest `NodeAnchorScopes` the winning
+//!   set's device wrote SINCE ITS PRECEDING SET and at or before this one, empty when it wrote none
+//!   there. An author publishes its scopes ahead of its set, so a pull torn after a later scopes op
+//!   (`scopes A, anchors A, scopes B`) still pairs set A with scopes A — the device's latest would
+//!   pair it with B's, and the set B that follows would then read as no change — and a set the
+//!   device published without scopes takes none rather than an earlier publication's.
 //! - edge **presence** — the last-in-order `EdgeAdd`/`EdgeRemove`; present iff the winner is an
 //!   add.
 //! - edge **resolved anchor** — the last-in-order `Rebind`; rides along iff the edge is present,
@@ -27,12 +34,17 @@
 //! "Tombstones never resurrect" is EMERGENT, not an absorbing flag: an out-of-order or duplicated
 //! older `EdgeAdd` sorts before a newer `EdgeRemove` and loses. `Snapshot` is inert this increment.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Bound;
 
 use super::op::{
-    self, EdgeKey, EdgeSpec, Entry, MemoryOp, NodeContent, NodeId, NodeStatus, OpMeta,
+    self, AnchorScope, EdgeKey, EdgeSpec, Entry, MemoryOp, NodeContent, NodeId, NodeStatus, OpMeta,
     PortableAnchor, ResolvedAnchor,
 };
+
+/// A node's anchor scopes, keyed by the anchor identity `(binding_kind, binding_id)` each
+/// describes: the value is the target's scope hash (see [`AnchorScope`]).
+pub type AnchorScopes = BTreeMap<(String, String), String>;
 
 /// The converged projection: existing nodes (content + status) and present edges (spec + resolved
 /// anchor), each keyed for a stable, sorted, byte-reproducible ordering.
@@ -63,6 +75,10 @@ pub struct ProjectedNode {
     /// The hash of the source text the author anchored to, or `None` when none was published.
     /// `None` surfaces UNMARKED downstream — an absent hash is not evidence of drift.
     pub source_text_hash: Option<String>,
+    /// The scope of each symbol anchor's target in the winning set, from the device that wrote it;
+    /// empty when it published none. Absence is not evidence — a drain compares scopes only where
+    /// both the previous and the new set carry one.
+    pub anchor_scopes: AnchorScopes,
     /// The `(lamport, device)` of the entry whose `NodeAnchors` won the anchors register, or
     /// `None` with no set folded. The content projection maps it to that entry's author
     /// account, which is how the drain tells a set its own account's `anchors/1` already
@@ -87,6 +103,12 @@ struct NodeAccum {
     anchors: Option<(Vec<PortableAnchor>, OpMeta)>,
     /// Each device's latest `NodeSourceHash`, to pair with that device's anchor set.
     source_text_hash_by_device: BTreeMap<op::DeviceFingerprint, String>,
+    /// Each device's `NodeAnchorScopes` by Lamport, so a set pairs with the latest scopes its
+    /// device wrote within its own publication (see the module docs).
+    anchor_scopes_by_device: BTreeMap<op::DeviceFingerprint, BTreeMap<u64, AnchorScopes>>,
+    /// The Lamport of every `NodeAnchors` each device wrote — the publication boundaries the
+    /// scopes lookup is bounded by.
+    anchor_set_lamports_by_device: BTreeMap<op::DeviceFingerprint, BTreeSet<u64>>,
 }
 
 /// Per-edge LWW accumulators, resolved into a [`ProjectedEdge`] only if the edge is present.
@@ -179,8 +201,30 @@ pub fn project(entries: &[Entry]) -> ProjectedState {
                 // Full-set replacement, like content — an anchor set is one register, not a
                 // per-binding merge, so a later op saying "these two" retires a binding the
                 // earlier one named.
-                nodes.entry(node_id.clone()).or_default().anchors =
-                    Some((canonical_anchors(anchors), entry.meta));
+                let node = nodes.entry(node_id.clone()).or_default();
+                node.anchors = Some((canonical_anchors(anchors), entry.meta));
+                node.anchor_set_lamports_by_device
+                    .entry(entry.meta.device)
+                    .or_default()
+                    .insert(entry.meta.lamport);
+            },
+            MemoryOp::NodeAnchorScopes { node_id, scopes } => {
+                // A full set per publication: the set that follows on the same chain takes the
+                // latest one at or before it, and an empty set retracts.
+                let scopes: AnchorScopes = scopes
+                    .iter()
+                    .map(|scope| {
+                        let AnchorScope { binding_kind, binding_id, scope_hash } = scope.clone();
+                        ((binding_kind, binding_id), scope_hash)
+                    })
+                    .collect();
+                nodes
+                    .entry(node_id.clone())
+                    .or_default()
+                    .anchor_scopes_by_device
+                    .entry(entry.meta.device)
+                    .or_default()
+                    .insert(entry.meta.lamport, scopes);
             },
             // Inert boundary marker this increment (§5.4/C4).
             MemoryOp::Snapshot => {},
@@ -216,11 +260,29 @@ pub fn project(entries: &[Entry]) -> ProjectedState {
                 };
                 let source_text_hash = anchors_meta
                     .and_then(|meta| acc.source_text_hash_by_device.get(&meta.device).cloned());
+                let anchor_scopes = anchors_meta
+                    .and_then(|meta| {
+                        let by_lamport = acc.anchor_scopes_by_device.get(&meta.device)?;
+                        // This publication's companion only: reaching back past the device's
+                        // preceding set would attach an earlier publication's scopes to a set
+                        // published without any.
+                        let preceding = acc
+                            .anchor_set_lamports_by_device
+                            .get(&meta.device)
+                            .and_then(|sets| sets.range(..meta.lamport).next_back().copied());
+                        let from = preceding.map_or(Bound::Unbounded, Bound::Excluded);
+                        by_lamport
+                            .range((from, Bound::Included(meta.lamport)))
+                            .next_back()
+                            .map(|(_, scopes)| scopes.clone())
+                    })
+                    .unwrap_or_default();
                 Some((id, ProjectedNode {
                     content,
                     status: acc.status.unwrap_or_default(),
                     anchors,
                     source_text_hash,
+                    anchor_scopes,
                     anchors_meta,
                 }))
             })
@@ -354,6 +416,83 @@ mod tests {
         let node = &state.nodes[&NodeId::from("mem_1")];
         assert_eq!(node.anchors.as_ref().unwrap()[0].binding_id, "b");
         assert_eq!(node.source_text_hash.as_deref(), Some("second"));
+    }
+
+    /// A device's anchor scopes pair with ITS set exactly as its hash does: the winning set's
+    /// device supplies them, a device that published none supplies an empty map, and a later
+    /// empty set from the winning device retracts.
+    #[test]
+    fn anchor_scopes_pair_with_the_winning_set_s_device() {
+        let scopes = |dev: u8, hash: &str| MemoryOp::NodeAnchorScopes {
+            node_id: NodeId::from("mem_1"),
+            scopes: vec![AnchorScope {
+                binding_kind: "symbol".to_string(),
+                binding_id: dev.to_string(),
+                scope_hash: hash.to_string(),
+            }],
+        };
+        let key = |dev: u8| ("symbol".to_string(), dev.to_string());
+        // Device 2 publishes scopes beside its set; device 1 (an older binary) publishes none.
+        for (x, y) in [(5, 6), (6, 5), (5, 9), (9, 5)] {
+            let state = project(&[
+                at(1, 1, create("mem_1", "t")),
+                at(x, 1, anchors_op("mem_1", &["1"])),
+                at(y, 2, scopes(2, "s2")),
+                at(y + 1, 2, anchors_op("mem_1", &["2"])),
+            ]);
+            let node = &state.nodes[&NodeId::from("mem_1")];
+            let set_from_2 = node.anchors.as_ref().unwrap()[0].binding_id == "2";
+            if set_from_2 {
+                assert_eq!(node.anchor_scopes.get(&key(2)).map(String::as_str), Some("s2"));
+            } else {
+                assert!(node.anchor_scopes.is_empty(), "writers at {x}/{y}: device 1 has none");
+            }
+        }
+        let retracted = project(&[
+            at(1, 2, create("mem_1", "t")),
+            at(2, 2, scopes(2, "s2")),
+            at(3, 2, anchors_op("mem_1", &["2"])),
+            at(4, 2, MemoryOp::NodeAnchorScopes { node_id: NodeId::from("mem_1"), scopes: vec![] }),
+            at(5, 2, anchors_op("mem_1", &["2"])),
+        ]);
+        assert!(retracted.nodes[&NodeId::from("mem_1")].anchor_scopes.is_empty());
+    }
+
+    /// An author publishes its scopes AHEAD of its set on one chain, and a pull can stop between
+    /// them. The set pairs with the latest scopes its device wrote since its preceding set, so a
+    /// prefix torn after the next publication's scopes still describes the set it holds — the
+    /// device's latest would pair set A with B's scopes, and set B arriving next would read as no
+    /// change at all — and a set the device later publishes without scopes (an older binary on the
+    /// same device) takes none, not an earlier publication's.
+    #[test]
+    fn a_set_pairs_with_the_scopes_published_at_or_before_it_not_the_device_s_latest() {
+        let scopes = |hash: &str| MemoryOp::NodeAnchorScopes {
+            node_id: NodeId::from("mem_1"),
+            scopes: vec![AnchorScope {
+                binding_kind: "symbol".to_string(),
+                binding_id: "twin".to_string(),
+                scope_hash: hash.to_string(),
+            }],
+        };
+        let key = ("symbol".to_string(), "twin".to_string());
+        let torn = [
+            at(1, 1, create("mem_1", "t")),
+            at(2, 1, scopes("alpha")),
+            at(3, 1, anchors_op("mem_1", &["twin"])),
+            at(4, 1, scopes("beta")),
+        ];
+        let node = &project(&torn).nodes[&NodeId::from("mem_1")];
+        assert_eq!(node.anchor_scopes.get(&key).map(String::as_str), Some("alpha"));
+
+        let mut complete = torn.to_vec();
+        complete.push(at(5, 1, anchors_op("mem_1", &["twin"])));
+        let node = &project(&complete).nodes[&NodeId::from("mem_1")];
+        assert_eq!(node.anchor_scopes.get(&key).map(String::as_str), Some("beta"));
+
+        let mut without_scopes = complete.clone();
+        without_scopes.push(at(6, 1, anchors_op("mem_1", &["twin"])));
+        let node = &project(&without_scopes).nodes[&NodeId::from("mem_1")];
+        assert!(node.anchor_scopes.is_empty(), "a set published without scopes takes none");
     }
 
     /// The anchors register remembers WHICH entry won it — the content projection maps that entry

--- a/crates/rag-rat-oplog/src/store.rs
+++ b/crates/rag-rat-oplog/src/store.rs
@@ -679,6 +679,7 @@ pub fn load_projection(conn: &Connection, stream: StreamId) -> anyhow::Result<Pr
                 // is an explicit schema change, not a silent assumption.
                 anchors: None,
                 source_text_hash: None,
+                anchor_scopes: Default::default(),
                 anchors_meta: None,
             });
         }
@@ -783,13 +784,14 @@ impl From<NodeContentRow> for NodeContent {
     }
 }
 
-/// One anchor of a node's projected anchor set. Mirrors `op::PortableAnchor` field for field; the
-/// op type stays serde-free because its wire is minicbor, and this row shape is local and rebuilt
-/// wholesale like its siblings.
+/// One anchor of a node's projected anchor set. Mirrors `op::PortableAnchor` field for field, plus
+/// the target's scope hash from the paired `node_anchor_scopes` register; the op type stays
+/// serde-free because its wire is minicbor, and this row shape is local and rebuilt wholesale like
+/// its siblings.
 #[derive(Serialize, Deserialize)]
 pub(super) struct PortableAnchorRow {
-    binding_kind: String,
-    binding_id: String,
+    pub(super) binding_kind: String,
+    pub(super) binding_id: String,
     path: Option<String>,
     start_line: Option<i64>,
     end_line: Option<i64>,
@@ -802,6 +804,10 @@ pub(super) struct PortableAnchorRow {
     signature_hash: Option<String>,
     moniker_tool: Option<String>,
     moniker_tool_version: Option<String>,
+    /// From the scopes register, not the anchor; absent in rows written before it existed, which
+    /// a rebuild refolds anyway.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) scope_hash: Option<String>,
 }
 
 impl From<&PortableAnchor> for PortableAnchorRow {
@@ -821,6 +827,7 @@ impl From<&PortableAnchor> for PortableAnchorRow {
             signature_hash: anchor.signature_hash.clone(),
             moniker_tool: anchor.moniker_tool.clone(),
             moniker_tool_version: anchor.moniker_tool_version.clone(),
+            scope_hash: None,
         }
     }
 }

--- a/crates/rag-rat-query/src/memory/validate.rs
+++ b/crates/rag-rat-query/src/memory/validate.rs
@@ -76,12 +76,19 @@ pub(crate) fn validate_logical_symbol_binding(
     // target contradicts the recorded kind or signature (see `RETARGETED_REASON`); then it is held
     // back, and only rejected if the relocation pick finds something better.
     let retargeted = is_retargeted(binding);
+    let published_scope = if retargeted { published_scope_for(conn, binding)? } else { None };
     let mut held_back = None;
     if let Some(id) = binding.logical_symbol_id
         && let Some(hit) = crate::symbol::lookup_logical_by_id(conn, id)?
     {
         let trusted = !retargeted
-            || target_agrees(binding, &hit.kind, logical_symbol_signature(conn, id)?.as_deref());
+            || target_agrees(
+                binding,
+                &hit.kind,
+                logical_symbol_signature(conn, id)?.as_deref(),
+                logical_symbol_scope(conn, id)?.as_deref(),
+                published_scope.as_deref(),
+            );
         if trusted {
             answer_retarget_mark(binding);
             return validate_live_logical_symbol(conn, binding, id);
@@ -109,7 +116,10 @@ pub(crate) fn validate_logical_symbol_binding(
                    (SELECT s.signature FROM logical_symbol_members m
                       JOIN symbols s ON s.id = m.symbol_id
                      WHERE m.logical_symbol_id = ls.id LIMIT 1),
-                   ls.id
+                   ls.id,
+                   (SELECT s.scope_path FROM logical_symbol_members m
+                      JOIN symbols s ON s.id = m.symbol_id
+                     WHERE m.logical_symbol_id = ls.id LIMIT 1)
             FROM logical_symbols ls
             WHERE ls.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
               AND ls.repo_id = ?2
@@ -123,6 +133,7 @@ pub(crate) fn validate_logical_symbol_binding(
                 kind: row.get(2)?,
                 signature: row.get(3)?,
                 logical_symbol_id: row.get(4)?,
+                scope: row.get(5)?,
             })
         })?;
         rows.collect::<rusqlite::Result<_>>()?
@@ -131,8 +142,9 @@ pub(crate) fn validate_logical_symbol_binding(
     // names a row that no longer exists, or — on a retargeted row — names a live row that
     // contradicts the binding. Impl twins are still separated where it matters — the stable-id arm
     // above resolves them on its own, since the logical key hashes `scope_path`.
-    let relocated = pick_relocation_twin(candidates, binding, retargeted);
-    if let Some(RelocationTwin { id, path, kind, signature, .. }) = relocated {
+    let relocated =
+        pick_relocation_twin(candidates, binding, retargeted, published_scope.as_deref());
+    if let Some(RelocationTwin { id, path, kind, signature, scope, .. }) = relocated {
         // The pick came back to the very handle the retarget check held back: nothing that matches
         // the author's evidence answers to its name here. Validate it live — relocating would
         // report `relocated` on every pass, since this arm does not rewrite the recorded
@@ -140,7 +152,13 @@ pub(crate) fn validate_logical_symbol_binding(
         if Some(id) == held_back {
             return validate_live_logical_symbol(conn, binding, id);
         }
-        if target_agrees(binding, &kind, signature.as_deref()) {
+        if target_agrees(
+            binding,
+            &kind,
+            signature.as_deref(),
+            scope.as_deref(),
+            published_scope.as_deref(),
+        ) {
             answer_retarget_mark(binding);
         }
         binding.logical_symbol_id = Some(id);
@@ -204,6 +222,123 @@ fn is_retargeted(binding: &RepoMemoryBinding) -> bool {
     binding.relocation_reason.as_deref() == Some(RETARGETED_REASON)
 }
 
+/// What a published anchor set said a symbol anchor's target is: the kind, the signature hash and
+/// the scope hash its author recorded. The drain records these per anchor identity as the memory's
+/// `anchors_applied_targets` — the baseline a later set is compared against to tell a retarget from
+/// a republish of the same target — and the validator reads the scope back on a
+/// [`RETARGETED_REASON`] row, where it is the author's evidence of which same-named twin the row
+/// moved to.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AppliedTarget {
+    pub symbol_kind: Option<String>,
+    pub signature_hash: Option<String>,
+    /// `hex_sha256` of the target's scope path as the AUTHOR's index derives it, from the
+    /// `node_anchor_scopes` register; `None` when the author published none for this anchor.
+    pub scope_hash: Option<String>,
+}
+
+/// The applied targets of one memory, keyed by anchor identity `(binding_kind, binding_id)`.
+pub type AppliedTargets = std::collections::BTreeMap<(String, String), AppliedTarget>;
+
+/// One serialized applied target: `(kind, id, symbol_kind, signature_hash, scope_hash)`.
+type AppliedTargetRow<'a> = (&'a str, &'a str, Option<&'a str>, Option<&'a str>, Option<&'a str>);
+
+/// Serialize [`AppliedTargets`] for `repo_memories.anchors_applied_targets`: one
+/// [`AppliedTargetRow`] per anchor.
+pub fn encode_applied_targets(targets: &AppliedTargets) -> anyhow::Result<String> {
+    let rows: Vec<AppliedTargetRow<'_>> = targets
+        .iter()
+        .map(|((kind, id), target)| {
+            (
+                kind.as_str(),
+                id.as_str(),
+                target.symbol_kind.as_deref(),
+                target.signature_hash.as_deref(),
+                target.scope_hash.as_deref(),
+            )
+        })
+        .collect();
+    Ok(serde_json::to_string(&rows)?)
+}
+
+/// Parse [`encode_applied_targets`]'s output, or the four-tuple rows written before the scope
+/// existed; `None` when nothing was recorded or it does not parse, which leaves the retarget
+/// decision to the row's own values.
+pub fn decode_applied_targets(json: Option<&str>) -> Option<AppliedTargets> {
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum Row {
+        WithScope(String, String, Option<String>, Option<String>, Option<String>),
+        Legacy(String, String, Option<String>, Option<String>),
+    }
+    let rows: Vec<Row> = serde_json::from_str(json?).ok()?;
+    Some(
+        rows.into_iter()
+            .map(|row| match row {
+                Row::WithScope(kind, id, symbol_kind, signature_hash, scope_hash) =>
+                    ((kind, id), AppliedTarget { symbol_kind, signature_hash, scope_hash }),
+                Row::Legacy(kind, id, symbol_kind, signature_hash) =>
+                    ((kind, id), AppliedTarget { symbol_kind, signature_hash, scope_hash: None }),
+            })
+            .collect(),
+    )
+}
+
+/// The scope the author published for a [`RETARGETED_REASON`] row's target, from the memory's
+/// applied targets; `None` when none was recorded for this anchor.
+fn published_scope_for(
+    conn: &Connection,
+    binding: &RepoMemoryBinding,
+) -> anyhow::Result<Option<String>> {
+    let json: Option<String> = conn
+        .query_row(
+            "SELECT anchors_applied_targets FROM repo_memories WHERE id = ?1",
+            [&binding.memory_id],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+    Ok(decode_applied_targets(json.as_deref())
+        .and_then(|targets| {
+            targets.get(&(binding.binding_kind.clone(), binding.binding_id.clone())).cloned()
+        })
+        .and_then(|target| target.scope_hash))
+}
+
+/// Whether a live target's scope path agrees with the scope the author published: yes when either
+/// side is unknown (the author published none, or the row predates the scope column), else by
+/// hash.
+fn scope_agrees(live_scope: Option<&str>, published_scope: Option<&str>) -> bool {
+    match (live_scope.filter(|scope| !scope.is_empty()), published_scope) {
+        (Some(live), Some(published)) => hex_sha256(live.as_bytes()) == published,
+        _ => true,
+    }
+}
+
+/// A symbol row's scope path; `None` for a row that predates the column, as for a missing row.
+fn symbol_scope(conn: &Connection, id: i64) -> anyhow::Result<Option<String>> {
+    Ok(conn
+        .query_row("SELECT scope_path FROM symbols WHERE id = ?1", [id], |row| {
+            row.get::<_, Option<String>>(0)
+        })
+        .optional()?
+        .flatten())
+}
+
+/// The scope path a logical symbol's members share (it is part of the logical key).
+fn logical_symbol_scope(conn: &Connection, id: i64) -> anyhow::Result<Option<String>> {
+    Ok(conn
+        .query_row(
+            "SELECT s.scope_path FROM logical_symbol_members m
+               JOIN symbols s ON s.id = m.symbol_id
+              WHERE m.logical_symbol_id = ?1 LIMIT 1",
+            [id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten())
+}
+
 /// Clear [`RETARGETED_REASON`]: validation found a target agreeing with the author's evidence.
 fn answer_retarget_mark(binding: &mut RepoMemoryBinding) {
     if is_retargeted(binding) {
@@ -211,11 +346,19 @@ fn answer_retarget_mark(binding: &mut RepoMemoryBinding) {
     }
 }
 
-/// Whether a symbol of `kind` and `signature` agrees with everything the binding records of its
-/// target — the evidence a retargeted row must be answered with.
-fn target_agrees(binding: &RepoMemoryBinding, kind: &str, signature: Option<&str>) -> bool {
+/// Whether a symbol of `kind`, `signature` and `scope` agrees with everything the binding records
+/// of its target — the evidence a retargeted row must be answered with. `published_scope` is the
+/// author's, read from the memory's applied targets; the row itself records no scope.
+fn target_agrees(
+    binding: &RepoMemoryBinding,
+    kind: &str,
+    signature: Option<&str>,
+    scope: Option<&str>,
+    published_scope: Option<&str>,
+) -> bool {
     binding.symbol_kind.as_deref().is_none_or(|bound| bound == kind)
         && binding_signature_agrees(binding, signature).unwrap_or(true)
+        && scope_agrees(scope, published_scope)
 }
 
 /// Whether `signature` hashes to the binding's recorded signature hash; `None` when either side has
@@ -246,6 +389,8 @@ struct RelocationTwin {
     signature: Option<String>,
     /// The logical group this twin belongs to — for a logical-symbol candidate, itself.
     logical_symbol_id: Option<i64>,
+    /// Its scope path — for a logical-symbol candidate, the one its members share.
+    scope: Option<String>,
 }
 
 /// Choose which same-qualified-name twin a gone binding relocates onto (#491): the stored
@@ -264,12 +409,16 @@ struct RelocationTwin {
 ///
 /// On a row its writer marked [`RETARGETED_REASON`] the recorded kind and signature outrank the
 /// handle instead: the writer set them, while the handle can be the one it left (a rebind from a
-/// struct to its impl keeps the struct's handle beside the impl's kind). The handle still decides
-/// where they tie — including evidence no candidate matches, which names nothing here.
+/// struct to its impl keeps the struct's handle beside the impl's kind). The author's published
+/// scope (`published_scope`) ranks next, below both: it separates twins that agree on kind and
+/// signature — two impls of different traits for one type — and never overrides the evidence those
+/// already give. The handle still decides where all three tie — including evidence no candidate
+/// matches, which names nothing here — so a held-back handle keeps its row over an equal twin.
 fn pick_relocation_twin(
     candidates: Vec<RelocationTwin>,
     binding: &RepoMemoryBinding,
     retargeted: bool,
+    published_scope: Option<&str>,
 ) -> Option<RelocationTwin> {
     candidates
         .into_iter()
@@ -281,12 +430,15 @@ fn pick_relocation_twin(
             );
             let signature_agrees =
                 binding_signature_agrees(binding, twin.signature.as_deref()).unwrap_or(false);
+            let scope_matches = published_scope.is_some_and(|published| {
+                twin.scope.as_deref().is_some_and(|scope| hex_sha256(scope.as_bytes()) == published)
+            });
             // Candidates arrive id-ascending; max_by_key keeps the LAST maximum, so compare on
             // (score, negated id) to keep the lowest-id winner among evidence ties.
-            let [kind, signature, group] =
-                [kind_agrees, signature_agrees, group_agrees].map(u8::from);
+            let [kind, signature, group, scope] =
+                [kind_agrees, signature_agrees, group_agrees, scope_matches].map(u8::from);
             let score = if retargeted {
-                (kind << 2) | (signature << 1) | group
+                (kind << 3) | (signature << 2) | (scope << 1) | group
             } else {
                 (group << 2) | (kind << 1) | signature
             };
@@ -326,11 +478,19 @@ pub(crate) fn validate_symbol_binding(
 ) -> anyhow::Result<String> {
     // As on the logical path: a contradicting live row is held back, not trusted.
     let retargeted = is_retargeted(binding);
+    let published_scope = if retargeted { published_scope_for(conn, binding)? } else { None };
     let mut held_back = None;
     if let Some(id) = binding.symbol_id
         && let Some(hit) = crate::symbol::lookup_by_id(conn, id)?
     {
-        let trusted = !retargeted || target_agrees(binding, &hit.kind, hit.signature.as_deref());
+        let trusted = !retargeted
+            || target_agrees(
+                binding,
+                &hit.kind,
+                hit.signature.as_deref(),
+                symbol_scope(conn, id)?.as_deref(),
+                published_scope.as_deref(),
+            );
         if trusted {
             answer_retarget_mark(binding);
             return validate_live_symbol(conn, binding, id, hit.qualified_name);
@@ -348,7 +508,8 @@ pub(crate) fn validate_symbol_binding(
             "
             SELECT symbols.id, files.path, symbols.kind, symbols.signature,
                    (SELECT m.logical_symbol_id FROM logical_symbol_members m
-                     WHERE m.symbol_id = symbols.id LIMIT 1)
+                     WHERE m.symbol_id = symbols.id LIMIT 1),
+                   symbols.scope_path
             FROM symbols
             JOIN files ON files.id = symbols.file_id
             WHERE symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
@@ -362,12 +523,14 @@ pub(crate) fn validate_symbol_binding(
                 kind: row.get(2)?,
                 signature: row.get(3)?,
                 logical_symbol_id: row.get(4)?,
+                scope: row.get(5)?,
             })
         })?;
         rows.collect::<rusqlite::Result<_>>()?
     };
-    let relocated = pick_relocation_twin(candidates, binding, retargeted);
-    if let Some(RelocationTwin { id, path, kind, signature, .. }) = relocated {
+    let relocated =
+        pick_relocation_twin(candidates, binding, retargeted, published_scope.as_deref());
+    if let Some(RelocationTwin { id, path, kind, signature, scope, .. }) = relocated {
         // Back at the row the retarget check held back: nothing that matches the author's evidence
         // answers to the name here. Validate it live rather than relocate onto itself; the mark
         // stays for a checkout that holds the author's target.
@@ -375,7 +538,13 @@ pub(crate) fn validate_symbol_binding(
             let qualified_name = binding.binding_id.clone();
             return validate_live_symbol(conn, binding, id, qualified_name);
         }
-        if target_agrees(binding, &kind, signature.as_deref()) {
+        if target_agrees(
+            binding,
+            &kind,
+            signature.as_deref(),
+            scope.as_deref(),
+            published_scope.as_deref(),
+        ) {
             answer_retarget_mark(binding);
         }
         binding.symbol_id = Some(id);
@@ -1350,6 +1519,7 @@ mod call_path_receiver_type_hint_tests {
             kind: kind.to_string(),
             signature: None,
             logical_symbol_id: Some(group),
+            scope: None,
         }
     }
 
@@ -1367,6 +1537,7 @@ mod call_path_receiver_type_hint_tests {
             vec![relocation_twin(1, "struct", 7), relocation_twin(2, "impl", 8)],
             &binding,
             true,
+            None,
         );
         assert_eq!(picked.map(|twin| twin.id), Some(2));
     }
@@ -1385,6 +1556,7 @@ mod call_path_receiver_type_hint_tests {
             vec![relocation_twin(1, "struct", 8), relocation_twin(2, "enum", 7)],
             &binding,
             false,
+            None,
         );
         assert_eq!(picked.map(|twin| twin.id), Some(2));
     }
@@ -1402,8 +1574,68 @@ mod call_path_receiver_type_hint_tests {
             vec![relocation_twin(1, "impl", 7), relocation_twin(2, "impl", 8)],
             &binding,
             false,
+            None,
         );
         assert_eq!(picked.map(|twin| twin.id), Some(2));
+    }
+
+    /// On a retargeted row the author's published scope separates twins that agree on kind and
+    /// signature — two impls of different traits for one type — and outranks the handle, which
+    /// names the impl the author left. It never outranks the kind or the signature, and where no
+    /// candidate carries it the handle still decides.
+    #[test]
+    fn on_a_retargeted_row_the_published_scope_breaks_a_kind_and_signature_tie() {
+        let scoped = |id: i64, kind: &str, group: i64, scope: &str| RelocationTwin {
+            scope: Some(scope.to_string()),
+            ..relocation_twin(id, kind, group)
+        };
+        let binding = RepoMemoryBinding {
+            symbol_kind: Some("impl".to_string()),
+            logical_symbol_id: Some(7),
+            ..call_path_binding("mem", "seq")
+        };
+        let beta = hex_sha256(b"Twin as Beta");
+        let twins =
+            || vec![scoped(1, "impl", 7, "Twin as Alpha"), scoped(2, "impl", 8, "Twin as Beta")];
+        let pick = |retargeted: bool, scope: Option<&str>| {
+            pick_relocation_twin(twins(), &binding, retargeted, scope).map(|twin| twin.id)
+        };
+        assert_eq!(pick(true, Some(&beta)), Some(2), "the scope names Beta over the Alpha handle");
+        assert_eq!(pick(true, Some(&hex_sha256(b"Twin as Gamma"))), Some(1), "unmatched: handle");
+        assert_eq!(pick(true, None), Some(1), "no scope published: handle");
+        assert_eq!(pick(false, Some(&beta)), Some(1), "an unmarked row never reads the scope");
+
+        let mut struct_binding = binding;
+        struct_binding.symbol_kind = Some("struct".to_string());
+        let picked = pick_relocation_twin(
+            vec![scoped(1, "struct", 8, "Twin as Alpha"), scoped(2, "impl", 9, "Twin as Beta")],
+            &struct_binding,
+            true,
+            Some(&beta),
+        );
+        assert_eq!(picked.map(|twin| twin.id), Some(1), "the kind outranks the scope");
+    }
+
+    /// The applied-targets codec round-trips the scope and still reads rows written before it.
+    #[test]
+    fn applied_targets_decode_both_tuple_shapes() {
+        let key = ("symbol".to_string(), "src/lib.rs::Twin".to_string());
+        let target = AppliedTarget {
+            symbol_kind: Some("impl".to_string()),
+            signature_hash: Some("sig".to_string()),
+            scope_hash: Some("scope".to_string()),
+        };
+        let targets: AppliedTargets = [(key.clone(), target.clone())].into_iter().collect();
+        let json = encode_applied_targets(&targets).unwrap();
+        assert_eq!(decode_applied_targets(Some(&json)).unwrap()[&key], target);
+
+        let legacy = r#"[["symbol","src/lib.rs::Twin","impl","sig"]]"#;
+        assert_eq!(decode_applied_targets(Some(legacy)).unwrap()[&key], AppliedTarget {
+            scope_hash: None,
+            ..target
+        });
+        assert_eq!(decode_applied_targets(None), None);
+        assert_eq!(decode_applied_targets(Some("not json")), None);
     }
 
     fn call_path_binding(memory_id: &str, edge_sequence_hash: &str) -> RepoMemoryBinding {


### PR DESCRIPTION
## Problem

Two impls of different traits for one type, with the trait on the line after `impl` (`impl` / `Alpha for Twin`, `impl` / `Beta for Twin`), agree on the qualified name, the kind and the captured signature. A foreign author's rebind of a synced memory between them changed nothing the portable anchor carries.

- The drain refreshed the row in place and kept its logical handle, which still named Alpha.
- It did not mark the row `retargeted`, because neither the kind nor the signature changed.
- The validator kept the memory on Alpha, beside Beta's published source hash, so it read `stale` (#1276).

## Fix

The anchor already carries four of the five components of the index's logical key: path, qualified name, kind and signature. The fifth, the target's scope path (`Twin as Beta`), is what separates the twins, and every language backend derives one. The author now publishes it, and the receiver judges the retarget by it.

**Wire (`rag-rat-oplog/src/op.rs`).** A new op kind, `node_anchor_scopes`: `(binding_kind, binding_id, scope_hash)` per symbol anchor, sorted and capped like the anchor set. It is a sibling of `node_anchors`, not a wider `PortableAnchor`: that encoding is frozen, and widening it would cost every older binary the anchors themselves. An older receiver retains the new kind opaque, so its behaviour is unchanged.

**Fold (`project.rs`).** The scopes pair with the winning anchor set by device, as the source hash does, but positionally: the set takes the latest scopes its device wrote after its preceding set and at or before this one. The author publishes scopes ahead of the set, so a pull torn after a later publication's scopes (`scopes A, anchors A, scopes B`) still pairs set A with scopes A, and a later set the same device published without scopes takes none rather than an earlier publication's. An empty set retracts.

**Projection (`content_projection.rs`, `store.rs`).** Each `anchors_json` row gains an optional `scope_hash`, read back as `ProjectedContentNode.anchor_scopes`. `CONTENT_PROJECTOR_VERSION` moves to 7, so a store re-folds retained scope ops on upgrade.

**Author (`authoring.rs`).** `anchor_publication_ops` publishes hash, scopes, then the set. The scope is read through the row's own handle from `symbols.scope_path`, hashed, and only while that row still answers to the binding's qualified name: a raw symbol id is a rowid reassigned on reindex, with no foreign key, so a stale one can name an unrelated live symbol. A dead handle publishes nothing for that anchor.

A set published before the scope op existed projects symbol anchors with no scope, and nothing used to republish it. The anchor sweep (`read_anchor_backfill_ids`) now selects such a memory again while its binding still resolves a scope, so an upgraded author republishes its unchanged set once with scopes beside it. The sweep converges: the republished scope lands in the projection, and a binding that resolves none is never selected. It republishes only a set this account authored whose local bindings still equal the projected set by target and by rebind stamp (`created_at_ms`, which each rebind restamps and `anchors/1` carries verbatim): a contributor's set on an owner-created memory is the contributor's to publish (re-signing it as the owner's would outlive the contributor's revocation), and a sibling device's newer rebind the local rows have yet to catch up with must not be overwritten by them, even a rebind between twins the target columns cannot tell apart. This costs one publication per pre-existing symbol-bound memory, within the sweep's existing per-pass budget.

**Drain (`drain.rs`).** The applied-targets baseline records the scope beside the kind and signature. `refresh_binding` marks `retargeted` when the scope changed while the kind and signature did not, and only when both the recorded and the published scope are known. A scope missing on either side is no evidence: an upgrade must not retarget every symbol row on its first publication. The baseline also follows the paired scopes when the set's bytes did not change (the upgrade's re-fold of retained scope ops, or the author's republish above): a scope the baseline lacks is filled in, so the next rebind has a recorded scope to differ from; one the publication no longer carries is cleared; a changed one replaces the old. None of that marks the row: a rebind always changes the set's bytes, so a scope moving under identical ones is a change of derivation, not of target, and a mark would hold back every such row at once. It re-baselines only anchors a held row still matches by target, as the set-changed path does, so a row relocated locally since has no scope recorded on its behalf. Off-shape scopes are dropped where they would be stored, never quarantined.

**Validator (`validate.rs`).** On a `retargeted` row it reads the published scope from the memory's applied targets. A live handle whose target's scope disagrees is held back. The relocation pick ranks the scope below the kind and the signature and above the handle, so it separates twins those two agree on and never overrides them. Where no candidate carries the published scope, the handle stands, validated live, and the mark waits for a checkout that holds the author's target. Unmarked rows never read the scope.

`AppliedTarget` and its JSON codec move to `rag-rat-query` so the drain and the validator share one shape; the codec still reads the four-tuple rows written before the scope existed.

## Failure modes considered

- **An unchanged republish** carries the same scope as the baseline, so nothing is marked.
- **An author's edit of the same target** publishes no set. A rebind to the same target republishes the same scope.
- **A hash arriving ahead of its set** reads no scopes: they are consulted on a set change, keyed to the set's device by the fold.
- **A sibling whose text equals the author's** is never consulted. Text is not evidence anywhere in this change.
- **A receiver that renamed the trait** has no candidate carrying the author's scope. The handle wins the pick and is validated live; the memory reads `stale`, and the mark stays.
- **Mixed versions.** Older receivers behave as before. An older author publishes no scopes, so newer receivers mark nothing new for it. Two author devices on different versions pair each set with its own device's scopes.
- **Repeated inherent impls** (`impl Twin {}` twice) share a scope. The held-back handle wins the tie, so the binding stays where it is. With a dead handle the pick falls to the lowest id, as it does today.

## Compatibility

No schema migration. `relocation_reason` is checkout-local and never replicated, `anchors_json` is a local projection row rebuilt on refold, and the applied-targets codec accepts both tuple shapes. The projector bump forces one re-fold on upgrade. Memories that existed before the upgrade gain a scope baseline through the author's republish above; until that republish reaches a receiver, a twin rebind of such a memory compares against nothing and reads `stale` on the old twin, as today.

## Tests

- `op.rs`: golden vector for `node_anchor_scopes`; limits, ordering and the empty retraction.
- `project.rs`: `anchor_scopes_pair_with_the_winning_set_s_device`; `a_set_pairs_with_the_scopes_published_at_or_before_it_not_the_device_s_latest` (the torn pull).
- `drain.rs`: `a_changed_published_scope_marks_a_retarget_and_a_missing_one_never_does` covers first sight, same scope, changed scope, missing on either side, an off-shape scope, and, under an unchanged set, a scope appearing, changing (recorded, unmarked), withdrawn, and one for a locally relocated row (skipped).
- `authoring.rs`: `the_anchor_sweep_republishes_a_projected_set_whose_symbol_anchor_lacks_a_scope`: selected only while the projected anchor lacks a scope and the binding resolves one; a set another account authored, one the local rows no longer match by target, and one whose rebind stamp the local rows have yet to reach, are not.
- `validate.rs`: the pick with a published scope; the applied-targets codec on both tuple shapes.
- `refresh.rs`, against a real index of two identical-signature trait impls:
  - `a_published_rebind_between_identical_signature_twins_follows_the_scope` (raw id and logical handle): lands on Beta and reads `current`; a same-scope republish marks nothing; a scope nothing here has keeps the handle and the mark;
  - `a_linked_checkout_without_the_authors_twin_leaves_the_scope_retarget_to_the_base`: a worktree that renamed Beta's trait leaves the mark and the handle on the raw-id arm, and the base checkout answers on Beta; on the logical arm, whose candidates are repo-wide by design, the worktree answers itself by moving the handle to Beta's group, and the base validates it live;
  - `a_linked_checkout_holding_the_authors_twin_answers_the_scope_retarget_for_both`: a worktree that only edited Beta's body answers, and the base then lands on its own Beta;
  - `the_author_publishes_each_symbol_anchor_s_scope_beside_the_set`, by raw id and logical handle, read back both from the authored ops and from the projection, so the op, the fold's pairing and `anchors_json` are exercised end to end.

The twin tests fail with the drain's scope comparison removed, and with the scope dropped from the pick.

